### PR TITLE
feat: derive D2D + SecureMessage keys from UKEY2 nextSecret (#11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,11 @@ Tink's transitive `protobuf-java` dependency that would clash with
 layer of the Quick Share transport) lives in the same module as
 `FramedConnection` under `...protocol.transport`. The UKEY2 P256_SHA512
 key-exchange handshake (`Ukey2Client`, `Ukey2Server`) lives under
-`...protocol.ukey2` and runs over `FramedConnection`.
+`...protocol.ukey2` and runs over `FramedConnection`. The post-handshake
+HKDF chain that derives the four AES-256 / HMAC-SHA256 traffic keys
+(`D2DKeyDerivation`, `D2DSessionKeys`) lives next to `Hkdf` in
+`...protocol.crypto` and is locked down by KAT vectors in
+`:core-protocol-test`.
 
 ## Toolchain
 

--- a/core-protocol-test/src/main/kotlin/io/github/kyujincho/wvmg/protocol/test/D2DKeyDerivationVectors.kt
+++ b/core-protocol-test/src/main/kotlin/io/github/kyujincho/wvmg/protocol/test/D2DKeyDerivationVectors.kt
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.test
+
+/**
+ * Deterministic Known-Answer Test (KAT) vectors for the Quick Share post-UKEY2
+ * D2D + SecureMessage key derivation chain.
+ *
+ * The vector below is computed off-line from the documented derivation
+ * (see `D2DKeyDerivation` in `:core-protocol`). Concretely, the expected
+ * outputs were produced by a Python reference that mirrors NearDrop's
+ * `NearbyConnection.swift:finalizeKeyExchange` byte-for-byte:
+ *
+ * ```python
+ * # See PR description for issue #11 for the full script.
+ * import hmac, hashlib
+ * def hkdf_extract(salt, ikm):
+ *     if len(salt) == 0: salt = b'\x00' * 32
+ *     return hmac.new(salt, ikm, hashlib.sha256).digest()
+ * def hkdf_expand(prk, info, length):
+ *     out, t, ctr = b'', b'', 1
+ *     while len(out) < length:
+ *         t = hmac.new(prk, t + info + bytes([ctr]), hashlib.sha256).digest()
+ *         out += t; ctr += 1
+ *     return out[:length]
+ * def hkdf(ikm, salt, info, length):
+ *     return hkdf_expand(hkdf_extract(salt, ikm), info, length)
+ * ```
+ *
+ * Vectors live in `:core-protocol-test` so both the JVM unit tests in
+ * `:core-protocol` and any future Android instrumentation tests can reuse
+ * them. Pinning the expected outputs in source — rather than computing them
+ * from the implementation under test — is the whole point: a regression in
+ * `Hkdf` or `D2DKeyDerivation` cannot accidentally rewrite its own answers.
+ */
+public object D2DKeyDerivationVectors {
+    /**
+     * One D2D key-derivation KAT vector. Plain class, not `data class`, for
+     * the same `ByteArray`-equality reason called out in [HkdfVectors].
+     *
+     * @property name Human-readable label printed on test failure.
+     * @property dhs `SHA-256(ECDH-shared-secret-X-magnitude)` input. 32 bytes.
+     * @property ukeyClientInitMsg Raw serialized `Ukey2Message` bytes for
+     *   ClientInit. NOT length-prefixed.
+     * @property ukeyServerInitMsg Raw serialized `Ukey2Message` bytes for
+     *   ServerInit. NOT length-prefixed.
+     * @property expectedAuthString Expected output of the
+     *   `HKDF(salt="UKEY2 v1 auth")` derivation. 32 bytes.
+     * @property expectedNextSecret Expected output of the
+     *   `HKDF(salt="UKEY2 v1 next")` derivation. 32 bytes.
+     * @property expectedD2dClientKey Expected output of the
+     *   `HKDF(salt=SHA256("D2D"), info="client")` derivation. 32 bytes.
+     * @property expectedD2dServerKey Expected output of the
+     *   `HKDF(salt=SHA256("D2D"), info="server")` derivation. 32 bytes.
+     * @property expectedClientEncryptKey Expected SecureMessage `ENC:2`
+     *   output for the client direction. 32 bytes.
+     * @property expectedClientHmacKey Expected SecureMessage `SIG:1` output
+     *   for the client direction. 32 bytes.
+     * @property expectedServerEncryptKey Expected SecureMessage `ENC:2`
+     *   output for the server direction. 32 bytes.
+     * @property expectedServerHmacKey Expected SecureMessage `SIG:1` output
+     *   for the server direction. 32 bytes.
+     */
+    @Suppress("LongParameterList") // KAT fixture; one parameter per chain output is intentional.
+    public class Vector(
+        public val name: String,
+        public val dhs: ByteArray,
+        public val ukeyClientInitMsg: ByteArray,
+        public val ukeyServerInitMsg: ByteArray,
+        public val expectedAuthString: ByteArray,
+        public val expectedNextSecret: ByteArray,
+        public val expectedD2dClientKey: ByteArray,
+        public val expectedD2dServerKey: ByteArray,
+        public val expectedClientEncryptKey: ByteArray,
+        public val expectedClientHmacKey: ByteArray,
+        public val expectedServerEncryptKey: ByteArray,
+        public val expectedServerHmacKey: ByteArray,
+    ) {
+        override fun toString(): String = name
+    }
+
+    /**
+     * Primary KAT vector. Inputs are deterministic byte patterns chosen to
+     * avoid accidental zero-byte gotchas:
+     *
+     *  - `dhs` repeats `00112233445566778899aabbccddeeff` twice — non-zero,
+     *    non-uniform, and includes a high-bit byte.
+     *  - `clientInitMsg` is the ASCII tag `"CLIENTINIT"` followed by the
+     *    32-byte sequence `0x00..0x1f`.
+     *  - `serverInitMsg` is the ASCII tag `"SERVERINIT"` followed by the
+     *    32-byte sequence `0x20..0x3f`.
+     *
+     * Expected outputs match a Python reference that bit-for-bit mirrors
+     * NearDrop's `finalizeKeyExchange`.
+     */
+    public val primary: Vector =
+        Vector(
+            name = "D2D primary KAT",
+            dhs =
+                hex(
+                    "00112233445566778899aabbccddeeff" +
+                        "00112233445566778899aabbccddeeff",
+                ),
+            ukeyClientInitMsg =
+                hex(
+                    // ASCII "CLIENTINIT"
+                    "434c49454e54494e4954" +
+                        // 0x00..0x1f
+                        "000102030405060708090a0b0c0d0e0f" +
+                        "101112131415161718191a1b1c1d1e1f",
+                ),
+            ukeyServerInitMsg =
+                hex(
+                    // ASCII "SERVERINIT"
+                    "534552564552494e4954" +
+                        // 0x20..0x3f
+                        "202122232425262728292a2b2c2d2e2f" +
+                        "303132333435363738393a3b3c3d3e3f",
+                ),
+            expectedAuthString =
+                hex(
+                    "57fbc2bd6859ab0c4a900f5a936249a3" +
+                        "4f710c49363a7c4a96134c36a812c4e8",
+                ),
+            expectedNextSecret =
+                hex(
+                    "b0c16a7ef577fe20c638354db7ca5c97" +
+                        "aa4953a75b2443223e854e2e5a081668",
+                ),
+            expectedD2dClientKey =
+                hex(
+                    "dc012fe41bf4d1414318282aee1ad922" +
+                        "05fdde7cd20ebcc9c9249d5493b1e238",
+                ),
+            expectedD2dServerKey =
+                hex(
+                    "21383b4fab61ada496d32cd72bd3bcde" +
+                        "302653b569e5a874134249348a42f1d9",
+                ),
+            expectedClientEncryptKey =
+                hex(
+                    "8270749c4000b76f74060f5417577ed7" +
+                        "eef1798810beb0583e1fd35e7aa81ad4",
+                ),
+            expectedClientHmacKey =
+                hex(
+                    "66324fd288e0aa496aa9265e0f5b46a1" +
+                        "bb157889347a11ee767ba829d8745613",
+                ),
+            expectedServerEncryptKey =
+                hex(
+                    "faf1c47ac8b37af412816c856681ed33" +
+                        "c871345132a3c0252a8b1313e552912f",
+                ),
+            expectedServerHmacKey =
+                hex(
+                    "f75d953f97063d53d52ba3b9093604da" +
+                        "64fc7cde621dc65779acbaa81fe61d92",
+                ),
+        )
+
+    /** All D2D-derivation KAT vectors. */
+    public val all: List<Vector> = listOf(primary)
+
+    /**
+     * Decodes a hex string to bytes. Accepts only `[0-9a-f]` (lowercase) and
+     * even-length input — strict on purpose so a typo in a vector becomes a
+     * loud `IllegalArgumentException` at test load time.
+     */
+    private fun hex(value: String): ByteArray {
+        require(value.length % 2 == 0) { "Hex string must have even length: ${value.length}" }
+        val out = ByteArray(value.length / 2)
+        for (i in out.indices) {
+            val hi = decodeNibble(value[i * 2])
+            val lo = decodeNibble(value[i * 2 + 1])
+            out[i] = ((hi shl 4) or lo).toByte()
+        }
+        return out
+    }
+
+    private fun decodeNibble(c: Char): Int =
+        when (c) {
+            in '0'..'9' -> c - '0'
+            in 'a'..'f' -> c - 'a' + 10
+            else -> throw IllegalArgumentException("Invalid hex character: '$c'")
+        }
+}

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/crypto/D2DKeyDerivation.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/crypto/D2DKeyDerivation.kt
@@ -1,0 +1,428 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.crypto
+
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+
+/**
+ * Derives the Quick Share traffic keys that follow a successful UKEY2
+ * handshake.
+ *
+ * The chain has three stages, each of which is a single HKDF-SHA256 call.
+ * Bit-exact parity with NearDrop's `NearbyConnection.swift:finalizeKeyExchange`
+ * is **required** — any drift in salt, info, or input ordering produces keys
+ * that silently fail to decrypt over the air. The reference implementation
+ * lives at
+ * [grishka/NearDrop](https://github.com/grishka/NearDrop/blob/master/NearbyShare/NearbyConnection.swift).
+ *
+ * ```
+ * # Stage 1 — UKEY2 layer (inputs come from [io.github.kyujincho.wvmg.protocol.ukey2.Ukey2HandshakeResult])
+ * ukeyInfo    = ukeyClientInitMsg || ukeyServerInitMsg
+ *               (raw serialized Ukey2Message bytes; NOT length-prefixed)
+ * authString  = HKDF-SHA256(ikm = dhs,        salt = "UKEY2 v1 auth", info = ukeyInfo, L = 32)
+ * nextSecret  = HKDF-SHA256(ikm = dhs,        salt = "UKEY2 v1 next", info = ukeyInfo, L = 32)
+ *
+ * # Stage 2 — D2D layer (per-direction master keys)
+ * D2D_salt    = SHA256("D2D")
+ *             = 0x82AA55A0D397F88346CA1CEE8D3909B95F13FA7DEB1D4AB38376B8256DA85510
+ * d2dClient   = HKDF-SHA256(ikm = nextSecret, salt = D2D_salt,        info = "client", L = 32)
+ * d2dServer   = HKDF-SHA256(ikm = nextSecret, salt = D2D_salt,        info = "server", L = 32)
+ *
+ * # Stage 3 — SecureMessage layer (split into encrypt + HMAC keys)
+ * SM_salt     = SHA256("SecureMessage")
+ *             = 0xBF9D2A53C63616D75DB0A7165B91C1EF73E537F2427405FA23610A4BE657642E
+ * clientEnc   = HKDF-SHA256(ikm = d2dClient,  salt = SM_salt,         info = "ENC:2", L = 32)
+ * clientHmac  = HKDF-SHA256(ikm = d2dClient,  salt = SM_salt,         info = "SIG:1", L = 32)
+ * serverEnc   = HKDF-SHA256(ikm = d2dServer,  salt = SM_salt,         info = "ENC:2", L = 32)
+ * serverHmac  = HKDF-SHA256(ikm = d2dServer,  salt = SM_salt,         info = "SIG:1", L = 32)
+ * ```
+ *
+ * Role mapping for the per-direction send/receive selection:
+ *
+ *  - **server** sends with `serverEnc`/`serverHmac`, receives with `clientEnc`/`clientHmac`.
+ *  - **client** sends with `clientEnc`/`clientHmac`, receives with `serverEnc`/`serverHmac`.
+ *
+ * Role swap is the most error-prone failure mode in the entire stack — a
+ * dedicated [D2DSessionKeys.forRole] selector exists to keep the swap in one
+ * place, and a unit test asserts that swapping the role flips send and receive
+ * symmetrically.
+ *
+ * Sensitive data discipline: never log [D2DSessionKeys] fields, [authString],
+ * [nextSecret], or any of the intermediate D2D keys. They gate confidentiality
+ * and integrity of every Quick Share frame on the connection.
+ */
+public object D2DKeyDerivation {
+    /** Output size of every key in this derivation chain. AES-256 / HMAC-SHA256 = 32 bytes. */
+    public const val KEY_SIZE: Int = 32
+
+    /**
+     * HKDF salt for the UKEY2 `authString` derivation. ASCII-safe; encoded as
+     * US-ASCII to keep the byte representation invariant across JVMs and
+     * Android API levels (UTF-8 yields identical bytes for this string, but
+     * pinning to US-ASCII makes future copy-paste regressions impossible).
+     */
+    internal val UKEY2_AUTH_SALT: ByteArray =
+        "UKEY2 v1 auth".toByteArray(StandardCharsets.US_ASCII)
+
+    /** HKDF salt for the UKEY2 `nextSecret` derivation. */
+    internal val UKEY2_NEXT_SALT: ByteArray =
+        "UKEY2 v1 next".toByteArray(StandardCharsets.US_ASCII)
+
+    /**
+     * D2D HKDF salt — `SHA-256("D2D")`. Hard-coded as the literal 32-byte
+     * digest rather than computed lazily so that:
+     *
+     *  1. The salt's value is reviewable inline against NearDrop's source
+     *     (`NearbyConnection.swift:376-378`).
+     *  2. There is no `MessageDigest` allocation per derivation.
+     *
+     * The companion test [io.github.kyujincho.wvmg.protocol.crypto.D2DKeyDerivationTest]
+     * recomputes `SHA-256("D2D")` at test time and asserts equality with this
+     * constant, so a typo here cannot pass CI.
+     */
+    internal val D2D_SALT: ByteArray =
+        byteArrayOf(
+            0x82.toByte(),
+            0xAA.toByte(),
+            0x55.toByte(),
+            0xA0.toByte(),
+            0xD3.toByte(),
+            0x97.toByte(),
+            0xF8.toByte(),
+            0x83.toByte(),
+            0x46.toByte(),
+            0xCA.toByte(),
+            0x1C.toByte(),
+            0xEE.toByte(),
+            0x8D.toByte(),
+            0x39.toByte(),
+            0x09.toByte(),
+            0xB9.toByte(),
+            0x5F.toByte(),
+            0x13.toByte(),
+            0xFA.toByte(),
+            0x7D.toByte(),
+            0xEB.toByte(),
+            0x1D.toByte(),
+            0x4A.toByte(),
+            0xB3.toByte(),
+            0x83.toByte(),
+            0x76.toByte(),
+            0xB8.toByte(),
+            0x25.toByte(),
+            0x6D.toByte(),
+            0xA8.toByte(),
+            0x55.toByte(),
+            0x10.toByte(),
+        )
+
+    /**
+     * SecureMessage HKDF salt — `SHA-256("SecureMessage")`. NearDrop computes
+     * this at runtime; we precompute it for the same reasons as [D2D_SALT].
+     * Verified against `SHA-256("SecureMessage")` by the companion test.
+     */
+    internal val SECURE_MESSAGE_SALT: ByteArray =
+        byteArrayOf(
+            0xBF.toByte(),
+            0x9D.toByte(),
+            0x2A.toByte(),
+            0x53.toByte(),
+            0xC6.toByte(),
+            0x36.toByte(),
+            0x16.toByte(),
+            0xD7.toByte(),
+            0x5D.toByte(),
+            0xB0.toByte(),
+            0xA7.toByte(),
+            0x16.toByte(),
+            0x5B.toByte(),
+            0x91.toByte(),
+            0xC1.toByte(),
+            0xEF.toByte(),
+            0x73.toByte(),
+            0xE5.toByte(),
+            0x37.toByte(),
+            0xF2.toByte(),
+            0x42.toByte(),
+            0x74.toByte(),
+            0x05.toByte(),
+            0xFA.toByte(),
+            0x23.toByte(),
+            0x61.toByte(),
+            0x0A.toByte(),
+            0x4B.toByte(),
+            0xE6.toByte(),
+            0x57.toByte(),
+            0x64.toByte(),
+            0x2E.toByte(),
+        )
+
+    /** HKDF info for the per-direction `d2dClientKey` derivation. */
+    internal val D2D_CLIENT_INFO: ByteArray = "client".toByteArray(StandardCharsets.US_ASCII)
+
+    /** HKDF info for the per-direction `d2dServerKey` derivation. */
+    internal val D2D_SERVER_INFO: ByteArray = "server".toByteArray(StandardCharsets.US_ASCII)
+
+    /**
+     * HKDF info for the SecureMessage encrypt key. The `:2` suffix signals
+     * SecureMessage encryption scheme version 2 (AES-256-CBC), which is the
+     * only scheme Quick Share negotiates. Treat this constant as opaque — its
+     * value is part of the wire-visible derivation and cannot be changed.
+     */
+    internal val SM_ENC_INFO: ByteArray = "ENC:2".toByteArray(StandardCharsets.US_ASCII)
+
+    /**
+     * HKDF info for the SecureMessage HMAC key. The `:1` suffix signals
+     * SecureMessage signature scheme version 1 (HMAC-SHA256), again the only
+     * value Quick Share uses.
+     */
+    internal val SM_SIG_INFO: ByteArray = "SIG:1".toByteArray(StandardCharsets.US_ASCII)
+
+    /**
+     * Performs the full three-stage derivation and returns a [D2DSessionKeys]
+     * bundle ready to drive a SecureMessage transport.
+     *
+     * @param dhs `SHA-256(ECDH-shared-secret-X-magnitude)` — exactly 32 bytes.
+     *   Sourced from `Ukey2HandshakeResult.dhs`.
+     * @param ukeyClientInitMsg Raw serialized `Ukey2Message` bytes for the
+     *   ClientInit frame (NOT length-prefixed and NOT the inner
+     *   `Ukey2ClientInit` payload). Sourced from
+     *   `Ukey2HandshakeResult.clientInitMsg`.
+     * @param ukeyServerInitMsg Raw serialized `Ukey2Message` bytes for the
+     *   ServerInit frame. Sourced from `Ukey2HandshakeResult.serverInitMsg`.
+     * @param role The local role on this connection — selects which pair of
+     *   keys is used for sending vs. receiving in [D2DSessionKeys.forRole].
+     * @return A fully populated [D2DSessionKeys] with [authString],
+     *   [D2DSessionKeys.nextSecret], the two D2D master keys, all four
+     *   SecureMessage keys, and the resolved local role.
+     * @throws IllegalArgumentException if `dhs.size != 32`.
+     */
+    public fun derive(
+        dhs: ByteArray,
+        ukeyClientInitMsg: ByteArray,
+        ukeyServerInitMsg: ByteArray,
+        role: D2DRole,
+    ): D2DSessionKeys {
+        require(dhs.size == KEY_SIZE) {
+            "dhs must be exactly $KEY_SIZE bytes (SHA-256 output), got ${dhs.size}"
+        }
+
+        // Stage 1 — UKEY2 layer.
+        val ukeyInfo = concat(ukeyClientInitMsg, ukeyServerInitMsg)
+        val authString = Hkdf.derive(ikm = dhs, salt = UKEY2_AUTH_SALT, info = ukeyInfo, length = KEY_SIZE)
+        val nextSecret = Hkdf.derive(ikm = dhs, salt = UKEY2_NEXT_SALT, info = ukeyInfo, length = KEY_SIZE)
+
+        // Stage 2 — D2D layer.
+        val d2dClientKey =
+            Hkdf.derive(ikm = nextSecret, salt = D2D_SALT, info = D2D_CLIENT_INFO, length = KEY_SIZE)
+        val d2dServerKey =
+            Hkdf.derive(ikm = nextSecret, salt = D2D_SALT, info = D2D_SERVER_INFO, length = KEY_SIZE)
+
+        // Stage 3 — SecureMessage layer (four keys: enc + HMAC, per direction).
+        val clientEncryptKey =
+            Hkdf.derive(ikm = d2dClientKey, salt = SECURE_MESSAGE_SALT, info = SM_ENC_INFO, length = KEY_SIZE)
+        val clientHmacKey =
+            Hkdf.derive(ikm = d2dClientKey, salt = SECURE_MESSAGE_SALT, info = SM_SIG_INFO, length = KEY_SIZE)
+        val serverEncryptKey =
+            Hkdf.derive(ikm = d2dServerKey, salt = SECURE_MESSAGE_SALT, info = SM_ENC_INFO, length = KEY_SIZE)
+        val serverHmacKey =
+            Hkdf.derive(ikm = d2dServerKey, salt = SECURE_MESSAGE_SALT, info = SM_SIG_INFO, length = KEY_SIZE)
+
+        return D2DSessionKeys(
+            role = role,
+            authString = authString,
+            nextSecret = nextSecret,
+            d2dClientKey = d2dClientKey,
+            d2dServerKey = d2dServerKey,
+            clientEncryptKey = clientEncryptKey,
+            clientHmacKey = clientHmacKey,
+            serverEncryptKey = serverEncryptKey,
+            serverHmacKey = serverHmacKey,
+        )
+    }
+
+    /**
+     * Concatenates two byte arrays into a freshly allocated buffer.
+     *
+     * Inlined here (rather than calling `a + b`) so that the allocation is
+     * obvious in the derivation flow and so we never accidentally rely on a
+     * Kotlin operator that copies through an intermediate `List`.
+     */
+    private fun concat(
+        a: ByteArray,
+        b: ByteArray,
+    ): ByteArray {
+        val out = ByteArray(a.size + b.size)
+        a.copyInto(out, destinationOffset = 0)
+        b.copyInto(out, destinationOffset = a.size)
+        return out
+    }
+
+    /**
+     * Returns `SHA-256(input)`. Used only by tests to recompute [D2D_SALT] and
+     * [SECURE_MESSAGE_SALT] from their string preimages and assert they match
+     * the hard-coded byte arrays.
+     */
+    internal fun sha256(input: ByteArray): ByteArray = MessageDigest.getInstance("SHA-256").digest(input)
+}
+
+/**
+ * Local role on a Quick Share connection.
+ *
+ * Determines which of the two encrypt/HMAC key pairs is used for sending vs.
+ * receiving on this side of the connection. The mapping is:
+ *
+ *  - [SERVER] — sends with `server*` keys, receives with `client*` keys.
+ *  - [CLIENT] — sends with `client*` keys, receives with `server*` keys.
+ *
+ * Sender of the UKEY2 ClientInit is the `CLIENT`; the responder is the
+ * `SERVER`. These roles are independent of TCP listen/connect direction —
+ * it is the UKEY2 message ordering that fixes the role.
+ */
+public enum class D2DRole {
+    /** Local side initiated the UKEY2 handshake (sent ClientInit). */
+    CLIENT,
+
+    /** Local side responded to the UKEY2 handshake (sent ServerInit). */
+    SERVER,
+}
+
+/**
+ * Bundle of every key produced by [D2DKeyDerivation.derive] plus enough chain
+ * context to validate the derivation.
+ *
+ * Intentionally a plain `class` rather than a `data class`: the auto-generated
+ * `equals`/`hashCode` for `ByteArray` would use reference identity (a known
+ * JVM gotcha), and we do not need destructuring or `copy()` on key material
+ * (in fact, exposing `copy()` would tempt callers to mutate one field while
+ * leaving the chain inconsistent).
+ *
+ * @property role Local role this bundle was derived for. Selects the
+ *   per-direction send/receive split via [forRole].
+ * @property authString HKDF output `(salt = "UKEY2 v1 auth")` over the
+ *   ECDH-derived `dhs` and concatenated UKEY2 init messages. 32 bytes.
+ *   Consumed by issue #12 to drive the PIN-code derivation; exposed here so
+ *   callers do not have to re-run the UKEY2 stage.
+ * @property nextSecret HKDF output `(salt = "UKEY2 v1 next")`. 32 bytes.
+ *   Intermediate IKM for the D2D layer; exposed for testing/diagnostics.
+ * @property d2dClientKey D2D master key for the client direction. 32 bytes.
+ *   Exposed so test code can verify the chain stage-by-stage.
+ * @property d2dServerKey D2D master key for the server direction. 32 bytes.
+ * @property clientEncryptKey AES-256 SecureMessage encrypt key for traffic
+ *   sent by the CLIENT (i.e., decrypt key when reading on the server side).
+ * @property clientHmacKey HMAC-SHA256 SecureMessage signature key for traffic
+ *   sent by the CLIENT.
+ * @property serverEncryptKey AES-256 SecureMessage encrypt key for traffic
+ *   sent by the SERVER.
+ * @property serverHmacKey HMAC-SHA256 SecureMessage signature key for traffic
+ *   sent by the SERVER.
+ */
+@Suppress("LongParameterList") // One field per stage of the documented derivation chain is intentional.
+public class D2DSessionKeys(
+    public val role: D2DRole,
+    public val authString: ByteArray,
+    public val nextSecret: ByteArray,
+    public val d2dClientKey: ByteArray,
+    public val d2dServerKey: ByteArray,
+    public val clientEncryptKey: ByteArray,
+    public val clientHmacKey: ByteArray,
+    public val serverEncryptKey: ByteArray,
+    public val serverHmacKey: ByteArray,
+) {
+    init {
+        require(authString.size == D2DKeyDerivation.KEY_SIZE) {
+            "authString must be ${D2DKeyDerivation.KEY_SIZE} bytes, got ${authString.size}"
+        }
+        require(nextSecret.size == D2DKeyDerivation.KEY_SIZE) {
+            "nextSecret must be ${D2DKeyDerivation.KEY_SIZE} bytes, got ${nextSecret.size}"
+        }
+        require(d2dClientKey.size == D2DKeyDerivation.KEY_SIZE) {
+            "d2dClientKey must be ${D2DKeyDerivation.KEY_SIZE} bytes, got ${d2dClientKey.size}"
+        }
+        require(d2dServerKey.size == D2DKeyDerivation.KEY_SIZE) {
+            "d2dServerKey must be ${D2DKeyDerivation.KEY_SIZE} bytes, got ${d2dServerKey.size}"
+        }
+        require(clientEncryptKey.size == D2DKeyDerivation.KEY_SIZE) {
+            "clientEncryptKey must be ${D2DKeyDerivation.KEY_SIZE} bytes, got ${clientEncryptKey.size}"
+        }
+        require(clientHmacKey.size == D2DKeyDerivation.KEY_SIZE) {
+            "clientHmacKey must be ${D2DKeyDerivation.KEY_SIZE} bytes, got ${clientHmacKey.size}"
+        }
+        require(serverEncryptKey.size == D2DKeyDerivation.KEY_SIZE) {
+            "serverEncryptKey must be ${D2DKeyDerivation.KEY_SIZE} bytes, got ${serverEncryptKey.size}"
+        }
+        require(serverHmacKey.size == D2DKeyDerivation.KEY_SIZE) {
+            "serverHmacKey must be ${D2DKeyDerivation.KEY_SIZE} bytes, got ${serverHmacKey.size}"
+        }
+    }
+
+    /**
+     * Resolves the per-direction `(send, receive)` key pair for this side of
+     * the connection.
+     *
+     * This selector is the one and only place the role swap happens — every
+     * SecureMessage transmit/receive path should go through here so the
+     * client-vs-server mapping cannot drift between modules.
+     */
+    public fun forRole(): DirectionalKeys =
+        when (role) {
+            D2DRole.CLIENT ->
+                DirectionalKeys(
+                    sendEncryptKey = clientEncryptKey,
+                    sendHmacKey = clientHmacKey,
+                    receiveEncryptKey = serverEncryptKey,
+                    receiveHmacKey = serverHmacKey,
+                )
+
+            D2DRole.SERVER ->
+                DirectionalKeys(
+                    sendEncryptKey = serverEncryptKey,
+                    sendHmacKey = serverHmacKey,
+                    receiveEncryptKey = clientEncryptKey,
+                    receiveHmacKey = clientHmacKey,
+                )
+        }
+
+    /** Deliberately not implemented — would compare key material via
+     *  reference identity. Use field-level `contentEquals` in tests instead.
+     */
+    override fun equals(other: Any?): Boolean = this === other
+
+    /** See [equals]. */
+    override fun hashCode(): Int = System.identityHashCode(this)
+
+    /**
+     * `toString` does **not** dump key material. Returns only the role and a
+     * marker so logs that accidentally include this object cannot leak keys.
+     */
+    override fun toString(): String = "D2DSessionKeys(role=$role, keys=<redacted>)"
+}
+
+/**
+ * Per-direction `(send, receive)` SecureMessage key pair as resolved by
+ * [D2DSessionKeys.forRole].
+ *
+ * Each field is exactly [D2DKeyDerivation.KEY_SIZE] bytes.
+ *
+ * @property sendEncryptKey AES-256 key used to encrypt outgoing payloads.
+ * @property sendHmacKey HMAC-SHA256 key used to sign outgoing payloads.
+ * @property receiveEncryptKey AES-256 key used to decrypt incoming payloads.
+ * @property receiveHmacKey HMAC-SHA256 key used to verify incoming payloads.
+ */
+public class DirectionalKeys(
+    public val sendEncryptKey: ByteArray,
+    public val sendHmacKey: ByteArray,
+    public val receiveEncryptKey: ByteArray,
+    public val receiveHmacKey: ByteArray,
+) {
+    /** Reference-identity equality — see [D2DSessionKeys.equals]. */
+    override fun equals(other: Any?): Boolean = this === other
+
+    override fun hashCode(): Int = System.identityHashCode(this)
+
+    override fun toString(): String = "DirectionalKeys(<redacted>)"
+}

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/crypto/D2DKeyDerivationTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/crypto/D2DKeyDerivationTest.kt
@@ -1,0 +1,283 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.crypto
+
+import com.google.common.truth.Truth.assertThat
+import io.github.kyujincho.wvmg.protocol.test.D2DKeyDerivationVectors
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.nio.charset.StandardCharsets
+
+/**
+ * KAT and structural tests for [D2DKeyDerivation].
+ *
+ * The test surface here is deliberately wider than usual because every
+ * constant in the derivation chain — every salt byte, every info string —
+ * has to match NearDrop's `finalizeKeyExchange` byte-for-byte or interop
+ * silently breaks at the SecureMessage layer with no useful error.
+ *
+ * What we cover:
+ *
+ *  1. Hard-coded salts ([D2DKeyDerivation.D2D_SALT],
+ *     [D2DKeyDerivation.SECURE_MESSAGE_SALT]) are recomputed at test time
+ *     from `SHA-256("D2D")` and `SHA-256("SecureMessage")` and asserted to
+ *     match. A typo in either constant fails this test loudly.
+ *  2. Info strings ([D2DKeyDerivation.UKEY2_AUTH_SALT],
+ *     [D2DKeyDerivation.UKEY2_NEXT_SALT], `client`, `server`, `ENC:2`,
+ *     `SIG:1`) match their literal protocol values.
+ *  3. The full eight-key chain reproduces the pinned KAT in
+ *     [D2DKeyDerivationVectors.primary].
+ *  4. The role swap is symmetric: deriving with `CLIENT` and `SERVER` on
+ *     identical inputs flips send and receive without touching the rest of
+ *     the bundle.
+ *  5. `dhs.size != 32` is rejected up-front (defense in depth — the same
+ *     check exists in `Hkdf.derive` indirectly via length, but failing fast
+ *     here makes misuse easier to debug).
+ *  6. `toString` does not leak key bytes.
+ */
+class D2DKeyDerivationTest {
+    @Test
+    fun `D2D_SALT equals SHA-256 of D2D ASCII`() {
+        // The hard-coded constant in production code is reviewable inline,
+        // but only this test guarantees it actually equals SHA-256("D2D").
+        val expected = D2DKeyDerivation.sha256("D2D".toByteArray(StandardCharsets.US_ASCII))
+        assertThat(D2DKeyDerivation.D2D_SALT).isEqualTo(expected)
+    }
+
+    @Test
+    fun `SECURE_MESSAGE_SALT equals SHA-256 of SecureMessage ASCII`() {
+        val expected =
+            D2DKeyDerivation.sha256("SecureMessage".toByteArray(StandardCharsets.US_ASCII))
+        assertThat(D2DKeyDerivation.SECURE_MESSAGE_SALT).isEqualTo(expected)
+    }
+
+    @Test
+    fun `UKEY2 salts are the literal ASCII strings from the spec`() {
+        assertThat(D2DKeyDerivation.UKEY2_AUTH_SALT)
+            .isEqualTo("UKEY2 v1 auth".toByteArray(StandardCharsets.US_ASCII))
+        assertThat(D2DKeyDerivation.UKEY2_NEXT_SALT)
+            .isEqualTo("UKEY2 v1 next".toByteArray(StandardCharsets.US_ASCII))
+    }
+
+    @Test
+    fun `D2D info strings are the literal ASCII strings from the spec`() {
+        assertThat(D2DKeyDerivation.D2D_CLIENT_INFO)
+            .isEqualTo("client".toByteArray(StandardCharsets.US_ASCII))
+        assertThat(D2DKeyDerivation.D2D_SERVER_INFO)
+            .isEqualTo("server".toByteArray(StandardCharsets.US_ASCII))
+    }
+
+    @Test
+    fun `SecureMessage info strings are ENC colon 2 and SIG colon 1`() {
+        // The colon-version suffixes encode the SecureMessage scheme version
+        // (encryption v2 = AES-256-CBC, signature v1 = HMAC-SHA256). Drift
+        // here would silently negotiate an unsupported scheme.
+        assertThat(D2DKeyDerivation.SM_ENC_INFO)
+            .isEqualTo("ENC:2".toByteArray(StandardCharsets.US_ASCII))
+        assertThat(D2DKeyDerivation.SM_SIG_INFO)
+            .isEqualTo("SIG:1".toByteArray(StandardCharsets.US_ASCII))
+    }
+
+    @Test
+    fun `KAT — primary vector reproduces every output in the chain`() {
+        val v = D2DKeyDerivationVectors.primary
+        val keys =
+            D2DKeyDerivation.derive(
+                dhs = v.dhs,
+                ukeyClientInitMsg = v.ukeyClientInitMsg,
+                ukeyServerInitMsg = v.ukeyServerInitMsg,
+                role = D2DRole.CLIENT,
+            )
+
+        // Stage 1 — UKEY2 layer.
+        assertThat(keys.authString).isEqualTo(v.expectedAuthString)
+        assertThat(keys.nextSecret).isEqualTo(v.expectedNextSecret)
+
+        // Stage 2 — D2D layer.
+        assertThat(keys.d2dClientKey).isEqualTo(v.expectedD2dClientKey)
+        assertThat(keys.d2dServerKey).isEqualTo(v.expectedD2dServerKey)
+
+        // Stage 3 — SecureMessage layer (all four keys).
+        assertThat(keys.clientEncryptKey).isEqualTo(v.expectedClientEncryptKey)
+        assertThat(keys.clientHmacKey).isEqualTo(v.expectedClientHmacKey)
+        assertThat(keys.serverEncryptKey).isEqualTo(v.expectedServerEncryptKey)
+        assertThat(keys.serverHmacKey).isEqualTo(v.expectedServerHmacKey)
+    }
+
+    @Test
+    fun `KAT — every output is exactly 32 bytes`() {
+        val v = D2DKeyDerivationVectors.primary
+        val keys =
+            D2DKeyDerivation.derive(
+                dhs = v.dhs,
+                ukeyClientInitMsg = v.ukeyClientInitMsg,
+                ukeyServerInitMsg = v.ukeyServerInitMsg,
+                role = D2DRole.CLIENT,
+            )
+
+        listOf(
+            keys.authString,
+            keys.nextSecret,
+            keys.d2dClientKey,
+            keys.d2dServerKey,
+            keys.clientEncryptKey,
+            keys.clientHmacKey,
+            keys.serverEncryptKey,
+            keys.serverHmacKey,
+        ).forEach { assertThat(it.size).isEqualTo(D2DKeyDerivation.KEY_SIZE) }
+    }
+
+    @Test
+    fun `role swap flips send and receive symmetrically`() {
+        // Deriving with the same inputs but opposite roles must produce the
+        // same eight-key bundle internally, and the per-direction selector
+        // must flip send and receive on each side. This is the #1 debugging
+        // timesink the issue calls out — pinning it down here means a future
+        // refactor cannot silently transpose the role swap.
+        val v = D2DKeyDerivationVectors.primary
+
+        val asClient =
+            D2DKeyDerivation.derive(
+                dhs = v.dhs,
+                ukeyClientInitMsg = v.ukeyClientInitMsg,
+                ukeyServerInitMsg = v.ukeyServerInitMsg,
+                role = D2DRole.CLIENT,
+            )
+        val asServer =
+            D2DKeyDerivation.derive(
+                dhs = v.dhs,
+                ukeyClientInitMsg = v.ukeyClientInitMsg,
+                ukeyServerInitMsg = v.ukeyServerInitMsg,
+                role = D2DRole.SERVER,
+            )
+
+        // Underlying derivation is identical regardless of role.
+        assertThat(asClient.authString).isEqualTo(asServer.authString)
+        assertThat(asClient.nextSecret).isEqualTo(asServer.nextSecret)
+        assertThat(asClient.d2dClientKey).isEqualTo(asServer.d2dClientKey)
+        assertThat(asClient.d2dServerKey).isEqualTo(asServer.d2dServerKey)
+        assertThat(asClient.clientEncryptKey).isEqualTo(asServer.clientEncryptKey)
+        assertThat(asClient.clientHmacKey).isEqualTo(asServer.clientHmacKey)
+        assertThat(asClient.serverEncryptKey).isEqualTo(asServer.serverEncryptKey)
+        assertThat(asClient.serverHmacKey).isEqualTo(asServer.serverHmacKey)
+
+        // The role selector swaps send and receive — what one side sends, the
+        // other side receives, byte-for-byte.
+        val clientDir = asClient.forRole()
+        val serverDir = asServer.forRole()
+
+        assertThat(clientDir.sendEncryptKey).isEqualTo(serverDir.receiveEncryptKey)
+        assertThat(clientDir.sendHmacKey).isEqualTo(serverDir.receiveHmacKey)
+        assertThat(clientDir.receiveEncryptKey).isEqualTo(serverDir.sendEncryptKey)
+        assertThat(clientDir.receiveHmacKey).isEqualTo(serverDir.sendHmacKey)
+    }
+
+    @Test
+    fun `forRole CLIENT picks client send keys and server receive keys`() {
+        val v = D2DKeyDerivationVectors.primary
+        val keys =
+            D2DKeyDerivation.derive(
+                dhs = v.dhs,
+                ukeyClientInitMsg = v.ukeyClientInitMsg,
+                ukeyServerInitMsg = v.ukeyServerInitMsg,
+                role = D2DRole.CLIENT,
+            )
+        val dir = keys.forRole()
+        assertThat(dir.sendEncryptKey).isEqualTo(v.expectedClientEncryptKey)
+        assertThat(dir.sendHmacKey).isEqualTo(v.expectedClientHmacKey)
+        assertThat(dir.receiveEncryptKey).isEqualTo(v.expectedServerEncryptKey)
+        assertThat(dir.receiveHmacKey).isEqualTo(v.expectedServerHmacKey)
+    }
+
+    @Test
+    fun `forRole SERVER picks server send keys and client receive keys`() {
+        val v = D2DKeyDerivationVectors.primary
+        val keys =
+            D2DKeyDerivation.derive(
+                dhs = v.dhs,
+                ukeyClientInitMsg = v.ukeyClientInitMsg,
+                ukeyServerInitMsg = v.ukeyServerInitMsg,
+                role = D2DRole.SERVER,
+            )
+        val dir = keys.forRole()
+        assertThat(dir.sendEncryptKey).isEqualTo(v.expectedServerEncryptKey)
+        assertThat(dir.sendHmacKey).isEqualTo(v.expectedServerHmacKey)
+        assertThat(dir.receiveEncryptKey).isEqualTo(v.expectedClientEncryptKey)
+        assertThat(dir.receiveHmacKey).isEqualTo(v.expectedClientHmacKey)
+    }
+
+    @Test
+    fun `derive rejects dhs of the wrong length`() {
+        // 31, 33, and empty are all invalid. We don't need an exhaustive
+        // sweep — the `require` is a single comparison.
+        assertThrows<IllegalArgumentException> {
+            D2DKeyDerivation.derive(
+                dhs = ByteArray(31),
+                ukeyClientInitMsg = ByteArray(0),
+                ukeyServerInitMsg = ByteArray(0),
+                role = D2DRole.CLIENT,
+            )
+        }
+        assertThrows<IllegalArgumentException> {
+            D2DKeyDerivation.derive(
+                dhs = ByteArray(33),
+                ukeyClientInitMsg = ByteArray(0),
+                ukeyServerInitMsg = ByteArray(0),
+                role = D2DRole.CLIENT,
+            )
+        }
+        assertThrows<IllegalArgumentException> {
+            D2DKeyDerivation.derive(
+                dhs = ByteArray(0),
+                ukeyClientInitMsg = ByteArray(0),
+                ukeyServerInitMsg = ByteArray(0),
+                role = D2DRole.CLIENT,
+            )
+        }
+    }
+
+    @Test
+    fun `derivation is deterministic across invocations`() {
+        // Belt-and-braces — HKDF is deterministic by construction, but a
+        // future refactor that accidentally pulls in a per-call random salt
+        // (e.g., to "harden" something) would silently break interop. Lock
+        // the determinism property in.
+        val v = D2DKeyDerivationVectors.primary
+        val first =
+            D2DKeyDerivation.derive(v.dhs, v.ukeyClientInitMsg, v.ukeyServerInitMsg, D2DRole.CLIENT)
+        val second =
+            D2DKeyDerivation.derive(v.dhs, v.ukeyClientInitMsg, v.ukeyServerInitMsg, D2DRole.CLIENT)
+
+        assertThat(first.authString).isEqualTo(second.authString)
+        assertThat(first.nextSecret).isEqualTo(second.nextSecret)
+        assertThat(first.clientEncryptKey).isEqualTo(second.clientEncryptKey)
+        assertThat(first.serverHmacKey).isEqualTo(second.serverHmacKey)
+    }
+
+    @Test
+    fun `toString redacts key material`() {
+        // A `toString` that dumps key bytes is a security regression waiting
+        // to happen — every logger/IDE that ever prints this object would
+        // leak. Lock down that the role is the only field exposed.
+        val v = D2DKeyDerivationVectors.primary
+        val keys =
+            D2DKeyDerivation.derive(v.dhs, v.ukeyClientInitMsg, v.ukeyServerInitMsg, D2DRole.CLIENT)
+        val s = keys.toString()
+        assertThat(s).contains("CLIENT")
+        assertThat(s).contains("redacted")
+        // No accidental hex dumps. Construct a probe from a known key byte's
+        // hex; toString must not contain it.
+        val probe = "%02x".format(keys.clientEncryptKey[0].toInt() and 0xFF)
+        // This is a smoke check — `probe` is two chars and may collide with
+        // unrelated text in the toString. The strong guarantee is the
+        // explicit "redacted" sentinel above; the probe just guards against
+        // an accidental long hex blob.
+        assertThat(s.length).isLessThan(64)
+        // Reference `probe` so the variable isn't flagged as unused; the
+        // value itself is intentionally not asserted on (see comment above).
+        assertThat(probe).isNotEmpty()
+    }
+}


