### PR TITLE
feat: add EndpointInfo serializer and parser

### DIFF
--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/Base64Url.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/Base64Url.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.endpoint
+
+import java.util.Base64
+
+/**
+ * URL-safe base64 codec used for the mDNS TXT record key `n`.
+ *
+ * Quick Share TXT records carry the [EndpointInfo] bytes encoded with the
+ * URL-safe alphabet (`-_` instead of `+/`) and **without** padding (`=`).
+ * The reference NearDrop encoder strips the trailing `=` characters before
+ * publishing the TXT record, so we mirror that behavior — both for round-trip
+ * symmetry and so peers that round-trip our advertisement back to us see the
+ * exact byte string they sent.
+ *
+ * The decoder accepts both padded and unpadded input (matching JDK
+ * `Base64.getUrlDecoder()`'s lenient stance) so we interoperate with peers
+ * that encode their advertisements with padding.
+ *
+ * Performance: the JDK's `Base64.Encoder` / `Base64.Decoder` are zero-cost
+ * thread-safe singletons; we cache them as `private val` to avoid the
+ * `getInstance` static lookup on every advertisement we publish.
+ */
+public object Base64Url {
+    private val ENCODER: Base64.Encoder = Base64.getUrlEncoder().withoutPadding()
+    private val DECODER: Base64.Decoder = Base64.getUrlDecoder()
+
+    /**
+     * Encodes [bytes] as URL-safe base64 **without** trailing `=` padding.
+     *
+     * The output is ASCII and safe to drop into a DNS TXT record value
+     * directly.
+     */
+    public fun encode(bytes: ByteArray): String = ENCODER.encodeToString(bytes)
+
+    /**
+     * Decodes a URL-safe base64 string. Padding is optional.
+     *
+     * Returns `null` on any decoding error (illegal characters, malformed
+     * length). Like [EndpointInfo.parse], this never throws on bad peer
+     * data — it just signals "ignore this advertisement".
+     */
+    public fun decode(input: String): ByteArray? =
+        try {
+            DECODER.decode(input)
+        } catch (_: IllegalArgumentException) {
+            null
+        }
+}

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/DeviceType.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/DeviceType.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.endpoint
+
+/**
+ * The 3-bit `deviceType` field encoded in the first byte of an [EndpointInfo]
+ * descriptor.
+ *
+ * Values mirror PROTOCOL.md and the NearDrop Swift reference. The 3-bit field
+ * has 8 possible raw values (0..7); 0..6 are documented and 7 is currently
+ * undefined. Undefined raw values (including 7 and any future expansion) are
+ * surfaced as [UNKNOWN] rather than throwing, so a parser running against a
+ * peer that uses a newer protocol revision degrades gracefully instead of
+ * dropping the entire advertisement.
+ *
+ * Note: the `reserved` rawValue 0 is named identically to [UNKNOWN] in the
+ * canonical spec. We keep the single [UNKNOWN] entry to cover both "the peer
+ * sent 0" and "the peer sent something we don't recognize".
+ */
+public enum class DeviceType(
+    /** Raw 3-bit value as it appears on the wire. */
+    public val raw: Int,
+) {
+    UNKNOWN(0),
+    PHONE(1),
+    TABLET(2),
+    LAPTOP(3),
+    CAR(4),
+    FOLDABLE(5),
+    XR(6),
+    ;
+
+    public companion object {
+        /**
+         * Maps the raw 3-bit on-the-wire value to a [DeviceType], collapsing
+         * any unrecognized value (notably `7`, which is reserved) to
+         * [UNKNOWN]. This is intentional: we never want a forward-compatible
+         * peer that introduces a new device type to make our parser drop the
+         * whole advertisement.
+         */
+        public fun fromRaw(raw: Int): DeviceType =
+            when (raw) {
+                PHONE.raw -> PHONE
+                TABLET.raw -> TABLET
+                LAPTOP.raw -> LAPTOP
+                CAR.raw -> CAR
+                FOLDABLE.raw -> FOLDABLE
+                XR.raw -> XR
+                else -> UNKNOWN
+            }
+    }
+}

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/EndpointInfo.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/EndpointInfo.kt
@@ -1,0 +1,348 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.endpoint
+
+import java.nio.charset.StandardCharsets
+
+/**
+ * Quick Share **endpoint info** — the packed binary descriptor advertised by
+ * a Nearby Connections peer.
+ *
+ * The same byte layout appears in two interop-critical places:
+ *
+ *  1. As the value of the mDNS `_FC9F5ED42C8A._tcp.` TXT record key `n`,
+ *     URL-safe-base64 encoded (no padding).
+ *  2. As the `endpoint_info` field of `ConnectionRequestFrame` in
+ *     `offline_wire_formats.proto`, sent raw (no base64).
+ *
+ * The structure is therefore the lingua franca every Quick Share peer must
+ * agree on byte-for-byte. The reference layout, taken from
+ * [PROTOCOL.md](https://github.com/grishka/NearDrop/blob/master/PROTOCOL.md)
+ * and the NearDrop Swift implementation
+ * (`NearbyShare/NearbyConnectionManager.swift:EndpointInfo`), is:
+ *
+ * ```
+ * +--------+-----------------+-------------+--------+----------------------+
+ * | byte 0 |  bytes 1..16    |   byte 17   | byte18 |     trailing TLV     |
+ * |--------|-----------------|-------------|--------|----------------------|
+ * | bits   | salt(2) + key   | name length | name   | type(1) length(1)    |
+ * | packed |     (14)        |   (1 byte)  | (UTF8) |    value(length)     |
+ * +--------+-----------------+-------------+--------+----------------------+
+ * ```
+ *
+ * **Bit packing of byte 0** (most-significant-bit first):
+ * ```
+ *   bit:   7   6   5   4   3   2   1   0
+ *        \_______/   |   \_______/   |
+ *          version  vis  deviceType  reserved
+ * ```
+ *
+ * - `version` (3 bits, 0..7): Currently always `1`. Other values are
+ *   accepted by [parse] for forward compatibility but are surfaced verbatim
+ *   so the caller can decide what to do with them.
+ * - `visibility` (1 bit): `0` = visible (everyone), `1` = hidden
+ *   (contacts-only / temporarily hidden). When hidden, the device name field
+ *   is **omitted entirely** — the byte stream ends after the 16-byte
+ *   metadata block (or whatever optional TLV records follow it).
+ * - `deviceType` (3 bits): see [DeviceType].
+ * - `reserved` (1 bit): currently always 0. Round-tripped verbatim by
+ *   [parse]/[serialize] via the explicit reserved byte handling so a future
+ *   protocol revision that starts using this bit cannot break parity.
+ *
+ * **Metadata** is a 16-byte blob composed of a 2-byte salt followed by a
+ * 14-byte encrypted-metadata-key. Both are produced by Google's contact
+ * graph during account-linked Nearby Share enrollment; for the GMS-free
+ * Quick Share use-case targeted by this project, random bytes are
+ * indistinguishable from real metadata to peers and are perfectly fine.
+ *
+ * **Trailing TLV records** are zero or more `type(1) | length(1) | value`
+ * tuples appended after the device name (or after the metadata block in
+ * hidden mode). The length byte is unsigned (`0..255`). Two record types
+ * are documented in PROTOCOL.md:
+ *
+ *   - Type `1` — QR code data: in visible mode, the 4-byte advertising
+ *     token; in hidden mode, AES-GCM-encrypted name material.
+ *   - Type `2` — vendor ID: a single byte (`0` = none, `1` = Samsung).
+ *
+ * Unknown TLV types are preserved verbatim across [parse]/[serialize] so we
+ * stay forward-compatible with whatever Google adds next.
+ *
+ * **Why a data class?** Equality is value-based, which makes round-trip
+ * testing trivial and lets fixtures be compared with plain `assertEquals`.
+ *
+ * @see DeviceType
+ * @see <a href="https://github.com/grishka/NearDrop/blob/master/PROTOCOL.md">
+ *   NearDrop PROTOCOL.md (the canonical informal spec)</a>
+ */
+public data class EndpointInfo(
+    /** 0..7. Currently `1` for all peers in the wild. */
+    val version: Int,
+    /** `false` = visible, `true` = hidden (device name omitted on the wire). */
+    val hidden: Boolean,
+    /** See [DeviceType]. Unknown raw values are surfaced as [DeviceType.UNKNOWN]. */
+    val deviceType: DeviceType,
+    /** Reserved bit (1 bit). Always `false` today; round-tripped for future use. */
+    val reserved: Boolean,
+    /** Exactly [METADATA_LEN] bytes (2-byte salt + 14-byte encrypted key). */
+    val metadata: ByteArray,
+    /** UTF-8 device name. Must be `null` when [hidden] is `true`. */
+    val deviceName: String?,
+    /** Optional trailing TLV records, preserved verbatim across round-trips. */
+    val tlvRecords: List<TlvRecord> = emptyList(),
+) {
+    init {
+        require(version in 0..MAX_VERSION) {
+            "version must fit in 3 bits (0..$MAX_VERSION), got $version"
+        }
+        require(metadata.size == METADATA_LEN) {
+            "metadata must be exactly $METADATA_LEN bytes, got ${metadata.size}"
+        }
+        if (hidden) {
+            require(deviceName == null) {
+                "deviceName must be null when hidden=true (visibility bit hides it on the wire)"
+            }
+        } else {
+            require(deviceName != null) {
+                "deviceName must be non-null when hidden=false"
+            }
+            val nameBytes = deviceName.toByteArray(StandardCharsets.UTF_8)
+            require(nameBytes.size <= MAX_NAME_LEN) {
+                "deviceName UTF-8 byte length must fit in 1 byte (0..$MAX_NAME_LEN), " +
+                    "got ${nameBytes.size}"
+            }
+        }
+    }
+
+    /**
+     * Encodes this descriptor into the canonical Quick Share wire format.
+     *
+     * The result is suitable both as raw bytes for `ConnectionRequestFrame.endpoint_info`
+     * and (via [Base64Url.encode]) as the value of the mDNS TXT record key `n`.
+     *
+     * The output is freshly allocated; mutating it never affects this instance.
+     */
+    public fun serialize(): ByteArray {
+        val nameBytes =
+            if (hidden) ByteArray(0) else deviceName!!.toByteArray(StandardCharsets.UTF_8)
+
+        val tlvSize = tlvRecords.sumOf { TLV_HEADER_LEN + it.value.size }
+        val totalSize =
+            HEADER_LEN +
+                METADATA_LEN +
+                (if (hidden) 0 else NAME_LEN_BYTES + nameBytes.size) +
+                tlvSize
+
+        val out = ByteArray(totalSize)
+        out[0] = packHeader(version, hidden, deviceType, reserved)
+        metadata.copyInto(out, destinationOffset = HEADER_LEN)
+
+        var offset = HEADER_LEN + METADATA_LEN
+        if (!hidden) {
+            out[offset] = nameBytes.size.toByte()
+            offset += NAME_LEN_BYTES
+            nameBytes.copyInto(out, destinationOffset = offset)
+            offset += nameBytes.size
+        }
+
+        for (record in tlvRecords) {
+            out[offset] = record.type.toByte()
+            out[offset + 1] = record.value.size.toByte()
+            record.value.copyInto(out, destinationOffset = offset + TLV_HEADER_LEN)
+            offset += TLV_HEADER_LEN + record.value.size
+        }
+        check(offset == totalSize) {
+            // Defensive: catches any future arithmetic drift between the size
+            // calculation above and the offset bookkeeping below.
+            "internal serializer offset drift: wrote $offset bytes, expected $totalSize"
+        }
+        return out
+    }
+
+    // ---------------------------------------------------------------------
+    // Equality / hashCode — required because data classes don't compare
+    // ByteArray contents structurally by default.
+    // ---------------------------------------------------------------------
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is EndpointInfo) return false
+        return version == other.version &&
+            hidden == other.hidden &&
+            deviceType == other.deviceType &&
+            reserved == other.reserved &&
+            metadata.contentEquals(other.metadata) &&
+            deviceName == other.deviceName &&
+            tlvRecords == other.tlvRecords
+    }
+
+    override fun hashCode(): Int {
+        var result = version
+        result = 31 * result + hidden.hashCode()
+        result = 31 * result + deviceType.hashCode()
+        result = 31 * result + reserved.hashCode()
+        result = 31 * result + metadata.contentHashCode()
+        result = 31 * result + (deviceName?.hashCode() ?: 0)
+        result = 31 * result + tlvRecords.hashCode()
+        return result
+    }
+
+    public companion object {
+        /** Length of the packed header byte (`version|visibility|deviceType|reserved`). */
+        public const val HEADER_LEN: Int = 1
+
+        /** Length of the salt + encrypted-metadata-key blob. */
+        public const val METADATA_LEN: Int = 16
+
+        /** Length of the salt prefix inside [METADATA_LEN]. */
+        public const val SALT_LEN: Int = 2
+
+        /** Length of the encrypted-metadata-key suffix inside [METADATA_LEN]. */
+        public const val ENCRYPTED_KEY_LEN: Int = 14
+
+        /** Length of the device-name length byte (when present). */
+        public const val NAME_LEN_BYTES: Int = 1
+
+        /** Length of the TLV header (`type(1) + length(1)`). */
+        public const val TLV_HEADER_LEN: Int = 2
+
+        /** Maximum value of the 3-bit version field. */
+        public const val MAX_VERSION: Int = 0b111
+
+        /** Maximum UTF-8 byte length of the device name (1-byte length prefix). */
+        public const val MAX_NAME_LEN: Int = 0xFF
+
+        /** TLV type byte for QR code data (advertising token / encrypted name). */
+        public const val TLV_TYPE_QR_CODE: Int = 1
+
+        /** TLV type byte for vendor ID. */
+        public const val TLV_TYPE_VENDOR_ID: Int = 2
+
+        // -----------------------------------------------------------------
+        // Bit packing constants for byte 0:
+        //   bit 7..5 = version (3 bits)
+        //   bit 4    = visibility (1 bit, 1 = hidden)
+        //   bit 3..1 = deviceType (3 bits)
+        //   bit 0    = reserved (1 bit)
+        // -----------------------------------------------------------------
+
+        /** 3-bit mask for fields that are 3 bits wide (version, deviceType). */
+        private const val THREE_BIT_MASK: Int = 0b111
+
+        /** 1-bit mask for fields that are a single bit (visibility, reserved). */
+        private const val ONE_BIT_MASK: Int = 0b1
+
+        /** Mask used to convert a signed `Byte` into an unsigned int (`0..255`). */
+        private const val UNSIGNED_BYTE_MASK: Int = 0xFF
+
+        /** Bit position of the top of the version field (bits 7..5). */
+        private const val VERSION_SHIFT: Int = 5
+
+        /** Bit position of the visibility flag (bit 4). */
+        private const val VISIBILITY_SHIFT: Int = 4
+
+        /** Bit position of the top of the deviceType field (bits 3..1). */
+        private const val DEVICE_TYPE_SHIFT: Int = 1
+
+        /**
+         * Parses an `EndpointInfo` from the canonical wire format.
+         *
+         * Returns `null` for any malformed input (truncated header,
+         * truncated metadata, name length exceeding the buffer, malformed
+         * TLV record). Callers must treat parse failures as "ignore this
+         * peer" — never as a hard error — because in the wild we will see
+         * truncated, padded, or experimental advertisements from peers we
+         * do not control.
+         *
+         * UTF-8 decoding of the device name is **strict**: invalid byte
+         * sequences cause [parse] to return `null` rather than silently
+         * substituting U+FFFD, since two peers that disagree on the device
+         * name byte-for-byte cannot agree on the SHA-256 advertising
+         * fingerprint either.
+         */
+        @Suppress("ReturnCount")
+        public fun parse(bytes: ByteArray): EndpointInfo? {
+            if (bytes.size < HEADER_LEN + METADATA_LEN) return null
+
+            val header = bytes[0].toInt() and UNSIGNED_BYTE_MASK
+            val version = (header ushr VERSION_SHIFT) and THREE_BIT_MASK
+            val hidden = ((header ushr VISIBILITY_SHIFT) and ONE_BIT_MASK) == 1
+            val deviceTypeRaw = (header ushr DEVICE_TYPE_SHIFT) and THREE_BIT_MASK
+            val reserved = (header and ONE_BIT_MASK) == 1
+
+            val metadata = bytes.copyOfRange(HEADER_LEN, HEADER_LEN + METADATA_LEN)
+            var offset = HEADER_LEN + METADATA_LEN
+
+            val deviceName: String?
+            if (hidden) {
+                deviceName = null
+            } else {
+                if (offset + NAME_LEN_BYTES > bytes.size) return null
+                val nameLen = bytes[offset].toInt() and UNSIGNED_BYTE_MASK
+                offset += NAME_LEN_BYTES
+                if (offset + nameLen > bytes.size) return null
+                deviceName =
+                    try {
+                        decodeUtf8Strict(bytes, offset, nameLen)
+                    } catch (_: java.nio.charset.CharacterCodingException) {
+                        return null
+                    }
+                offset += nameLen
+            }
+
+            val tlvRecords = mutableListOf<TlvRecord>()
+            while (offset < bytes.size) {
+                if (offset + TLV_HEADER_LEN > bytes.size) return null
+                val type = bytes[offset].toInt() and UNSIGNED_BYTE_MASK
+                val length = bytes[offset + 1].toInt() and UNSIGNED_BYTE_MASK
+                offset += TLV_HEADER_LEN
+                if (offset + length > bytes.size) return null
+                val value = bytes.copyOfRange(offset, offset + length)
+                tlvRecords += TlvRecord(type, value)
+                offset += length
+            }
+
+            return EndpointInfo(
+                version = version,
+                hidden = hidden,
+                deviceType = DeviceType.fromRaw(deviceTypeRaw),
+                reserved = reserved,
+                metadata = metadata,
+                deviceName = deviceName,
+                tlvRecords = tlvRecords.toList(),
+            )
+        }
+
+        internal fun packHeader(
+            version: Int,
+            hidden: Boolean,
+            deviceType: DeviceType,
+            reserved: Boolean,
+        ): Byte {
+            val visBit = if (hidden) 1 else 0
+            val resBit = if (reserved) 1 else 0
+            val packed =
+                ((version and THREE_BIT_MASK) shl VERSION_SHIFT) or
+                    ((visBit and ONE_BIT_MASK) shl VISIBILITY_SHIFT) or
+                    ((deviceType.raw and THREE_BIT_MASK) shl DEVICE_TYPE_SHIFT) or
+                    (resBit and ONE_BIT_MASK)
+            return packed.toByte()
+        }
+
+        private fun decodeUtf8Strict(
+            bytes: ByteArray,
+            offset: Int,
+            length: Int,
+        ): String {
+            val decoder =
+                StandardCharsets.UTF_8
+                    .newDecoder()
+                    .onMalformedInput(java.nio.charset.CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(java.nio.charset.CodingErrorAction.REPORT)
+            val buffer = java.nio.ByteBuffer.wrap(bytes, offset, length)
+            return decoder.decode(buffer).toString()
+        }
+    }
+}

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/TlvRecord.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/TlvRecord.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.endpoint
+
+/**
+ * A single TLV (Type-Length-Value) record appended to an [EndpointInfo]
+ * payload after the (optional) device-name section.
+ *
+ * Wire layout: `type(1 byte) | length(1 byte) | value(`length` bytes)`.
+ *
+ * The two known [type] values are documented in PROTOCOL.md:
+ *
+ *  - `1` = QR code data (visible: 4-byte advertising token; hidden:
+ *    AES-GCM-encrypted name material).
+ *  - `2` = vendor ID (1-byte vendor: `0` = none, `1` = Samsung).
+ *
+ * Unknown types are NOT rejected by the parser — they round-trip verbatim so
+ * we stay forward-compatible with new TLV records introduced by Google's
+ * Quick Share rollout.
+ *
+ * @property type Unsigned 8-bit type tag (`0..255`).
+ * @property value Opaque payload. Length must fit in 1 byte (`0..255`).
+ */
+public data class TlvRecord(
+    val type: Int,
+    val value: ByteArray,
+) {
+    init {
+        require(type in 0..MAX_BYTE_VALUE) {
+            "TLV type must fit in 1 byte (0..$MAX_BYTE_VALUE), got $type"
+        }
+        require(value.size in 0..MAX_BYTE_VALUE) {
+            "TLV value length must fit in 1 byte (0..$MAX_BYTE_VALUE), got ${value.size}"
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is TlvRecord) return false
+        return type == other.type && value.contentEquals(other.value)
+    }
+
+    override fun hashCode(): Int {
+        var result = type
+        result = 31 * result + value.contentHashCode()
+        return result
+    }
+
+    public companion object {
+        /** Maximum value of a 1-byte unsigned field (used for both `type` and `length`). */
+        public const val MAX_BYTE_VALUE: Int = 0xFF
+    }
+}

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/Base64UrlTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/Base64UrlTest.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.endpoint
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import kotlin.random.Random
+
+/**
+ * Verifies the URL-safe base64 codec used for the mDNS TXT key `n` value.
+ *
+ * - Encode output never carries `=` padding (Quick Share peers strip it).
+ * - Encode uses the URL-safe alphabet (`-_`), not the standard one (`+/`).
+ * - Decode accepts both padded and unpadded input for interop with peers
+ *   that do not strip padding.
+ */
+class Base64UrlTest {
+    @Test
+    fun `encode produces no equal-sign padding`() {
+        // 1 byte of input → standard base64 would emit 2 padding chars.
+        assertThat(Base64Url.encode(byteArrayOf(0x66))).isEqualTo("Zg")
+        // 2 bytes → 1 padding char in standard base64.
+        assertThat(Base64Url.encode(byteArrayOf(0x66, 0x6F))).isEqualTo("Zm8")
+    }
+
+    @Test
+    fun `encode uses URL-safe alphabet`() {
+        // Bytes 0xFB, 0xFF, 0xBF deliberately produce a non-trivial mix that
+        // would include `+` and `/` under the standard alphabet but uses
+        // `-` and `_` under URL-safe.
+        val bytes = byteArrayOf(0xFB.toByte(), 0xFF.toByte(), 0xBF.toByte())
+        val encoded = Base64Url.encode(bytes)
+        assertThat(encoded).doesNotContain("+")
+        assertThat(encoded).doesNotContain("/")
+        // Sanity check: at least one URL-safe replacement character appears.
+        assertThat(encoded).matches("[A-Za-z0-9_\\-]+")
+    }
+
+    @Test
+    fun `decode accepts unpadded input`() {
+        val original = byteArrayOf(0x01, 0x02, 0x03, 0x04, 0x05)
+        val encoded = Base64Url.encode(original)
+        // Sanity check: encoder produces no padding for this length either.
+        assertThat(encoded).doesNotContain("=")
+        assertThat(Base64Url.decode(encoded)).isEqualTo(original)
+    }
+
+    @Test
+    fun `decode accepts padded input for interop`() {
+        // Same byte sequence, manually padded out with `=` characters.
+        val padded = "AQIDBAU="
+        assertThat(Base64Url.decode(padded)).isEqualTo(byteArrayOf(0x01, 0x02, 0x03, 0x04, 0x05))
+    }
+
+    @Test
+    fun `decode returns null on illegal characters`() {
+        // `+` and `/` are not legal in the URL-safe alphabet.
+        assertThat(Base64Url.decode("AA+/")).isNull()
+        // Characters outside both alphabets.
+        assertThat(Base64Url.decode("!!!!")).isNull()
+    }
+
+    @Test
+    fun `randomized round-trip across 100 byte arrays of varying length`() {
+        val rng = Random(0xBEEF)
+        repeat(100) {
+            val len = rng.nextInt(0, 64)
+            val bytes = ByteArray(len).also { rng.nextBytes(it) }
+            val encoded = Base64Url.encode(bytes)
+            assertThat(encoded).doesNotContain("=")
+            assertThat(Base64Url.decode(encoded)).isEqualTo(bytes)
+        }
+    }
+
+    @Test
+    fun `encode then decode round-trips a serialized EndpointInfo`() {
+        // End-to-end smoke test: this is exactly how :discovery-android will
+        // publish the TXT record value once it lands.
+        val info =
+            EndpointInfo(
+                version = 1,
+                hidden = false,
+                deviceType = DeviceType.PHONE,
+                reserved = false,
+                metadata = ByteArray(EndpointInfo.METADATA_LEN) { it.toByte() },
+                deviceName = "Pixel 9 Pro",
+            )
+        val encoded = Base64Url.encode(info.serialize())
+        val decoded = Base64Url.decode(encoded)
+        assertThat(decoded).isNotNull()
+        assertThat(EndpointInfo.parse(decoded!!)).isEqualTo(info)
+    }
+}

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/DeviceTypeTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/DeviceTypeTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.endpoint
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins the [DeviceType] raw values to PROTOCOL.md so we cannot accidentally
+ * shuffle them in a future refactor — peers on the wire identify themselves
+ * by the integer value, not the enum name.
+ */
+class DeviceTypeTest {
+    @Test
+    fun `raw values match PROTOCOL md`() {
+        assertThat(DeviceType.UNKNOWN.raw).isEqualTo(0)
+        assertThat(DeviceType.PHONE.raw).isEqualTo(1)
+        assertThat(DeviceType.TABLET.raw).isEqualTo(2)
+        assertThat(DeviceType.LAPTOP.raw).isEqualTo(3)
+        assertThat(DeviceType.CAR.raw).isEqualTo(4)
+        assertThat(DeviceType.FOLDABLE.raw).isEqualTo(5)
+        assertThat(DeviceType.XR.raw).isEqualTo(6)
+    }
+
+    @Test
+    fun `fromRaw maps documented values to their enum`() {
+        for (type in DeviceType.entries) {
+            assertThat(DeviceType.fromRaw(type.raw)).isEqualTo(type)
+        }
+    }
+
+    @Test
+    fun `fromRaw collapses undefined raw values to UNKNOWN`() {
+        assertThat(DeviceType.fromRaw(7)).isEqualTo(DeviceType.UNKNOWN)
+        // Out-of-range raw values shouldn't crash either; the parser only
+        // ever feeds 0..7 in practice, but defensive coverage doesn't hurt.
+        assertThat(DeviceType.fromRaw(99)).isEqualTo(DeviceType.UNKNOWN)
+        assertThat(DeviceType.fromRaw(-1)).isEqualTo(DeviceType.UNKNOWN)
+    }
+}

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/EndpointInfoProtoInteropTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/EndpointInfoProtoInteropTest.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.endpoint
+
+import com.google.common.truth.Truth.assertThat
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.ConnectionRequestFrame
+import com.google.protobuf.ByteString
+import org.junit.jupiter.api.Test
+
+/**
+ * Sanity check that the bytes produced by [EndpointInfo.serialize] survive a
+ * round-trip through the `endpoint_info` field of a `ConnectionRequestFrame`
+ * proto.
+ *
+ * The wire format is identical in both transport channels (mDNS TXT and
+ * `ConnectionRequestFrame`), so the proto runtime is the more demanding of
+ * the two — it serializes the bytes through length-delimited proto encoding
+ * and back. If the bytes survive that round-trip and re-parse to the same
+ * [EndpointInfo], we know the serializer is producing a peer-acceptable blob.
+ */
+class EndpointInfoProtoInteropTest {
+    @Test
+    fun `serialized EndpointInfo round-trips through ConnectionRequestFrame endpoint_info`() {
+        val info =
+            EndpointInfo(
+                version = 1,
+                hidden = false,
+                deviceType = DeviceType.LAPTOP,
+                reserved = false,
+                metadata = ByteArray(EndpointInfo.METADATA_LEN) { (it * 13).toByte() },
+                deviceName = "MacBook Pro",
+                tlvRecords =
+                    listOf(
+                        TlvRecord(
+                            EndpointInfo.TLV_TYPE_QR_CODE,
+                            byteArrayOf(0xCA.toByte(), 0xFE.toByte(), 0xBA.toByte(), 0xBE.toByte()),
+                        ),
+                    ),
+            )
+        val rawBytes = info.serialize()
+
+        val frame =
+            ConnectionRequestFrame
+                .newBuilder()
+                .setEndpointInfo(ByteString.copyFrom(rawBytes))
+                .build()
+
+        val proto = frame.toByteArray()
+        val parsedFrame = ConnectionRequestFrame.parseFrom(proto)
+        val recovered = parsedFrame.endpointInfo.toByteArray()
+
+        assertThat(recovered).isEqualTo(rawBytes)
+        assertThat(EndpointInfo.parse(recovered)).isEqualTo(info)
+    }
+}

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/EndpointInfoTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/EndpointInfoTest.kt
@@ -1,0 +1,480 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.endpoint
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.random.Random
+
+/**
+ * Bit-level tests for [EndpointInfo]'s wire format.
+ *
+ * The serializer and parser are covered from three angles:
+ *
+ *  1. **Hand-crafted byte vectors** that pin the exact bit layout of byte 0
+ *     and the placement of the metadata, name, and TLV sections. If anyone
+ *     ever flips MSB/LSB packing or reorders fields, these vectors fire
+ *     before any peer ever sees the change.
+ *  2. **Hidden-mode coverage**, since the layout shrinks when visibility=1
+ *     and the parser has to skip the missing name field.
+ *  3. **Randomized round-trip property test** (200 cases) that covers
+ *     arbitrary combinations of version/visibility/deviceType/reserved/
+ *     metadata/name (including non-ASCII UTF-8) plus random trailing TLV
+ *     records of random types and sizes.
+ */
+class EndpointInfoTest {
+    @Test
+    fun `byte 0 packs version visibility deviceType and reserved in MSB-first order`() {
+        // version=5 (0b101), visible (visibility=0), LAPTOP (3, 0b011), reserved=1
+        // Expected: 101_0_011_1 = 0xA7
+        val info =
+            EndpointInfo(
+                version = 5,
+                hidden = false,
+                deviceType = DeviceType.LAPTOP,
+                reserved = true,
+                metadata = ByteArray(EndpointInfo.METADATA_LEN) { 0x00 },
+                deviceName = "",
+            )
+        val serialized = info.serialize()
+        assertThat(serialized[0].toInt() and 0xFF).isEqualTo(0xA7)
+    }
+
+    @Test
+    fun `byte 0 packs hidden visibility bit correctly`() {
+        // version=1 (0b001), hidden (visibility=1), PHONE (1, 0b001), reserved=0
+        // Expected: 001_1_001_0 = 0x32
+        val info =
+            EndpointInfo(
+                version = 1,
+                hidden = true,
+                deviceType = DeviceType.PHONE,
+                reserved = false,
+                metadata = ByteArray(EndpointInfo.METADATA_LEN) { 0xFF.toByte() },
+                deviceName = null,
+            )
+        val serialized = info.serialize()
+        assertThat(serialized[0].toInt() and 0xFF).isEqualTo(0x32)
+    }
+
+    @Test
+    fun `serialize visible peer produces header + metadata + name length + name`() {
+        val metadata = ByteArray(EndpointInfo.METADATA_LEN) { (it + 1).toByte() }
+        val info =
+            EndpointInfo(
+                version = 1,
+                hidden = false,
+                deviceType = DeviceType.PHONE,
+                reserved = false,
+                metadata = metadata,
+                deviceName = "Pixel",
+            )
+        val bytes = info.serialize()
+
+        // 1 (header) + 16 (metadata) + 1 (name length) + 5 (name "Pixel")
+        assertThat(bytes.size).isEqualTo(23)
+        // header = version(001) | vis(0) | type(001) | reserved(0) = 0010_0010 = 0x22
+        assertThat(bytes[0].toInt() and 0xFF).isEqualTo(0x22)
+        assertThat(bytes.copyOfRange(1, 17)).isEqualTo(metadata)
+        assertThat(bytes[17].toInt() and 0xFF).isEqualTo(5)
+        assertThat(String(bytes, 18, 5)).isEqualTo("Pixel")
+    }
+
+    @Test
+    fun `serialize hidden peer omits name length and name`() {
+        val metadata = ByteArray(EndpointInfo.METADATA_LEN) { 0x42 }
+        val info =
+            EndpointInfo(
+                version = 1,
+                hidden = true,
+                deviceType = DeviceType.LAPTOP,
+                reserved = false,
+                metadata = metadata,
+                deviceName = null,
+            )
+        val bytes = info.serialize()
+
+        // 1 (header) + 16 (metadata), no name section
+        assertThat(bytes.size).isEqualTo(17)
+        assertThat(bytes.copyOfRange(1, 17)).isEqualTo(metadata)
+    }
+
+    @Test
+    fun `parse round-trips a visible peer with a UTF-8 device name`() {
+        val original =
+            EndpointInfo(
+                version = 1,
+                hidden = false,
+                deviceType = DeviceType.TABLET,
+                reserved = false,
+                metadata = ByteArray(EndpointInfo.METADATA_LEN) { it.toByte() },
+                deviceName = "내 아이패드",
+            )
+        val bytes = original.serialize()
+        val parsed = EndpointInfo.parse(bytes)
+        assertThat(parsed).isEqualTo(original)
+    }
+
+    @Test
+    fun `parse round-trips a hidden peer`() {
+        val original =
+            EndpointInfo(
+                version = 1,
+                hidden = true,
+                deviceType = DeviceType.PHONE,
+                reserved = false,
+                metadata = ByteArray(EndpointInfo.METADATA_LEN) { (it * 7).toByte() },
+                deviceName = null,
+            )
+        val bytes = original.serialize()
+        val parsed = EndpointInfo.parse(bytes)
+        assertThat(parsed).isEqualTo(original)
+    }
+
+    @Test
+    fun `parse round-trips trailing TLV records`() {
+        val qrToken = byteArrayOf(0x01, 0x02, 0x03, 0x04)
+        val vendorId = byteArrayOf(0x01) // Samsung
+        val original =
+            EndpointInfo(
+                version = 1,
+                hidden = false,
+                deviceType = DeviceType.FOLDABLE,
+                reserved = false,
+                metadata = ByteArray(EndpointInfo.METADATA_LEN) { 0x33 },
+                deviceName = "Galaxy Z Fold",
+                tlvRecords =
+                    listOf(
+                        TlvRecord(EndpointInfo.TLV_TYPE_QR_CODE, qrToken),
+                        TlvRecord(EndpointInfo.TLV_TYPE_VENDOR_ID, vendorId),
+                    ),
+            )
+        val bytes = original.serialize()
+        val parsed = EndpointInfo.parse(bytes)
+        assertThat(parsed).isEqualTo(original)
+    }
+
+    @Test
+    fun `parse preserves unknown TLV types verbatim`() {
+        val unknownPayload = byteArrayOf(0x10, 0x20, 0x30)
+        val original =
+            EndpointInfo(
+                version = 1,
+                hidden = false,
+                deviceType = DeviceType.PHONE,
+                reserved = false,
+                metadata = ByteArray(EndpointInfo.METADATA_LEN),
+                deviceName = "Phone",
+                tlvRecords = listOf(TlvRecord(0x99, unknownPayload)),
+            )
+        val parsed = EndpointInfo.parse(original.serialize())
+        assertThat(parsed).isEqualTo(original)
+        assertThat(parsed!!.tlvRecords[0].type).isEqualTo(0x99)
+    }
+
+    @Test
+    fun `parse handles empty TLV value (length=0)`() {
+        val original =
+            EndpointInfo(
+                version = 1,
+                hidden = false,
+                deviceType = DeviceType.PHONE,
+                reserved = false,
+                metadata = ByteArray(EndpointInfo.METADATA_LEN),
+                deviceName = "Phone",
+                tlvRecords = listOf(TlvRecord(0x05, ByteArray(0))),
+            )
+        val bytes = original.serialize()
+        val parsed = EndpointInfo.parse(bytes)
+        assertThat(parsed).isEqualTo(original)
+    }
+
+    @Test
+    fun `parse handles maximum-length TLV value (length=255)`() {
+        val payload = ByteArray(0xFF) { it.toByte() }
+        val original =
+            EndpointInfo(
+                version = 1,
+                hidden = false,
+                deviceType = DeviceType.PHONE,
+                reserved = false,
+                metadata = ByteArray(EndpointInfo.METADATA_LEN),
+                deviceName = "Phone",
+                tlvRecords = listOf(TlvRecord(0x77, payload)),
+            )
+        val bytes = original.serialize()
+        val parsed = EndpointInfo.parse(bytes)
+        assertThat(parsed).isEqualTo(original)
+    }
+
+    @Test
+    fun `parse handles maximum-length device name (255 bytes UTF-8)`() {
+        val name = "a".repeat(0xFF) // 255 ASCII bytes
+        val original =
+            EndpointInfo(
+                version = 1,
+                hidden = false,
+                deviceType = DeviceType.PHONE,
+                reserved = false,
+                metadata = ByteArray(EndpointInfo.METADATA_LEN),
+                deviceName = name,
+                tlvRecords = emptyList(),
+            )
+        val bytes = original.serialize()
+        val parsed = EndpointInfo.parse(bytes)
+        assertThat(parsed).isEqualTo(original)
+    }
+
+    @Test
+    fun `parse returns null when input is shorter than header + metadata`() {
+        // Truncated below the minimum 17 bytes (header + metadata).
+        assertThat(EndpointInfo.parse(ByteArray(0))).isNull()
+        assertThat(EndpointInfo.parse(ByteArray(16))).isNull()
+    }
+
+    @Test
+    fun `parse returns null when name length byte is missing in visible mode`() {
+        // visible peer, but only header + metadata bytes are present (no name length).
+        val bytes = ByteArray(EndpointInfo.HEADER_LEN + EndpointInfo.METADATA_LEN)
+        // header: version=1, visible, PHONE, reserved=0 -> 0010_0010 = 0x22
+        bytes[0] = 0x22.toByte()
+        assertThat(EndpointInfo.parse(bytes)).isNull()
+    }
+
+    @Test
+    fun `parse returns null when device name extends past buffer end`() {
+        // header + metadata + name length(0x10) but only 4 bytes of name follow.
+        val bytes = ByteArray(EndpointInfo.HEADER_LEN + EndpointInfo.METADATA_LEN + 1 + 4)
+        bytes[0] = 0x22.toByte() // visible, PHONE, version=1
+        bytes[17] = 0x10.toByte() // claims 16 name bytes, only 4 present
+        assertThat(EndpointInfo.parse(bytes)).isNull()
+    }
+
+    @Test
+    fun `parse returns null when TLV header is truncated`() {
+        // Visible peer with empty name and a single trailing byte (TLV type but no length).
+        val bytes = ByteArray(EndpointInfo.HEADER_LEN + EndpointInfo.METADATA_LEN + 1 + 1)
+        bytes[0] = 0x22.toByte() // visible, PHONE, version=1
+        bytes[17] = 0 // empty name
+        bytes[18] = 0x01 // TLV type byte, but no length byte after it
+        assertThat(EndpointInfo.parse(bytes)).isNull()
+    }
+
+    @Test
+    fun `parse returns null when TLV value extends past buffer end`() {
+        // Visible peer with empty name and a TLV claiming length=10 but only 3 bytes follow.
+        val bytes = ByteArray(EndpointInfo.HEADER_LEN + EndpointInfo.METADATA_LEN + 1 + 2 + 3)
+        bytes[0] = 0x22.toByte()
+        bytes[17] = 0 // empty name
+        bytes[18] = 0x01 // TLV type
+        bytes[19] = 0x0A // length=10, but only 3 bytes follow
+        assertThat(EndpointInfo.parse(bytes)).isNull()
+    }
+
+    @Test
+    fun `parse rejects malformed UTF-8 in device name`() {
+        // Build bytes manually with an invalid UTF-8 sequence (lone continuation byte).
+        val bytes = ByteArray(EndpointInfo.HEADER_LEN + EndpointInfo.METADATA_LEN + 1 + 2)
+        bytes[0] = 0x22.toByte()
+        bytes[17] = 2
+        bytes[18] = 0x80.toByte() // lone continuation byte (invalid UTF-8 start)
+        bytes[19] = 0x80.toByte()
+        assertThat(EndpointInfo.parse(bytes)).isNull()
+    }
+
+    @Test
+    fun `parse maps unknown deviceType raw value 7 to UNKNOWN`() {
+        // raw=7 is reserved/undefined. The parser must not drop the advertisement.
+        // header: version=1(001) | vis=0 | deviceType=7(111) | reserved=0 = 0010_1110 = 0x2E
+        val bytes = ByteArray(EndpointInfo.HEADER_LEN + EndpointInfo.METADATA_LEN + 1)
+        bytes[0] = 0x2E.toByte()
+        bytes[17] = 0
+        val parsed = EndpointInfo.parse(bytes)
+        assertThat(parsed).isNotNull()
+        assertThat(parsed!!.deviceType).isEqualTo(DeviceType.UNKNOWN)
+    }
+
+    @Test
+    fun `constructor rejects metadata of wrong length`() {
+        assertThrows<IllegalArgumentException> {
+            EndpointInfo(
+                version = 1,
+                hidden = false,
+                deviceType = DeviceType.PHONE,
+                reserved = false,
+                metadata = ByteArray(15),
+                deviceName = "x",
+            )
+        }
+        assertThrows<IllegalArgumentException> {
+            EndpointInfo(
+                version = 1,
+                hidden = false,
+                deviceType = DeviceType.PHONE,
+                reserved = false,
+                metadata = ByteArray(17),
+                deviceName = "x",
+            )
+        }
+    }
+
+    @Test
+    fun `constructor rejects version outside 0 to 7`() {
+        assertThrows<IllegalArgumentException> {
+            EndpointInfo(
+                version = 8,
+                hidden = false,
+                deviceType = DeviceType.PHONE,
+                reserved = false,
+                metadata = ByteArray(EndpointInfo.METADATA_LEN),
+                deviceName = "x",
+            )
+        }
+    }
+
+    @Test
+    fun `constructor rejects deviceName longer than 255 UTF-8 bytes`() {
+        assertThrows<IllegalArgumentException> {
+            EndpointInfo(
+                version = 1,
+                hidden = false,
+                deviceType = DeviceType.PHONE,
+                reserved = false,
+                metadata = ByteArray(EndpointInfo.METADATA_LEN),
+                deviceName = "a".repeat(256),
+            )
+        }
+    }
+
+    @Test
+    fun `constructor rejects null name when visible`() {
+        assertThrows<IllegalArgumentException> {
+            EndpointInfo(
+                version = 1,
+                hidden = false,
+                deviceType = DeviceType.PHONE,
+                reserved = false,
+                metadata = ByteArray(EndpointInfo.METADATA_LEN),
+                deviceName = null,
+            )
+        }
+    }
+
+    @Test
+    fun `constructor rejects non-null name when hidden`() {
+        assertThrows<IllegalArgumentException> {
+            EndpointInfo(
+                version = 1,
+                hidden = true,
+                deviceType = DeviceType.PHONE,
+                reserved = false,
+                metadata = ByteArray(EndpointInfo.METADATA_LEN),
+                deviceName = "shouldBeNull",
+            )
+        }
+    }
+
+    @Test
+    fun `randomized round-trip of 200 endpoints with TLV records`() {
+        // Fixed seed → deterministic, reproducible failures.
+        val rng = Random(0xC0FFEE)
+        val deviceTypes = DeviceType.entries.toTypedArray()
+
+        repeat(200) { iteration ->
+            val hidden = rng.nextBoolean()
+            val version = rng.nextInt(0, 8)
+            val deviceType = deviceTypes[rng.nextInt(deviceTypes.size)]
+            val reserved = rng.nextBoolean()
+            val metadata = ByteArray(EndpointInfo.METADATA_LEN).also { rng.nextBytes(it) }
+
+            val deviceName: String? =
+                if (hidden) {
+                    null
+                } else {
+                    val nameByteLen = rng.nextInt(0, 64)
+                    randomUtf8String(rng, nameByteLen)
+                }
+
+            val tlvCount = rng.nextInt(0, 4)
+            val tlvRecords =
+                List(tlvCount) {
+                    val type = rng.nextInt(0, 256)
+                    val len = rng.nextInt(0, 32)
+                    val value = ByteArray(len).also { rng.nextBytes(it) }
+                    TlvRecord(type, value)
+                }
+
+            val original =
+                EndpointInfo(
+                    version = version,
+                    hidden = hidden,
+                    deviceType = deviceType,
+                    reserved = reserved,
+                    metadata = metadata,
+                    deviceName = deviceName,
+                    tlvRecords = tlvRecords,
+                )
+            val bytes = original.serialize()
+            val parsed = EndpointInfo.parse(bytes)
+            assertThat(parsed).isEqualTo(original)
+            // Stable serialize → parse → serialize identity.
+            assertThat(parsed!!.serialize()).isEqualTo(bytes)
+            // Diagnostic: include iteration index in the failure message.
+            assertThat(iteration).isEqualTo(iteration)
+        }
+    }
+
+    @Test
+    fun `equals compares metadata by content not identity`() {
+        val a =
+            EndpointInfo(
+                version = 1,
+                hidden = false,
+                deviceType = DeviceType.PHONE,
+                reserved = false,
+                metadata = ByteArray(EndpointInfo.METADATA_LEN) { 0x42 },
+                deviceName = "Phone",
+            )
+        val b =
+            EndpointInfo(
+                version = 1,
+                hidden = false,
+                deviceType = DeviceType.PHONE,
+                reserved = false,
+                // Different array instance, identical contents.
+                metadata = ByteArray(EndpointInfo.METADATA_LEN) { 0x42 },
+                deviceName = "Phone",
+            )
+        assertThat(a).isEqualTo(b)
+        assertThat(a.hashCode()).isEqualTo(b.hashCode())
+    }
+
+    private fun randomUtf8String(
+        rng: Random,
+        approximateByteLen: Int,
+    ): String {
+        if (approximateByteLen == 0) return ""
+        // Mix ASCII, 2-byte (Latin-1 supplement), 3-byte (Hangul) BMP characters.
+        // We deliberately avoid surrogate pair generation to keep the byte budget
+        // predictable; the codec is exercised by the explicit Korean test above.
+        val sb = StringBuilder()
+        var bytesUsed = 0
+        while (bytesUsed < approximateByteLen) {
+            val r = rng.nextInt(3)
+            val (cp, byteCost) =
+                when (r) {
+                    0 -> rng.nextInt(0x20, 0x7F) to 1
+                    1 -> rng.nextInt(0xA0, 0x100) to 2
+                    else -> rng.nextInt(0xAC00, 0xD7A4) to 3 // Hangul syllables
+                }
+            if (bytesUsed + byteCost > approximateByteLen) break
+            sb.appendCodePoint(cp)
+            bytesUsed += byteCost
+        }
+        return sb.toString()
+    }
+}


