### PR TITLE
feat: add Phase 1 permissions onboarding

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,50 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <!--
+      Phase 1 permission set for Quick Share over Wi-Fi LAN.
+
+      Runtime (must be requested at app start, gated by API level):
+        * NEARBY_WIFI_DEVICES (API 33+) — required for any local-network
+          discovery/advertising. We never derive physical location from peer
+          scans, so we set neverForLocation per Google's guidance and skip
+          ACCESS_FINE_LOCATION on API 33+ devices.
+        * POST_NOTIFICATIONS (API 33+) — used by the foreground transfer
+          service notification (#21) and incoming-transfer notifications.
+
+      Compile-time (no runtime prompt):
+        * CHANGE_WIFI_MULTICAST_STATE — held while mDNS is active via
+          WifiManager.MulticastLock. mDNS multicasts (224.0.0.251) are
+          dropped on Android by default unless the lock is acquired.
+        * INTERNET / ACCESS_NETWORK_STATE / ACCESS_WIFI_STATE — local
+          socket I/O, network/Wi-Fi state inspection.
+
+      Phase 2 (BLUETOOTH_*) and READ_MEDIA_* are intentionally omitted —
+      see issue #26 scope notes.
+    -->
+
+    <!-- Wi-Fi peer discovery on API 33+. neverForLocation tells Android we
+         do not infer physical location from these scans, so the platform
+         skips the location permission requirement. -->
+    <uses-permission
+        android:name="android.permission.NEARBY_WIFI_DEVICES"
+        android:usesPermissionFlags="neverForLocation"
+        tools:targetApi="33" />
+
+    <!-- Notification posting on API 33+. Pre-33 devices show notifications
+         without a runtime prompt, so the manifest-level entry is gated. -->
+    <uses-permission
+        android:name="android.permission.POST_NOTIFICATIONS"
+        tools:targetApi="33" />
+
+    <!-- Multicast lock for mDNS service discovery (compile-time). -->
+    <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
+
+    <!-- General networking (compile-time). -->
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
 
     <application
         android:allowBackup="false"
@@ -20,6 +65,11 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <activity
+            android:name=".onboarding.PermissionsOnboardingActivity"
+            android:exported="false"
+            android:label="@string/onboarding_title" />
 
     </application>
 

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/MainActivity.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/MainActivity.kt
@@ -19,28 +19,51 @@ import io.github.kyujincho.wvmg.onboarding.PermissionsOnboardingActivity
  * of the phase rolls in.
  *
  * The one bit of real logic today is the permissions gate: if any of
- * the runtime permissions Phase 1 needs (#26) is missing, we send the
- * user to [PermissionsOnboardingActivity] before they see any app UI.
- * Onboarding does not block proceeding when only optional permissions
- * remain denied — see the activity for the policy.
+ * the runtime permissions Phase 1 needs (#26) is missing on cold start,
+ * we send the user to [PermissionsOnboardingActivity] before they see
+ * any app UI. Onboarding does not block proceeding when only optional
+ * permissions remain denied — see the activity for the policy.
  */
 class MainActivity : AppCompatActivity() {
+    /**
+     * Latched once we've routed to the onboarding screen for this
+     * activity instance, so that pressing back from onboarding does
+     * not bounce the user straight back into it on every onStart.
+     * The next cold start (process death / fresh task) re-evaluates.
+     */
+    private var onboardingLaunched: Boolean = false
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+        // Restore the flag across configuration changes so we don't
+        // re-route on rotate.
+        savedInstanceState?.let {
+            onboardingLaunched = it.getBoolean(STATE_ONBOARDING_LAUNCHED, false)
+        }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putBoolean(STATE_ONBOARDING_LAUNCHED, onboardingLaunched)
     }
 
     override fun onStart() {
         super.onStart()
-        // Re-check on every onStart so the user can return from the
-        // onboarding screen (or from system Settings) without being
-        // bounced into a stale state. Once #21 lands, the foreground
-        // service will repeat this check at start time and surface a
-        // dismissible error instead of relaunching onboarding.
+        // Route to onboarding at most once per activity instance. Once
+        // #21 lands, the foreground service will re-check at start time
+        // and surface a dismissible error instead of relaunching
+        // onboarding from here.
+        if (onboardingLaunched) return
         if (!PermissionRequirements.allGranted(this) &&
             !PermissionRequirements.onlyOptionalMissing(this)
         ) {
+            onboardingLaunched = true
             startActivity(Intent(this, PermissionsOnboardingActivity::class.java))
         }
+    }
+
+    private companion object {
+        const val STATE_ONBOARDING_LAUNCHED = "wvmg.main.onboardingLaunched"
     }
 }

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/MainActivity.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/MainActivity.kt
@@ -5,19 +5,42 @@
  */
 package io.github.kyujincho.wvmg
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import io.github.kyujincho.wvmg.onboarding.PermissionRequirements
+import io.github.kyujincho.wvmg.onboarding.PermissionsOnboardingActivity
 
 /**
  * Empty launcher activity for the WhenVivoMeetsGoogle app.
  *
  * Phase 1's job here is purely scaffold — the real device list, transfer
- * status, and settings screens replace this implementation as the rest of
- * the phase rolls in.
+ * status, and settings screens replace this implementation as the rest
+ * of the phase rolls in.
+ *
+ * The one bit of real logic today is the permissions gate: if any of
+ * the runtime permissions Phase 1 needs (#26) is missing, we send the
+ * user to [PermissionsOnboardingActivity] before they see any app UI.
+ * Onboarding does not block proceeding when only optional permissions
+ * remain denied — see the activity for the policy.
  */
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+    }
+
+    override fun onStart() {
+        super.onStart()
+        // Re-check on every onStart so the user can return from the
+        // onboarding screen (or from system Settings) without being
+        // bounced into a stale state. Once #21 lands, the foreground
+        // service will repeat this check at start time and surface a
+        // dismissible error instead of relaunching onboarding.
+        if (!PermissionRequirements.allGranted(this) &&
+            !PermissionRequirements.onlyOptionalMissing(this)
+        ) {
+            startActivity(Intent(this, PermissionsOnboardingActivity::class.java))
+        }
     }
 }

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/onboarding/PermissionRequirements.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/onboarding/PermissionRequirements.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.onboarding
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.annotation.StringRes
+import androidx.core.content.ContextCompat
+import io.github.kyujincho.wvmg.R
+
+/**
+ * Single source of truth for the runtime permissions Phase 1 needs.
+ *
+ * Compile-time permissions (`CHANGE_WIFI_MULTICAST_STATE`, `INTERNET`,
+ * `ACCESS_NETWORK_STATE`, `ACCESS_WIFI_STATE`) are declared in the
+ * manifest and never appear here — they are granted at install time.
+ *
+ * Runtime permissions are gated by API level:
+ *   * `NEARBY_WIFI_DEVICES` and `POST_NOTIFICATIONS` only exist on API 33+.
+ *     On older devices they are simply absent from this list and the
+ *     onboarding screen reports them as automatically granted, since
+ *     pre-33 platforms either rely on different permissions (legacy
+ *     Wi-Fi discovery does not need NEARBY_WIFI_DEVICES) or post
+ *     notifications without a prompt.
+ */
+internal object PermissionRequirements {
+    /**
+     * Describes a single runtime permission for the onboarding UI: the
+     * Android permission identifier plus user-facing copy explaining
+     * **why** the app needs it.
+     */
+    internal data class Requirement(
+        val permission: String,
+        @StringRes val titleRes: Int,
+        @StringRes val rationaleRes: Int,
+        @StringRes val grantedRes: Int,
+        @StringRes val deniedRes: Int,
+    )
+
+    /**
+     * The set of runtime permissions that need to be requested on the
+     * **current** device. Empty on API < 33 — Phase 1 has no runtime
+     * permissions on those devices.
+     */
+    internal fun requirementsFor(): List<Requirement> =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            tiramisuRequirements()
+        } else {
+            emptyList()
+        }
+
+    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
+    private fun tiramisuRequirements(): List<Requirement> =
+        listOf(
+            Requirement(
+                permission = Manifest.permission.NEARBY_WIFI_DEVICES,
+                titleRes = R.string.permission_nearby_wifi_title,
+                rationaleRes = R.string.permission_nearby_wifi_rationale,
+                grantedRes = R.string.permission_status_granted,
+                deniedRes = R.string.permission_status_denied,
+            ),
+            Requirement(
+                permission = Manifest.permission.POST_NOTIFICATIONS,
+                titleRes = R.string.permission_notifications_title,
+                rationaleRes = R.string.permission_notifications_rationale,
+                grantedRes = R.string.permission_status_granted,
+                deniedRes = R.string.permission_status_optional_denied,
+            ),
+        )
+
+    /**
+     * Returns the permissions from [requirementsFor] that are not yet
+     * granted on this device. Used by [PermissionsOnboardingActivity] to
+     * decide what to request, and by `MainActivity` to gate whether
+     * onboarding needs to be shown at all.
+     */
+    internal fun missingPermissions(context: Context): List<String> =
+        requirementsFor()
+            .map(Requirement::permission)
+            .filter { permission ->
+                ContextCompat.checkSelfPermission(context, permission) !=
+                    PackageManager.PERMISSION_GRANTED
+            }
+
+    /**
+     * True when every runtime permission Phase 1 asks for has been
+     * granted (or is not applicable to the current API level).
+     */
+    internal fun allGranted(context: Context): Boolean = missingPermissions(context).isEmpty()
+
+    /**
+     * True when the only outstanding permissions are non-blocking ones
+     * (currently just `POST_NOTIFICATIONS`). The service can run in
+     * degraded mode in that case — see issue #26 acceptance criteria.
+     */
+    internal fun onlyOptionalMissing(context: Context): Boolean {
+        val missing = missingPermissions(context)
+        if (missing.isEmpty()) return false
+        return missing.all { it == OPTIONAL_POST_NOTIFICATIONS }
+    }
+
+    /**
+     * `Manifest.permission.POST_NOTIFICATIONS` exists only on API 33+.
+     * Holding the literal string as a constant keeps the comparison in
+     * [onlyOptionalMissing] safe to call on every API level.
+     */
+    private const val OPTIONAL_POST_NOTIFICATIONS = "android.permission.POST_NOTIFICATIONS"
+}

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/onboarding/PermissionsOnboardingActivity.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/onboarding/PermissionsOnboardingActivity.kt
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.onboarding
+
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Bundle
+import android.provider.Settings
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+import io.github.kyujincho.wvmg.R
+import io.github.kyujincho.wvmg.databinding.ActivityPermissionsOnboardingBinding
+import io.github.kyujincho.wvmg.databinding.ItemPermissionRowBinding
+
+/**
+ * Single-screen onboarding for the runtime permissions Phase 1 needs.
+ *
+ * Responsibilities:
+ *   1. Show every required runtime permission with rationale text so the
+ *      user understands **why** Quick Share over LAN needs it.
+ *   2. Drive the system permission prompt for any not-yet-granted ones.
+ *   3. Surface post-grant state inline (granted / denied / optional-denied)
+ *      so the user can see at a glance what still needs attention.
+ *   4. Let the user proceed once mandatory permissions are granted —
+ *      `POST_NOTIFICATIONS` denials are non-blocking (degraded mode).
+ *
+ * Pre-33 devices have no runtime permissions to request; the activity
+ * detects that path and shows a "you're all set" state instead of a
+ * permission grid.
+ */
+class PermissionsOnboardingActivity : AppCompatActivity() {
+    private lateinit var binding: ActivityPermissionsOnboardingBinding
+    private val rowsByPermission: MutableMap<String, ItemPermissionRowBinding> = mutableMapOf()
+
+    /**
+     * Multi-permission request launcher. We request the full set in one
+     * dialog so the user does not get a chain of system prompts.
+     */
+    private val permissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { results ->
+            // The result map is the source of truth for the rows we just
+            // asked about. For any permission that was already granted
+            // before launch (and so was not re-requested) we still need
+            // to refresh the row from the system, hence refreshAllRows().
+            results.forEach { (permission, _) -> refreshRow(permission) }
+            refreshAllRows()
+            updateContinueButton()
+        }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityPermissionsOnboardingBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        renderPermissionRows()
+        binding.onboardingGrantButton.setOnClickListener { onGrantClicked() }
+        binding.onboardingContinueButton.setOnClickListener { finish() }
+        binding.onboardingSettingsButton.setOnClickListener { openAppSettings() }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        // The user may have toggled permissions in system Settings while
+        // we were paused, so re-sync state every time we come back.
+        refreshAllRows()
+        updateContinueButton()
+    }
+
+    private fun renderPermissionRows() {
+        val requirements = PermissionRequirements.requirementsFor()
+        val container: LinearLayout = binding.onboardingPermissionList
+        container.removeAllViews()
+        rowsByPermission.clear()
+
+        if (requirements.isEmpty()) {
+            // Pre-33 devices: nothing to request. Show a friendly empty
+            // state and hide the grant button so the only action is
+            // "continue".
+            binding.onboardingEmptyState.visibility = View.VISIBLE
+            binding.onboardingGrantButton.visibility = View.GONE
+            return
+        }
+
+        binding.onboardingEmptyState.visibility = View.GONE
+        binding.onboardingGrantButton.visibility = View.VISIBLE
+
+        val inflater = LayoutInflater.from(this)
+        for (requirement in requirements) {
+            val row =
+                ItemPermissionRowBinding.inflate(inflater, container, false).also {
+                    it.permissionRowTitle.setText(requirement.titleRes)
+                    it.permissionRowRationale.setText(requirement.rationaleRes)
+                }
+            container.addView(row.root)
+            rowsByPermission[requirement.permission] = row
+            renderRowState(requirement, row)
+        }
+    }
+
+    private fun refreshRow(permission: String) {
+        val requirement =
+            PermissionRequirements
+                .requirementsFor()
+                .firstOrNull { it.permission == permission } ?: return
+        val row = rowsByPermission[permission] ?: return
+        renderRowState(requirement, row)
+    }
+
+    private fun refreshAllRows() {
+        for (requirement in PermissionRequirements.requirementsFor()) {
+            val row = rowsByPermission[requirement.permission] ?: continue
+            renderRowState(requirement, row)
+        }
+    }
+
+    private fun renderRowState(
+        requirement: PermissionRequirements.Requirement,
+        row: ItemPermissionRowBinding,
+    ) {
+        val granted =
+            ContextCompat.checkSelfPermission(this, requirement.permission) ==
+                PackageManager.PERMISSION_GRANTED
+        val statusView: TextView = row.permissionRowStatus
+        if (granted) {
+            statusView.setText(requirement.grantedRes)
+            statusView.setTextColor(ContextCompat.getColor(this, android.R.color.holo_green_dark))
+        } else {
+            statusView.setText(requirement.deniedRes)
+            statusView.setTextColor(ContextCompat.getColor(this, android.R.color.holo_orange_dark))
+        }
+    }
+
+    private fun onGrantClicked() {
+        val missing = PermissionRequirements.missingPermissions(this)
+        if (missing.isEmpty()) {
+            updateContinueButton()
+            return
+        }
+
+        // If the system has stopped showing the rationale dialog (user
+        // tapped "Don't ask again"), `shouldShowRequestPermissionRationale`
+        // returns false even though the permission isn't granted. In that
+        // case the only path forward is the system Settings screen, so we
+        // surface that button to the user.
+        val needsSettingsFallback =
+            missing.any { permission ->
+                !shouldShowRequestPermissionRationale(permission) &&
+                    !isFirstTimeRequest(permission)
+            }
+        if (needsSettingsFallback) {
+            binding.onboardingSettingsButton.visibility = View.VISIBLE
+        }
+        permissionLauncher.launch(missing.toTypedArray())
+    }
+
+    /**
+     * Heuristic for "have we ever asked for this permission before?".
+     * The Android platform doesn't expose this directly, so we check
+     * `shouldShowRequestPermissionRationale` against a sentinel:
+     *   * granted   -> not first time
+     *   * denied with rationale flag false on the very first launch is
+     *     indistinguishable from "permanent deny"; we accept that minor
+     *     UX wrinkle — at worst we show the Settings shortcut one
+     *     prompt earlier than strictly necessary.
+     */
+    private fun isFirstTimeRequest(permission: String): Boolean {
+        val granted =
+            ContextCompat.checkSelfPermission(this, permission) ==
+                PackageManager.PERMISSION_GRANTED
+        if (granted) return false
+        // If we've never launched the request, the launcher hasn't
+        // recorded any state. The cheapest signal we have is that the
+        // Settings button is still hidden (its visibility flips on the
+        // first denial-with-permanent path).
+        return binding.onboardingSettingsButton.visibility != View.VISIBLE
+    }
+
+    private fun openAppSettings() {
+        val intent =
+            Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                data = Uri.fromParts("package", packageName, null)
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+        startActivity(intent)
+    }
+
+    private fun updateContinueButton() {
+        // The continue button is always enabled — the user can leave
+        // onboarding even with denials, and the service-start gate
+        // (issue #21) re-checks at runtime. Optional-only denials show
+        // a softer label so the user knows they can proceed but with
+        // degraded notifications.
+        binding.onboardingContinueButton.isEnabled = true
+        binding.onboardingContinueButton.setText(
+            when {
+                PermissionRequirements.allGranted(this) -> R.string.onboarding_continue
+                PermissionRequirements.onlyOptionalMissing(this) -> R.string.onboarding_continue_degraded
+                else -> R.string.onboarding_continue_partial
+            },
+        )
+    }
+}

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/onboarding/PermissionsOnboardingActivity.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/onboarding/PermissionsOnboardingActivity.kt
@@ -42,17 +42,34 @@ class PermissionsOnboardingActivity : AppCompatActivity() {
     private val rowsByPermission: MutableMap<String, ItemPermissionRowBinding> = mutableMapOf()
 
     /**
+     * True once the user has tapped "Grant permissions" at least once
+     * in this activity instance. Used to distinguish a true first-run
+     * request (where `shouldShowRequestPermissionRationale` returning
+     * false means "first ever ask") from a permanent denial (where the
+     * same flag means "Don't ask again").
+     */
+    private var hasRequestedOnce: Boolean = false
+
+    /**
      * Multi-permission request launcher. We request the full set in one
      * dialog so the user does not get a chain of system prompts.
      */
     private val permissionLauncher =
         registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { results ->
-            // The result map is the source of truth for the rows we just
-            // asked about. For any permission that was already granted
-            // before launch (and so was not re-requested) we still need
-            // to refresh the row from the system, hence refreshAllRows().
-            results.forEach { (permission, _) -> refreshRow(permission) }
+            // Re-sync every row from the system. We cannot trust the
+            // results map alone because permissions that were already
+            // granted at launch time are absent from it.
             refreshAllRows()
+            // Surface the Settings shortcut for any permission that came
+            // back denied without the rationale flag — that's the
+            // platform's "Don't ask again" signal.
+            val permanentlyDenied =
+                results.any { (permission, granted) ->
+                    !granted && !shouldShowRequestPermissionRationale(permission)
+                }
+            if (permanentlyDenied) {
+                binding.onboardingSettingsButton.visibility = View.VISIBLE
+            }
             updateContinueButton()
         }
 
@@ -61,10 +78,29 @@ class PermissionsOnboardingActivity : AppCompatActivity() {
         binding = ActivityPermissionsOnboardingBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
+        // Restore launch state across configuration changes so we don't
+        // mistakenly treat a rotation as a fresh first run.
+        savedInstanceState?.let {
+            hasRequestedOnce = it.getBoolean(STATE_HAS_REQUESTED_ONCE, false)
+            if (it.getBoolean(STATE_SETTINGS_BUTTON_VISIBLE, false)) {
+                // Visibility is restored after the views are inflated.
+                binding.onboardingSettingsButton.visibility = View.VISIBLE
+            }
+        }
+
         renderPermissionRows()
         binding.onboardingGrantButton.setOnClickListener { onGrantClicked() }
         binding.onboardingContinueButton.setOnClickListener { finish() }
         binding.onboardingSettingsButton.setOnClickListener { openAppSettings() }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putBoolean(STATE_HAS_REQUESTED_ONCE, hasRequestedOnce)
+        outState.putBoolean(
+            STATE_SETTINGS_BUTTON_VISIBLE,
+            binding.onboardingSettingsButton.visibility == View.VISIBLE,
+        )
     }
 
     override fun onResume() {
@@ -106,15 +142,6 @@ class PermissionsOnboardingActivity : AppCompatActivity() {
         }
     }
 
-    private fun refreshRow(permission: String) {
-        val requirement =
-            PermissionRequirements
-                .requirementsFor()
-                .firstOrNull { it.permission == permission } ?: return
-        val row = rowsByPermission[permission] ?: return
-        renderRowState(requirement, row)
-    }
-
     private fun refreshAllRows() {
         for (requirement in PermissionRequirements.requirementsFor()) {
             val row = rowsByPermission[requirement.permission] ?: continue
@@ -146,42 +173,21 @@ class PermissionsOnboardingActivity : AppCompatActivity() {
             return
         }
 
-        // If the system has stopped showing the rationale dialog (user
-        // tapped "Don't ask again"), `shouldShowRequestPermissionRationale`
-        // returns false even though the permission isn't granted. In that
-        // case the only path forward is the system Settings screen, so we
-        // surface that button to the user.
-        val needsSettingsFallback =
-            missing.any { permission ->
-                !shouldShowRequestPermissionRationale(permission) &&
-                    !isFirstTimeRequest(permission)
+        // If we've already asked at least once and the platform still
+        // says rationale is not appropriate for any missing permission,
+        // the user has hit "Don't ask again". The only remaining path
+        // is the system Settings screen, so reveal that shortcut now —
+        // we still issue the launch in case the platform decides to
+        // re-prompt.
+        if (hasRequestedOnce) {
+            val permanentlyDenied =
+                missing.any { permission -> !shouldShowRequestPermissionRationale(permission) }
+            if (permanentlyDenied) {
+                binding.onboardingSettingsButton.visibility = View.VISIBLE
             }
-        if (needsSettingsFallback) {
-            binding.onboardingSettingsButton.visibility = View.VISIBLE
         }
+        hasRequestedOnce = true
         permissionLauncher.launch(missing.toTypedArray())
-    }
-
-    /**
-     * Heuristic for "have we ever asked for this permission before?".
-     * The Android platform doesn't expose this directly, so we check
-     * `shouldShowRequestPermissionRationale` against a sentinel:
-     *   * granted   -> not first time
-     *   * denied with rationale flag false on the very first launch is
-     *     indistinguishable from "permanent deny"; we accept that minor
-     *     UX wrinkle — at worst we show the Settings shortcut one
-     *     prompt earlier than strictly necessary.
-     */
-    private fun isFirstTimeRequest(permission: String): Boolean {
-        val granted =
-            ContextCompat.checkSelfPermission(this, permission) ==
-                PackageManager.PERMISSION_GRANTED
-        if (granted) return false
-        // If we've never launched the request, the launcher hasn't
-        // recorded any state. The cheapest signal we have is that the
-        // Settings button is still hidden (its visibility flips on the
-        // first denial-with-permanent path).
-        return binding.onboardingSettingsButton.visibility != View.VISIBLE
     }
 
     private fun openAppSettings() {
@@ -207,5 +213,10 @@ class PermissionsOnboardingActivity : AppCompatActivity() {
                 else -> R.string.onboarding_continue_partial
             },
         )
+    }
+
+    private companion object {
+        const val STATE_HAS_REQUESTED_ONCE = "wvmg.onboarding.hasRequestedOnce"
+        const val STATE_SETTINGS_BUTTON_VISIBLE = "wvmg.onboarding.settingsButtonVisible"
     }
 }

--- a/app/src/main/res/layout/activity_permissions_onboarding.xml
+++ b/app/src/main/res/layout/activity_permissions_onboarding.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Single-screen runtime-permission onboarding for Phase 1 (#26).
+
+  Layout shape:
+    * Header explains why Quick Share over LAN needs the permissions.
+    * Scrollable list of permission rows (one per Requirement).
+    * Footer with "Grant permissions" + "Continue" + "Open settings"
+      (settings is hidden until we detect a permanent denial).
+-->
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="24dp">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/onboarding_title"
+            android:textAppearance="@style/TextAppearance.AppCompat.Headline"
+            android:textStyle="bold" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:text="@string/onboarding_intro"
+            android:textAppearance="@style/TextAppearance.AppCompat.Body1" />
+
+        <TextView
+            android:id="@+id/onboarding_empty_state"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:text="@string/onboarding_empty_state"
+            android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+            android:visibility="gone" />
+
+        <LinearLayout
+            android:id="@+id/onboarding_permission_list"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:orientation="vertical" />
+
+        <Button
+            android:id="@+id/onboarding_grant_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:text="@string/onboarding_grant_button" />
+
+        <Button
+            android:id="@+id/onboarding_settings_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/onboarding_open_settings"
+            android:visibility="gone" />
+
+        <Button
+            android:id="@+id/onboarding_continue_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/onboarding_continue" />
+
+    </LinearLayout>
+
+</ScrollView>

--- a/app/src/main/res/layout/item_permission_row.xml
+++ b/app/src/main/res/layout/item_permission_row.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  One row per runtime permission in the onboarding list. Title carries
+  the human-readable permission name, rationale explains why we need
+  it, status surfaces granted/denied state in real time.
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="16dp"
+    android:orientation="vertical"
+    android:padding="12dp">
+
+    <TextView
+        android:id="@+id/permission_row_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAppearance="@style/TextAppearance.AppCompat.Subhead"
+        android:textStyle="bold" />
+
+    <TextView
+        android:id="@+id/permission_row_rationale"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:textAppearance="@style/TextAppearance.AppCompat.Body1" />
+
+    <TextView
+        android:id="@+id/permission_row_status"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="6dp"
+        android:textAppearance="@style/TextAppearance.AppCompat.Caption"
+        android:textStyle="italic" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">WhenVivoMeetsGoogle</string>
+
+    <!-- Permissions onboarding (#26). -->
+    <string name="onboarding_title">App permissions</string>
+    <string name="onboarding_intro">Quick Share needs a small set of Android permissions to discover nearby devices over your local Wi-Fi network and to keep you informed about transfers. Each permission below explains exactly what it is used for.</string>
+    <string name="onboarding_empty_state">Your device does not require any runtime permissions for Phase 1. You are all set.</string>
+    <string name="onboarding_grant_button">Grant permissions</string>
+    <string name="onboarding_open_settings">Open app settings</string>
+    <string name="onboarding_continue">Continue</string>
+    <string name="onboarding_continue_partial">Continue without all permissions</string>
+    <string name="onboarding_continue_degraded">Continue without notifications</string>
+
+    <!-- NEARBY_WIFI_DEVICES (API 33+). -->
+    <string name="permission_nearby_wifi_title">Nearby Wi-Fi devices</string>
+    <string name="permission_nearby_wifi_rationale">Required to discover and advertise to other Quick Share devices on the same Wi-Fi network. Quick Share never uses this to determine your physical location.</string>
+
+    <!-- POST_NOTIFICATIONS (API 33+). -->
+    <string name="permission_notifications_title">Notifications</string>
+    <string name="permission_notifications_rationale">Used to show the foreground transfer service indicator and to alert you about incoming files. Without this permission, transfers still work but you will not be notified about them.</string>
+
+    <!-- Permission status labels. -->
+    <string name="permission_status_granted">Granted</string>
+    <string name="permission_status_denied">Required - not granted</string>
+    <string name="permission_status_optional_denied">Optional - not granted (degraded mode)</string>
 </resources>

--- a/app/src/test/kotlin/io/github/kyujincho/wvmg/AndroidManifestPermissionsTest.kt
+++ b/app/src/test/kotlin/io/github/kyujincho/wvmg/AndroidManifestPermissionsTest.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Manifest-level regression test for the Phase 1 permission set (#26).
+ *
+ * We read `app/src/main/AndroidManifest.xml` as a plain text file rather
+ * than going through the Android build system. The intent is to catch
+ * accidental drift — for example, someone removing the
+ * `neverForLocation` flag, or adding a Phase 2 permission ahead of
+ * schedule — without paying the cost of pulling Robolectric into the
+ * `:app` module just for this one test.
+ *
+ * The CI job `:app:test` runs this on every PR.
+ */
+class AndroidManifestPermissionsTest {
+    private val manifest: String by lazy {
+        // The working directory for module unit tests is the module root,
+        // i.e. `<repo>/app`, so a relative path is enough.
+        val file = File("src/main/AndroidManifest.xml")
+        assertTrue("AndroidManifest.xml should exist at ${file.absolutePath}", file.exists())
+        file.readText()
+    }
+
+    @Test
+    fun `nearby wifi devices declared with neverForLocation flag`() {
+        assertTrue(
+            "NEARBY_WIFI_DEVICES permission must be declared",
+            manifest.contains("android.permission.NEARBY_WIFI_DEVICES"),
+        )
+        // The neverForLocation flag tells Android we do not derive
+        // physical location from peer scans; without it the platform
+        // requires ACCESS_FINE_LOCATION on top of NEARBY_WIFI_DEVICES.
+        assertTrue(
+            "NEARBY_WIFI_DEVICES must use neverForLocation",
+            manifest.contains("android:usesPermissionFlags=\"neverForLocation\""),
+        )
+    }
+
+    @Test
+    fun `post notifications permission declared`() {
+        assertTrue(
+            "POST_NOTIFICATIONS must be declared (gated by API 33+)",
+            manifest.contains("android.permission.POST_NOTIFICATIONS"),
+        )
+    }
+
+    @Test
+    fun `compile-time wifi and network permissions declared`() {
+        val required =
+            listOf(
+                "android.permission.CHANGE_WIFI_MULTICAST_STATE",
+                "android.permission.INTERNET",
+                "android.permission.ACCESS_NETWORK_STATE",
+                "android.permission.ACCESS_WIFI_STATE",
+            )
+        for (permission in required) {
+            assertTrue("$permission must be declared", manifest.contains(permission))
+        }
+    }
+
+    @Test
+    fun `phase 2 permissions are not declared in phase 1`() {
+        // Bluetooth permissions belong to Phase 2 (BLE auto-discovery).
+        // Declaring them now would surface unnecessary install-time
+        // permission warnings to users — guard against that here.
+        val phase2Forbidden =
+            listOf(
+                "android.permission.BLUETOOTH_SCAN",
+                "android.permission.BLUETOOTH_ADVERTISE",
+                "android.permission.BLUETOOTH_CONNECT",
+            )
+        for (permission in phase2Forbidden) {
+            assertFalse(
+                "$permission must NOT be declared in Phase 1",
+                manifest.contains(permission),
+            )
+        }
+    }
+
+    @Test
+    fun `media permissions are not declared in phase 1`() {
+        // Phase 1 uses the system share-intent flow, which does not need
+        // direct media access. READ_MEDIA_* would surface needless
+        // permissions to users — guard against that drift.
+        val mediaForbidden =
+            listOf(
+                "android.permission.READ_MEDIA_IMAGES",
+                "android.permission.READ_MEDIA_VIDEO",
+                "android.permission.READ_MEDIA_AUDIO",
+                "android.permission.ACCESS_FINE_LOCATION",
+                "android.permission.ACCESS_COARSE_LOCATION",
+            )
+        for (permission in mediaForbidden) {
+            assertFalse(
+                "$permission must NOT be declared in Phase 1",
+                manifest.contains(permission),
+            )
+        }
+    }
+
+    @Test
+    fun `permissions onboarding activity is registered and not exported`() {
+        assertTrue(
+            "PermissionsOnboardingActivity must be registered",
+            manifest.contains(".onboarding.PermissionsOnboardingActivity"),
+        )
+        // Internal activity — must not be launchable from other apps.
+        val onboardingBlock =
+            manifest
+                .substringAfter(".onboarding.PermissionsOnboardingActivity")
+                .substringBefore("</activity>")
+        assertTrue(
+            "PermissionsOnboardingActivity must declare android:exported=\"false\"",
+            onboardingBlock.contains("android:exported=\"false\""),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Closes #26.

Wires Phase 1's runtime and compile-time permission set into the app and exposes them through a single onboarding screen.

### Manifest (`app/src/main/AndroidManifest.xml`)

- `NEARBY_WIFI_DEVICES` (API 33+) with `android:usesPermissionFlags="neverForLocation"` so we skip the location permission requirement.
- `POST_NOTIFICATIONS` (API 33+) gated with `tools:targetApi="33"`.
- `CHANGE_WIFI_MULTICAST_STATE`, `INTERNET`, `ACCESS_NETWORK_STATE`, `ACCESS_WIFI_STATE` declared as compile-time.
- `PermissionsOnboardingActivity` registered with `android:exported="false"`.

Phase 2 `BLUETOOTH_*` and `READ_MEDIA_*` are intentionally absent — guarded by the regression test below.

### Onboarding flow

`PermissionsOnboardingActivity` (single screen):

1. Renders a row per runtime permission with title, rationale, and live granted/denied status.
2. Calls `RequestMultiplePermissions` once for all missing permissions so the user gets a single chained system dialog.
3. Detects permanent denials (via `shouldShowRequestPermissionRationale`) and reveals an "Open app settings" shortcut.
4. The continue button is always enabled — `POST_NOTIFICATIONS` denials are non-blocking ("Continue without notifications"); `NEARBY_WIFI_DEVICES` denials show "Continue without all permissions" so the user is aware the app will be degraded.
5. `onResume` re-syncs state, so toggling permissions in Settings reflects immediately.

`PermissionRequirements` is the single source of truth for what Phase 1 needs and which permissions are optional. Pre-API-33 devices return an empty list and see an "all set" empty state.

`MainActivity.onStart` routes to onboarding when any non-optional permission is missing, so the gate applies on cold start and on return from Settings.

### Tests

`AndroidManifestPermissionsTest` (JVM unit test under `:app:test`) reads `AndroidManifest.xml` directly and asserts:

- `NEARBY_WIFI_DEVICES` is declared with `neverForLocation`.
- `POST_NOTIFICATIONS` is declared.
- All four compile-time permissions are declared.
- Phase 2 `BLUETOOTH_*` permissions are NOT declared.
- `READ_MEDIA_*` and `ACCESS_*_LOCATION` are NOT declared.
- `PermissionsOnboardingActivity` is registered and not exported.

This catches manifest drift without pulling Robolectric into `:app`.

### Verification

- `./gradlew :app:assembleDebug` — green.
- `./gradlew staticAnalysis` — ktlint + detekt green.
- `./gradlew :app:test` — 6/6 passing.
- `./gradlew :core-protocol:test` — green.