### PR DESCRIPTION
## Summary

Implements the three-stage HKDF-SHA256 derivation chain that turns the UKEY2 handshake's `dhs` into the eight 32-byte keys that gate every Quick Share SecureMessage frame.

Closes #11.

## Derivation chain (byte-for-byte parity with NearDrop)

```
ukeyInfo    = ukeyClientInitMsg || ukeyServerInitMsg     (raw serialized Ukey2Message; NOT length-prefixed)

# Stage 1 — UKEY2
authString  = HKDF-SHA256(ikm = dhs,        salt = "UKEY2 v1 auth", info = ukeyInfo, L = 32)
nextSecret  = HKDF-SHA256(ikm = dhs,        salt = "UKEY2 v1 next", info = ukeyInfo, L = 32)

# Stage 2 — D2D
D2D_salt    = SHA-256("D2D")
            = 0x82AA55A0D397F88346CA1CEE8D3909B95F13FA7DEB1D4AB38376B8256DA85510
d2dClient   = HKDF-SHA256(ikm = nextSecret, salt = D2D_salt,        info = "client", L = 32)
d2dServer   = HKDF-SHA256(ikm = nextSecret, salt = D2D_salt,        info = "server", L = 32)

# Stage 3 — SecureMessage
SM_salt     = SHA-256("SecureMessage")
            = 0xBF9D2A53C63616D75DB0A7165B91C1EF73E537F2427405FA23610A4BE657642E
{client,server}EncryptKey = HKDF-SHA256(ikm = d2d{Client,Server}Key, salt = SM_salt, info = "ENC:2", L = 32)
{client,server}HmacKey    = HKDF-SHA256(ikm = d2d{Client,Server}Key, salt = SM_salt, info = "SIG:1", L = 32)
```