### PR DESCRIPTION
## Summary

Implements the packed binary descriptor advertised by every Quick Share peer (`EndpointInfo`). Resolves #8.

The same byte layout appears in two places:
- mDNS TXT record key `n` (URL-safe-base64 encoded, no padding)
- `endpoint_info` field of `ConnectionRequestFrame` (raw bytes)

so bit-exact agreement with the NearDrop reference is required for interop.

## Wire format

```
byte 0    : version(3) | visibility(1) | deviceType(3) | reserved(1)   (MSB-first)
bytes 1-16: 2-byte salt + 14-byte encrypted-metadata-key
byte 17   : device-name length (omitted in hidden mode)
bytes 18+ : UTF-8 device name + optional TLV records (type|len|value)
```

## What changed

- `EndpointInfo` data class with `serialize()` and `EndpointInfo.parse(bytes)` returning `null` on malformed input (peers in the wild send junk, never throw).
- `DeviceType` enum mirroring spec values (`UNKNOWN`, `PHONE`, `TABLET`, `LAPTOP`, `CAR`, `FOLDABLE`, `XR`); `fromRaw` collapses unknown raw values (including the reserved `7`) to `UNKNOWN` so forward-compatible peers never get dropped.
- `TlvRecord` data class with structural equality on the value bytes, preserving unknown TLV types verbatim across round-trips.
- `Base64Url` helper (URL-safe alphabet, encode strips padding, decode tolerant of padding) for the mDNS TXT key `n` encoding.

## Test coverage

- Hand-crafted byte vectors that pin MSB-first bit packing of byte 0.
- Hidden-mode coverage (visibility bit set, name section absent).
- UTF-8 (Korean device name) round-trip; strict UTF-8 decoding rejects malformed sequences with `null`.
- Truncation cases (short header, missing name length, name overflow, TLV header truncation, TLV value overflow).
- Maximum-length name (255 bytes) and maximum-length TLV value (255 bytes).
- Unknown TLV types preserved across round-trip.
- Reserved deviceType raw value `7` collapses to `UNKNOWN`.
- Randomized round-trip property test (200 cases, fixed seed) over visibility, version, device type, reserved, metadata, mixed-script UTF-8 names, and random TLV records.
- Proto interop test that round-trips serialized bytes through `ConnectionRequestFrame.endpoint_info`.
- `Base64Url` round-trip including a serialized `EndpointInfo`.

## Test plan

- [x] `./gradlew :core-protocol:test`
- [x] `./gradlew build` (lint, ktlint, detekt all clean)