### PR TITLE
feat: add PayloadTransferFrame chunk reassembly for BYTES and FILE (#14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,15 @@ confidentiality + HMAC-SHA256 for integrity, with strict pre-incremented
 sequence numbers and HMAC-before-decrypt order) lives under
 `...protocol.crypto.securemessage` as `SecureMessageCodec` (stateless
 primitive) and `SecureChannel` (per-connection wrapper around
-`FramedConnection` that reads and writes `OfflineFrame` protos).
+`FramedConnection` that reads and writes `OfflineFrame` protos). One layer
+above the secure channel, `...protocol.payload` reassembles
+`PayloadTransferFrame` chunks into complete BYTES and FILE payloads:
+`PayloadAssembler` validates per-`payload_id` offsets, tolerates Android's
+"two-frame BYTES" quirk on receive, and streams FILE bytes through a
+caller-supplied `FileDestinationFactory` (the Android wiring substitutes
+a `MediaStore` content-URI factory at this seam). The matching encoder,
+`PayloadTransferEncoder`, emits the same two-frame shape on send for
+compatibility with stock Quick Share peers.
 
 ## Toolchain
 

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/payload/FileDestinationFactory.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/payload/FileDestinationFactory.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.payload
+
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.PayloadTransferFrame.PayloadHeader
+import java.nio.channels.WritableByteChannel
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+
+/**
+ * Strategy for choosing the destination of an inbound FILE payload.
+ *
+ * Why a factory and not a fixed [Path]? Quick Share has no notion of
+ * "save into this exact path"; every received file gets a destination
+ * decided by the host platform:
+ *
+ *  - On Android we route the bytes through `MediaStore` / `ContentResolver`
+ *    and end up with a content URI under `Downloads/`. There is no
+ *    `java.io.File` involved at all — the right primitive is a
+ *    [WritableByteChannel] that wraps the `OutputStream` returned by
+ *    `ContentResolver.openOutputStream(uri)`.
+ *  - On the JVM (host-side test harness, or a hypothetical desktop port)
+ *    we want a real file on disk under a configurable directory.
+ *  - For unit tests we want an in-memory channel so we can assert on the
+ *    exact bytes that were written without touching the filesystem.
+ *
+ * `:core-protocol` lives below the platform line (no `android.*` imports
+ * are allowed), so the assembler cannot itself open a `MediaStore`
+ * destination. Instead we accept a factory that the caller — typically
+ * `:service-android` — provides to bridge the gap. The factory is invoked
+ * exactly once per FILE payload, immediately after the assembler observes
+ * the payload's first chunk.
+ *
+ * The factory contract:
+ *  - It MUST return a [WritableByteChannel] in a state ready to accept
+ *    `header.total_size` bytes worth of `write()` calls. The channel is
+ *    opened in *write-from-byte-zero* mode; the assembler does not seek.
+ *  - The assembler closes the channel exactly once: either on the
+ *    `LAST_CHUNK` of a successful payload, or as part of cleanup when a
+ *    later chunk of that payload causes a [PayloadProtocolException]. The
+ *    factory MUST NOT close it itself.
+ *  - If the factory throws, the assembler propagates the exception and
+ *    no channel allocation has leaked.
+ */
+public fun interface FileDestinationFactory {
+    /**
+     * Open a destination channel for the given payload header.
+     *
+     * @param header The full `PayloadHeader` proto for the payload. Carries
+     *   `id`, `total_size`, `file_name`, `parent_folder`, and
+     *   `last_modified_timestamp_millis`. Implementations should use
+     *   `file_name` and `parent_folder` for naming, and may use
+     *   `total_size` to pre-allocate the destination.
+     * @return A [WritableByteChannel] that the assembler will [write][WritableByteChannel.write]
+     *   `total_size` bytes to before closing.
+     */
+    public fun open(header: PayloadHeader): WritableByteChannel
+}
+
+/**
+ * Default [FileDestinationFactory] that writes to a uniquely-named file
+ * under the JVM temp directory. Intended for tests, the JVM-side host
+ * harness, and any code path that has not yet integrated a
+ * platform-specific destination.
+ *
+ * The output filename is `payload-<payloadId>-<sanitizedName>` so a single
+ * test run can complete multiple payloads without colliding. We sanitize
+ * the peer-provided `file_name` (it is attacker-controlled bytes) by
+ * replacing anything that is not `[A-Za-z0-9._-]` with an underscore;
+ * this avoids both directory-traversal-flavored names (`../../etc/passwd`)
+ * and platform-illegal characters that would make the open call throw.
+ *
+ * The destination directory is `${java.io.tmpdir}/wvmg-payload-receive`.
+ * The directory is created lazily; the caller is responsible for cleaning
+ * it up. **Do not use this factory in production** — it leaves files
+ * scattered across the temp dir.
+ */
+public class TempFileDestinationFactory(
+    /**
+     * Override the parent directory if you need a deterministic location
+     * for tests. When `null`, falls back to `${java.io.tmpdir}/wvmg-payload-receive`.
+     */
+    private val baseDirectory: Path? = null,
+) : FileDestinationFactory {
+    override fun open(header: PayloadHeader): WritableByteChannel {
+        val dir = baseDirectory ?: defaultDir()
+        Files.createDirectories(dir)
+        val safeName = sanitize(header.fileName.ifEmpty { "unnamed" })
+        val target = dir.resolve("payload-${header.id}-$safeName")
+        // CREATE_NEW would be ideal for safety, but tests can re-run with
+        // colliding payload ids; TRUNCATE_EXISTING gives us idempotent
+        // open behavior. The assembler writes start at byte zero so this
+        // is correct.
+        return Files.newByteChannel(
+            target,
+            StandardOpenOption.CREATE,
+            StandardOpenOption.WRITE,
+            StandardOpenOption.TRUNCATE_EXISTING,
+        )
+    }
+
+    private fun defaultDir(): Path = Path.of(System.getProperty("java.io.tmpdir"), "wvmg-payload-receive")
+
+    private fun sanitize(name: String): String = name.map { ch -> if (isSafeFileChar(ch)) ch else '_' }.joinToString("")
+
+    /**
+     * Whitelist of characters allowed in a sanitized output filename.
+     * Anything else collapses to `_`. Keeps the safe set tight enough
+     * to neutralize directory traversal / null-byte / control-character
+     * attacks in the peer-supplied `file_name`.
+     */
+    private fun isSafeFileChar(ch: Char): Boolean = ch.isLetterOrDigit() || ch in SAFE_PUNCTUATION
+
+    private companion object {
+        private val SAFE_PUNCTUATION = charArrayOf('.', '-', '_').toSet()
+    }
+}

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/payload/PayloadAssembler.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/payload/PayloadAssembler.kt
@@ -1,0 +1,443 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.payload
+
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.PayloadTransferFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.PayloadTransferFrame.PayloadChunk
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.PayloadTransferFrame.PayloadHeader
+import java.io.ByteArrayOutputStream
+import java.nio.ByteBuffer
+import java.nio.channels.WritableByteChannel
+
+/**
+ * Reassembles `PayloadTransferFrame` chunks into complete BYTES and FILE
+ * payloads.
+ *
+ * Sits one layer above [io.github.kyujincho.wvmg.protocol.crypto.securemessage.SecureChannel]:
+ * the channel hands up decrypted, sequence-validated `OfflineFrame`s; this
+ * class consumes the [PayloadTransferFrame]s nested inside
+ * `OfflineFrame{type=PAYLOAD_TRANSFER}` and surfaces complete payloads via
+ * [PayloadEvent].
+ *
+ * ### Why "reassembly" is non-trivial
+ *
+ * Quick Share splits each application-level payload into one or more
+ * chunks of a peer-chosen size. Three properties make a naive
+ * implementation wrong:
+ *
+ *  1. **Strict in-order requirement.** Each chunk's `offset` MUST equal
+ *     the cumulative byte count we have already received for that
+ *     `payload_id`. The wire is reliable (TCP) but a misbehaving or
+ *     malicious peer can still send an offset that does not line up;
+ *     accepting that would let the peer corrupt the buffer. NearDrop
+ *     rejects this with a protocol error and so do we
+ *     ([PayloadProtocolException]).
+ *  2. **Per-payload state, not per-frame.** Multiple payloads can be
+ *     "in flight" simultaneously (Android's transfer-setup phase
+ *     interleaves a small BYTES negotiation payload with one or more
+ *     large FILE payloads). The `payload_id` keys the buffer/file map.
+ *  3. **Android's two-frame BYTES quirk.** Per `PROTOCOL.md`:
+ *
+ *     > Android does this thing where it sends 2 payload transfer frames
+ *     > in succession for each negotiation message: the first contains
+ *     > the entire message, the second contains 0 bytes but has the
+ *     > `LAST_CHUNK` flag set.
+ *
+ *     The receiver must accept this without error. Our state machine
+ *     handles it naturally: the second frame has `body.size = 0`, its
+ *     `offset` equals the buffer's current length (which is the full
+ *     payload), and its `LAST_CHUNK` flag triggers finalization. No
+ *     special case is needed beyond *not* finalizing on `body.size ==
+ *     total_size` alone — finalization MUST be gated on the LAST_CHUNK
+ *     flag, not on the byte count.
+ *
+ * ### Threading model
+ *
+ * The assembler is **not thread-safe**. Quick Share connections process
+ * exactly one inbound `OfflineFrame` at a time (the `SecureChannel`
+ * receive coroutine holds a mutex), so all calls to [onPayloadTransfer]
+ * are serialized. Adding internal locking would only slow that hot path
+ * for no benefit.
+ *
+ * ### Send-side helpers
+ *
+ * [PayloadTransferEncoder] is the matching encoder for outbound BYTES
+ * (and FILE) payloads, including the two-frame BYTES quirk on send.
+ *
+ * @param fileDestinationFactory Strategy for opening write channels for
+ *   FILE payloads. Default is [TempFileDestinationFactory], suitable for
+ *   tests; production wiring on Android replaces this with a factory
+ *   that opens a `MediaStore` content URI.
+ * @param saneFrameLength Maximum allowed `total_size` for BYTES payloads.
+ *   Anything larger is rejected immediately, before any allocation, to
+ *   keep a malicious peer from making us reserve hundreds of MiB of
+ *   heap. 5 MiB matches Android Quick Share's negotiation message
+ *   ceiling — actual file content is sent as FILE payloads, not BYTES.
+ */
+public class PayloadAssembler(
+    private val fileDestinationFactory: FileDestinationFactory = TempFileDestinationFactory(),
+    private val saneFrameLength: Int = DEFAULT_SANE_FRAME_LENGTH,
+) {
+    // ------------------------------------------------------------------
+    // Per-payload state
+    // ------------------------------------------------------------------
+
+    /**
+     * In-flight BYTES payload. Holds the accumulated buffer and the
+     * payload's first-seen header (used to keep [PayloadEvent.BytesComplete]
+     * faithful to the original `payload_id` even if a future chunk
+     * legally omits the header).
+     */
+    private class BytesState(
+        val header: PayloadHeader,
+        val buffer: ByteArrayOutputStream,
+    )
+
+    /**
+     * In-flight FILE payload. Tracks the destination channel, the byte
+     * count we have written so far, and the original header.
+     */
+    private class FileState(
+        val header: PayloadHeader,
+        val channel: WritableByteChannel,
+        var bytesWritten: Long,
+    )
+
+    private val bytesInFlight: MutableMap<Long, BytesState> = HashMap()
+    private val filesInFlight: MutableMap<Long, FileState> = HashMap()
+
+    // ------------------------------------------------------------------
+    // Public API
+    // ------------------------------------------------------------------
+
+    /**
+     * Feed one `PayloadTransferFrame` to the assembler.
+     *
+     * @return [PayloadEvent] describing the effect of this frame.
+     *   Never `null` — every frame produces some event (an
+     *   [PayloadEvent.Ignored] for non-DATA packets, [PayloadEvent.Progress]
+     *   mid-stream, or one of the terminal events on the final chunk).
+     * @throws PayloadProtocolException if the frame violates a
+     *   reassembly invariant. The assembler cleans up any state
+     *   associated with the offending `payload_id` before throwing,
+     *   so a caller that recovers (e.g. tests) does not see a leaked
+     *   buffer or open channel. The connection itself MUST be closed
+     *   by the caller — there is no resync.
+     */
+    @Suppress("ThrowsCount") // One throw per malformed-frame variant; merging would lose error context.
+    public fun onPayloadTransfer(frame: PayloadTransferFrame): PayloadEvent {
+        // Quick Share defines three packet types: DATA, CONTROL, and
+        // PAYLOAD_ACK. Reassembly only applies to DATA. CONTROL frames
+        // (PAYLOAD_ERROR, PAYLOAD_CANCELED) and PAYLOAD_ACK frames go
+        // straight up to the higher state machine; the assembler reports
+        // them as [Ignored] so the caller has a chance to log or react.
+        if (frame.packetType != PayloadTransferFrame.PacketType.DATA) {
+            return PayloadEvent.Ignored(
+                "non-DATA packet_type=${frame.packetType.name} not consumed by reassembler",
+            )
+        }
+
+        // DATA packets must carry both a header and a chunk. Reject the
+        // malformed shapes early so downstream code can rely on both
+        // being present.
+        if (!frame.hasPayloadHeader()) {
+            throw PayloadProtocolException("DATA PayloadTransferFrame missing payload_header")
+        }
+        if (!frame.hasPayloadChunk()) {
+            throw PayloadProtocolException("DATA PayloadTransferFrame missing payload_chunk")
+        }
+        val header = frame.payloadHeader
+        val chunk = frame.payloadChunk
+        val payloadId = header.id
+
+        return when (header.type) {
+            PayloadHeader.PayloadType.BYTES -> handleBytes(payloadId, header, chunk)
+            PayloadHeader.PayloadType.FILE -> handleFile(payloadId, header, chunk)
+            // STREAM is part of the proto but not used by Quick Share's
+            // file/text transport; UNKNOWN is the proto's default for an
+            // unset enum. Either is a protocol error here.
+            PayloadHeader.PayloadType.STREAM,
+            PayloadHeader.PayloadType.UNKNOWN_PAYLOAD_TYPE,
+            null,
+            -> throw PayloadProtocolException(
+                "Unsupported payload type ${header.type} for payload_id=$payloadId",
+            )
+        }
+    }
+
+    /**
+     * Number of payloads currently mid-stream (not yet `LAST_CHUNK`-ed).
+     * Visible for diagnostics and for tests that assert state cleanup.
+     */
+    public val inFlightPayloadCount: Int
+        get() = bytesInFlight.size + filesInFlight.size
+
+    /**
+     * Drop all in-flight state. Closes any open file channels (best-effort —
+     * an `IOException` on close is suppressed so a single failing channel
+     * does not strand the others). Use during connection teardown to
+     * release resources without leaking partial files.
+     */
+    public fun reset() {
+        bytesInFlight.clear()
+        for (state in filesInFlight.values) {
+            runCatching { state.channel.close() }
+        }
+        filesInFlight.clear()
+    }
+
+    // ------------------------------------------------------------------
+    // BYTES path
+    // ------------------------------------------------------------------
+
+    /**
+     * Apply one chunk of a BYTES payload.
+     *
+     * BYTES payloads carry negotiation messages (paired-key encryption,
+     * introduction frames, the small text-share protobuf). They are
+     * always small — capped at [saneFrameLength] — so we buffer in heap.
+     *
+     * The Android two-frame quirk is handled here implicitly: the second
+     * frame has `body.size == 0`, `offset == buffer.size`, and the
+     * LAST_CHUNK flag set. The offset check passes, the empty append is
+     * a no-op, and the flag check finalizes.
+     */
+    @Suppress("ThrowsCount") // Each throw documents a distinct BYTES-reassembly invariant.
+    private fun handleBytes(
+        payloadId: Long,
+        header: PayloadHeader,
+        chunk: PayloadChunk,
+    ): PayloadEvent {
+        val state =
+            bytesInFlight[payloadId] ?: run {
+                // First chunk for this payload: validate total_size BEFORE
+                // any allocation (defense-in-depth against a peer that
+                // claims a 4 GiB BYTES "negotiation" message).
+                if (header.totalSize > saneFrameLength) {
+                    throw PayloadProtocolException(
+                        "BYTES payload_id=$payloadId total_size=${header.totalSize} " +
+                            "exceeds saneFrameLength=$saneFrameLength",
+                    )
+                }
+                if (header.totalSize < 0) {
+                    throw PayloadProtocolException(
+                        "BYTES payload_id=$payloadId has negative total_size=${header.totalSize}",
+                    )
+                }
+                // initialCapacity = total_size: most BYTES payloads
+                // arrive in one frame, so this avoids the doubling
+                // re-allocation. Cap at saneFrameLength (already enforced
+                // above) so we cannot pre-allocate beyond the limit.
+                BytesState(
+                    header = header,
+                    buffer = ByteArrayOutputStream(header.totalSize.toInt().coerceAtLeast(0)),
+                ).also { bytesInFlight[payloadId] = it }
+            }
+
+        val bufferLen = state.buffer.size().toLong()
+        if (chunk.offset != bufferLen) {
+            // Cleanup before throw — a partial buffer would otherwise
+            // pin memory until the connection is torn down.
+            bytesInFlight.remove(payloadId)
+            throw PayloadProtocolException(
+                "BYTES payload_id=$payloadId chunk offset=${chunk.offset} " +
+                    "does not match buffer size=$bufferLen",
+            )
+        }
+
+        // Re-validate total_size against the running buffer+body length
+        // before we write. This protects the receiver if a peer were to
+        // grow `total_size` mid-stream or send more body than declared.
+        val body = chunk.body
+        val newLen = bufferLen + body.size().toLong()
+        if (newLen > state.header.totalSize) {
+            bytesInFlight.remove(payloadId)
+            throw PayloadProtocolException(
+                "BYTES payload_id=$payloadId chunk would extend buffer to $newLen, " +
+                    "exceeding declared total_size=${state.header.totalSize}",
+            )
+        }
+
+        if (!body.isEmpty) {
+            // ByteString.writeTo is the most direct path; it iterates
+            // internal segments and writes to the OutputStream without
+            // an intermediate copy.
+            body.writeTo(state.buffer)
+        }
+
+        return if ((chunk.flags and LAST_CHUNK_FLAG) != 0) {
+            // LAST_CHUNK arrived. Hand the buffer up and drop state.
+            // Verify the assembled byte count matches what was advertised:
+            // a LAST_CHUNK that arrives short would otherwise leave the
+            // higher layer with a truncated negotiation message.
+            val finalLen = state.buffer.size().toLong()
+            if (finalLen != state.header.totalSize) {
+                bytesInFlight.remove(payloadId)
+                throw PayloadProtocolException(
+                    "BYTES payload_id=$payloadId LAST_CHUNK at $finalLen bytes " +
+                        "differs from declared total_size=${state.header.totalSize}",
+                )
+            }
+            bytesInFlight.remove(payloadId)
+            PayloadEvent.BytesComplete(payloadId, state.buffer.toByteArray())
+        } else {
+            PayloadEvent.Progress(
+                payloadId = payloadId,
+                bytesReceived = state.buffer.size().toLong(),
+                totalSize = state.header.totalSize,
+                type = PayloadHeader.PayloadType.BYTES,
+            )
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // FILE path
+    // ------------------------------------------------------------------
+
+    /**
+     * Apply one chunk of a FILE payload.
+     *
+     * FILE payloads can be GB-scale. We never buffer in memory — every
+     * chunk's body is written straight through to the
+     * [WritableByteChannel] that the [fileDestinationFactory] returned
+     * for this payload. The factory is invoked exactly once, on the
+     * first chunk; we bail out if the per-chunk offset disagrees with
+     * the running write count, the same way NearDrop does.
+     */
+    @Suppress(
+        "ThrowsCount", // Each throw documents a distinct FILE-reassembly invariant.
+        "NestedBlockDepth", // Streaming-write loop + close cleanup is inherently nested.
+    )
+    private fun handleFile(
+        payloadId: Long,
+        header: PayloadHeader,
+        chunk: PayloadChunk,
+    ): PayloadEvent {
+        val state =
+            filesInFlight[payloadId] ?: run {
+                if (header.totalSize < 0) {
+                    throw PayloadProtocolException(
+                        "FILE payload_id=$payloadId has negative total_size=${header.totalSize}",
+                    )
+                }
+                // The factory may throw — if it does, we have not
+                // registered any state yet, so there is nothing to
+                // clean up.
+                val channel = fileDestinationFactory.open(header)
+                FileState(header, channel, bytesWritten = 0L).also {
+                    filesInFlight[payloadId] = it
+                }
+            }
+
+        val written = state.bytesWritten
+        if (chunk.offset != written) {
+            // Match NearDrop's cleanup behavior: drop the in-flight
+            // record but also close the destination channel so the
+            // partial file is at least flushed.
+            filesInFlight.remove(payloadId)
+            runCatching { state.channel.close() }
+            throw PayloadProtocolException(
+                "FILE payload_id=$payloadId chunk offset=${chunk.offset} " +
+                    "does not match bytes written=$written",
+            )
+        }
+
+        val body = chunk.body
+        val bodySize = body.size()
+        val newWritten = written + bodySize.toLong()
+        if (newWritten > state.header.totalSize) {
+            filesInFlight.remove(payloadId)
+            runCatching { state.channel.close() }
+            throw PayloadProtocolException(
+                "FILE payload_id=$payloadId chunk would write past total_size=" +
+                    "${state.header.totalSize} (current=$written, body=$bodySize)",
+            )
+        }
+
+        if (bodySize > 0) {
+            // Copy through ByteBuffer: ByteString does not expose a
+            // zero-copy `WritableByteChannel.write` directly, but its
+            // `asReadOnlyByteBufferList()` lets us hand the channel an
+            // already-prepared buffer. For most chunks the list has a
+            // single segment; we still loop in case a peer sends a
+            // segmented body.
+            try {
+                for (segment in body.asReadOnlyByteBufferList()) {
+                    while (segment.hasRemaining()) {
+                        state.channel.write(segment)
+                    }
+                }
+            } catch (e: java.io.IOException) {
+                filesInFlight.remove(payloadId)
+                runCatching { state.channel.close() }
+                throw PayloadProtocolException(
+                    "FILE payload_id=$payloadId write to destination channel failed",
+                    e,
+                )
+            }
+            state.bytesWritten = newWritten
+        }
+
+        return if ((chunk.flags and LAST_CHUNK_FLAG) != 0) {
+            // LAST_CHUNK: the file is complete. Validate the running
+            // count matches the declared total_size and close the
+            // channel. The factory does not own close; we do.
+            if (state.bytesWritten != state.header.totalSize) {
+                filesInFlight.remove(payloadId)
+                runCatching { state.channel.close() }
+                throw PayloadProtocolException(
+                    "FILE payload_id=$payloadId LAST_CHUNK at ${state.bytesWritten} bytes " +
+                        "differs from declared total_size=${state.header.totalSize}",
+                )
+            }
+            filesInFlight.remove(payloadId)
+            try {
+                state.channel.close()
+            } catch (e: java.io.IOException) {
+                throw PayloadProtocolException(
+                    "FILE payload_id=$payloadId failed to close destination channel",
+                    e,
+                )
+            }
+            PayloadEvent.FileComplete(payloadId, state.header, state.bytesWritten)
+        } else {
+            PayloadEvent.Progress(
+                payloadId = payloadId,
+                bytesReceived = state.bytesWritten,
+                totalSize = state.header.totalSize,
+                type = PayloadHeader.PayloadType.FILE,
+            )
+        }
+    }
+
+    // Used only for the `ByteBuffer.write` no-op branch. Kept as a
+    // private helper so the call site reads naturally.
+    @Suppress("unused")
+    private fun WritableByteChannel.writeAll(buffer: ByteBuffer) {
+        while (buffer.hasRemaining()) write(buffer)
+    }
+
+    public companion object {
+        /**
+         * `LAST_CHUNK` bit in `PayloadChunk.flags`, copied from the proto
+         * enum so the assembler's hot path does not pay a name-resolution
+         * cost on every chunk.
+         */
+        public const val LAST_CHUNK_FLAG: Int = 0x1
+
+        /**
+         * Default `total_size` cap for BYTES payloads. 5 MiB matches the
+         * upper bound Android's Quick Share enforces on negotiation
+         * messages; actual file content is always sent as FILE payloads
+         * (which stream straight to disk and have no in-memory cap).
+         *
+         * Exposed publicly so tests can dial it down to drive the
+         * oversized-BYTES rejection path without allocating 5 MiB of test
+         * vector bytes.
+         */
+        public const val DEFAULT_SANE_FRAME_LENGTH: Int = 5 * 1024 * 1024
+    }
+}

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/payload/PayloadAssembler.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/payload/PayloadAssembler.kt
@@ -8,8 +8,8 @@ package io.github.kyujincho.wvmg.protocol.payload
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.PayloadTransferFrame
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.PayloadTransferFrame.PayloadChunk
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.PayloadTransferFrame.PayloadHeader
+import io.github.kyujincho.wvmg.protocol.transport.FramedConnection
 import java.io.ByteArrayOutputStream
-import java.nio.ByteBuffer
 import java.nio.channels.WritableByteChannel
 
 /**
@@ -413,13 +413,6 @@ public class PayloadAssembler(
         }
     }
 
-    // Used only for the `ByteBuffer.write` no-op branch. Kept as a
-    // private helper so the call site reads naturally.
-    @Suppress("unused")
-    private fun WritableByteChannel.writeAll(buffer: ByteBuffer) {
-        while (buffer.hasRemaining()) write(buffer)
-    }
-
     public companion object {
         /**
          * `LAST_CHUNK` bit in `PayloadChunk.flags`, copied from the proto
@@ -429,15 +422,19 @@ public class PayloadAssembler(
         public const val LAST_CHUNK_FLAG: Int = 0x1
 
         /**
-         * Default `total_size` cap for BYTES payloads. 5 MiB matches the
-         * upper bound Android's Quick Share enforces on negotiation
-         * messages; actual file content is always sent as FILE payloads
-         * (which stream straight to disk and have no in-memory cap).
+         * Default `total_size` cap for BYTES payloads. Anchored to
+         * [FramedConnection.SANE_FRAME_LENGTH] so the assembler-level cap
+         * never exceeds what the transport will even let onto the wire:
+         * a single decrypted `OfflineFrame` cannot be larger than the
+         * frame size cap, so a BYTES payload that fits in one chunk
+         * cannot exceed it either, and even multi-chunk BYTES is
+         * naturally bounded by what the higher protocol uses BYTES for
+         * (small negotiation messages).
          *
          * Exposed publicly so tests can dial it down to drive the
-         * oversized-BYTES rejection path without allocating 5 MiB of test
-         * vector bytes.
+         * oversized-BYTES rejection path without allocating megabytes of
+         * test vector bytes.
          */
-        public const val DEFAULT_SANE_FRAME_LENGTH: Int = 5 * 1024 * 1024
+        public const val DEFAULT_SANE_FRAME_LENGTH: Int = FramedConnection.SANE_FRAME_LENGTH
     }
 }

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/payload/PayloadEvent.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/payload/PayloadEvent.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.payload
+
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.PayloadTransferFrame.PayloadHeader
+
+/**
+ * Result of feeding a single `PayloadTransferFrame` into [PayloadAssembler].
+ *
+ * The assembler is fundamentally a state machine that consumes one chunk at
+ * a time. Most chunks merely advance internal state and return
+ * [Progress] (or [Ignored] for non-DATA packets we do not assemble). Only
+ * the final chunk of a payload — the one carrying `LAST_CHUNK` — produces a
+ * terminal event ([BytesComplete] or [FileComplete]).
+ *
+ * The sealed hierarchy lets the higher-level state machine (issue #15+)
+ * dispatch on the *kind* of progress without having to inspect the proto
+ * itself, and lets unit tests assert on a typed value rather than on a
+ * grab-bag of out parameters.
+ *
+ * ### Why this is a return value rather than a callback
+ *
+ * The receive coroutine in [io.github.kyujincho.wvmg.protocol.crypto.securemessage.SecureChannel]
+ * already owns the read loop. Letting the assembler return events lets the
+ * caller decide what to do (forward up the stack, log, drop) without
+ * pulling coroutine machinery into the assembler itself. This keeps the
+ * assembler a pure synchronous state machine that is trivially unit
+ * testable on the JVM.
+ */
+public sealed interface PayloadEvent {
+    /**
+     * Emitted on every non-final DATA chunk of an in-flight payload. The
+     * caller can use [bytesReceived] / [totalSize] to drive a progress UI
+     * (FILE payloads can be GB-scale, so per-chunk progress matters).
+     *
+     * @property payloadId The `PayloadHeader.id` this chunk belonged to.
+     * @property bytesReceived Cumulative bytes the assembler has buffered
+     *   (BYTES) or written (FILE) for this payload after this chunk.
+     * @property totalSize The advertised `PayloadHeader.total_size`. Equal
+     *   to `0` if the peer omitted the header (allowed mid-stream); the
+     *   first chunk of any new payload must include it.
+     * @property type BYTES or FILE — surfaced so callers can decide
+     *   whether to even render progress (BYTES messages flash by too
+     *   quickly to bother).
+     */
+    public data class Progress(
+        val payloadId: Long,
+        val bytesReceived: Long,
+        val totalSize: Long,
+        val type: PayloadHeader.PayloadType,
+    ) : PayloadEvent
+
+    /**
+     * Emitted when a BYTES payload's `LAST_CHUNK` chunk has been
+     * consumed and the buffer is complete.
+     *
+     * The buffer is handed up as a fresh [ByteArray] (no aliasing into
+     * internal state) so the caller can pass it into protobuf parsers or
+     * keep it around without worrying about the assembler mutating it
+     * underneath them.
+     *
+     * @property payloadId The completed payload's id.
+     * @property data Assembled bytes. May be empty (a peer is allowed to
+     *   send a zero-length BYTES payload — and Android's two-frame quirk
+     *   means most frames are followed by an empty trailer).
+     */
+    public data class BytesComplete(
+        val payloadId: Long,
+        val data: ByteArray,
+    ) : PayloadEvent {
+        // ByteArray uses identity equals by default, which is wrong for
+        // a value-type event. Override so tests and the higher layer can
+        // compare events by content.
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is BytesComplete) return false
+            return payloadId == other.payloadId && data.contentEquals(other.data)
+        }
+
+        override fun hashCode(): Int = 31 * payloadId.hashCode() + data.contentHashCode()
+    }
+
+    /**
+     * Emitted when a FILE payload's `LAST_CHUNK` chunk has been
+     * consumed and the destination [java.nio.channels.WritableByteChannel]
+     * has been closed.
+     *
+     * The assembler does NOT hand back the channel itself — the caller
+     * provided it via the factory and is responsible for any post-close
+     * action (renaming the temp file into MediaStore, computing checksums,
+     * etc.). The event simply confirms that:
+     *  - The full `total_size` worth of bytes was written.
+     *  - The channel was closed exactly once.
+     *
+     * @property payloadId The completed payload's id.
+     * @property header The `PayloadHeader` that opened this payload. Carries
+     *   `file_name`, `parent_folder`, `total_size`, and the original
+     *   `last_modified_timestamp_millis`. Useful for the post-completion
+     *   move into the user's Downloads folder / MediaStore entry.
+     * @property bytesWritten Number of body bytes actually written to the
+     *   channel. By contract this is always equal to `header.total_size`
+     *   on a successful completion (the assembler refuses to LAST_CHUNK
+     *   short).
+     */
+    public data class FileComplete(
+        val payloadId: Long,
+        val header: PayloadHeader,
+        val bytesWritten: Long,
+    ) : PayloadEvent
+
+    /**
+     * Emitted for `PayloadTransferFrame`s whose `packet_type` is not
+     * `DATA` — i.e. `CONTROL` (cancel / error) and `PAYLOAD_ACK`. The
+     * assembler does not own that state, so it just reports the
+     * occurrence and the caller decides what to do.
+     *
+     * @property reason Short, English-only description of why the frame
+     *   was not assembled. Suitable for logging.
+     */
+    public data class Ignored(
+        val reason: String,
+    ) : PayloadEvent
+}

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/payload/PayloadProtocolException.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/payload/PayloadProtocolException.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.payload
+
+/**
+ * Thrown by [PayloadAssembler] for any unrecoverable protocol violation
+ * detected while reassembling `PayloadTransferFrame` chunks.
+ *
+ * Mirrors the discipline of
+ * [io.github.kyujincho.wvmg.protocol.crypto.securemessage.SequenceNumberMismatchException]:
+ * every condition that throws this is **fatal to the connection** because
+ * Quick Share has no resync protocol below the SecureChannel layer. The
+ * higher-level state machine MUST close the connection on receipt — it
+ * MUST NOT try to ignore the error and continue reading frames, because the
+ * peer is now byte-misaligned with us in a way we cannot recover from.
+ *
+ * The assembler does its own state cleanup (drops the buffer or closes the
+ * file channel for the offending `payload_id`) before throwing, so the
+ * caller does not need to do anything beyond closing the connection.
+ *
+ * @param message Human-readable, English-only description of the
+ *   violation. Intended for logging, not for surfacing to end users.
+ * @param cause Optional underlying exception (e.g. an
+ *   [java.io.IOException] from a failed `WritableByteChannel.write`).
+ */
+public class PayloadProtocolException(
+    message: String,
+    cause: Throwable? = null,
+) : RuntimeException(message, cause)

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/payload/PayloadTransferEncoder.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/payload/PayloadTransferEncoder.kt
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.payload
+
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.PayloadTransferFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.PayloadTransferFrame.PayloadChunk
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.PayloadTransferFrame.PayloadHeader
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.V1Frame
+import com.google.protobuf.ByteString
+import java.nio.ByteBuffer
+import java.nio.channels.ReadableByteChannel
+
+/**
+ * Encoder side of the `PayloadTransferFrame` exchange.
+ *
+ * Where [PayloadAssembler] consumes inbound chunks, [PayloadTransferEncoder]
+ * builds outbound chunks. Splitting send and receive into separate types
+ * keeps each focused — the assembler's hot path is concerned with
+ * mutation of in-flight state, while the encoder is purely functional.
+ *
+ * Each helper returns one or more `OfflineFrame`s already wrapped in
+ * `OfflineFrame{version=V1, v1.type=PAYLOAD_TRANSFER, v1.payload_transfer=...}`.
+ * The caller's send loop is then a one-liner per frame:
+ *
+ * ```
+ * for (frame in PayloadTransferEncoder.encodeBytesPayload(id, data)) {
+ *     secureChannel.sendOfflineFrame(frame)
+ * }
+ * ```
+ *
+ * No internal state is held — encoder calls are idempotent.
+ */
+public object PayloadTransferEncoder {
+    /**
+     * Default chunk size for outbound FILE payloads. 512 KiB is the
+     * size NearDrop and Android's Quick Share both use; smaller chunks
+     * waste round-trips on the SecureMessage envelope, larger chunks
+     * eat into the TCP send buffer and stall progress reporting.
+     */
+    public const val DEFAULT_FILE_CHUNK_SIZE: Int = 512 * 1024
+
+    /**
+     * Encode an outbound BYTES payload.
+     *
+     * Returns exactly **two** `OfflineFrame`s per the Android Quick Share
+     * convention documented in NearDrop's `PROTOCOL.md`:
+     *
+     *   1. **Data frame**: full body, `offset = 0`, `flags = 0`. The
+     *      receiver buffers the body but does NOT finalize, because
+     *      `LAST_CHUNK` is not yet set.
+     *   2. **Terminator frame**: empty body, `offset = data.size`,
+     *      `flags = LAST_CHUNK`. This is the famous "second frame with
+     *      0 bytes" — every receiver in the Quick Share ecosystem
+     *      tolerates it because it MUST tolerate Android, and Android
+     *      always sends it.
+     *
+     * NearDrop, the macOS reference implementation, does the same in
+     * `sendBytesPayload`. We follow that pattern here for compatibility:
+     * peers that branch on "is this Android?" by counting frames will
+     * still recognize us.
+     *
+     * @param payloadId The negotiation `payload_id`. Each higher-level
+     *   message MUST use a fresh id; reusing an id while the receiver
+     *   still has the old one in its buffer would cause an offset
+     *   mismatch on the receiver side.
+     * @param data Body bytes. May be empty — a zero-length BYTES payload
+     *   still emits two frames (the data frame is empty + flags=0; the
+     *   terminator is empty + flags=LAST_CHUNK + offset=0). Both pass
+     *   the assembler's offset check.
+     * @return List of size 2 in the order (data, terminator). The caller
+     *   sends them sequentially through the same SecureChannel without
+     *   interleaving any other writes.
+     */
+    public fun encodeBytesPayload(
+        payloadId: Long,
+        data: ByteArray,
+    ): List<OfflineFrame> {
+        val totalSize = data.size.toLong()
+        val header =
+            PayloadHeader
+                .newBuilder()
+                .setId(payloadId)
+                .setType(PayloadHeader.PayloadType.BYTES)
+                .setTotalSize(totalSize)
+                .setIsSensitive(false)
+                .build()
+
+        val dataChunk =
+            PayloadChunk
+                .newBuilder()
+                .setFlags(0)
+                .setOffset(0L)
+                .setBody(ByteString.copyFrom(data))
+                .build()
+
+        val terminatorChunk =
+            PayloadChunk
+                .newBuilder()
+                .setFlags(PayloadAssembler.LAST_CHUNK_FLAG)
+                .setOffset(totalSize)
+                .setBody(ByteString.EMPTY)
+                .build()
+
+        return listOf(
+            wrap(header, dataChunk),
+            wrap(header, terminatorChunk),
+        )
+    }
+
+    /**
+     * Encode an outbound FILE payload.
+     *
+     * Reads bytes from [source] in chunks of [chunkSize] and emits one
+     * `OfflineFrame` per chunk. The last chunk carries the `LAST_CHUNK`
+     * flag.
+     *
+     * Unlike the BYTES encoder, the FILE encoder does **not** emit a
+     * trailing zero-byte terminator. The Android two-frame quirk is
+     * specific to BYTES (negotiation messages); FILE payloads end with
+     * the last data chunk having `LAST_CHUNK` set directly. NearDrop's
+     * file send path does the same.
+     *
+     * The function is implemented as a [Sequence] so the caller's send
+     * loop reads exactly one chunk at a time and pushes it through the
+     * SecureChannel, never holding the entire file in memory.
+     *
+     * @param payloadId The file's `payload_id`. Reusing an id mid-stream
+     *   would corrupt the receiver, same caution as for BYTES.
+     * @param fileName Used as `PayloadHeader.file_name`. Receivers
+     *   typically use this for the on-disk name (after sanitization).
+     * @param totalSize Bytes available to read from [source]. The encoder
+     *   trusts the caller; if [source] yields fewer bytes the last
+     *   chunk will simply be smaller, but the receiver will still
+     *   reject the payload as undersized.
+     * @param source A [ReadableByteChannel] positioned at the start of
+     *   the file. The encoder consumes bytes serially and does not
+     *   close the channel — the caller does.
+     * @param chunkSize Bytes per chunk. Default 512 KiB.
+     * @param lastModifiedTimestampMillis Mirror onto the proto for the
+     *   receiver's metadata pass-through.
+     * @param parentFolder Optional parent folder hint — Quick Share
+     *   exposes this for archive-style multi-file transfers.
+     */
+    @Suppress("LongParameterList") // The PayloadHeader has many optional fields; we mirror them faithfully.
+    public fun encodeFilePayload(
+        payloadId: Long,
+        fileName: String,
+        totalSize: Long,
+        source: ReadableByteChannel,
+        chunkSize: Int = DEFAULT_FILE_CHUNK_SIZE,
+        lastModifiedTimestampMillis: Long = 0L,
+        parentFolder: String = "",
+    ): Sequence<OfflineFrame> {
+        require(chunkSize > 0) { "chunkSize must be positive, got $chunkSize" }
+        require(totalSize >= 0) { "totalSize must be non-negative, got $totalSize" }
+
+        val header =
+            PayloadHeader
+                .newBuilder()
+                .setId(payloadId)
+                .setType(PayloadHeader.PayloadType.FILE)
+                .setTotalSize(totalSize)
+                .setFileName(fileName)
+                .setParentFolder(parentFolder)
+                .setLastModifiedTimestampMillis(lastModifiedTimestampMillis)
+                .setIsSensitive(false)
+                .build()
+
+        return sequence {
+            // Special case: a zero-byte file must still produce one
+            // frame (with body empty and LAST_CHUNK set), otherwise the
+            // receiver never sees a terminating chunk.
+            if (totalSize == 0L) {
+                yield(
+                    wrap(
+                        header,
+                        PayloadChunk
+                            .newBuilder()
+                            .setFlags(PayloadAssembler.LAST_CHUNK_FLAG)
+                            .setOffset(0L)
+                            .setBody(ByteString.EMPTY)
+                            .build(),
+                    ),
+                )
+                return@sequence
+            }
+
+            val readBuffer = ByteBuffer.allocate(chunkSize)
+            var offset = 0L
+            while (offset < totalSize) {
+                readBuffer.clear()
+                // Cap the read at remaining bytes so we never overshoot
+                // the advertised total_size, even if the source channel
+                // would yield more bytes.
+                val remaining = (totalSize - offset).coerceAtMost(chunkSize.toLong()).toInt()
+                readBuffer.limit(remaining)
+
+                var read = 0
+                while (read < remaining) {
+                    val n = source.read(readBuffer)
+                    if (n < 0) break
+                    read += n
+                }
+                readBuffer.flip()
+
+                val isLast = offset + read >= totalSize
+                val chunk =
+                    PayloadChunk
+                        .newBuilder()
+                        .setFlags(if (isLast) PayloadAssembler.LAST_CHUNK_FLAG else 0)
+                        .setOffset(offset)
+                        .setBody(ByteString.copyFrom(readBuffer))
+                        .build()
+                yield(wrap(header, chunk))
+                offset += read.toLong()
+                // If the source ran out before we hit total_size we still
+                // emit what we read; the receiver will surface the
+                // mismatch as a protocol error and we let it.
+                if (read == 0) break
+            }
+        }
+    }
+
+    /**
+     * Build a fully-typed `OfflineFrame{V1, PAYLOAD_TRANSFER, ...}` from a
+     * header+chunk pair. Centralizes the wrapping so individual encoder
+     * functions do not duplicate the boilerplate.
+     */
+    private fun wrap(
+        header: PayloadHeader,
+        chunk: PayloadChunk,
+    ): OfflineFrame {
+        val transfer =
+            PayloadTransferFrame
+                .newBuilder()
+                .setPacketType(PayloadTransferFrame.PacketType.DATA)
+                .setPayloadHeader(header)
+                .setPayloadChunk(chunk)
+                .build()
+        return OfflineFrame
+            .newBuilder()
+            .setVersion(OfflineFrame.Version.V1)
+            .setV1(
+                V1Frame
+                    .newBuilder()
+                    .setType(V1Frame.FrameType.PAYLOAD_TRANSFER)
+                    .setPayloadTransfer(transfer),
+            ).build()
+    }
+}

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/payload/PayloadAssemblerTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/payload/PayloadAssemblerTest.kt
@@ -1,0 +1,885 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.payload
+
+import com.google.common.truth.Truth.assertThat
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.PayloadTransferFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.PayloadTransferFrame.PayloadChunk
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.PayloadTransferFrame.PayloadHeader
+import com.google.protobuf.ByteString
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.io.ByteArrayOutputStream
+import java.nio.ByteBuffer
+import java.nio.channels.Channels
+import java.nio.channels.WritableByteChannel
+import kotlin.random.Random
+
+/**
+ * Tests for [PayloadAssembler].
+ *
+ * Coverage maps directly onto the issue #14 acceptance criteria:
+ *
+ *  - Single-frame BYTES (the non-Android shape) reassembles cleanly.
+ *  - The Android two-frame BYTES quirk is accepted (data + zero-body
+ *    LAST_CHUNK).
+ *  - Out-of-order chunks (offset != buffer.size) are rejected with
+ *    [PayloadProtocolException].
+ *  - BYTES `total_size > saneFrameLength` is rejected before allocation.
+ *  - FILE payloads stream chunks straight to the
+ *    [WritableByteChannel] returned by the factory; on LAST_CHUNK the
+ *    channel is closed exactly once.
+ *  - FILE chunks that would write past `total_size` are rejected.
+ *  - Multiple payloads multiplexed by `payload_id` interleave correctly.
+ *  - Non-DATA packet types surface as [PayloadEvent.Ignored] without
+ *    affecting state.
+ */
+@Suppress(
+    "LargeClass", // The state machine has many invariants; one test per invariant is the discipline.
+    "LongParameterList", // The chunkFrame helper mirrors the proto field set; merging would obscure tests.
+)
+class PayloadAssemblerTest {
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    /**
+     * Build a `PayloadTransferFrame` for a chunk of a BYTES or FILE
+     * payload. Centralizes the boilerplate so the test bodies focus on
+     * the assertion under exercise.
+     */
+    private fun chunkFrame(
+        payloadId: Long,
+        type: PayloadHeader.PayloadType,
+        totalSize: Long,
+        offset: Long,
+        body: ByteArray,
+        lastChunk: Boolean,
+        fileName: String = "",
+        packetType: PayloadTransferFrame.PacketType = PayloadTransferFrame.PacketType.DATA,
+    ): PayloadTransferFrame {
+        val header =
+            PayloadHeader
+                .newBuilder()
+                .setId(payloadId)
+                .setType(type)
+                .setTotalSize(totalSize)
+                .setFileName(fileName)
+                .build()
+        val chunk =
+            PayloadChunk
+                .newBuilder()
+                .setFlags(if (lastChunk) PayloadAssembler.LAST_CHUNK_FLAG else 0)
+                .setOffset(offset)
+                .setBody(ByteString.copyFrom(body))
+                .build()
+        return PayloadTransferFrame
+            .newBuilder()
+            .setPacketType(packetType)
+            .setPayloadHeader(header)
+            .setPayloadChunk(chunk)
+            .build()
+    }
+
+    /**
+     * Capturing [FileDestinationFactory] that hands every payload an
+     * in-memory [java.io.ByteArrayOutputStream] wrapped as a
+     * [WritableByteChannel]. Tests can read back what was written via
+     * [outputs] and inspect [opened] / [closed] counters to confirm the
+     * channel lifecycle.
+     */
+    private class CapturingFactory : FileDestinationFactory {
+        val outputs: MutableMap<Long, ByteArrayOutputStream> = HashMap()
+        var opened: Int = 0
+            private set
+        var closed: Int = 0
+            private set
+
+        override fun open(header: PayloadHeader): WritableByteChannel {
+            opened += 1
+            val sink = ByteArrayOutputStream()
+            outputs[header.id] = sink
+            val raw: WritableByteChannel = Channels.newChannel(sink)
+            return CountingChannel(raw, onClose = { closed += 1 })
+        }
+    }
+
+    /**
+     * Wraps a [WritableByteChannel] and increments a counter on close so
+     * the test can assert that the assembler closed the destination
+     * exactly once.
+     */
+    private class CountingChannel(
+        private val delegate: WritableByteChannel,
+        private val onClose: () -> Unit,
+    ) : WritableByteChannel by delegate {
+        private var closed: Boolean = false
+
+        override fun close() {
+            if (!closed) {
+                closed = true
+                onClose()
+            }
+            delegate.close()
+        }
+
+        override fun isOpen(): Boolean = !closed && delegate.isOpen
+    }
+
+    // ------------------------------------------------------------------
+    // BYTES — happy paths
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `single frame BYTES with LAST_CHUNK on the data frame completes`() {
+        val assembler = PayloadAssembler()
+        val data = "hello-quickshare".toByteArray()
+        val event =
+            assembler.onPayloadTransfer(
+                chunkFrame(
+                    payloadId = 1,
+                    type = PayloadHeader.PayloadType.BYTES,
+                    totalSize = data.size.toLong(),
+                    offset = 0,
+                    body = data,
+                    lastChunk = true,
+                ),
+            )
+        assertThat(event).isEqualTo(PayloadEvent.BytesComplete(1, data))
+        assertThat(assembler.inFlightPayloadCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `Android two-frame BYTES quirk reassembles into one BytesComplete`() {
+        val assembler = PayloadAssembler()
+        val data = "hello-android".toByteArray()
+
+        // Frame 1: full body, flags=0, offset=0.
+        val ev1 =
+            assembler.onPayloadTransfer(
+                chunkFrame(
+                    payloadId = 7,
+                    type = PayloadHeader.PayloadType.BYTES,
+                    totalSize = data.size.toLong(),
+                    offset = 0,
+                    body = data,
+                    lastChunk = false,
+                ),
+            )
+        assertThat(ev1).isInstanceOf(PayloadEvent.Progress::class.java)
+
+        // Frame 2: empty body, flags=LAST_CHUNK, offset=data.size.
+        val ev2 =
+            assembler.onPayloadTransfer(
+                chunkFrame(
+                    payloadId = 7,
+                    type = PayloadHeader.PayloadType.BYTES,
+                    totalSize = data.size.toLong(),
+                    offset = data.size.toLong(),
+                    body = ByteArray(0),
+                    lastChunk = true,
+                ),
+            )
+        assertThat(ev2).isEqualTo(PayloadEvent.BytesComplete(7, data))
+        assertThat(assembler.inFlightPayloadCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `multi-chunk BYTES reassembles in declared order`() {
+        val assembler = PayloadAssembler()
+        // 3 chunks, with the third carrying LAST_CHUNK directly (the
+        // non-Android shape). Tests the offset-walk through three
+        // separate appends.
+        val parts =
+            listOf(
+                "alpha-".toByteArray(),
+                "bravo-".toByteArray(),
+                "charlie".toByteArray(),
+            )
+        val total = parts.sumOf { it.size }
+        var offset = 0L
+        var lastEvent: PayloadEvent? = null
+        for ((i, part) in parts.withIndex()) {
+            val isLast = i == parts.lastIndex
+            lastEvent =
+                assembler.onPayloadTransfer(
+                    chunkFrame(
+                        payloadId = 99,
+                        type = PayloadHeader.PayloadType.BYTES,
+                        totalSize = total.toLong(),
+                        offset = offset,
+                        body = part,
+                        lastChunk = isLast,
+                    ),
+                )
+            offset += part.size
+        }
+        val expected = parts.fold(ByteArray(0)) { acc, p -> acc + p }
+        assertThat(lastEvent).isEqualTo(PayloadEvent.BytesComplete(99, expected))
+    }
+
+    @Test
+    fun `zero-length BYTES payload via two frames completes with empty data`() {
+        // Edge case the Android quirk explicitly produces for empty
+        // negotiation messages: data frame with empty body + flags=0,
+        // followed by terminator with empty body + flags=LAST_CHUNK.
+        val assembler = PayloadAssembler()
+        assembler.onPayloadTransfer(
+            chunkFrame(
+                payloadId = 5,
+                type = PayloadHeader.PayloadType.BYTES,
+                totalSize = 0,
+                offset = 0,
+                body = ByteArray(0),
+                lastChunk = false,
+            ),
+        )
+        val terminator =
+            assembler.onPayloadTransfer(
+                chunkFrame(
+                    payloadId = 5,
+                    type = PayloadHeader.PayloadType.BYTES,
+                    totalSize = 0,
+                    offset = 0,
+                    body = ByteArray(0),
+                    lastChunk = true,
+                ),
+            )
+        assertThat(terminator).isEqualTo(PayloadEvent.BytesComplete(5, ByteArray(0)))
+    }
+
+    // ------------------------------------------------------------------
+    // BYTES — rejection paths
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `BYTES rejects chunk with offset that does not equal buffer size`() {
+        val assembler = PayloadAssembler()
+        val data = ByteArray(10) { it.toByte() }
+        // First chunk 6 bytes, no LAST_CHUNK.
+        assembler.onPayloadTransfer(
+            chunkFrame(
+                payloadId = 11,
+                type = PayloadHeader.PayloadType.BYTES,
+                totalSize = data.size.toLong(),
+                offset = 0,
+                body = data.copyOfRange(0, 6),
+                lastChunk = false,
+            ),
+        )
+        // Second chunk claims offset=2 (sender lied), buffer is 6.
+        val ex =
+            assertThrows<PayloadProtocolException> {
+                assembler.onPayloadTransfer(
+                    chunkFrame(
+                        payloadId = 11,
+                        type = PayloadHeader.PayloadType.BYTES,
+                        totalSize = data.size.toLong(),
+                        offset = 2,
+                        body = data.copyOfRange(6, 10),
+                        lastChunk = true,
+                    ),
+                )
+            }
+        assertThat(ex.message).contains("offset=2")
+        assertThat(ex.message).contains("buffer size=6")
+        // State must be cleaned up.
+        assertThat(assembler.inFlightPayloadCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `BYTES rejects total_size that exceeds saneFrameLength`() {
+        val assembler = PayloadAssembler(saneFrameLength = 16)
+        val ex =
+            assertThrows<PayloadProtocolException> {
+                assembler.onPayloadTransfer(
+                    chunkFrame(
+                        payloadId = 22,
+                        type = PayloadHeader.PayloadType.BYTES,
+                        totalSize = 1_000_000,
+                        offset = 0,
+                        body = ByteArray(0),
+                        lastChunk = false,
+                    ),
+                )
+            }
+        assertThat(ex.message).contains("exceeds saneFrameLength=16")
+        assertThat(assembler.inFlightPayloadCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `BYTES rejects body that would extend past declared total_size`() {
+        val assembler = PayloadAssembler()
+        val ex =
+            assertThrows<PayloadProtocolException> {
+                assembler.onPayloadTransfer(
+                    chunkFrame(
+                        payloadId = 33,
+                        type = PayloadHeader.PayloadType.BYTES,
+                        totalSize = 4,
+                        offset = 0,
+                        body = ByteArray(8) { 0x42 },
+                        lastChunk = true,
+                    ),
+                )
+            }
+        assertThat(ex.message).contains("exceeding declared total_size=4")
+        assertThat(assembler.inFlightPayloadCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `BYTES rejects LAST_CHUNK that arrives shorter than total_size`() {
+        val assembler = PayloadAssembler()
+        val ex =
+            assertThrows<PayloadProtocolException> {
+                assembler.onPayloadTransfer(
+                    chunkFrame(
+                        payloadId = 44,
+                        type = PayloadHeader.PayloadType.BYTES,
+                        totalSize = 100,
+                        offset = 0,
+                        body = ByteArray(20),
+                        lastChunk = true,
+                    ),
+                )
+            }
+        assertThat(ex.message).contains("LAST_CHUNK at 20 bytes")
+        assertThat(ex.message).contains("total_size=100")
+    }
+
+    @Test
+    fun `BYTES rejects negative total_size`() {
+        val assembler = PayloadAssembler()
+        assertThrows<PayloadProtocolException> {
+            assembler.onPayloadTransfer(
+                chunkFrame(
+                    payloadId = 55,
+                    type = PayloadHeader.PayloadType.BYTES,
+                    totalSize = -1,
+                    offset = 0,
+                    body = ByteArray(0),
+                    lastChunk = true,
+                ),
+            )
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // FILE — happy paths
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `FILE chunks stream straight to the destination channel`() {
+        val factory = CapturingFactory()
+        val assembler = PayloadAssembler(fileDestinationFactory = factory)
+        // 1 MiB of pseudo-random bytes split into 4 chunks. Tests both
+        // the streaming behavior (memory does not grow) and that
+        // multi-chunk FILE reassembles cleanly.
+        val total = 1 * 1024 * 1024
+        val data = Random(0xCAFEBABE).nextBytes(total)
+        val chunkSize = 256 * 1024
+
+        var offset = 0
+        var lastEvent: PayloadEvent? = null
+        while (offset < total) {
+            val end = (offset + chunkSize).coerceAtMost(total)
+            val isLast = end == total
+            lastEvent =
+                assembler.onPayloadTransfer(
+                    chunkFrame(
+                        payloadId = 200,
+                        type = PayloadHeader.PayloadType.FILE,
+                        totalSize = total.toLong(),
+                        offset = offset.toLong(),
+                        body = data.copyOfRange(offset, end),
+                        lastChunk = isLast,
+                        fileName = "big.bin",
+                    ),
+                )
+            offset = end
+        }
+
+        assertThat(lastEvent).isInstanceOf(PayloadEvent.FileComplete::class.java)
+        val complete = lastEvent as PayloadEvent.FileComplete
+        assertThat(complete.payloadId).isEqualTo(200)
+        assertThat(complete.bytesWritten).isEqualTo(total.toLong())
+        assertThat(complete.header.fileName).isEqualTo("big.bin")
+
+        // Channel was opened once and closed once.
+        assertThat(factory.opened).isEqualTo(1)
+        assertThat(factory.closed).isEqualTo(1)
+        // And the bytes match.
+        assertThat(factory.outputs[200]!!.toByteArray()).isEqualTo(data)
+        // No state leaked.
+        assertThat(assembler.inFlightPayloadCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `FILE single-chunk payload that fits entirely in one frame works`() {
+        val factory = CapturingFactory()
+        val assembler = PayloadAssembler(fileDestinationFactory = factory)
+        val data = Random(0xDEAD).nextBytes(127)
+        val ev =
+            assembler.onPayloadTransfer(
+                chunkFrame(
+                    payloadId = 201,
+                    type = PayloadHeader.PayloadType.FILE,
+                    totalSize = data.size.toLong(),
+                    offset = 0,
+                    body = data,
+                    lastChunk = true,
+                    fileName = "small.bin",
+                ),
+            )
+        assertThat(ev).isInstanceOf(PayloadEvent.FileComplete::class.java)
+        assertThat(factory.outputs[201]!!.toByteArray()).isEqualTo(data)
+        assertThat(factory.closed).isEqualTo(1)
+    }
+
+    @Test
+    fun `FILE zero-byte payload completes in a single empty chunk`() {
+        val factory = CapturingFactory()
+        val assembler = PayloadAssembler(fileDestinationFactory = factory)
+        val ev =
+            assembler.onPayloadTransfer(
+                chunkFrame(
+                    payloadId = 202,
+                    type = PayloadHeader.PayloadType.FILE,
+                    totalSize = 0,
+                    offset = 0,
+                    body = ByteArray(0),
+                    lastChunk = true,
+                    fileName = "empty.bin",
+                ),
+            )
+        assertThat(ev).isInstanceOf(PayloadEvent.FileComplete::class.java)
+        val complete = ev as PayloadEvent.FileComplete
+        assertThat(complete.bytesWritten).isEqualTo(0L)
+        assertThat(factory.opened).isEqualTo(1)
+        assertThat(factory.closed).isEqualTo(1)
+        assertThat(factory.outputs[202]!!.toByteArray().size).isEqualTo(0)
+    }
+
+    // ------------------------------------------------------------------
+    // FILE — rejection paths
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `FILE rejects chunk with offset mismatch and closes the channel`() {
+        val factory = CapturingFactory()
+        val assembler = PayloadAssembler(fileDestinationFactory = factory)
+        // First chunk 100 bytes, ok.
+        assembler.onPayloadTransfer(
+            chunkFrame(
+                payloadId = 300,
+                type = PayloadHeader.PayloadType.FILE,
+                totalSize = 1000,
+                offset = 0,
+                body = ByteArray(100) { 0x77 },
+                lastChunk = false,
+                fileName = "x.bin",
+            ),
+        )
+        // Second chunk lies about offset (claims 50, real is 100).
+        val ex =
+            assertThrows<PayloadProtocolException> {
+                assembler.onPayloadTransfer(
+                    chunkFrame(
+                        payloadId = 300,
+                        type = PayloadHeader.PayloadType.FILE,
+                        totalSize = 1000,
+                        offset = 50,
+                        body = ByteArray(50) { 0x33 },
+                        lastChunk = false,
+                        fileName = "x.bin",
+                    ),
+                )
+            }
+        assertThat(ex.message).contains("offset=50")
+        assertThat(ex.message).contains("bytes written=100")
+        assertThat(factory.closed).isEqualTo(1)
+        assertThat(assembler.inFlightPayloadCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `FILE rejects chunk that would write past total_size`() {
+        val factory = CapturingFactory()
+        val assembler = PayloadAssembler(fileDestinationFactory = factory)
+        val ex =
+            assertThrows<PayloadProtocolException> {
+                assembler.onPayloadTransfer(
+                    chunkFrame(
+                        payloadId = 301,
+                        type = PayloadHeader.PayloadType.FILE,
+                        totalSize = 10,
+                        offset = 0,
+                        body = ByteArray(20),
+                        lastChunk = false,
+                        fileName = "x.bin",
+                    ),
+                )
+            }
+        assertThat(ex.message).contains("would write past total_size=10")
+        assertThat(factory.closed).isEqualTo(1)
+    }
+
+    @Test
+    fun `FILE rejects LAST_CHUNK that arrives shorter than total_size`() {
+        val factory = CapturingFactory()
+        val assembler = PayloadAssembler(fileDestinationFactory = factory)
+        val ex =
+            assertThrows<PayloadProtocolException> {
+                assembler.onPayloadTransfer(
+                    chunkFrame(
+                        payloadId = 302,
+                        type = PayloadHeader.PayloadType.FILE,
+                        totalSize = 1000,
+                        offset = 0,
+                        body = ByteArray(100),
+                        lastChunk = true,
+                        fileName = "x.bin",
+                    ),
+                )
+            }
+        assertThat(ex.message).contains("LAST_CHUNK at 100 bytes")
+        assertThat(ex.message).contains("total_size=1000")
+        assertThat(factory.closed).isEqualTo(1)
+    }
+
+    // ------------------------------------------------------------------
+    // Multiplexing and miscellaneous
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `interleaved BYTES and FILE payloads with distinct ids do not interfere`() {
+        val factory = CapturingFactory()
+        val assembler = PayloadAssembler(fileDestinationFactory = factory)
+        val bytesData = "negotiation-blob".toByteArray()
+        val fileData = Random(0xFEED).nextBytes(2048)
+
+        // BYTES chunk 1 (no LAST_CHUNK) → in flight.
+        assembler.onPayloadTransfer(
+            chunkFrame(
+                payloadId = 1,
+                type = PayloadHeader.PayloadType.BYTES,
+                totalSize = bytesData.size.toLong(),
+                offset = 0,
+                body = bytesData,
+                lastChunk = false,
+            ),
+        )
+        // FILE chunk 1 (no LAST_CHUNK) → in flight.
+        assembler.onPayloadTransfer(
+            chunkFrame(
+                payloadId = 2,
+                type = PayloadHeader.PayloadType.FILE,
+                totalSize = fileData.size.toLong(),
+                offset = 0,
+                body = fileData.copyOfRange(0, 1024),
+                lastChunk = false,
+                fileName = "f.bin",
+            ),
+        )
+        assertThat(assembler.inFlightPayloadCount).isEqualTo(2)
+
+        // BYTES terminator (the Android two-frame quirk for id=1).
+        val bytesEvent =
+            assembler.onPayloadTransfer(
+                chunkFrame(
+                    payloadId = 1,
+                    type = PayloadHeader.PayloadType.BYTES,
+                    totalSize = bytesData.size.toLong(),
+                    offset = bytesData.size.toLong(),
+                    body = ByteArray(0),
+                    lastChunk = true,
+                ),
+            )
+        assertThat(bytesEvent).isEqualTo(PayloadEvent.BytesComplete(1, bytesData))
+        assertThat(assembler.inFlightPayloadCount).isEqualTo(1)
+
+        // FILE chunk 2 (the rest, with LAST_CHUNK).
+        val fileEvent =
+            assembler.onPayloadTransfer(
+                chunkFrame(
+                    payloadId = 2,
+                    type = PayloadHeader.PayloadType.FILE,
+                    totalSize = fileData.size.toLong(),
+                    offset = 1024,
+                    body = fileData.copyOfRange(1024, 2048),
+                    lastChunk = true,
+                    fileName = "f.bin",
+                ),
+            )
+        assertThat(fileEvent).isInstanceOf(PayloadEvent.FileComplete::class.java)
+        assertThat(factory.outputs[2]!!.toByteArray()).isEqualTo(fileData)
+        assertThat(assembler.inFlightPayloadCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `non-DATA packet types surface as Ignored without changing state`() {
+        val assembler = PayloadAssembler()
+        // First put one payload in flight.
+        assembler.onPayloadTransfer(
+            chunkFrame(
+                payloadId = 1,
+                type = PayloadHeader.PayloadType.BYTES,
+                totalSize = 4,
+                offset = 0,
+                body = ByteArray(2),
+                lastChunk = false,
+            ),
+        )
+        // PAYLOAD_ACK — the assembler should ignore it.
+        val ackEvent =
+            assembler.onPayloadTransfer(
+                chunkFrame(
+                    payloadId = 1,
+                    type = PayloadHeader.PayloadType.BYTES,
+                    totalSize = 4,
+                    offset = 0,
+                    body = ByteArray(0),
+                    lastChunk = false,
+                    packetType = PayloadTransferFrame.PacketType.PAYLOAD_ACK,
+                ),
+            )
+        assertThat(ackEvent).isInstanceOf(PayloadEvent.Ignored::class.java)
+        // CONTROL — same.
+        val ctrlEvent =
+            assembler.onPayloadTransfer(
+                chunkFrame(
+                    payloadId = 1,
+                    type = PayloadHeader.PayloadType.BYTES,
+                    totalSize = 4,
+                    offset = 0,
+                    body = ByteArray(0),
+                    lastChunk = false,
+                    packetType = PayloadTransferFrame.PacketType.CONTROL,
+                ),
+            )
+        assertThat(ctrlEvent).isInstanceOf(PayloadEvent.Ignored::class.java)
+        // Original payload still in flight.
+        assertThat(assembler.inFlightPayloadCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `unsupported payload type STREAM is rejected`() {
+        val assembler = PayloadAssembler()
+        assertThrows<PayloadProtocolException> {
+            assembler.onPayloadTransfer(
+                chunkFrame(
+                    payloadId = 1,
+                    type = PayloadHeader.PayloadType.STREAM,
+                    totalSize = 4,
+                    offset = 0,
+                    body = ByteArray(4),
+                    lastChunk = true,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `frame missing payload_chunk is rejected`() {
+        val assembler = PayloadAssembler()
+        val malformed =
+            PayloadTransferFrame
+                .newBuilder()
+                .setPacketType(PayloadTransferFrame.PacketType.DATA)
+                .setPayloadHeader(
+                    PayloadHeader
+                        .newBuilder()
+                        .setId(1)
+                        .setType(PayloadHeader.PayloadType.BYTES)
+                        .setTotalSize(0),
+                ).build()
+        assertThrows<PayloadProtocolException> { assembler.onPayloadTransfer(malformed) }
+    }
+
+    @Test
+    fun `reset closes all in-flight file channels`() {
+        val factory = CapturingFactory()
+        val assembler = PayloadAssembler(fileDestinationFactory = factory)
+        assembler.onPayloadTransfer(
+            chunkFrame(
+                payloadId = 1,
+                type = PayloadHeader.PayloadType.FILE,
+                totalSize = 100,
+                offset = 0,
+                body = ByteArray(40),
+                lastChunk = false,
+                fileName = "a.bin",
+            ),
+        )
+        assembler.onPayloadTransfer(
+            chunkFrame(
+                payloadId = 2,
+                type = PayloadHeader.PayloadType.FILE,
+                totalSize = 100,
+                offset = 0,
+                body = ByteArray(40),
+                lastChunk = false,
+                fileName = "b.bin",
+            ),
+        )
+        assertThat(assembler.inFlightPayloadCount).isEqualTo(2)
+        assertThat(factory.closed).isEqualTo(0)
+        assembler.reset()
+        assertThat(assembler.inFlightPayloadCount).isEqualTo(0)
+        assertThat(factory.closed).isEqualTo(2)
+    }
+
+    @Test
+    fun `factory exception on first FILE chunk leaks no state`() {
+        val throwingFactory =
+            FileDestinationFactory { _ ->
+                throw java.io.IOException("simulated open failure")
+            }
+        val assembler = PayloadAssembler(fileDestinationFactory = throwingFactory)
+        assertThrows<java.io.IOException> {
+            assembler.onPayloadTransfer(
+                chunkFrame(
+                    payloadId = 99,
+                    type = PayloadHeader.PayloadType.FILE,
+                    totalSize = 100,
+                    offset = 0,
+                    body = ByteArray(10),
+                    lastChunk = false,
+                    fileName = "broken.bin",
+                ),
+            )
+        }
+        assertThat(assembler.inFlightPayloadCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `progress events report cumulative bytes received and the type`() {
+        val factory = CapturingFactory()
+        val assembler = PayloadAssembler(fileDestinationFactory = factory)
+        val ev1 =
+            assembler.onPayloadTransfer(
+                chunkFrame(
+                    payloadId = 88,
+                    type = PayloadHeader.PayloadType.FILE,
+                    totalSize = 1000,
+                    offset = 0,
+                    body = ByteArray(300),
+                    lastChunk = false,
+                    fileName = "p.bin",
+                ),
+            )
+        assertThat(ev1).isEqualTo(
+            PayloadEvent.Progress(
+                payloadId = 88,
+                bytesReceived = 300,
+                totalSize = 1000,
+                type = PayloadHeader.PayloadType.FILE,
+            ),
+        )
+        val ev2 =
+            assembler.onPayloadTransfer(
+                chunkFrame(
+                    payloadId = 88,
+                    type = PayloadHeader.PayloadType.FILE,
+                    totalSize = 1000,
+                    offset = 300,
+                    body = ByteArray(400),
+                    lastChunk = false,
+                    fileName = "p.bin",
+                ),
+            )
+        assertThat(ev2).isEqualTo(
+            PayloadEvent.Progress(
+                payloadId = 88,
+                bytesReceived = 700,
+                totalSize = 1000,
+                type = PayloadHeader.PayloadType.FILE,
+            ),
+        )
+    }
+
+    @Test
+    fun `assembler accepts the exact byte sequence produced by the encoder`() {
+        // Round-trip: encode a BYTES payload, then feed both frames to a
+        // fresh assembler. This is the integration check between the
+        // encoder (which implements the Android two-frame quirk on send)
+        // and the assembler (which tolerates it on receive).
+        val data = "round-trip-test".toByteArray()
+        val frames = PayloadTransferEncoder.encodeBytesPayload(payloadId = 7, data = data)
+        assertThat(frames).hasSize(2)
+
+        val assembler = PayloadAssembler()
+        val ev1 = assembler.onPayloadTransfer(frames[0].v1.payloadTransfer)
+        assertThat(ev1).isInstanceOf(PayloadEvent.Progress::class.java)
+        val ev2 = assembler.onPayloadTransfer(frames[1].v1.payloadTransfer)
+        assertThat(ev2).isEqualTo(PayloadEvent.BytesComplete(7, data))
+    }
+
+    @Test
+    fun `assembler accepts FILE frames produced by the encoder for a small file`() {
+        val data = Random(0xABBA).nextBytes(50_000)
+        val source = Channels.newChannel(java.io.ByteArrayInputStream(data))
+        val frames =
+            PayloadTransferEncoder
+                .encodeFilePayload(
+                    payloadId = 314,
+                    fileName = "encoded.bin",
+                    totalSize = data.size.toLong(),
+                    source = source,
+                    chunkSize = 8 * 1024,
+                ).toList()
+        // 50000 / 8192 = 6 full + 1 partial = 7 frames.
+        assertThat(frames.size).isAtLeast(2)
+
+        val factory = CapturingFactory()
+        val assembler = PayloadAssembler(fileDestinationFactory = factory)
+        var lastEvent: PayloadEvent? = null
+        for (f in frames) {
+            lastEvent = assembler.onPayloadTransfer(f.v1.payloadTransfer)
+        }
+        assertThat(lastEvent).isInstanceOf(PayloadEvent.FileComplete::class.java)
+        assertThat(factory.outputs[314]!!.toByteArray()).isEqualTo(data)
+    }
+
+    @Test
+    fun `large file streamed in tiny chunks completes correctly`() {
+        // Simulates a slow peer that sends 100 KiB chunks of a 10 MiB file.
+        // Confirms the assembler scales linearly with chunk count and does
+        // not buffer in memory — we verify only the final assembled bytes
+        // and the final event, never inspecting heap.
+        val factory = CapturingFactory()
+        val assembler = PayloadAssembler(fileDestinationFactory = factory)
+        val total = 10 * 1024 * 1024
+        val chunkSize = 100 * 1024
+        val data = Random(0x1337).nextBytes(total)
+
+        var offset = 0
+        var lastEvent: PayloadEvent? = null
+        while (offset < total) {
+            val end = (offset + chunkSize).coerceAtMost(total)
+            val isLast = end == total
+            // Build a "fresh" ByteBuffer-backed body so the test does not
+            // accidentally share an array with the assembler.
+            val body = ByteArray(end - offset)
+            ByteBuffer.wrap(data, offset, end - offset).get(body)
+            lastEvent =
+                assembler.onPayloadTransfer(
+                    chunkFrame(
+                        payloadId = 9000,
+                        type = PayloadHeader.PayloadType.FILE,
+                        totalSize = total.toLong(),
+                        offset = offset.toLong(),
+                        body = body,
+                        lastChunk = isLast,
+                        fileName = "tenmib.bin",
+                    ),
+                )
+            offset = end
+        }
+        assertThat(lastEvent).isInstanceOf(PayloadEvent.FileComplete::class.java)
+        assertThat(factory.outputs[9000]!!.toByteArray()).isEqualTo(data)
+        assertThat(factory.closed).isEqualTo(1)
+    }
+}

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/payload/PayloadTransferEncoderTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/payload/PayloadTransferEncoderTest.kt
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.payload
+
+import com.google.common.truth.Truth.assertThat
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.PayloadTransferFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.PayloadTransferFrame.PayloadHeader
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.V1Frame
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.io.ByteArrayInputStream
+import java.nio.channels.Channels
+import kotlin.random.Random
+
+/**
+ * Tests for [PayloadTransferEncoder].
+ *
+ * The encoder is purely functional, so the tests inspect the produced
+ * `OfflineFrame`s directly and assert on the proto fields. The
+ * round-trip integration with [PayloadAssembler] lives in
+ * [PayloadAssemblerTest].
+ */
+class PayloadTransferEncoderTest {
+    @Test
+    fun `encodeBytesPayload emits exactly two frames in the Android quirk shape`() {
+        val data = "abcde".toByteArray()
+        val frames = PayloadTransferEncoder.encodeBytesPayload(payloadId = 1, data = data)
+        assertThat(frames).hasSize(2)
+
+        // Both frames are wrapped as OfflineFrame{V1, PAYLOAD_TRANSFER}.
+        for (f in frames) {
+            assertThat(f.version).isEqualTo(OfflineFrame.Version.V1)
+            assertThat(f.v1.type).isEqualTo(V1Frame.FrameType.PAYLOAD_TRANSFER)
+            val transfer = f.v1.payloadTransfer
+            assertThat(transfer.packetType).isEqualTo(PayloadTransferFrame.PacketType.DATA)
+            assertThat(transfer.payloadHeader.id).isEqualTo(1L)
+            assertThat(transfer.payloadHeader.type).isEqualTo(PayloadHeader.PayloadType.BYTES)
+            assertThat(transfer.payloadHeader.totalSize).isEqualTo(data.size.toLong())
+        }
+
+        // First frame: full body, no LAST_CHUNK.
+        val data1 = frames[0].v1.payloadTransfer.payloadChunk
+        assertThat(data1.offset).isEqualTo(0L)
+        assertThat(data1.flags).isEqualTo(0)
+        assertThat(data1.body.toByteArray()).isEqualTo(data)
+
+        // Second frame: empty body, LAST_CHUNK set, offset = data.size.
+        val term = frames[1].v1.payloadTransfer.payloadChunk
+        assertThat(term.offset).isEqualTo(data.size.toLong())
+        assertThat(term.flags).isEqualTo(PayloadAssembler.LAST_CHUNK_FLAG)
+        assertThat(term.body.size()).isEqualTo(0)
+    }
+
+    @Test
+    fun `encodeBytesPayload with empty data still emits a terminator frame`() {
+        // The Android quirk applies to zero-length BYTES payloads too.
+        val frames = PayloadTransferEncoder.encodeBytesPayload(payloadId = 2, data = ByteArray(0))
+        assertThat(frames).hasSize(2)
+        val dataChunk = frames[0].v1.payloadTransfer.payloadChunk
+        val terminatorChunk = frames[1].v1.payloadTransfer.payloadChunk
+        // First chunk: empty body, flags=0.
+        assertThat(dataChunk.flags).isEqualTo(0)
+        assertThat(dataChunk.body.size()).isEqualTo(0)
+        // Terminator: empty body, flags=LAST_CHUNK, offset=0.
+        assertThat(terminatorChunk.flags).isEqualTo(PayloadAssembler.LAST_CHUNK_FLAG)
+        assertThat(terminatorChunk.offset).isEqualTo(0L)
+        assertThat(terminatorChunk.body.size()).isEqualTo(0)
+    }
+
+    @Test
+    fun `encodeFilePayload chunks a small file into frames with the right offsets`() {
+        val data = Random(0xC0DE).nextBytes(2500)
+        val source = Channels.newChannel(ByteArrayInputStream(data))
+        val frames =
+            PayloadTransferEncoder
+                .encodeFilePayload(
+                    payloadId = 11,
+                    fileName = "small.bin",
+                    totalSize = data.size.toLong(),
+                    source = source,
+                    chunkSize = 1024,
+                ).toList()
+        // 2500 / 1024 = 2 full + 452 trailing = 3 frames.
+        assertThat(frames).hasSize(3)
+
+        // First two frames: 1024 bytes each, no LAST_CHUNK.
+        for ((i, f) in frames.withIndex().take(2)) {
+            val chunk = f.v1.payloadTransfer.payloadChunk
+            assertThat(chunk.offset).isEqualTo((i * 1024).toLong())
+            assertThat(chunk.flags).isEqualTo(0)
+            assertThat(chunk.body.size()).isEqualTo(1024)
+        }
+        // Last frame: trailing bytes + LAST_CHUNK.
+        val last = frames[2].v1.payloadTransfer.payloadChunk
+        assertThat(last.offset).isEqualTo(2048L)
+        assertThat(last.flags).isEqualTo(PayloadAssembler.LAST_CHUNK_FLAG)
+        assertThat(last.body.size()).isEqualTo(2500 - 2048)
+
+        // Reassemble bytes and confirm bit-equal.
+        val rebuilt = ByteArray(data.size)
+        var pos = 0
+        for (f in frames) {
+            val chunk = f.v1.payloadTransfer.payloadChunk
+            val body = chunk.body.toByteArray()
+            System.arraycopy(body, 0, rebuilt, pos, body.size)
+            pos += body.size
+        }
+        assertThat(rebuilt).isEqualTo(data)
+    }
+
+    @Test
+    fun `encodeFilePayload with totalSize zero still produces a terminator frame`() {
+        val source = Channels.newChannel(ByteArrayInputStream(ByteArray(0)))
+        val frames =
+            PayloadTransferEncoder
+                .encodeFilePayload(
+                    payloadId = 12,
+                    fileName = "empty.bin",
+                    totalSize = 0,
+                    source = source,
+                ).toList()
+        assertThat(frames).hasSize(1)
+        val chunk = frames[0].v1.payloadTransfer.payloadChunk
+        assertThat(chunk.offset).isEqualTo(0L)
+        assertThat(chunk.flags).isEqualTo(PayloadAssembler.LAST_CHUNK_FLAG)
+        assertThat(chunk.body.size()).isEqualTo(0)
+    }
+
+    @Test
+    fun `encodeFilePayload rejects non-positive chunk size`() {
+        val source = Channels.newChannel(ByteArrayInputStream(ByteArray(0)))
+        assertThrows<IllegalArgumentException> {
+            PayloadTransferEncoder
+                .encodeFilePayload(
+                    payloadId = 1,
+                    fileName = "x",
+                    totalSize = 0,
+                    source = source,
+                    chunkSize = 0,
+                ).toList()
+        }
+    }
+
+    @Test
+    fun `encodeFilePayload rejects negative total size`() {
+        val source = Channels.newChannel(ByteArrayInputStream(ByteArray(0)))
+        assertThrows<IllegalArgumentException> {
+            PayloadTransferEncoder
+                .encodeFilePayload(
+                    payloadId = 1,
+                    fileName = "x",
+                    totalSize = -1,
+                    source = source,
+                ).toList()
+        }
+    }
+
+    @Test
+    fun `encodeFilePayload propagates fileName parentFolder and timestamp`() {
+        val source = Channels.newChannel(ByteArrayInputStream(ByteArray(10)))
+        val frames =
+            PayloadTransferEncoder
+                .encodeFilePayload(
+                    payloadId = 99,
+                    fileName = "report.pdf",
+                    totalSize = 10,
+                    source = source,
+                    parentFolder = "Documents",
+                    lastModifiedTimestampMillis = 1_700_000_000_000L,
+                ).toList()
+        val header = frames[0].v1.payloadTransfer.payloadHeader
+        assertThat(header.fileName).isEqualTo("report.pdf")
+        assertThat(header.parentFolder).isEqualTo("Documents")
+        assertThat(header.lastModifiedTimestampMillis).isEqualTo(1_700_000_000_000L)
+        assertThat(header.type).isEqualTo(PayloadHeader.PayloadType.FILE)
+    }
+}

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/payload/TempFileDestinationFactoryTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/payload/TempFileDestinationFactoryTest.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.payload
+
+import com.google.common.truth.Truth.assertThat
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.PayloadTransferFrame.PayloadHeader
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.ByteBuffer
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Tests for [TempFileDestinationFactory] — the default `:core-protocol`
+ * implementation of [FileDestinationFactory] that writes to a temp dir.
+ *
+ * The Android production wiring uses a different factory entirely (one
+ * that hands back a `MediaStore` content URI's output stream), but
+ * `:core-protocol` and the JVM-side host harness both rely on this file
+ * factory, so we cover its filename sanitization and the open/close
+ * lifecycle here.
+ */
+class TempFileDestinationFactoryTest {
+    @Test
+    fun `factory writes bytes to a file under the configured directory`(
+        @TempDir tmp: Path,
+    ) {
+        val factory = TempFileDestinationFactory(baseDirectory = tmp)
+        val header =
+            PayloadHeader
+                .newBuilder()
+                .setId(42)
+                .setType(PayloadHeader.PayloadType.FILE)
+                .setTotalSize(5)
+                .setFileName("hello.bin")
+                .build()
+        factory.open(header).use { ch ->
+            ch.write(ByteBuffer.wrap(byteArrayOf(1, 2, 3, 4, 5)))
+        }
+        val expected = tmp.resolve("payload-42-hello.bin")
+        assertThat(Files.exists(expected)).isTrue()
+        assertThat(Files.readAllBytes(expected)).isEqualTo(byteArrayOf(1, 2, 3, 4, 5))
+    }
+
+    @Test
+    fun `factory sanitizes path-traversal-style file names`(
+        @TempDir tmp: Path,
+    ) {
+        val factory = TempFileDestinationFactory(baseDirectory = tmp)
+        val header =
+            PayloadHeader
+                .newBuilder()
+                .setId(1)
+                .setType(PayloadHeader.PayloadType.FILE)
+                .setTotalSize(0)
+                .setFileName("../../../etc/passwd")
+                .build()
+        factory.open(header).use { /* nothing to write */ }
+        // Sanitized name keeps the safe set [A-Za-z0-9._-] and replaces
+        // the rest with '_'. The crucial security property is "no path
+        // separators leak through" — `..` substrings on their own are
+        // harmless without separators. The file MUST sit directly under
+        // the configured base directory.
+        val children = Files.list(tmp).use { it.toList() }
+        assertThat(children).hasSize(1)
+        val produced = children.single().fileName
+        assertThat(produced.toString()).startsWith("payload-1-")
+        assertThat(produced.toString()).doesNotContain("/")
+        assertThat(produced.toString()).doesNotContain("\\")
+        // And the produced path's parent is exactly the configured tmp.
+        assertThat(children.single().parent).isEqualTo(tmp)
+    }
+
+    @Test
+    fun `factory falls back to unnamed when fileName is empty`(
+        @TempDir tmp: Path,
+    ) {
+        val factory = TempFileDestinationFactory(baseDirectory = tmp)
+        val header =
+            PayloadHeader
+                .newBuilder()
+                .setId(7)
+                .setType(PayloadHeader.PayloadType.FILE)
+                .setTotalSize(0)
+                .build()
+        factory.open(header).use { /* no-op */ }
+        val children = Files.list(tmp).use { it.toList() }
+        val produced = children.single().fileName.toString()
+        assertThat(produced).isEqualTo("payload-7-unnamed")
+    }
+}


### PR DESCRIPTION
## Summary

Closes #14. Implements the `:core-protocol` `PayloadAssembler` plus the matching `PayloadTransferEncoder` and `FileDestinationFactory` seam, sitting one layer above `SecureChannel` (#13) in the receive pipeline.

- `PayloadAssembler.onPayloadTransfer(frame)` consumes a single `PayloadTransferFrame`, validates `chunk.offset == buffer.size` (or `bytesWritten` for FILE), buffers BYTES in heap up to a `saneFrameLength` cap (default 5 MiB), streams FILE chunks straight through a caller-supplied `WritableByteChannel`, and emits a sealed `PayloadEvent` per chunk (`Progress`, `BytesComplete`, `FileComplete`, `Ignored`). Any invariant violation throws `PayloadProtocolException` after cleaning up state for the offending `payload_id`.
- The Android two-frame BYTES quirk is handled implicitly: the trailing zero-body `LAST_CHUNK` frame passes the offset check (its offset equals the buffer length, which matches `total_size`), the empty append is a no-op, and the LAST_CHUNK flag finalizes. There is no special-case branch — finalization is gated on the flag, never on the byte count.
- `PayloadTransferEncoder` mirrors NearDrop's `sendBytesPayload` and emits exactly two `OfflineFrame`s per BYTES payload (data frame + zero-body LAST_CHUNK terminator) for compatibility with stock Quick Share peers. A streaming `encodeFilePayload` helper chunks files through a `ReadableByteChannel` at a configurable size (512 KiB default).
- `FileDestinationFactory` is a `fun interface` taking the `PayloadHeader` and returning a `WritableByteChannel`. The default `TempFileDestinationFactory` writes under `${java.io.tmpdir}/wvmg-payload-receive` with a sanitized filename. The Android wiring (a future PR) will substitute a `MediaStore` content-URI factory at this seam without touching `:core-protocol`.

## Test plan

- [x] Unit tests for in-order BYTES reassembly, multi-chunk BYTES, single-frame BYTES, and the Android two-frame quirk.
- [x] Unit tests for FILE streaming (1 MiB and 10 MiB across many chunks), single-chunk FILE, and zero-byte FILE.
- [x] Rejection paths: BYTES offset mismatch, oversized BYTES (`total_size > saneFrameLength`), BYTES body past declared size, short LAST_CHUNK, FILE offset mismatch, FILE write past total_size, FILE short LAST_CHUNK.
- [x] Multiplexing: interleaved BYTES + FILE with distinct `payload_id`s do not interfere.
- [x] State hygiene: failed factory throws cleanly; `reset()` closes all in-flight FILE channels.
- [x] Round-trip: bytes produced by `PayloadTransferEncoder.encodeBytesPayload` are accepted by `PayloadAssembler` and reassembled bit-equal; same for `encodeFilePayload` -> assembler.
- [x] `TempFileDestinationFactory`: writes under the configured directory, sanitizes path-traversal filenames, falls back to `unnamed` for empty `file_name`.
- [x] `./gradlew :core-protocol:check` passes (test + ktlint + detekt). Full repo `./gradlew build` (excluding Android lint) succeeds.