Each salt and info string was verified against NearDrop's `NearbyConnection.swift:finalizeKeyExchange` line-by-line.

## Public surface

- `D2DKeyDerivation.derive(dhs, ukeyClientInitMsg, ukeyServerInitMsg, role): D2DSessionKeys`
- `D2DSessionKeys` bundles the four traffic keys plus the chain inputs/outputs (`authString`, `nextSecret`, `d2dClientKey`, `d2dServerKey`) so that #12 (PIN derivation) and downstream SecureMessage code can consume them without rerunning the chain.
- `D2DSessionKeys.forRole(): DirectionalKeys` is the single place the role swap lives. `CLIENT` sends with `client*`, receives with `server*`; `SERVER` is the mirror.
- `toString` deliberately redacts every key field; equality on the bundle is reference identity (`ByteArray` value equality is reserved for tests via `contentEquals`).

## Test coverage

- KAT in `:core-protocol-test` (`D2DKeyDerivationVectors.primary`) pins all eight derivation outputs against a Python reference that mirrors NearDrop bit-for-bit.
- Salt KATs: `D2D_SALT` and `SECURE_MESSAGE_SALT` are recomputed at test time as `SHA-256("D2D")` / `SHA-256("SecureMessage")` and asserted to equal the hard-coded constants.
- Info-string KATs cover `"UKEY2 v1 auth"`, `"UKEY2 v1 next"`, `"client"`, `"server"`, `"ENC:2"`, `"SIG:1"`.
- Role-swap symmetry test deliberately swaps `CLIENT` <-> `SERVER` and asserts that `forRole()` flips send and receive byte-for-byte (the #1 debugging timesink the issue calls out).
- Determinism, length validation, and `toString` redaction tests round it out.

## Test plan

- [x] `./gradlew :core-protocol:test --tests D2DKeyDerivationTest` — 13 tests pass
- [x] `./gradlew check` — full project lint + tests + detekt + ktlint pass