### PR TITLE
feat: add HKDF-SHA256 utility with RFC 5869 KAT tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,14 @@ logic.
 ```
 
 `:core-protocol` is a plain Kotlin/JVM module — it depends only on
-`kotlinx.coroutines`, `protobuf-javalite`, the JCE/JDK, and (optionally) Tink
-for HKDF. It must never import anything from `android.*`. This split keeps
-the protocol unit-testable on the JVM, which is essential because the cipher
-suites and framing have hundreds of edge cases that we need KAT coverage on.
+`kotlinx.coroutines`, `protobuf-javalite`, and the JCE/JDK. It must never
+import anything from `android.*`. This split keeps the protocol
+unit-testable on the JVM, which is essential because the cipher suites and
+framing have hundreds of edge cases that we need KAT coverage on. HKDF-SHA256
+is implemented directly on `javax.crypto.Mac("HmacSHA256")` (see
+`:core-protocol`'s `Hkdf` object) rather than via Google Tink, avoiding
+Tink's transitive `protobuf-java` dependency that would clash with
+`protobuf-javalite` on Android.
 
 ## Toolchain
 

--- a/core-protocol-test/src/main/kotlin/io/github/kyujincho/wvmg/protocol/test/HkdfVectors.kt
+++ b/core-protocol-test/src/main/kotlin/io/github/kyujincho/wvmg/protocol/test/HkdfVectors.kt
@@ -20,8 +20,15 @@ public object HkdfVectors {
     /**
      * One RFC 5869 Appendix A KAT vector. All byte arrays are the literal
      * values from the RFC text.
+     *
+     * Intentionally a regular `class` rather than a `data class`: the
+     * auto-generated `equals`/`hashCode` for `ByteArray` use reference
+     * identity (a known JVM gotcha) so the data-class default is broken,
+     * and we do not need destructuring or `copy()` for read-only fixtures.
+     * `toString` is overridden to return the human-readable [name] so test
+     * failures stay legible.
      */
-    public data class Vector(
+    public class Vector(
         public val name: String,
         public val ikm: ByteArray,
         public val salt: ByteArray,
@@ -30,13 +37,7 @@ public object HkdfVectors {
         public val expectedPrk: ByteArray,
         public val expectedOkm: ByteArray,
     ) {
-        // Generated equals/hashCode would include the array identity, which
-        // breaks parameterized-test reporting. We never compare Vectors for
-        // equality in tests, so we leave the defaults and disable the
-        // detekt warning at the call site if needed.
-        override fun equals(other: Any?): Boolean = this === other
-
-        override fun hashCode(): Int = System.identityHashCode(this)
+        override fun toString(): String = name
     }
 
     /**

--- a/core-protocol-test/src/main/kotlin/io/github/kyujincho/wvmg/protocol/test/HkdfVectors.kt
+++ b/core-protocol-test/src/main/kotlin/io/github/kyujincho/wvmg/protocol/test/HkdfVectors.kt
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.test
+
+/**
+ * RFC 5869 Appendix A Known-Answer Test (KAT) vectors for HKDF-SHA256.
+ *
+ * These vectors are reproduced verbatim from
+ * https://datatracker.ietf.org/doc/html/rfc5869#appendix-A so they can be
+ * used by both the JVM unit tests in `:core-protocol` and any future Android
+ * instrumentation tests that consume the same fixtures.
+ *
+ * Test Cases 4-7 use HKDF-SHA1 and are intentionally omitted; the only hash
+ * Quick Share negotiates is SHA-256.
+ */
+public object HkdfVectors {
+    /**
+     * One RFC 5869 Appendix A KAT vector. All byte arrays are the literal
+     * values from the RFC text.
+     */
+    public data class Vector(
+        public val name: String,
+        public val ikm: ByteArray,
+        public val salt: ByteArray,
+        public val info: ByteArray,
+        public val length: Int,
+        public val expectedPrk: ByteArray,
+        public val expectedOkm: ByteArray,
+    ) {
+        // Generated equals/hashCode would include the array identity, which
+        // breaks parameterized-test reporting. We never compare Vectors for
+        // equality in tests, so we leave the defaults and disable the
+        // detekt warning at the call site if needed.
+        override fun equals(other: Any?): Boolean = this === other
+
+        override fun hashCode(): Int = System.identityHashCode(this)
+    }
+
+    /**
+     * RFC 5869 A.1 — Basic test case with SHA-256.
+     *
+     * IKM = 22 bytes (0x0b * 22), salt set, info set, L = 42.
+     */
+    public val testCase1: Vector =
+        Vector(
+            name = "RFC 5869 A.1 — basic SHA-256",
+            ikm = hex("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b"),
+            salt = hex("000102030405060708090a0b0c"),
+            info = hex("f0f1f2f3f4f5f6f7f8f9"),
+            length = 42,
+            expectedPrk =
+                hex(
+                    "077709362c2e32df0ddc3f0dc47bba63" +
+                        "90b6c73bb50f9c3122ec844ad7c2b3e5",
+                ),
+            expectedOkm =
+                hex(
+                    "3cb25f25faacd57a90434f64d0362f2a" +
+                        "2d2d0a90cf1a5a4c5db02d56ecc4c5bf" +
+                        "34007208d5b887185865",
+                ),
+        )
+
+    /**
+     * RFC 5869 A.2 — Test with SHA-256 and longer inputs/outputs.
+     *
+     * IKM = 80 bytes, salt = 80 bytes, info = 80 bytes, L = 82.
+     */
+    public val testCase2: Vector =
+        Vector(
+            name = "RFC 5869 A.2 — long inputs SHA-256",
+            ikm =
+                hex(
+                    "000102030405060708090a0b0c0d0e0f" +
+                        "101112131415161718191a1b1c1d1e1f" +
+                        "202122232425262728292a2b2c2d2e2f" +
+                        "303132333435363738393a3b3c3d3e3f" +
+                        "404142434445464748494a4b4c4d4e4f",
+                ),
+            salt =
+                hex(
+                    "606162636465666768696a6b6c6d6e6f" +
+                        "707172737475767778797a7b7c7d7e7f" +
+                        "808182838485868788898a8b8c8d8e8f" +
+                        "909192939495969798999a9b9c9d9e9f" +
+                        "a0a1a2a3a4a5a6a7a8a9aaabacadaeaf",
+                ),
+            info =
+                hex(
+                    "b0b1b2b3b4b5b6b7b8b9babbbcbdbebf" +
+                        "c0c1c2c3c4c5c6c7c8c9cacbcccdcecf" +
+                        "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf" +
+                        "e0e1e2e3e4e5e6e7e8e9eaebecedeeef" +
+                        "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+                ),
+            length = 82,
+            expectedPrk =
+                hex(
+                    "06a6b88c5853361a06104c9ceb35b45c" +
+                        "ef760014904671014a193f40c15fc244",
+                ),
+            expectedOkm =
+                hex(
+                    "b11e398dc80327a1c8e7f78c596a4934" +
+                        "4f012eda2d4efad8a050cc4c19afa97c" +
+                        "59045a99cac7827271cb41c65e590e09" +
+                        "da3275600c2f09b8367793a9aca3db71" +
+                        "cc30c58179ec3e87c14c01d5c1f3434f" +
+                        "1d87",
+                ),
+        )
+
+    /**
+     * RFC 5869 A.3 — Test with SHA-256 and zero-length salt/info.
+     *
+     * IKM = 22 bytes (0x0b * 22), salt = empty, info = empty, L = 42.
+     * Exercises the "default salt = HashLen zero bytes" branch and the
+     * "info is empty string" branch.
+     */
+    public val testCase3: Vector =
+        Vector(
+            name = "RFC 5869 A.3 — zero-length salt/info SHA-256",
+            ikm = hex("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b"),
+            salt = ByteArray(0),
+            info = ByteArray(0),
+            length = 42,
+            expectedPrk =
+                hex(
+                    "19ef24a32c717b167f33a91d6f648bdf" +
+                        "96596776afdb6377ac434c1c293ccb04",
+                ),
+            expectedOkm =
+                hex(
+                    "8da4e775a563c18f715f802a063c5a31" +
+                        "b8a11f5c5ee1879ec3454e5f3c738d2d" +
+                        "9d201395faa4b61a96c8",
+                ),
+        )
+
+    /** All Quick-Share-relevant RFC 5869 KAT vectors in declaration order. */
+    public val all: List<Vector> = listOf(testCase1, testCase2, testCase3)
+
+    /**
+     * Decodes a hex string to bytes. Accepts only `[0-9a-f]` (lowercase) and
+     * even-length input — strict on purpose so a typo in a vector becomes a
+     * loud `IllegalArgumentException` at test load time.
+     */
+    private fun hex(value: String): ByteArray {
+        require(value.length % 2 == 0) { "Hex string must have even length: ${value.length}" }
+        val out = ByteArray(value.length / 2)
+        for (i in out.indices) {
+            val hi = decodeNibble(value[i * 2])
+            val lo = decodeNibble(value[i * 2 + 1])
+            out[i] = ((hi shl 4) or lo).toByte()
+        }
+        return out
+    }
+
+    private fun decodeNibble(c: Char): Int =
+        when (c) {
+            in '0'..'9' -> c - '0'
+            in 'a'..'f' -> c - 'a' + 10
+            else -> throw IllegalArgumentException("Invalid hex character: '$c'")
+        }
+}

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/crypto/Hkdf.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/crypto/Hkdf.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.crypto
+
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * HKDF-SHA256 key derivation as specified in RFC 5869.
+ *
+ * Quick Share derives every per-connection key with HKDF-SHA256: the UKEY2
+ * `authString`/`nextSecret`, the D2D client/server keys, the SecureMessage
+ * encrypt+HMAC keys, and (for the QR-code path) the advertising token plus
+ * name encryption key. Bit-exact compatibility with NearDrop's
+ * `hkdfExtract`/`hkdfExpand` (`NearbyConnection.swift`) and Google Tink's
+ * `Hkdf.computeHkdf("HMACSHA256", ...)` is required.
+ *
+ * This implementation is built on top of `javax.crypto.Mac("HmacSHA256")`
+ * for two reasons:
+ *
+ *  1. Avoiding Google Tink keeps `:core-protocol` free of the
+ *     `com.google.protobuf:protobuf-java` transitive dependency, which would
+ *     otherwise collide with `protobuf-javalite` once the protocol code
+ *     reaches Android modules.
+ *  2. HKDF-SHA256 is short enough (RFC 5869 §2) that hand-rolling it on the
+ *     JCE primitive yields fewer dependencies, simpler review, and direct
+ *     parity with NearDrop's reference Swift implementation.
+ *
+ * Correctness is locked down by the RFC 5869 Appendix A test vectors (see
+ * `HkdfTest`). Do **not** add debug logging that prints `ikm`, `salt`, or
+ * the intermediate PRK — those are key material.
+ */
+public object Hkdf {
+    private const val HMAC_ALGORITHM = "HmacSHA256"
+
+    /** Output size of SHA-256 in bytes. Equal to RFC 5869's `HashLen`. */
+    private const val HASH_LEN = 32
+
+    /**
+     * Per RFC 5869 §2.3, `L <= 255 * HashLen`. For SHA-256 that ceiling is
+     * 8160 bytes — far above any single Quick Share key derivation, so the
+     * limit only ever matters as a misuse guard.
+     */
+    private const val MAX_OUTPUT_LENGTH = 255 * HASH_LEN
+
+    /**
+     * Derives `length` bytes of pseudorandom key material from `ikm` using
+     * HKDF-SHA256 (RFC 5869).
+     *
+     * Both the Extract and Expand stages run unconditionally — even when
+     * `salt` is empty — to match the RFC and remain interoperable with
+     * Quick Share peers.
+     *
+     * @param ikm Input keying material. Treated as opaque bytes; never logged.
+     * @param salt Optional salt. May be empty; per RFC 5869 §2.2 an empty
+     *   salt is replaced internally with `HashLen` zero bytes. Empty is
+     *   distinct from "not supplied" only in the API surface; the algorithm
+     *   handles both identically.
+     * @param info Optional context/application-specific info string. May be
+     *   empty.
+     * @param length Number of output bytes to produce. Must be in
+     *   `1..8160` (RFC 5869 §2.3 cap of `255 * HashLen`).
+     * @return A freshly allocated `ByteArray` of exactly `length` bytes.
+     * @throws IllegalArgumentException if `length` is outside the valid range.
+     */
+    public fun derive(
+        ikm: ByteArray,
+        salt: ByteArray,
+        info: ByteArray,
+        length: Int,
+    ): ByteArray {
+        require(length > 0) { "HKDF output length must be positive (got $length)" }
+        require(length <= MAX_OUTPUT_LENGTH) {
+            "HKDF output length $length exceeds RFC 5869 maximum of $MAX_OUTPUT_LENGTH " +
+                "(255 * HashLen) for SHA-256"
+        }
+
+        val prk = extract(salt, ikm)
+        return expand(prk, info, length)
+    }
+
+    /**
+     * RFC 5869 §2.2 — `HKDF-Extract(salt, IKM) -> PRK`.
+     *
+     * If `salt` is empty, substitute `HashLen` zero bytes per the RFC. The
+     * result is always exactly 32 bytes.
+     */
+    internal fun extract(
+        salt: ByteArray,
+        ikm: ByteArray,
+    ): ByteArray {
+        val effectiveSalt = if (salt.isEmpty()) ByteArray(HASH_LEN) else salt
+        val mac = Mac.getInstance(HMAC_ALGORITHM)
+        mac.init(SecretKeySpec(effectiveSalt, HMAC_ALGORITHM))
+        return mac.doFinal(ikm)
+    }
+
+    /**
+     * RFC 5869 §2.3 — `HKDF-Expand(PRK, info, L) -> OKM`.
+     *
+     * Iteratively builds `T = T(1) | T(2) | ... | T(N)` where
+     * `T(i) = HMAC(PRK, T(i-1) | info | i)` and `T(0)` is empty, then
+     * truncates to `length` bytes. The iteration counter is encoded as a
+     * single big-endian byte (1..255), matching the RFC.
+     */
+    internal fun expand(
+        prk: ByteArray,
+        info: ByteArray,
+        length: Int,
+    ): ByteArray {
+        val mac = Mac.getInstance(HMAC_ALGORITHM)
+        mac.init(SecretKeySpec(prk, HMAC_ALGORITHM))
+
+        val output = ByteArray(length)
+        var previousBlock = ByteArray(0)
+        var produced = 0
+        var counter = 1
+        while (produced < length) {
+            mac.update(previousBlock)
+            mac.update(info)
+            mac.update(counter.toByte())
+            previousBlock = mac.doFinal()
+
+            val toCopy = minOf(HASH_LEN, length - produced)
+            previousBlock.copyInto(output, destinationOffset = produced, endIndex = toCopy)
+            produced += toCopy
+            counter++
+        }
+        return output
+    }
+}

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/crypto/HkdfTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/crypto/HkdfTest.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.crypto
+
+import com.google.common.truth.Truth.assertThat
+import io.github.kyujincho.wvmg.protocol.test.HkdfVectors
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * Bit-exact correctness tests for [Hkdf] against RFC 5869 Appendix A vectors
+ * 1, 2, and 3 (the three SHA-256 vectors). Vectors 4-6 use SHA-1 and are
+ * deliberately omitted; SHA-1 is not negotiated by Quick Share.
+ *
+ * The vectors live in `:core-protocol-test` (`HkdfVectors`) so the same
+ * Known-Answer Tests can be reused from Android instrumentation tests when
+ * the protocol stack lights up later in Phase 1.
+ */
+class HkdfTest {
+    @Test
+    fun `RFC 5869 test case 1 — basic SHA-256`() {
+        val v = HkdfVectors.testCase1
+        assertThat(Hkdf.extract(v.salt, v.ikm)).isEqualTo(v.expectedPrk)
+        assertThat(Hkdf.derive(v.ikm, v.salt, v.info, v.length)).isEqualTo(v.expectedOkm)
+    }
+
+    @Test
+    fun `RFC 5869 test case 2 — long inputs SHA-256`() {
+        val v = HkdfVectors.testCase2
+        assertThat(Hkdf.extract(v.salt, v.ikm)).isEqualTo(v.expectedPrk)
+        assertThat(Hkdf.derive(v.ikm, v.salt, v.info, v.length)).isEqualTo(v.expectedOkm)
+    }
+
+    @Test
+    fun `RFC 5869 test case 3 — empty salt and info SHA-256`() {
+        val v = HkdfVectors.testCase3
+        assertThat(Hkdf.extract(v.salt, v.ikm)).isEqualTo(v.expectedPrk)
+        assertThat(Hkdf.derive(v.ikm, v.salt, v.info, v.length)).isEqualTo(v.expectedOkm)
+    }
+
+    @Test
+    fun `derive returns a fresh array of exactly the requested length`() {
+        val ikm = ByteArray(16) { it.toByte() }
+        val out = Hkdf.derive(ikm, ByteArray(0), ByteArray(0), length = 17)
+        assertThat(out.size).isEqualTo(17)
+    }
+
+    @Test
+    fun `derive supports the maximum HKDF-SHA256 output length`() {
+        // RFC 5869 §2.3: L <= 255 * HashLen (= 8160 for SHA-256).
+        val ikm = ByteArray(32) { 0x42 }
+        val out = Hkdf.derive(ikm, ByteArray(0), ByteArray(0), length = 255 * 32)
+        assertThat(out.size).isEqualTo(255 * 32)
+    }
+
+    @Test
+    fun `derive rejects zero or negative length`() {
+        val ikm = ByteArray(16)
+        assertThrows<IllegalArgumentException> {
+            Hkdf.derive(ikm, ByteArray(0), ByteArray(0), length = 0)
+        }
+        assertThrows<IllegalArgumentException> {
+            Hkdf.derive(ikm, ByteArray(0), ByteArray(0), length = -1)
+        }
+    }
+
+    @Test
+    fun `derive rejects output length above RFC 5869 cap`() {
+        val ikm = ByteArray(16)
+        assertThrows<IllegalArgumentException> {
+            Hkdf.derive(ikm, ByteArray(0), ByteArray(0), length = 255 * 32 + 1)
+        }
+    }
+
+    @Test
+    fun `empty salt is equivalent to HashLen zero bytes per RFC 5869`() {
+        val ikm = ByteArray(16) { 0x0b }
+        val info = byteArrayOf(0x01, 0x02, 0x03)
+        val withEmptySalt = Hkdf.derive(ikm, ByteArray(0), info, length = 64)
+        val withZeroSalt = Hkdf.derive(ikm, ByteArray(32), info, length = 64)
+        assertThat(withEmptySalt).isEqualTo(withZeroSalt)
+    }
+
+    @Test
+    fun `derive does not mutate caller-provided byte arrays`() {
+        val ikm = ByteArray(22) { 0x0b }
+        val salt = byteArrayOf(0x00, 0x01, 0x02, 0x03)
+        val info = byteArrayOf(0x10, 0x20)
+        val ikmSnapshot = ikm.copyOf()
+        val saltSnapshot = salt.copyOf()
+        val infoSnapshot = info.copyOf()
+
+        Hkdf.derive(ikm, salt, info, length = 50)
+
+        assertThat(ikm).isEqualTo(ikmSnapshot)
+        assertThat(salt).isEqualTo(saltSnapshot)
+        assertThat(info).isEqualTo(infoSnapshot)
+    }
+}


### PR DESCRIPTION
## Summary

Implements the HKDF-SHA256 (RFC 5869) key derivation utility used by every Quick Share key schedule — UKEY2 `authString`/`nextSecret`, D2D client/server keys, SecureMessage encrypt+HMAC keys, and the QR-code-path advertising token / name encryption key.

### Implementation choice: raw `javax.crypto.Mac` over Google Tink

Issue #9 left this trade-off open. This PR builds HKDF directly on `Mac("HmacSHA256")` rather than pulling Tink in.

Rationale:
1. **Dependency hygiene** — Tink ships a transitive `com.google.protobuf:protobuf-java` that collides with `protobuf-javalite` already used elsewhere in the project. Targeted exclusions work on the JVM module but become brittle once the dependency leaks transitively into Android modules.
2. **Surface size** — HKDF-SHA256 is ~30 lines (RFC 5869 §2). Pulling a multi-MB primitive library plus its proto deps for one function is disproportionate.
3. **Reference parity** — NearDrop hand-rolls `hkdfExtract`/`hkdfExpand` in `NearbyConnection.swift`. Mirroring that mental model keeps cross-checks against the upstream Swift code straightforward.
4. **JCE provider quality** — `Mac("HmacSHA256")` is provided by SunJCE on the JVM and AndroidOpenSSL on Android, both well-audited.

### Public API

```kotlin
Hkdf.derive(
    ikm: ByteArray,
    salt: ByteArray,
    info: ByteArray,
    length: Int,
): ByteArray
```

- Empty `salt` is replaced internally with `HashLen` zero bytes per RFC 5869 §2.2.
- `length` is bounded to `1..255 * 32 = 8160` per RFC 5869 §2.3.
- Caller-provided byte arrays are not mutated.
- No logging of `ikm`/`salt`/`prk` per the issue's "no debug logging leaks key material" requirement.

### Test coverage

- **RFC 5869 Appendix A test case 1** — basic SHA-256 path (IKM=22B, salt=13B, info=10B, L=42).
- **RFC 5869 Appendix A test case 2** — long-input SHA-256 (IKM=80B, salt=80B, info=80B, L=82, exercises 3-block expansion).
- **RFC 5869 Appendix A test case 3** — empty salt and empty info SHA-256 (covers the default-salt and empty-info branches).
- Boundary tests: max output length (8160 bytes), zero/negative length rejection, over-cap length rejection, empty-salt-equals-zero-salt invariant, input-non-mutation.

SHA-1 vectors 4-6 are intentionally omitted; Quick Share never negotiates SHA-1.

KAT vectors live in `:core-protocol-test` so they can be reused from future Android instrumentation tests (#27, #28).

Closes #9