### PR TITLE
feat: derive 4-digit PIN from UKEY2 authString (Chromium algorithm)

### DIFF
--- a/core-protocol-test/src/main/kotlin/io/github/kyujincho/wvmg/protocol/test/PinVectors.kt
+++ b/core-protocol-test/src/main/kotlin/io/github/kyujincho/wvmg/protocol/test/PinVectors.kt
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.test
+
+/**
+ * Known-Answer Test (KAT) vectors for the Quick Share 4-digit PIN derivation
+ * defined in `NearbyConnection.swift:pinCodeFromAuthKey`.
+ *
+ * These vectors are computed from a faithful reproduction of the Swift
+ * algorithm and cross-checked against the NearDrop reference source at
+ * https://github.com/grishka/NearDrop/blob/master/NearbyShare/NearbyConnection.swift.
+ *
+ * The vectors are grouped to lock down three things at once:
+ *
+ *  1. **Boundary cases** — empty input, all-zero input, the single-byte
+ *     baseline. These keep the loop boundary and `"%04d"` zero-padding
+ *     honest.
+ *  2. **Sign extension** — at least one vector contains a byte with the
+ *     high bit set (`0xFF`). The Swift reference uses
+ *     `Int(Int8(bitPattern: _byte))`, which produces `-1` for `0xFF`. The
+ *     equivalent on the JVM is `Byte.toInt()` (already sign-extending). A
+ *     buggy port that uses `b.toInt() and 0xFF` would produce a different
+ *     PIN here, and this vector is what catches that regression.
+ *  3. **Modulo wrap-around** — vectors long enough (32 bytes) that the
+ *     intermediate `hash` and `multiplier` wrap past the 9973 modulus
+ *     several times, exercising the truncated-remainder contract that
+ *     differs between Swift/Kotlin/Java (sign-of-dividend) and
+ *     Python/Lua (floored).
+ *
+ * The KAT vectors live in `:core-protocol-test` so the same answer-table can
+ * be reused from Android instrumentation tests when the protocol stack
+ * lights up later in Phase 1.
+ */
+public object PinVectors {
+    /**
+     * One PIN derivation KAT vector.
+     *
+     * Intentionally a regular `class` rather than a `data class`: the
+     * auto-generated `equals`/`hashCode` for `ByteArray` use reference
+     * identity (a known JVM gotcha) so the data-class default is broken,
+     * and we do not need destructuring or `copy()` for read-only fixtures.
+     * `toString` is overridden to return the human-readable [name] so test
+     * failures stay legible.
+     */
+    public class Vector(
+        public val name: String,
+        public val authString: ByteArray,
+        public val expectedPin: String,
+    ) {
+        init {
+            require(expectedPin.length == 4) { "Expected PIN must be exactly 4 chars: '$expectedPin'" }
+            require(expectedPin.all { it in '0'..'9' }) {
+                "Expected PIN must contain only ASCII digits: '$expectedPin'"
+            }
+        }
+
+        override fun toString(): String = name
+    }
+
+    /**
+     * Empty input — boundary case for the loop. `hash` stays `0`, `abs(0)`
+     * is `0`, padded to `"0000"`. Documents that the implementation does
+     * not reject empty input.
+     */
+    public val empty: Vector =
+        Vector(
+            name = "empty authString",
+            authString = ByteArray(0),
+            expectedPin = "0000",
+        )
+
+    /**
+     * Single zero byte — same expected PIN as the empty case but exercises
+     * one full pass through the loop body.
+     */
+    public val singleZeroByte: Vector =
+        Vector(
+            name = "single 0x00 byte",
+            authString = byteArrayOf(0x00),
+            expectedPin = "0000",
+        )
+
+    /**
+     * Single positive byte. Verifies the trivial path:
+     * `hash = (0 + 1 * 1) % 9973 = 1`, formatted as `"0001"`.
+     */
+    public val singlePositiveByte: Vector =
+        Vector(
+            name = "single 0x01 byte",
+            authString = byteArrayOf(0x01),
+            expectedPin = "0001",
+        )
+
+    /**
+     * Single byte with the high bit set (`0xFF`).
+     *
+     * Locks down the sign-extension contract: with correct `Byte.toInt()`
+     * sign extension, `signedByte = -1`, so
+     * `hash = (0 + (-1) * 1) % 9973 = -1`, and `abs(-1) = 1` formats to
+     * `"0001"`. A buggy unsigned port (`b.toInt() and 0xFF` -> 255) would
+     * produce `"0255"` instead, which this vector deliberately rules out.
+     */
+    public val singleHighBitByte: Vector =
+        Vector(
+            name = "single 0xFF byte (sign-extension guard)",
+            authString = byteArrayOf(0xFF.toByte()),
+            expectedPin = "0001",
+        )
+
+    /**
+     * Two-byte vector, both high-bit-set. Exercises sign extension across
+     * more than one loop iteration:
+     *
+     *   * iter 0: hash = (0 + (-1)*1) % 9973 = -1; multiplier = 31
+     *   * iter 1: hash = (-1 + (-1)*31) % 9973 = -32
+     *
+     * `abs(-32)` formats to `"0032"`.
+     */
+    public val twoHighBitBytes: Vector =
+        Vector(
+            name = "two 0xFF bytes (sign-extension across iterations)",
+            authString = byteArrayOf(0xFF.toByte(), 0xFF.toByte()),
+            expectedPin = "0032",
+        )
+
+    /**
+     * Two-byte positive vector. Exercises the multiplier update between
+     * iterations: `hash = (1 + 2*31) % 9973 = 63`, formatted as `"0063"`.
+     */
+    public val twoSmallPositiveBytes: Vector =
+        Vector(
+            name = "0x01 0x02 (multiplier step)",
+            authString = byteArrayOf(0x01, 0x02),
+            expectedPin = "0063",
+        )
+
+    /**
+     * 32 bytes of `0x7F` (the largest positive signed-int8 value, `+127`).
+     * Long enough that the intermediate `hash` and `multiplier` both
+     * exceed the modulus several times, locking down the truncated-mod
+     * semantics.
+     */
+    public val thirtyTwoMaxPositiveBytes: Vector =
+        Vector(
+            name = "32 bytes of 0x7F (multi-wrap, all positive)",
+            authString = ByteArray(32) { 0x7F.toByte() },
+            expectedPin = "8857",
+        )
+
+    /**
+     * 32 bytes of `0xFF` (the most-negative signed-int8 value of `-1`
+     * across many iterations). Combines sign extension with multi-wrap
+     * modulo behaviour.
+     */
+    public val thirtyTwoHighBitBytes: Vector =
+        Vector(
+            name = "32 bytes of 0xFF (multi-wrap, all negative)",
+            authString = ByteArray(32) { 0xFF.toByte() },
+            expectedPin = "6509",
+        )
+
+    /**
+     * 32 bytes spanning `0x00..0x1F` — strictly increasing, all positive,
+     * gives a hash trajectory unlike the constant-byte vectors above.
+     */
+    public val incrementingBytes: Vector =
+        Vector(
+            name = "0x00..0x1F (32 incrementing positive bytes)",
+            authString = ByteArray(32) { it.toByte() },
+            expectedPin = "5095",
+        )
+
+    /**
+     * 32 bytes alternating `0x80, 0x7F` (most-negative, most-positive).
+     * Forces the running `hash` to swing wide across the modulus in both
+     * directions, catching off-by-one errors in either the sign-extension
+     * or the truncated-mod path.
+     */
+    public val alternatingExtremeBytes: Vector =
+        Vector(
+            name = "0x80,0x7F repeating x16 (alternating extremes)",
+            authString = ByteArray(32) { if (it % 2 == 0) 0x80.toByte() else 0x7F.toByte() },
+            expectedPin = "9035",
+        )
+
+    /** All PIN derivation KAT vectors in declaration order. */
+    public val all: List<Vector> =
+        listOf(
+            empty,
+            singleZeroByte,
+            singlePositiveByte,
+            singleHighBitByte,
+            twoHighBitBytes,
+            twoSmallPositiveBytes,
+            thirtyTwoMaxPositiveBytes,
+            thirtyTwoHighBitBytes,
+            incrementingBytes,
+            alternatingExtremeBytes,
+        )
+}

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/crypto/pin/PinDerivation.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/crypto/pin/PinDerivation.kt
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.crypto.pin
+
+import kotlin.math.abs
+
+/**
+ * Derives the 4-digit visual confirmation PIN that Quick Share displays on
+ * both peers after the UKEY2 handshake completes.
+ *
+ * The algorithm is **not** the one specified by UKEY2 itself; it is a
+ * Chromium-specific construction that NearDrop ports verbatim in
+ * `NearbyConnection.swift:pinCodeFromAuthKey`. Both peers must produce the
+ * same digits for the same `authString`, so this implementation is required
+ * to be bit-exact with the Swift reference. Reproduced for clarity:
+ *
+ * ```swift
+ * internal static func pinCodeFromAuthKey(_ key: SymmetricKey) -> String {
+ *     var hash: Int = 0
+ *     var multiplier: Int = 1
+ *     let keyBytes: [UInt8] = key.withUnsafeBytes({ return [UInt8]($0) })
+ *     for _byte in keyBytes {
+ *         let byte = Int(Int8(bitPattern: _byte))
+ *         hash = (hash + byte * multiplier) % 9973
+ *         multiplier = (multiplier * 31) % 9973
+ *     }
+ *     return String(format: "%04d", abs(hash))
+ * }
+ * ```
+ *
+ * ### Why the implementation is one line of arithmetic but the contract is subtle
+ *
+ *  1. **Signed bytes.** Swift goes out of its way to reinterpret each `UInt8`
+ *     as `Int8` before widening to `Int`. The JVM's `Byte` is already signed
+ *     and `Byte.toInt()` sign-extends (`0xFF.toByte().toInt() == -1`), so on
+ *     the JVM side `b.toInt()` is sufficient — but only if it goes through
+ *     `Byte.toInt()` on a `Byte` value. Going through `Int.and(0xFF)` would
+ *     silently produce zero-extended (unsigned) values and break interop on
+ *     any peer that ever exchanges an authString with a high bit set. The
+ *     test suite pins this down with explicit `0xFF`-byte vectors.
+ *
+ *  2. **Truncated remainder.** Swift's `%` operator and Kotlin's `%`
+ *     operator on `Int` both use **truncated** division (the result carries
+ *     the sign of the dividend). Languages that implement floored division
+ *     (Python's `%`, Lua's `%`, etc.) would diverge here when `hash` goes
+ *     negative. We therefore intentionally do not reach for any
+ *     `Math.floorMod` helper.
+ *
+ *  3. **`abs` on the final hash is bounded.** After the modulo, `hash` is
+ *     always in `(-9973, 9973)`, so `kotlin.math.abs(Int)` cannot hit the
+ *     `Int.MIN_VALUE` undefined-behaviour edge that bites generic JVM code.
+ *
+ *  4. **Output is exactly 4 ASCII digits.** Zero-padded with leading zeros.
+ *     `"%04d"` in Java/Kotlin matches Swift's format string here because
+ *     `abs(hash) <= 9972 < 10000` so the field never overflows past 4
+ *     characters.
+ *
+ *  5. **Pure function — no key material is logged or returned.** Only the
+ *     4-digit string escapes this object. Callers are still responsible for
+ *     not logging the `authString` argument; this helper has no logging at
+ *     all by design.
+ *
+ *  6. **Empty `authString`.** Defined to return `"0000"`: the loop runs zero
+ *     times, `hash` stays `0`, `abs(0) = 0`, formatted as `0000`. We do not
+ *     reject empty input — defining the boundary is cheaper than asking
+ *     every caller to pre-validate, and matches the Swift reference, which
+ *     also returns `"0000"` for an empty key buffer.
+ *
+ * ### Public API
+ *
+ * One function: [deriveFourDigitPin]. The companion KAT vectors live in
+ * `:core-protocol-test` (`PinVectors`) so the same answer-table can be
+ * reused from Android instrumentation tests when the protocol stack lights
+ * up later in Phase 1.
+ */
+public object PinDerivation {
+    /**
+     * The Chromium PIN modulus. Hard-coded `9973` — the largest prime less
+     * than `10000`, picked so that `abs(hash) < 10000` and therefore always
+     * fits in 4 decimal digits.
+     */
+    private const val PIN_MODULUS: Int = 9973
+
+    /**
+     * The Chromium PIN multiplier seed. The accumulator `multiplier` is
+     * multiplied by `31` (mod [PIN_MODULUS]) on every byte.
+     */
+    private const val MULTIPLIER_STEP: Int = 31
+
+    /**
+     * Number of decimal digits the final PIN is zero-padded to. Constant
+     * because the modulus guarantees the result is always 1-4 digits.
+     */
+    private const val PIN_DIGITS: Int = 4
+
+    /**
+     * Derives the 4-digit visual confirmation PIN from a UKEY2 `authString`.
+     *
+     * Cross-validated against three classes of reference vectors:
+     *
+     *   * Trivial inputs (empty, single zero byte, single positive byte) —
+     *     guards the loop boundary and the zero-padding format.
+     *   * Single-byte negative inputs (e.g. `0xFF`) — guards the
+     *     sign-extension contract documented above.
+     *   * Multi-byte inputs that cause the intermediate `hash` and
+     *     `multiplier` to wrap modulo 9973 several times — guards the
+     *     truncated-remainder contract.
+     *
+     * @param authString Raw UKEY2 derived authentication string. Treated as
+     *   opaque bytes; never logged. May be empty (returns `"0000"`).
+     * @return A 4-character ASCII decimal string, zero-padded on the left.
+     *   Always exactly [PIN_DIGITS] characters long.
+     */
+    public fun deriveFourDigitPin(authString: ByteArray): String {
+        var hash = 0
+        var multiplier = 1
+        for (b in authString) {
+            // `Byte.toInt()` already sign-extends on the JVM (0xFF -> -1),
+            // matching Swift's `Int(Int8(bitPattern: _byte))`. Do not change
+            // this to `b.toInt() and 0xFF` — that would zero-extend and
+            // break interop with any peer that produces an authString
+            // containing bytes >= 0x80.
+            val signedByte = b.toInt()
+            hash = (hash + signedByte * multiplier) % PIN_MODULUS
+            multiplier = (multiplier * MULTIPLIER_STEP) % PIN_MODULUS
+        }
+        // After the modulo, `hash` is always in (-9973, 9973), so abs(hash)
+        // cannot overflow Int.MIN_VALUE (the only undefined case for
+        // `kotlin.math.abs(Int)` on the JVM).
+        return abs(hash).toString().padStart(PIN_DIGITS, '0')
+    }
+}

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/crypto/pin/PinDerivationTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/crypto/pin/PinDerivationTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.crypto.pin
+
+import com.google.common.truth.Truth.assertThat
+import io.github.kyujincho.wvmg.protocol.test.PinVectors
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+
+/**
+ * Bit-exact correctness tests for [PinDerivation] against the KAT vectors
+ * in `:core-protocol-test` (`PinVectors`). The vectors are computed from a
+ * faithful reproduction of the Swift reference algorithm and chosen to lock
+ * down each subtle property of the implementation:
+ *
+ *   * boundary cases (empty input, single byte),
+ *   * **signed-byte interpretation** (`0xFF` -> `-1`),
+ *   * **truncated-remainder** modulo behaviour over many iterations,
+ *   * **zero-padded 4-digit ASCII** output format.
+ */
+class PinDerivationTest {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("vectors")
+    fun `KAT vector matches NearDrop reference`(vector: PinVectors.Vector) {
+        val actual = PinDerivation.deriveFourDigitPin(vector.authString)
+        assertThat(actual).isEqualTo(vector.expectedPin)
+    }
+
+    @Test
+    fun `output is always exactly 4 ASCII digits`() {
+        for (vector in PinVectors.all) {
+            val pin = PinDerivation.deriveFourDigitPin(vector.authString)
+            assertThat(pin).hasLength(4)
+            assertThat(pin.all { it in '0'..'9' }).isTrue()
+        }
+    }
+
+    @Test
+    fun `empty authString returns 0000`() {
+        // Documented boundary: the loop runs zero times and the formatter
+        // pads `abs(0)` to four digits.
+        assertThat(PinDerivation.deriveFourDigitPin(ByteArray(0))).isEqualTo("0000")
+    }
+
+    @Test
+    fun `single 0xFF byte produces 0001 — sign-extension guard`() {
+        // This is the load-bearing test for the signed-byte contract. A
+        // buggy port that zero-extends (`b.toInt() and 0xFF`) would return
+        // "0255" here. With the correct `Byte.toInt()` sign extension,
+        // `0xFF` widens to `-1` and `abs(-1)` formats to "0001".
+        assertThat(PinDerivation.deriveFourDigitPin(byteArrayOf(0xFF.toByte())))
+            .isEqualTo("0001")
+    }
+
+    @Test
+    fun `result is deterministic — same input twice gives same PIN`() {
+        // Pure-function property: no hidden state, no RNG involvement.
+        val input = ByteArray(64) { (it * 7 - 3).toByte() }
+        val first = PinDerivation.deriveFourDigitPin(input)
+        val second = PinDerivation.deriveFourDigitPin(input)
+        assertThat(second).isEqualTo(first)
+    }
+
+    @Test
+    fun `does not mutate the input authString`() {
+        // Defence in depth: callers may pass a buffer they intend to wipe
+        // later. The function must read but not write.
+        val input = byteArrayOf(0x01, 0x02, 0x03, 0xFF.toByte())
+        val snapshot = input.copyOf()
+        PinDerivation.deriveFourDigitPin(input)
+        assertThat(input).isEqualTo(snapshot)
+    }
+
+    companion object {
+        @JvmStatic
+        fun vectors(): List<PinVectors.Vector> = PinVectors.all
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `PinDerivation.deriveFourDigitPin(authString: ByteArray): String` in `:core-protocol/.../crypto/pin/`, a pure-Kotlin port of NearDrop's `NearbyConnection.swift:pinCodeFromAuthKey`. Both Quick Share peers must produce the same digits for the same `authString`, so the implementation is bit-exact with the Swift reference.
- Adds 10 Known-Answer Test vectors in `:core-protocol-test` (`PinVectors`) so the same answer-table can be reused from Android instrumentation tests later in Phase 1.

## Why

Quick Share displays a 4-digit PIN on both peers after the UKEY2 handshake so the user can visually confirm there is no MITM. The algorithm is a Chromium-specific construction that is **not** the one specified by UKEY2 itself; deriving the PIN incorrectly is silent — both peers would proceed with the connection and the user could approve a transfer that another device is waiting on. The KAT table guards against the two failure modes that would not show up in a single-peer smoke test:

- **Sign extension.** Swift uses `Int(Int8(bitPattern: _byte))`. The JVM's `Byte.toInt()` already sign-extends, so `b.toInt()` is sufficient — but only if the conversion goes through `Byte.toInt()` and not `b.toInt() and 0xFF`, which would zero-extend. Vectors with `0xFF` bytes lock this down.
- **Truncated-remainder modulo.** Swift's `%` and Kotlin's `%` on `Int` both follow the sign of the dividend. Languages with floored division (Python's `%`, Lua's `%`) would diverge once `hash` goes negative. Multi-byte vectors that wrap the modulus several times catch any drift here.

## Algorithm

Reproduced from `NearbyConnection.swift:pinCodeFromAuthKey` for clarity:

```
hash       = 0
multiplier = 1
for each byte b (interpreted as signed int8):
    hash       = (hash + b * multiplier) mod 9973
    multiplier = (multiplier * 31) mod 9973
return "%04d" % abs(hash)
```

`9973` is the largest prime less than `10000`, so `abs(hash) < 10000` always fits in 4 decimal digits.

## Public API

- `io.github.kyujincho.wvmg.protocol.crypto.pin.PinDerivation.deriveFourDigitPin(authString: ByteArray): String`
- Returns exactly 4 ASCII digits (left-padded with `'0'`).
- Empty input returns `"0000"` — matches the Swift reference and removes the need for callers to pre-validate.
- Pure function: no logging, no mutation of the input buffer, deterministic.

## KAT Vectors

`:core-protocol-test/.../PinVectors.kt` exposes 10 vectors covering:

| Vector | Purpose |
|---|---|
| empty authString | loop-boundary + zero-padding |
| single 0x00 byte | one-iteration baseline |
| single 0x01 byte | trivial positive path |
| single 0xFF byte | sign-extension guard |
| two 0xFF bytes | sign extension across iterations |
| 0x01 0x02 | multiplier-step verification |
| 32x 0x7F | multi-wrap, all positive |
| 32x 0xFF | multi-wrap, all negative |
| 0x00..0x1F | strictly increasing positives |
| 0x80,0x7F repeating | alternating extremes, hash swings both signs |

All values were computed from a faithful reproduction of the Swift algorithm and cross-checked against the NearDrop source.

## Notes

- `:core-protocol` stays free of `android.*` dependencies — uses only `kotlin.math.abs` from the stdlib.
- Issue #11 (running in parallel) will surface the actual `authString` from the UKEY2 handshake; this PR does not depend on its API. Callers will pass the bytes returned by `Ukey2HandshakeResult` once both PRs land.

Closes #12.