### PR TITLE
feat: add Sharing.Nearby.Frame negotiation state machines (#15)

### DIFF
--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/sharing/InboundSharingFsm.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/sharing/InboundSharingFsm.kt
@@ -1,0 +1,282 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.sharing
+
+import java.security.SecureRandom
+
+/**
+ * Receiver-role Quick Share negotiation state machine.
+ *
+ * The FSM is **pure**: no I/O, no coroutines, no internal locking.
+ * The surrounding orchestration (issue #16 — `InboundConnection`) drives
+ * it by funneling every external stimulus through [onEvent] and
+ * interpreting the returned [SharingFsmEffect] list.
+ *
+ * ### Lifecycle
+ *
+ *  1. The orchestrator constructs the FSM after the UKEY2 + connection
+ *     response handshake completes. The constructor immediately puts the
+ *     FSM in [InboundSharingState.SentPairedKeyEncryption] **after**
+ *     producing the seed effect via [start]; the orchestrator must call
+ *     [start] exactly once before any [onEvent] call. (Initialisation is
+ *     split this way — rather than firing inside the constructor — so
+ *     the orchestrator can install error handling around the first emit.)
+ *  2. The orchestrator pumps inbound `Sharing.Nearby.Frame` arrivals,
+ *     user consent results, and user cancel requests through [onEvent].
+ *  3. When the FSM enters its terminal state ([InboundSharingState.ReceivingPayloads]
+ *     for the success path, [InboundSharingState.Disconnected] otherwise),
+ *     no further events advance state. Subsequent calls return an empty
+ *     effect list — they are safe and explicitly idempotent so the
+ *     orchestrator does not need to gate them itself.
+ *
+ * ### Why the FSM is `class` and not `object`
+ *
+ * Each Quick Share connection runs an independent state machine; the
+ * receiver FSM holds per-connection state ([state], internal flags) and
+ * a per-connection [SecureRandom]. Sharing one global instance across
+ * connections would tangle their negotiations. The class is constructed
+ * fresh per connection and discarded when the connection closes.
+ *
+ * ### Threading model
+ *
+ * Not thread-safe. The orchestrator is expected to serialize all calls
+ * (in practice this is trivial — the receive coroutine is the only one
+ * pumping inbound frames, and consent / cancel events are funnelled
+ * through it via a `Channel`).
+ *
+ * @param secureRandom Source of bytes for the outgoing
+ *   [PairedKeyEncryptionFrame] random fields. Pass a deterministic
+ *   stub from tests to make state assertions reproducible.
+ */
+public class InboundSharingFsm(
+    private val secureRandom: SecureRandom = SecureRandom(),
+) {
+    /**
+     * Current FSM state. Read-only outside the FSM; updated only by
+     * [onEvent] / [start]. Tests assert on this directly to verify the
+     * transition table.
+     */
+    public var state: InboundSharingState = InboundSharingState.SentPairedKeyEncryption
+        private set
+
+    private var started: Boolean = false
+
+    /**
+     * Drive the FSM to its initial state and produce the first outbound
+     * frame.
+     *
+     * Returns a one-element list containing a [SharingFsmEffect.SendFrame]
+     * carrying the receiver's `PairedKeyEncryptionFrame` (random
+     * `secret_id_hash` + `signed_data`). Subsequent calls return an
+     * empty list — [start] is idempotent so that the orchestrator's
+     * retry / re-enter logic cannot accidentally double-emit.
+     */
+    public fun start(): List<SharingFsmEffect> {
+        if (started) return emptyList()
+        started = true
+        return listOf(
+            SharingFsmEffect.SendFrame(
+                SharingFrames.pairedKeyEncryption(secureRandom = secureRandom),
+            ),
+        )
+    }
+
+    /**
+     * Apply one input event and produce the corresponding effect list.
+     *
+     * The list is ordered: the orchestrator MUST process effects in the
+     * order returned. In particular, when an event triggers both an
+     * outbound frame AND a terminal notification (e.g.
+     * `UserConsent(accept=false)` produces `SendFrame{REJECT}`, then
+     * `Rejected`, then `Cancelled`), the frame send precedes the
+     * teardown notification so the byte hits the wire before the
+     * orchestrator closes the connection.
+     */
+    @Suppress(
+        "ReturnCount", // One return per terminal/branch; merging would obscure the transition table.
+        "CyclomaticComplexMethod", // Each branch is a single transition; combining would actually hurt readability.
+    )
+    public fun onEvent(event: SharingFsmEvent): List<SharingFsmEffect> {
+        if (state == InboundSharingState.Disconnected) {
+            // Idempotent: the orchestrator can redundantly forward late
+            // events without us re-emitting effects.
+            return emptyList()
+        }
+
+        // Sender-only event — silently ignored.
+        if (event is SharingFsmEvent.UserConsent && state != InboundSharingState.WaitingForUserConsent) {
+            return listOf(
+                SharingFsmEffect.ProtocolError(
+                    "UserConsent received in state=$state (expected WaitingForUserConsent)",
+                ),
+            ).also { state = InboundSharingState.Disconnected }
+        }
+
+        // CANCEL handling is uniform across all non-terminal states.
+        if (event is SharingFsmEvent.UserCancel) {
+            return handleUserCancel()
+        }
+        if (event is SharingFsmEvent.FrameReceived && event.frame.v1.type == SharingFrameType.CANCEL) {
+            return handlePeerCancel()
+        }
+
+        return when (state) {
+            InboundSharingState.SentPairedKeyEncryption -> onSentPairedKeyEncryption(event)
+            InboundSharingState.SentPairedKeyResult -> onSentPairedKeyResult(event)
+            InboundSharingState.ReceivedPairedKeyResult -> onReceivedPairedKeyResult(event)
+            InboundSharingState.WaitingForUserConsent -> onWaitingForUserConsent(event)
+            InboundSharingState.ReceivingPayloads -> onReceivingPayloads(event)
+            // Disconnected handled at the top of the function; this
+            // branch is unreachable but Kotlin requires it for
+            // exhaustiveness.
+            InboundSharingState.Disconnected -> emptyList()
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Per-state handlers
+    // ------------------------------------------------------------------
+
+    /**
+     * In [InboundSharingState.SentPairedKeyEncryption] we expect a
+     * `Frame{PAIRED_KEY_ENCRYPTION}` from the peer. Anything else (other
+     * than CANCEL, handled above) is a protocol error.
+     */
+    @Suppress("ReturnCount") // One early return per validation step keeps the failure path readable.
+    private fun onSentPairedKeyEncryption(event: SharingFsmEvent): List<SharingFsmEffect> {
+        if (event !is SharingFsmEvent.FrameReceived) {
+            return protocolError("non-frame event in SentPairedKeyEncryption: ${event::class.simpleName}")
+        }
+        val frame = event.frame
+        if (frame.v1.type != SharingFrameType.PAIRED_KEY_ENCRYPTION) {
+            return protocolError("expected PAIRED_KEY_ENCRYPTION, got ${frame.v1.type}")
+        }
+        if (!frame.v1.hasPairedKeyEncryption()) {
+            return protocolError("PAIRED_KEY_ENCRYPTION frame missing paired_key_encryption body")
+        }
+        // We do not actually verify the peer's PKE contents — NearDrop
+        // does not either, and stock Android peers tolerate UNABLE
+        // responses. We just acknowledge receipt by sending our PKR.
+        state = InboundSharingState.SentPairedKeyResult
+        return listOf(
+            SharingFsmEffect.SendFrame(
+                SharingFrames.pairedKeyResult(PairedKeyResultStatus.UNABLE),
+            ),
+        )
+    }
+
+    /**
+     * In [InboundSharingState.SentPairedKeyResult] we expect the peer's
+     * `Frame{PAIRED_KEY_RESULT}`. Its `status` field is informational —
+     * NearDrop ignores it (any value still leads to introduction), so
+     * we do too.
+     */
+    @Suppress("ReturnCount") // One early return per validation step keeps the failure path readable.
+    private fun onSentPairedKeyResult(event: SharingFsmEvent): List<SharingFsmEffect> {
+        if (event !is SharingFsmEvent.FrameReceived) {
+            return protocolError("non-frame event in SentPairedKeyResult: ${event::class.simpleName}")
+        }
+        val frame = event.frame
+        if (frame.v1.type != SharingFrameType.PAIRED_KEY_RESULT) {
+            return protocolError("expected PAIRED_KEY_RESULT, got ${frame.v1.type}")
+        }
+        if (!frame.v1.hasPairedKeyResult()) {
+            return protocolError("PAIRED_KEY_RESULT frame missing paired_key_result body")
+        }
+        state = InboundSharingState.ReceivedPairedKeyResult
+        return emptyList()
+    }
+
+    /**
+     * In [InboundSharingState.ReceivedPairedKeyResult] we await the
+     * sender's `IntroductionFrame`. On arrival the FSM moves to
+     * [InboundSharingState.WaitingForUserConsent] and surfaces the
+     * introduction up to the consent UI.
+     */
+    @Suppress("ReturnCount") // One early return per validation step keeps the failure path readable.
+    private fun onReceivedPairedKeyResult(event: SharingFsmEvent): List<SharingFsmEffect> {
+        if (event !is SharingFsmEvent.FrameReceived) {
+            return protocolError("non-frame event in ReceivedPairedKeyResult: ${event::class.simpleName}")
+        }
+        val frame = event.frame
+        if (frame.v1.type != SharingFrameType.INTRODUCTION) {
+            return protocolError("expected INTRODUCTION, got ${frame.v1.type}")
+        }
+        if (!frame.v1.hasIntroduction()) {
+            return protocolError("INTRODUCTION frame missing introduction body")
+        }
+        state = InboundSharingState.WaitingForUserConsent
+        return listOf(SharingFsmEffect.IntroductionReceived(frame.v1.introduction))
+    }
+
+    /**
+     * In [InboundSharingState.WaitingForUserConsent] the only legal
+     * inputs are [SharingFsmEvent.UserConsent] or a CANCEL frame /
+     * UserCancel (handled in [onEvent] before dispatch). Inbound
+     * `Sharing.Nearby.Frame`s of any other kind are protocol errors.
+     */
+    private fun onWaitingForUserConsent(event: SharingFsmEvent): List<SharingFsmEffect> {
+        if (event !is SharingFsmEvent.UserConsent) {
+            // The peer is not supposed to push a frame at us while we are
+            // showing consent UI. Treat any inbound frame here as a
+            // protocol error.
+            return protocolError(
+                "unexpected ${event::class.simpleName} in WaitingForUserConsent",
+            )
+        }
+        return if (event.accept) {
+            state = InboundSharingState.ReceivingPayloads
+            listOf(
+                SharingFsmEffect.SendFrame(
+                    SharingFrames.connectionResponse(ConnectionResponseStatus.ACCEPT),
+                ),
+                SharingFsmEffect.ReadyToReceivePayloads,
+                SharingFsmEffect.Completed,
+            )
+        } else {
+            state = InboundSharingState.Disconnected
+            listOf(
+                SharingFsmEffect.SendFrame(
+                    SharingFrames.connectionResponse(ConnectionResponseStatus.REJECT),
+                ),
+                SharingFsmEffect.Rejected(ConnectionResponseStatus.REJECT),
+                SharingFsmEffect.Cancelled,
+            )
+        }
+    }
+
+    /**
+     * Once we are in [InboundSharingState.ReceivingPayloads] the
+     * negotiation FSM is "complete"; only CANCEL events from peer or
+     * user produce further effects (and are handled in [onEvent] before
+     * dispatch). Stray frames are protocol errors — for example, a
+     * second `IntroductionFrame` after we already accepted is illegal.
+     */
+    private fun onReceivingPayloads(event: SharingFsmEvent): List<SharingFsmEffect> =
+        protocolError("unexpected ${event::class.simpleName} in ReceivingPayloads")
+
+    // ------------------------------------------------------------------
+    // Cancel paths
+    // ------------------------------------------------------------------
+
+    private fun handleUserCancel(): List<SharingFsmEffect> {
+        state = InboundSharingState.Disconnected
+        return listOf(
+            SharingFsmEffect.SendFrame(SharingFrames.cancel()),
+            SharingFsmEffect.Cancelled,
+        )
+    }
+
+    private fun handlePeerCancel(): List<SharingFsmEffect> {
+        state = InboundSharingState.Disconnected
+        return listOf(SharingFsmEffect.Cancelled)
+    }
+
+    private fun protocolError(reason: String): List<SharingFsmEffect> {
+        state = InboundSharingState.Disconnected
+        return listOf(SharingFsmEffect.ProtocolError(reason))
+    }
+}

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/sharing/OutboundSharingFsm.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/sharing/OutboundSharingFsm.kt
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.sharing
+
+import java.security.SecureRandom
+
+/**
+ * Sender-role Quick Share negotiation state machine.
+ *
+ * Symmetric in spirit to [InboundSharingFsm]: it shares the
+ * paired-key handshake but has a different middle (it emits the
+ * `IntroductionFrame` instead of waiting for one, and waits for the
+ * `ConnectionResponseFrame` instead of waiting for user consent).
+ *
+ * ### Lifecycle
+ *
+ *  1. The orchestrator (issue #17 — `OutboundConnection`) constructs the
+ *     FSM with a pre-built [IntroductionFrame] containing
+ *     `file_metadata[]` / `text_metadata[]` for the items the user wants
+ *     to send. Each metadata entry's `payload_id` MUST match the
+ *     `payload_id` the orchestrator will use when streaming the actual
+ *     file bytes after [SharingFsmEffect.ReadyToSendPayloads] fires.
+ *  2. The orchestrator calls [start] exactly once. The FSM emits the
+ *     outbound `PairedKeyEncryptionFrame` and enters
+ *     [OutboundSharingState.SentPairedKeyEncryption].
+ *  3. The orchestrator pumps inbound `Sharing.Nearby.Frame` arrivals
+ *     and user cancel requests through [onEvent].
+ *  4. On peer ACCEPT, the FSM transitions to
+ *     [OutboundSharingState.SendingPayloads] and emits
+ *     [SharingFsmEffect.ReadyToSendPayloads]. The orchestrator now
+ *     streams FILE / BYTES application payloads.
+ *  5. On any non-ACCEPT response status, the FSM transitions to
+ *     [OutboundSharingState.Disconnected] and emits
+ *     [SharingFsmEffect.Rejected] with the peer's status — including
+ *     `REJECT`, `UNKNOWN`, `NOT_ENOUGH_SPACE`, `TIMED_OUT`, and
+ *     `UNSUPPORTED_ATTACHMENT_TYPE` (the issue's acceptance criteria
+ *     enumerate these).
+ *
+ * ### Threading model
+ *
+ * Same as [InboundSharingFsm]: not thread-safe; the orchestrator
+ * serializes all calls.
+ *
+ * @param introduction The [IntroductionFrame] to emit after the
+ *   paired-key dance completes. Built by the orchestrator from the
+ *   user's chosen files / text and the `payload_id`s reserved for
+ *   them. Stored by reference; the FSM does not copy.
+ * @param secureRandom Source of bytes for the outgoing
+ *   [PairedKeyEncryptionFrame] random fields.
+ */
+public class OutboundSharingFsm(
+    private val introduction: IntroductionFrame,
+    private val secureRandom: SecureRandom = SecureRandom(),
+) {
+    /** Current FSM state. See [InboundSharingFsm.state] for the contract. */
+    public var state: OutboundSharingState = OutboundSharingState.SentPairedKeyEncryption
+        private set
+
+    private var started: Boolean = false
+
+    /**
+     * Drive the FSM to its initial state and produce the seed
+     * `PairedKeyEncryptionFrame`. Idempotent — same contract as
+     * [InboundSharingFsm.start].
+     */
+    public fun start(): List<SharingFsmEffect> {
+        if (started) return emptyList()
+        started = true
+        return listOf(
+            SharingFsmEffect.SendFrame(
+                SharingFrames.pairedKeyEncryption(secureRandom = secureRandom),
+            ),
+        )
+    }
+
+    /**
+     * Apply one input event and produce the corresponding effect list.
+     *
+     * The list is ordered (frame send before terminal notifications).
+     * After [OutboundSharingState.Disconnected] every call returns an
+     * empty list.
+     */
+    @Suppress(
+        "ReturnCount", // One return per terminal/branch; merging would obscure the transition table.
+    )
+    public fun onEvent(event: SharingFsmEvent): List<SharingFsmEffect> {
+        if (state == OutboundSharingState.Disconnected) return emptyList()
+
+        // Receiver-only event — the sender FSM never gets a UserConsent.
+        // We treat the bug as a protocol error so it surfaces loudly
+        // rather than silently dropping the event.
+        if (event is SharingFsmEvent.UserConsent) {
+            return protocolError("UserConsent is receiver-only; sender FSM cannot accept it")
+        }
+
+        if (event is SharingFsmEvent.UserCancel) return handleUserCancel()
+        if (event is SharingFsmEvent.FrameReceived && event.frame.v1.type == SharingFrameType.CANCEL) {
+            return handlePeerCancel()
+        }
+
+        return when (state) {
+            OutboundSharingState.SentPairedKeyEncryption -> onSentPairedKeyEncryption(event)
+            OutboundSharingState.SentPairedKeyResult -> onSentPairedKeyResult(event)
+            OutboundSharingState.SentIntroduction -> onSentIntroduction(event)
+            OutboundSharingState.SendingPayloads -> onSendingPayloads(event)
+            OutboundSharingState.Disconnected -> emptyList()
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Per-state handlers
+    // ------------------------------------------------------------------
+
+    @Suppress("ReturnCount") // One early return per validation step keeps the failure path readable.
+    private fun onSentPairedKeyEncryption(event: SharingFsmEvent): List<SharingFsmEffect> {
+        if (event !is SharingFsmEvent.FrameReceived) {
+            return protocolError("non-frame event in SentPairedKeyEncryption: ${event::class.simpleName}")
+        }
+        val frame = event.frame
+        if (frame.v1.type != SharingFrameType.PAIRED_KEY_ENCRYPTION) {
+            return protocolError("expected PAIRED_KEY_ENCRYPTION, got ${frame.v1.type}")
+        }
+        if (!frame.v1.hasPairedKeyEncryption()) {
+            return protocolError("PAIRED_KEY_ENCRYPTION frame missing paired_key_encryption body")
+        }
+        state = OutboundSharingState.SentPairedKeyResult
+        return listOf(
+            SharingFsmEffect.SendFrame(
+                SharingFrames.pairedKeyResult(PairedKeyResultStatus.UNABLE),
+            ),
+        )
+    }
+
+    @Suppress("ReturnCount") // One early return per validation step keeps the failure path readable.
+    private fun onSentPairedKeyResult(event: SharingFsmEvent): List<SharingFsmEffect> {
+        if (event !is SharingFsmEvent.FrameReceived) {
+            return protocolError("non-frame event in SentPairedKeyResult: ${event::class.simpleName}")
+        }
+        val frame = event.frame
+        if (frame.v1.type != SharingFrameType.PAIRED_KEY_RESULT) {
+            return protocolError("expected PAIRED_KEY_RESULT, got ${frame.v1.type}")
+        }
+        if (!frame.v1.hasPairedKeyResult()) {
+            return protocolError("PAIRED_KEY_RESULT frame missing paired_key_result body")
+        }
+        state = OutboundSharingState.SentIntroduction
+        return listOf(
+            SharingFsmEffect.SendFrame(SharingFrames.introduction(introduction)),
+        )
+    }
+
+    @Suppress(
+        "ReturnCount", // One early return per validation step keeps the failure path readable.
+        "CyclomaticComplexMethod", // One branch per Status enum value; merging would lose specificity.
+    )
+    private fun onSentIntroduction(event: SharingFsmEvent): List<SharingFsmEffect> {
+        if (event !is SharingFsmEvent.FrameReceived) {
+            return protocolError("non-frame event in SentIntroduction: ${event::class.simpleName}")
+        }
+        val frame = event.frame
+        if (frame.v1.type != SharingFrameType.RESPONSE) {
+            return protocolError("expected RESPONSE (ConnectionResponseFrame), got ${frame.v1.type}")
+        }
+        if (!frame.v1.hasConnectionResponse()) {
+            return protocolError("RESPONSE frame missing connection_response body")
+        }
+        val status = frame.v1.connectionResponse.status
+        return when (status) {
+            ConnectionResponseStatus.ACCEPT -> {
+                state = OutboundSharingState.SendingPayloads
+                listOf(
+                    SharingFsmEffect.ReadyToSendPayloads,
+                    SharingFsmEffect.Completed,
+                )
+            }
+            ConnectionResponseStatus.REJECT,
+            ConnectionResponseStatus.UNKNOWN,
+            ConnectionResponseStatus.NOT_ENOUGH_SPACE,
+            ConnectionResponseStatus.TIMED_OUT,
+            ConnectionResponseStatus.UNSUPPORTED_ATTACHMENT_TYPE,
+            -> {
+                state = OutboundSharingState.Disconnected
+                listOf(
+                    SharingFsmEffect.Rejected(status),
+                    SharingFsmEffect.Cancelled,
+                )
+            }
+            // Defensive: protobuf-javalite synthesizes a `null` for an
+            // unset enum, but `connection_response.status` is `optional`
+            // with default UNKNOWN, so this branch is virtually
+            // unreachable. We still treat it as protocol error so a
+            // future proto extension surfacing a brand-new status code
+            // does not silently fall through as ACCEPT.
+            null -> protocolError("ConnectionResponseFrame.status was null")
+        }
+    }
+
+    /**
+     * Once we are in [OutboundSharingState.SendingPayloads] the
+     * negotiation FSM is complete; only CANCEL events produce further
+     * effects (handled in [onEvent] before dispatch). Stray frames are
+     * protocol errors.
+     */
+    private fun onSendingPayloads(event: SharingFsmEvent): List<SharingFsmEffect> =
+        protocolError("unexpected ${event::class.simpleName} in SendingPayloads")
+
+    // ------------------------------------------------------------------
+    // Cancel paths
+    // ------------------------------------------------------------------
+
+    private fun handleUserCancel(): List<SharingFsmEffect> {
+        state = OutboundSharingState.Disconnected
+        return listOf(
+            SharingFsmEffect.SendFrame(SharingFrames.cancel()),
+            SharingFsmEffect.Cancelled,
+        )
+    }
+
+    private fun handlePeerCancel(): List<SharingFsmEffect> {
+        state = OutboundSharingState.Disconnected
+        return listOf(SharingFsmEffect.Cancelled)
+    }
+
+    private fun protocolError(reason: String): List<SharingFsmEffect> {
+        state = OutboundSharingState.Disconnected
+        return listOf(SharingFsmEffect.ProtocolError(reason))
+    }
+}

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/sharing/SharingFrames.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/sharing/SharingFrames.kt
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.sharing
+
+import com.google.android.gms.nearby.sharing.Protocol
+import com.google.protobuf.ByteString
+import java.security.SecureRandom
+
+/**
+ * Convenience type aliases and builders for the `Sharing.Nearby.Frame`
+ * proto family used during Quick Share negotiation.
+ *
+ * The fully-qualified Java name of the negotiation frame is
+ * [com.google.android.gms.nearby.sharing.Protocol.Frame] — distinct from
+ * `OfflineFrame` (which lives in the `OfflineWireFormatsProto` family used
+ * by the Nearby Connections layer below us). The two namespaces are easy
+ * to confuse because the negotiation frames travel as **BYTES payloads**
+ * inside `OfflineFrame{type=PAYLOAD_TRANSFER}` envelopes — the `Sharing
+ * .Nearby.Frame` is the *contents* that the receiver pulls out of a
+ * BYTES payload after [io.github.kyujincho.wvmg.protocol.payload.PayloadAssembler]
+ * reassembles it.
+ *
+ * The aliases below give us short, unambiguous Kotlin names for the
+ * negotiation frames so the FSM code in this package does not have to
+ * repeat the long Java class path on every line.
+ */
+public typealias SharingFrame = Protocol.Frame
+
+/** Top-level versioned wrapper enum. */
+public typealias SharingFrameVersion = Protocol.Frame.Version
+
+/** Negotiation `V1Frame` — the envelope that carries a single oneof body. */
+public typealias SharingV1Frame = Protocol.V1Frame
+
+/** Negotiation `V1Frame.FrameType` — the discriminator for the oneof. */
+public typealias SharingFrameType = Protocol.V1Frame.FrameType
+
+/** Paired-key encryption frame (steps 1-2 of the choreography). */
+public typealias PairedKeyEncryptionFrame = Protocol.PairedKeyEncryptionFrame
+
+/** Paired-key result frame (steps 2-3 of the choreography). */
+public typealias PairedKeyResultFrame = Protocol.PairedKeyResultFrame
+
+/** Result-frame status enum (`SUCCESS | FAIL | UNABLE | UNKNOWN`). */
+public typealias PairedKeyResultStatus = Protocol.PairedKeyResultFrame.Status
+
+/** The introduction frame (step 3) — sender's metadata announcement. */
+public typealias IntroductionFrame = Protocol.IntroductionFrame
+
+/** Connection response frame (step 4-5) — receiver's accept/reject. */
+public typealias ConnectionResponseFrame = Protocol.ConnectionResponseFrame
+
+/** `ConnectionResponseFrame.Status` (`ACCEPT | REJECT | NOT_ENOUGH_SPACE | ...`). */
+public typealias ConnectionResponseStatus = Protocol.ConnectionResponseFrame.Status
+
+/**
+ * Builders and (de)serialization helpers for [SharingFrame].
+ *
+ * The negotiation FSM is pure (no I/O), so it deals in already-parsed
+ * `Sharing.Nearby.Frame` instances rather than raw bytes. The helpers
+ * here let consumers convert between the two forms at the FSM boundary:
+ *
+ *  - The receive side calls [parse] on a BYTES payload that
+ *    [io.github.kyujincho.wvmg.protocol.payload.PayloadAssembler]
+ *    surfaced.
+ *  - The send side calls [SharingFrame.toByteArray] on the FSM's
+ *    `SendFrame` effect and feeds it through
+ *    [io.github.kyujincho.wvmg.protocol.payload.PayloadTransferEncoder.encodeBytesPayload].
+ *
+ * All builders default `version = V1` because the only negotiation
+ * version Quick Share has ever shipped is V1; sending `UNKNOWN_VERSION`
+ * would cause every real peer to drop the connection.
+ */
+public object SharingFrames {
+    /**
+     * Default fill-byte counts for [pairedKeyEncryption], anchored on
+     * NearDrop's known-interoperable choices.
+     *
+     * Quick Share sender devices identify themselves using a contact
+     * certificate rooted in a Google account. A sending phone proves it
+     * "belongs to a contact" by signing the receiver's UKEY2 token with
+     * its private key and sending the result as `signed_data`, plus a
+     * 32-byte HMAC of the certificate `secret_id` as `secret_id_hash`.
+     * NearDrop bypasses this whole dance — it does not have a certificate
+     * store and it does not care to be recognized as a contact — by
+     * filling both fields with random bytes of plausible-looking lengths.
+     * Real Android peers receive this, fail to find a matching certificate,
+     * fall through to the "Everyone for 10 minutes" visibility path, and
+     * the transfer continues. The byte counts below match NearDrop:
+     * 6 bytes for `secret_id_hash`, 72 bytes for `signed_data`.
+     */
+    public const val DEFAULT_SECRET_ID_HASH_LENGTH: Int = 6
+    public const val DEFAULT_SIGNED_DATA_LENGTH: Int = 72
+
+    /**
+     * Build a `Sharing.Nearby.Frame` carrying a `PairedKeyEncryptionFrame`.
+     *
+     * The frame is filled with random bytes drawn from [secureRandom] for
+     * both `secret_id_hash` (default [DEFAULT_SECRET_ID_HASH_LENGTH]) and
+     * `signed_data` (default [DEFAULT_SIGNED_DATA_LENGTH]). NearDrop's
+     * field test confirms this is enough to interop with stock Quick
+     * Share peers — see the rationale above [DEFAULT_SECRET_ID_HASH_LENGTH].
+     *
+     * @param secureRandom Source of fill bytes. Production code passes a
+     *   default [SecureRandom]; tests pass a deterministic stub.
+     * @param secretIdHashLength Number of bytes for `secret_id_hash`.
+     * @param signedDataLength Number of bytes for `signed_data`.
+     */
+    public fun pairedKeyEncryption(
+        secureRandom: SecureRandom = SecureRandom(),
+        secretIdHashLength: Int = DEFAULT_SECRET_ID_HASH_LENGTH,
+        signedDataLength: Int = DEFAULT_SIGNED_DATA_LENGTH,
+    ): SharingFrame {
+        require(secretIdHashLength >= 0) { "secretIdHashLength must be non-negative" }
+        require(signedDataLength >= 0) { "signedDataLength must be non-negative" }
+        val secretIdHash = ByteArray(secretIdHashLength).also(secureRandom::nextBytes)
+        val signedData = ByteArray(signedDataLength).also(secureRandom::nextBytes)
+        val pke =
+            PairedKeyEncryptionFrame
+                .newBuilder()
+                .setSecretIdHash(ByteString.copyFrom(secretIdHash))
+                .setSignedData(ByteString.copyFrom(signedData))
+                .build()
+        return wrapV1(SharingFrameType.PAIRED_KEY_ENCRYPTION) {
+            setPairedKeyEncryption(pke)
+        }
+    }
+
+    /**
+     * Build a `Sharing.Nearby.Frame` carrying a `PairedKeyResultFrame`
+     * with the given status.
+     *
+     * The default status is `UNABLE` — same as NearDrop. UNABLE tells the
+     * peer "I cannot complete the paired-key verification, please proceed
+     * anyway", which is exactly the user-visible behavior we want for a
+     * client that has no contact certificate store.
+     */
+    public fun pairedKeyResult(status: PairedKeyResultStatus = PairedKeyResultStatus.UNABLE): SharingFrame {
+        val pkr =
+            PairedKeyResultFrame
+                .newBuilder()
+                .setStatus(status)
+                .build()
+        return wrapV1(SharingFrameType.PAIRED_KEY_RESULT) {
+            setPairedKeyResult(pkr)
+        }
+    }
+
+    /**
+     * Wrap an already-built [IntroductionFrame] into a top-level
+     * [SharingFrame]. Sender FSM uses this on send; receiver FSM never
+     * builds an introduction itself, but tests do — round-tripping
+     * through `parse` is the cleanest way to assert frame contents.
+     */
+    public fun introduction(intro: IntroductionFrame): SharingFrame =
+        wrapV1(SharingFrameType.INTRODUCTION) {
+            setIntroduction(intro)
+        }
+
+    /**
+     * Wrap a `ConnectionResponseFrame` with the given status into a
+     * top-level [SharingFrame]. Used by the receiver FSM to emit
+     * accept / reject after user consent.
+     */
+    public fun connectionResponse(status: ConnectionResponseStatus): SharingFrame {
+        val response =
+            ConnectionResponseFrame
+                .newBuilder()
+                .setStatus(status)
+                .build()
+        return wrapV1(SharingFrameType.RESPONSE) {
+            setConnectionResponse(response)
+        }
+    }
+
+    /**
+     * Build a `Sharing.Nearby.Frame` carrying a CANCEL signal.
+     *
+     * `CancelFrame` is intentionally bodyless in the proto — its mere
+     * presence (the `v1.type == CANCEL` discriminator) is the entire
+     * payload. Either side can emit this at any non-terminal state.
+     */
+    public fun cancel(): SharingFrame =
+        wrapV1(SharingFrameType.CANCEL) {
+            // Body intentionally empty: CancelFrame has no fields.
+        }
+
+    /**
+     * Parse a serialized [SharingFrame] from a BYTES payload body.
+     *
+     * The receiver pipeline calls this on the byte array surfaced by
+     * [io.github.kyujincho.wvmg.protocol.payload.PayloadEvent.BytesComplete].
+     * Throws [SharingFrameParseException] on any malformed proto;
+     * callers treat that as a fatal protocol error (close the
+     * connection, surface a transfer-failed UI).
+     */
+    @Throws(SharingFrameParseException::class)
+    public fun parse(bytes: ByteArray): SharingFrame =
+        try {
+            SharingFrame.parseFrom(bytes)
+        } catch (e: com.google.protobuf.InvalidProtocolBufferException) {
+            throw SharingFrameParseException("Sharing.Nearby.Frame proto failed to parse", e)
+        }
+
+    /**
+     * Common path for every FSM-emitted frame: wrap a configured V1Frame
+     * inside a `Frame{version=V1}` envelope. The [build] block configures
+     * the V1Frame oneof body (e.g. `setIntroduction(...)`).
+     *
+     * The receiver type is the Java builder rather than a Kotlin
+     * typealias because Kotlin does not resolve nested types through
+     * typealiases (`SharingV1Frame.Builder` does not parse where the
+     * underlying Java class works); the explicit FQN keeps the helper
+     * callable from `apply { ... }` blocks.
+     */
+    private inline fun wrapV1(
+        type: SharingFrameType,
+        build: Protocol.V1Frame.Builder.() -> Unit,
+    ): SharingFrame {
+        val v1 =
+            Protocol.V1Frame
+                .newBuilder()
+                .setType(type)
+                .apply(build)
+                .build()
+        return SharingFrame
+            .newBuilder()
+            .setVersion(SharingFrameVersion.V1)
+            .setV1(v1)
+            .build()
+    }
+}
+
+/**
+ * Thrown by [SharingFrames.parse] when the bytes the assembler handed
+ * up do not parse as a `Sharing.Nearby.Frame`. Treated as a fatal
+ * protocol error by the FSM consumer — there is no resync.
+ */
+public class SharingFrameParseException(
+    message: String,
+    cause: Throwable? = null,
+) : RuntimeException(message, cause)

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/sharing/SharingFsmEffect.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/sharing/SharingFsmEffect.kt
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.sharing
+
+/**
+ * Outputs produced by a Quick Share negotiation state machine in
+ * response to a single [SharingFsmEvent].
+ *
+ * The FSM never performs I/O directly — every external action it would
+ * like to take is reified as one of these effects, returned to the
+ * orchestrator (issues #16 / #17 / #22) which interprets them:
+ *
+ *  - [SendFrame] is sent through the BYTES-payload encoder
+ *    ([io.github.kyujincho.wvmg.protocol.payload.PayloadTransferEncoder.encodeBytesPayload])
+ *    and the resulting `OfflineFrame`s are pushed through the
+ *    [io.github.kyujincho.wvmg.protocol.crypto.securemessage.SecureChannel].
+ *  - [IntroductionReceived] tells the receiver UI to show the consent
+ *    sheet for the announced files / text.
+ *  - [ReadyToReceivePayloads] / [ReadyToSendPayloads] is the gate that
+ *    file streaming waits on; until it fires, no FILE / BYTES
+ *    application payloads are produced or accepted.
+ *  - [Rejected] / [Cancelled] / [Completed] / [ProtocolError] are all
+ *    terminal notifications. After any of these, the FSM is in
+ *    [InboundSharingState.Disconnected] / [OutboundSharingState.Disconnected]
+ *    and further events return an empty effect list.
+ *
+ * The list returned by `onEvent` is ordered: effects must be applied in
+ * the listed order. In practice that means a state transition that
+ * sends a frame *and* completes the FSM (for example, sender's
+ * `IntroductionFrame` → `ConnectionResponseFrame{ACCEPT}` does not
+ * complete it, but receiver's `UserConsent(accept=false)` does)
+ * surfaces the [SendFrame] before the [Rejected] / [Cancelled] /
+ * [Completed] notifier so the orchestrator pushes the bytes onto the
+ * wire before it tears the connection down.
+ */
+public sealed interface SharingFsmEffect {
+    /**
+     * The FSM wants to send the given [SharingFrame] to the peer.
+     *
+     * The orchestrator is responsible for:
+     *  1. Choosing a fresh BYTES-payload `payload_id` (any positive
+     *     `Long` that has not been used in the current connection
+     *     works — NearDrop uses `SecureRandom.nextLong()` and so should
+     *     we; reuse causes the receiver's [io.github.kyujincho.wvmg.protocol.payload.PayloadAssembler]
+     *     to reject the frame).
+     *  2. Calling [io.github.kyujincho.wvmg.protocol.payload.PayloadTransferEncoder.encodeBytesPayload]
+     *     with the serialized frame bytes.
+     *  3. Sending the resulting `OfflineFrame`s through the
+     *     [io.github.kyujincho.wvmg.protocol.crypto.securemessage.SecureChannel].
+     *
+     * @property frame The frame to serialize and send. Already a complete
+     *   `Sharing.Nearby.Frame` with `version = V1` and the appropriate
+     *   `v1.type` discriminator set.
+     */
+    public data class SendFrame(
+        val frame: SharingFrame,
+    ) : SharingFsmEffect
+
+    /**
+     * Receiver-only. The peer has sent its `IntroductionFrame` listing
+     * the files / text it wants to transfer. The orchestrator surfaces
+     * this to the consent UI; the user's accept/reject choice comes
+     * back as [SharingFsmEvent.UserConsent].
+     *
+     * @property introduction The full `IntroductionFrame` proto. Carries
+     *   `file_metadata[]`, `text_metadata[]`, `wifi_credentials_metadata[]`,
+     *   `app_metadata[]`, `stream_metadata[]`, `required_package`,
+     *   `start_transfer`, `use_case`, and `preview_payload_ids`. The
+     *   consent UI typically only renders `file_metadata` and
+     *   `text_metadata`.
+     */
+    public data class IntroductionReceived(
+        val introduction: IntroductionFrame,
+    ) : SharingFsmEffect
+
+    /**
+     * Receiver-only. The negotiation handshake is complete and the user
+     * accepted; the orchestrator should now begin accepting BYTES /
+     * FILE application payloads from the peer. Subsequent
+     * `PayloadTransferFrame`s for the announced `payload_id`s become
+     * meaningful from this point forward.
+     *
+     * Emitted exactly once, immediately after the FSM enqueues the
+     * `ConnectionResponseFrame{ACCEPT}` for sending.
+     */
+    public object ReadyToReceivePayloads : SharingFsmEffect
+
+    /**
+     * Sender-only. The peer accepted the introduction; the sender may
+     * begin streaming the announced FILE / BYTES (text) payloads.
+     *
+     * Emitted exactly once, immediately after the FSM observes the
+     * inbound `ConnectionResponseFrame{ACCEPT}`.
+     */
+    public object ReadyToSendPayloads : SharingFsmEffect
+
+    /**
+     * Sender-only. The peer rejected the transfer with a non-ACCEPT
+     * status. The orchestrator interprets the [status] for UI display
+     * (e.g. "Recipient rejected", "Recipient ran out of space", etc.),
+     * then closes the connection.
+     *
+     * Per the issue acceptance criteria, `REJECT` and `UNKNOWN` are
+     * surfaced here as user-rejected; `NOT_ENOUGH_SPACE`, `TIMED_OUT`,
+     * and `UNSUPPORTED_ATTACHMENT_TYPE` are surfaced with their
+     * specific status. The FSM does not itself classify them — the
+     * orchestrator is welcome to render UNKNOWN as "rejected" if it
+     * wishes.
+     *
+     * @property status The peer's `ConnectionResponseFrame.Status` —
+     *   never `ACCEPT` here, by construction.
+     */
+    public data class Rejected(
+        val status: ConnectionResponseStatus,
+    ) : SharingFsmEffect
+
+    /**
+     * Either side. A cancellation was processed — locally requested via
+     * [SharingFsmEvent.UserCancel] (in which case the FSM also emitted
+     * a [SendFrame] carrying a CANCEL frame), or remotely received via
+     * an inbound `Frame{CANCEL}`.
+     *
+     * The orchestrator should close the connection and surface a
+     * "Transfer cancelled" notification.
+     */
+    public object Cancelled : SharingFsmEffect
+
+    /**
+     * Either side. The negotiation FSM has nothing more to do — for the
+     * receiver, this means accepted-and-ready (so [ReadyToReceivePayloads]
+     * has already fired in the same effect list); for the sender it
+     * means accepted-and-ready (so [ReadyToSendPayloads] has fired).
+     *
+     * Issued AFTER the ready-to-stream effect so the orchestrator can
+     * walk the list in order without buffering. Strictly speaking the
+     * FSM does not need to emit [Completed] for the orchestrator to
+     * know — checking [InboundSharingFsm.state] / [OutboundSharingFsm.state]
+     * is equivalent — but the explicit notification makes for cleaner
+     * logging and simpler test assertions.
+     *
+     * Emitting [Completed] does NOT mean "the file transfer finished";
+     * file streaming happens *after* the FSM has accepted. The FSM
+     * itself only models the negotiation phase.
+     */
+    public object Completed : SharingFsmEffect
+
+    /**
+     * Either side. The FSM observed an event that violated its
+     * transition table — typically a frame in the wrong state, an
+     * unexpected `v1.type`, or an inbound frame whose body is missing
+     * the field its discriminator promised.
+     *
+     * The orchestrator MUST close the connection on this effect; there
+     * is no resync. After [ProtocolError] the FSM is in its terminal
+     * disconnected state.
+     *
+     * @property reason Short, English, log-suitable description.
+     */
+    public data class ProtocolError(
+        val reason: String,
+    ) : SharingFsmEffect
+}

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/sharing/SharingFsmEvent.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/sharing/SharingFsmEvent.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.sharing
+
+/**
+ * Inputs to a Quick Share negotiation state machine.
+ *
+ * The negotiation FSM is **pure**: it owns no I/O, no coroutines, no
+ * threading. The surrounding orchestration (issues #16 / #17 / #22)
+ * funnels every external stimulus into one of these events and calls
+ * [InboundSharingFsm.onEvent] / [OutboundSharingFsm.onEvent], then acts
+ * on the resulting [SharingFsmEffect] list.
+ *
+ * Three event kinds cover the entire input space:
+ *
+ *  - [FrameReceived] — a `Sharing.Nearby.Frame` came in over the wire.
+ *    The orchestrator already pulled it out of the surrounding BYTES
+ *    payload via [io.github.kyujincho.wvmg.protocol.payload.PayloadAssembler]
+ *    and parsed it via [SharingFrames.parse]. Parse failures are surfaced
+ *    out-of-band by the orchestrator (`SharingFrameParseException`) — they
+ *    do NOT travel through this event channel because there is no useful
+ *    response from the FSM, only "close the connection".
+ *  - [UserConsent] — the receiver-side user pressed accept or reject in
+ *    the consent UI. Sender FSMs never see this event.
+ *  - [UserCancel] — the local user pressed cancel. Either role can see
+ *    this; the FSM emits the matching outbound `CancelFrame` and moves
+ *    to a terminal state.
+ *
+ * Cancellation **from the peer** arrives as a [FrameReceived] whose
+ * `v1.type == CANCEL` — there is no separate event for it. The receive
+ * path treats inbound CANCEL identically regardless of which state the
+ * FSM happens to be in (every non-terminal state accepts it).
+ */
+public sealed interface SharingFsmEvent {
+    /**
+     * A `Sharing.Nearby.Frame` was decoded from a BYTES payload that
+     * the peer sent.
+     *
+     * @property frame Already-parsed frame. The FSM dispatches on
+     *   `frame.v1.type`. The frame's other fields are read on demand —
+     *   e.g. `frame.v1.connectionResponse.status` for the sender FSM's
+     *   response handling.
+     */
+    public data class FrameReceived(
+        val frame: SharingFrame,
+    ) : SharingFsmEvent
+
+    /**
+     * The local user accepted or rejected the incoming transfer in the
+     * consent UI. Receiver-only — issuing this to a sender FSM is a
+     * caller bug and is silently ignored (no effect, state unchanged).
+     *
+     * @property accept `true` for accept, `false` for reject.
+     */
+    public data class UserConsent(
+        val accept: Boolean,
+    ) : SharingFsmEvent
+
+    /**
+     * The local user requested cancellation. Both roles support this;
+     * the FSM emits a [SharingFsmEffect.SendFrame] carrying a
+     * `Sharing.Nearby.Frame{CANCEL}` plus a [SharingFsmEffect.Cancelled]
+     * notification, then transitions to its terminal disconnected state.
+     */
+    public object UserCancel : SharingFsmEvent
+}

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/sharing/SharingFsmState.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/sharing/SharingFsmState.kt
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.sharing
+
+/**
+ * States of the **inbound** Quick Share negotiation FSM.
+ *
+ * The naming mirrors NearDrop's `InboundNearbyConnection.State` (Swift
+ * reference implementation), which mirrors stock Android Quick Share's
+ * receive-side phase machine. Some states from NearDrop's enum are NOT
+ * present here because they correspond to handshake / transport-layer
+ * phases that this codebase splits across earlier modules:
+ *
+ *  - `initial`, `receivedConnectionRequest`, `sentUkeyServerInit`,
+ *    `receivedUkeyClientFinish`, `sentConnectionResponse` — handled by
+ *    [io.github.kyujincho.wvmg.protocol.transport.FramedConnection]
+ *    + [io.github.kyujincho.wvmg.protocol.ukey2.Ukey2Server] (issues
+ *    #7 / #10). The FSM in this module starts AFTER that handshake,
+ *    in [SentPairedKeyEncryption].
+ *  - `receivingFiles` — the post-negotiation file-streaming phase
+ *    (issues #16 / #19 / #23). The FSM marks the boundary by emitting
+ *    [SharingFsmEffect.ReadyToReceivePayloads] and transitioning to
+ *    [Disconnected] only on cancel / error / completion of file
+ *    streaming, which is reported back in by the orchestrator. To keep
+ *    THIS module pure-FSM, [ReceivingPayloads] is the post-consent
+ *    state and the orchestrator owns the actual file I/O.
+ *
+ * Transition diagram (`->` is a state transition, `(emit X)` is the
+ * effects produced):
+ *
+ * ```
+ *   [enter] -> SentPairedKeyEncryption           (emit SendFrame{PKE})
+ *   SentPairedKeyEncryption
+ *     +-- Frame{PAIRED_KEY_ENCRYPTION}      ->  ReceivedPairedKeyEncryption (emit SendFrame{PKR=UNABLE})
+ *     +-- Frame{CANCEL}                     ->  Disconnected               (emit Cancelled)
+ *     +-- UserCancel                        ->  Disconnected               (emit SendFrame{CANCEL}, Cancelled)
+ *     +-- *                                 ->  Disconnected               (emit ProtocolError)
+ *
+ *   ReceivedPairedKeyEncryption -> SentPairedKeyResult (transition is implicit; see code)
+ *   SentPairedKeyResult
+ *     +-- Frame{PAIRED_KEY_RESULT}          ->  ReceivedPairedKeyResult
+ *     ... (CANCEL / ProtocolError as above)
+ *
+ *   ReceivedPairedKeyResult
+ *     +-- Frame{INTRODUCTION}               ->  WaitingForUserConsent      (emit IntroductionReceived)
+ *     ... (CANCEL / ProtocolError as above)
+ *
+ *   WaitingForUserConsent
+ *     +-- UserConsent(true)   ->  ReceivingPayloads
+ *           (emit SendFrame{RESPONSE=ACCEPT}, ReadyToReceivePayloads, Completed)
+ *     +-- UserConsent(false)  ->  Disconnected
+ *           (emit SendFrame{RESPONSE=REJECT}, Rejected, Cancelled)
+ *     ... (CANCEL / ProtocolError as above)
+ *
+ *   ReceivingPayloads (terminal w.r.t. the FSM; the orchestrator owns it from here)
+ * ```
+ */
+public enum class InboundSharingState {
+    /**
+     * Initial state on entry. The FSM has just emitted a
+     * `PairedKeyEncryptionFrame` and is waiting for the peer's
+     * matching frame.
+     */
+    SentPairedKeyEncryption,
+
+    /**
+     * The peer's `PairedKeyEncryptionFrame` arrived; the FSM responded
+     * with `PairedKeyResultFrame{status=UNABLE}` and is waiting for the
+     * peer's matching result frame. (Distinct from [SentPairedKeyResult]
+     * by virtue of also having received PKE — they would otherwise be
+     * a single state.)
+     */
+    SentPairedKeyResult,
+
+    /**
+     * Both halves of the paired-key dance are done. The FSM is now
+     * waiting for the sender's `IntroductionFrame`.
+     */
+    ReceivedPairedKeyResult,
+
+    /**
+     * The introduction is in hand; the FSM is waiting for the user's
+     * accept / reject decision (delivered via [SharingFsmEvent.UserConsent]).
+     * No protocol frames are expected from the peer here EXCEPT
+     * `CancelFrame`.
+     */
+    WaitingForUserConsent,
+
+    /**
+     * The user accepted; `ConnectionResponseFrame{ACCEPT}` was sent;
+     * the FSM has signaled [SharingFsmEffect.ReadyToReceivePayloads].
+     * From the FSM's perspective negotiation is **complete** and the
+     * orchestrator is now responsible for receiving FILE / BYTES
+     * application payloads. The FSM remains in this state until the
+     * orchestrator drives it to [Disconnected] via [SharingFsmEvent.UserCancel]
+     * or until a peer `Frame{CANCEL}` arrives.
+     */
+    ReceivingPayloads,
+
+    /**
+     * Terminal. Reached after rejection, cancellation, protocol error,
+     * or successful completion. Subsequent events return an empty
+     * effect list.
+     */
+    Disconnected,
+}
+
+/**
+ * States of the **outbound** Quick Share negotiation FSM.
+ *
+ * Mirrors NearDrop's `OutboundNearbyConnection.State` for the same
+ * reasons documented on [InboundSharingState]. Pre-negotiation phases
+ * (UKEY2 client init, sending the connection request) live in earlier
+ * modules; the post-negotiation file-streaming phase (`SendingFiles`)
+ * lives in #17.
+ *
+ * Transition diagram:
+ *
+ * ```
+ *   [enter] -> SentPairedKeyEncryption           (emit SendFrame{PKE})
+ *   SentPairedKeyEncryption
+ *     +-- Frame{PAIRED_KEY_ENCRYPTION}      ->  ReceivedPairedKeyEncryption (emit SendFrame{PKR=UNABLE})
+ *     ... (CANCEL / ProtocolError as for inbound)
+ *
+ *   ReceivedPairedKeyEncryption -> SentPairedKeyResult (implicit; see code)
+ *   SentPairedKeyResult
+ *     +-- Frame{PAIRED_KEY_RESULT}          ->  SentIntroduction           (emit SendFrame{INTRODUCTION})
+ *     ... (CANCEL / ProtocolError as above)
+ *
+ *   SentIntroduction
+ *     +-- Frame{RESPONSE, status=ACCEPT}    ->  SendingPayloads            (emit ReadyToSendPayloads, Completed)
+ *     +-- Frame{RESPONSE, status=*}         ->  Disconnected               (emit Rejected, Cancelled)
+ *     ... (CANCEL / ProtocolError as above)
+ *
+ *   SendingPayloads (terminal w.r.t. the FSM)
+ * ```
+ */
+public enum class OutboundSharingState {
+    /** The FSM emitted `PairedKeyEncryptionFrame`; awaiting peer's PKE. */
+    SentPairedKeyEncryption,
+
+    /** PKE received and replied; awaiting peer's `PairedKeyResultFrame`. */
+    SentPairedKeyResult,
+
+    /**
+     * Paired-key dance done; the FSM has emitted the
+     * `IntroductionFrame` and is awaiting the receiver's
+     * `ConnectionResponseFrame`.
+     */
+    SentIntroduction,
+
+    /**
+     * Receiver accepted; the FSM has signaled [SharingFsmEffect.ReadyToSendPayloads]
+     * and the orchestrator is now sending FILE / BYTES application
+     * payloads. Like [InboundSharingState.ReceivingPayloads], this is
+     * the FSM's "negotiation complete" plateau.
+     */
+    SendingPayloads,
+
+    /**
+     * Terminal. Reached after rejection, cancellation, protocol error,
+     * or successful completion. Subsequent events return an empty
+     * effect list.
+     */
+    Disconnected,
+}

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/sharing/InboundSharingFsmTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/sharing/InboundSharingFsmTest.kt
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.sharing
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import java.security.SecureRandom
+
+/**
+ * Tests for [InboundSharingFsm].
+ *
+ * Coverage targets the full transition table:
+ *
+ *  - Happy path: PKE → PKR → INTRODUCTION → UserConsent(true) → ACCEPT
+ *    → ReadyToReceivePayloads → Completed.
+ *  - Reject path: UserConsent(false) → REJECT.
+ *  - User cancel from any non-terminal state.
+ *  - Peer cancel from any non-terminal state.
+ *  - Misordered frame (e.g. INTRODUCTION before paired-key dance) →
+ *    ProtocolError.
+ *  - Frame with mismatched discriminator/body (e.g. type=INTRODUCTION
+ *    but no introduction body) → ProtocolError.
+ *  - Idempotency of [InboundSharingFsm.start] and post-disconnect
+ *    [InboundSharingFsm.onEvent].
+ */
+@Suppress("LargeClass") // Negotiation has many invariants; one test per invariant is the discipline.
+class InboundSharingFsmTest {
+    private fun newFsm(): InboundSharingFsm = InboundSharingFsm(secureRandom = SecureRandom("seed".toByteArray()))
+
+    @Test
+    fun `start emits a single PairedKeyEncryptionFrame and is idempotent`() {
+        val fsm = newFsm()
+        val effects = fsm.start()
+
+        assertThat(effects).hasSize(1)
+        val send = effects[0] as SharingFsmEffect.SendFrame
+        assertThat(send.frame.v1.type).isEqualTo(SharingFrameType.PAIRED_KEY_ENCRYPTION)
+        assertThat(fsm.state).isEqualTo(InboundSharingState.SentPairedKeyEncryption)
+
+        // Second call must not re-emit.
+        assertThat(fsm.start()).isEmpty()
+    }
+
+    @Test
+    fun `happy path drives SentPKE through ReceivingPayloads`() {
+        val fsm = newFsm()
+        fsm.start()
+
+        // Step 1: peer sends PKE.
+        val afterPke =
+            fsm.onEvent(
+                SharingFsmEvent.FrameReceived(SharingFrames.pairedKeyEncryption()),
+            )
+        assertThat(afterPke).hasSize(1)
+        val pkrSend = afterPke[0] as SharingFsmEffect.SendFrame
+        assertThat(pkrSend.frame.v1.type).isEqualTo(SharingFrameType.PAIRED_KEY_RESULT)
+        assertThat(pkrSend.frame.v1.pairedKeyResult.status).isEqualTo(PairedKeyResultStatus.UNABLE)
+        assertThat(fsm.state).isEqualTo(InboundSharingState.SentPairedKeyResult)
+
+        // Step 2: peer sends PKR.
+        val afterPkr =
+            fsm.onEvent(SharingFsmEvent.FrameReceived(SharingFrames.pairedKeyResult()))
+        assertThat(afterPkr).isEmpty()
+        assertThat(fsm.state).isEqualTo(InboundSharingState.ReceivedPairedKeyResult)
+
+        // Step 3: peer sends Introduction.
+        val intro =
+            IntroductionFrame
+                .newBuilder()
+                .addFileMetadata(
+                    com.google.android.gms.nearby.sharing.Protocol.FileMetadata
+                        .newBuilder()
+                        .setName("photo.jpg")
+                        .setPayloadId(42L)
+                        .setSize(1024L)
+                        .build(),
+                ).build()
+        val afterIntro =
+            fsm.onEvent(SharingFsmEvent.FrameReceived(SharingFrames.introduction(intro)))
+        assertThat(afterIntro).hasSize(1)
+        val introNotify = afterIntro[0] as SharingFsmEffect.IntroductionReceived
+        assertThat(introNotify.introduction).isEqualTo(intro)
+        assertThat(fsm.state).isEqualTo(InboundSharingState.WaitingForUserConsent)
+
+        // Step 4: user accepts.
+        val afterAccept = fsm.onEvent(SharingFsmEvent.UserConsent(accept = true))
+        assertThat(afterAccept).hasSize(3)
+        val acceptSend = afterAccept[0] as SharingFsmEffect.SendFrame
+        assertThat(acceptSend.frame.v1.type).isEqualTo(SharingFrameType.RESPONSE)
+        assertThat(acceptSend.frame.v1.connectionResponse.status)
+            .isEqualTo(ConnectionResponseStatus.ACCEPT)
+        assertThat(afterAccept[1]).isInstanceOf(SharingFsmEffect.ReadyToReceivePayloads::class.java)
+        assertThat(afterAccept[2]).isInstanceOf(SharingFsmEffect.Completed::class.java)
+        assertThat(fsm.state).isEqualTo(InboundSharingState.ReceivingPayloads)
+    }
+
+    @Test
+    fun `reject path emits SendFrame REJECT then Rejected then Cancelled`() {
+        val fsm = driveToWaitingForUserConsent()
+
+        val effects = fsm.onEvent(SharingFsmEvent.UserConsent(accept = false))
+
+        assertThat(effects).hasSize(3)
+        val rejectSend = effects[0] as SharingFsmEffect.SendFrame
+        assertThat(rejectSend.frame.v1.type).isEqualTo(SharingFrameType.RESPONSE)
+        assertThat(rejectSend.frame.v1.connectionResponse.status)
+            .isEqualTo(ConnectionResponseStatus.REJECT)
+        val rejected = effects[1] as SharingFsmEffect.Rejected
+        assertThat(rejected.status).isEqualTo(ConnectionResponseStatus.REJECT)
+        assertThat(effects[2]).isInstanceOf(SharingFsmEffect.Cancelled::class.java)
+        assertThat(fsm.state).isEqualTo(InboundSharingState.Disconnected)
+    }
+
+    @Test
+    fun `user cancel from SentPairedKeyEncryption emits CancelFrame and Cancelled`() {
+        val fsm = newFsm()
+        fsm.start()
+
+        val effects = fsm.onEvent(SharingFsmEvent.UserCancel)
+
+        assertThat(effects).hasSize(2)
+        val send = effects[0] as SharingFsmEffect.SendFrame
+        assertThat(send.frame.v1.type).isEqualTo(SharingFrameType.CANCEL)
+        assertThat(effects[1]).isInstanceOf(SharingFsmEffect.Cancelled::class.java)
+        assertThat(fsm.state).isEqualTo(InboundSharingState.Disconnected)
+    }
+
+    @Test
+    fun `user cancel from WaitingForUserConsent still emits CancelFrame and Cancelled`() {
+        val fsm = driveToWaitingForUserConsent()
+
+        val effects = fsm.onEvent(SharingFsmEvent.UserCancel)
+
+        assertThat(effects).hasSize(2)
+        val send = effects[0] as SharingFsmEffect.SendFrame
+        assertThat(send.frame.v1.type).isEqualTo(SharingFrameType.CANCEL)
+        assertThat(effects[1]).isInstanceOf(SharingFsmEffect.Cancelled::class.java)
+        assertThat(fsm.state).isEqualTo(InboundSharingState.Disconnected)
+    }
+
+    @Test
+    fun `peer cancel emits Cancelled with no outbound frame`() {
+        val fsm = newFsm()
+        fsm.start()
+
+        val effects = fsm.onEvent(SharingFsmEvent.FrameReceived(SharingFrames.cancel()))
+
+        assertThat(effects).hasSize(1)
+        assertThat(effects[0]).isInstanceOf(SharingFsmEffect.Cancelled::class.java)
+        assertThat(fsm.state).isEqualTo(InboundSharingState.Disconnected)
+    }
+
+    @Test
+    fun `misordered frame INTRODUCTION before paired-key dance is a protocol error`() {
+        val fsm = newFsm()
+        fsm.start()
+
+        val intro = IntroductionFrame.newBuilder().build()
+        val effects = fsm.onEvent(SharingFsmEvent.FrameReceived(SharingFrames.introduction(intro)))
+
+        assertThat(effects).hasSize(1)
+        val err = effects[0] as SharingFsmEffect.ProtocolError
+        assertThat(err.reason).contains("PAIRED_KEY_ENCRYPTION")
+        assertThat(fsm.state).isEqualTo(InboundSharingState.Disconnected)
+    }
+
+    @Test
+    fun `frame with type=PAIRED_KEY_ENCRYPTION but no body is a protocol error`() {
+        val fsm = newFsm()
+        fsm.start()
+
+        // Build a frame with the right type but no paired_key_encryption body.
+        val malformed =
+            SharingFrame
+                .newBuilder()
+                .setVersion(SharingFrameVersion.V1)
+                .setV1(
+                    com.google.android.gms.nearby.sharing.Protocol.V1Frame
+                        .newBuilder()
+                        .setType(SharingFrameType.PAIRED_KEY_ENCRYPTION)
+                        .build(),
+                ).build()
+
+        val effects = fsm.onEvent(SharingFsmEvent.FrameReceived(malformed))
+
+        assertThat(effects).hasSize(1)
+        val err = effects[0] as SharingFsmEffect.ProtocolError
+        assertThat(err.reason).contains("missing paired_key_encryption body")
+        assertThat(fsm.state).isEqualTo(InboundSharingState.Disconnected)
+    }
+
+    @Test
+    fun `UserConsent in wrong state is a protocol error`() {
+        val fsm = newFsm()
+        fsm.start()
+
+        val effects = fsm.onEvent(SharingFsmEvent.UserConsent(accept = true))
+
+        assertThat(effects).hasSize(1)
+        assertThat(effects[0]).isInstanceOf(SharingFsmEffect.ProtocolError::class.java)
+        assertThat(fsm.state).isEqualTo(InboundSharingState.Disconnected)
+    }
+
+    @Test
+    fun `events after Disconnected return empty list`() {
+        val fsm = newFsm()
+        fsm.start()
+        fsm.onEvent(SharingFsmEvent.UserCancel) // Disconnected
+
+        assertThat(fsm.onEvent(SharingFsmEvent.UserCancel)).isEmpty()
+        assertThat(fsm.onEvent(SharingFsmEvent.FrameReceived(SharingFrames.cancel()))).isEmpty()
+        assertThat(fsm.onEvent(SharingFsmEvent.UserConsent(accept = true))).isEmpty()
+    }
+
+    @Test
+    fun `frame in ReceivingPayloads is a protocol error`() {
+        val fsm = driveToWaitingForUserConsent()
+        fsm.onEvent(SharingFsmEvent.UserConsent(accept = true))
+        // Now in ReceivingPayloads.
+
+        // Sending a stray frame in ReceivingPayloads should be flagged.
+        val effects =
+            fsm.onEvent(
+                SharingFsmEvent.FrameReceived(
+                    SharingFrames.connectionResponse(ConnectionResponseStatus.ACCEPT),
+                ),
+            )
+        assertThat(effects).hasSize(1)
+        assertThat(effects[0]).isInstanceOf(SharingFsmEffect.ProtocolError::class.java)
+        assertThat(fsm.state).isEqualTo(InboundSharingState.Disconnected)
+    }
+
+    @Test
+    fun `peer cancel during ReceivingPayloads cleanly disconnects`() {
+        val fsm = driveToWaitingForUserConsent()
+        fsm.onEvent(SharingFsmEvent.UserConsent(accept = true))
+
+        val effects = fsm.onEvent(SharingFsmEvent.FrameReceived(SharingFrames.cancel()))
+
+        assertThat(effects).hasSize(1)
+        assertThat(effects[0]).isInstanceOf(SharingFsmEffect.Cancelled::class.java)
+        assertThat(fsm.state).isEqualTo(InboundSharingState.Disconnected)
+    }
+
+    /**
+     * Drives the FSM through PKE / PKR / INTRODUCTION so the test body
+     * starts in [InboundSharingState.WaitingForUserConsent].
+     */
+    private fun driveToWaitingForUserConsent(): InboundSharingFsm {
+        val fsm = newFsm()
+        fsm.start()
+        fsm.onEvent(SharingFsmEvent.FrameReceived(SharingFrames.pairedKeyEncryption()))
+        fsm.onEvent(SharingFsmEvent.FrameReceived(SharingFrames.pairedKeyResult()))
+        fsm.onEvent(
+            SharingFsmEvent.FrameReceived(
+                SharingFrames.introduction(IntroductionFrame.newBuilder().build()),
+            ),
+        )
+        check(fsm.state == InboundSharingState.WaitingForUserConsent) {
+            "fixture state setup failed: ${fsm.state}"
+        }
+        return fsm
+    }
+}

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/sharing/OutboundSharingFsmTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/sharing/OutboundSharingFsmTest.kt
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.sharing
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import java.security.SecureRandom
+
+/**
+ * Tests for [OutboundSharingFsm].
+ *
+ * Coverage targets the full transition table:
+ *
+ *  - Happy path: PKE → PKR → INTRODUCTION emitted → RESPONSE{ACCEPT}
+ *    → ReadyToSendPayloads → Completed.
+ *  - Reject path: each non-ACCEPT `ConnectionResponseFrame.Status`
+ *    surfaces as [SharingFsmEffect.Rejected] with the original status.
+ *    The issue body lists `REJECT`, `UNKNOWN`, `NOT_ENOUGH_SPACE`,
+ *    `TIMED_OUT`, `UNSUPPORTED_ATTACHMENT_TYPE` — we exercise all five.
+ *  - User cancel from any non-terminal state.
+ *  - Peer cancel from any non-terminal state.
+ *  - Misordered frame → ProtocolError.
+ *  - UserConsent surfaced to the sender FSM is rejected (sender-only
+ *    bug-detection path).
+ */
+class OutboundSharingFsmTest {
+    private val introduction =
+        IntroductionFrame
+            .newBuilder()
+            .addFileMetadata(
+                com.google.android.gms.nearby.sharing.Protocol.FileMetadata
+                    .newBuilder()
+                    .setName("hello.txt")
+                    .setPayloadId(7L)
+                    .setSize(11L)
+                    .build(),
+            ).build()
+
+    private fun newFsm(): OutboundSharingFsm =
+        OutboundSharingFsm(
+            introduction = introduction,
+            secureRandom = SecureRandom("seed".toByteArray()),
+        )
+
+    @Test
+    fun `start emits a single PairedKeyEncryptionFrame and is idempotent`() {
+        val fsm = newFsm()
+        val effects = fsm.start()
+
+        assertThat(effects).hasSize(1)
+        val send = effects[0] as SharingFsmEffect.SendFrame
+        assertThat(send.frame.v1.type).isEqualTo(SharingFrameType.PAIRED_KEY_ENCRYPTION)
+        assertThat(fsm.state).isEqualTo(OutboundSharingState.SentPairedKeyEncryption)
+
+        assertThat(fsm.start()).isEmpty()
+    }
+
+    @Test
+    fun `happy path drives SentPKE through SendingPayloads`() {
+        val fsm = newFsm()
+        fsm.start()
+
+        // Step 1: peer sends PKE.
+        val afterPke =
+            fsm.onEvent(SharingFsmEvent.FrameReceived(SharingFrames.pairedKeyEncryption()))
+        val pkrSend = afterPke[0] as SharingFsmEffect.SendFrame
+        assertThat(pkrSend.frame.v1.type).isEqualTo(SharingFrameType.PAIRED_KEY_RESULT)
+        assertThat(fsm.state).isEqualTo(OutboundSharingState.SentPairedKeyResult)
+
+        // Step 2: peer sends PKR — sender emits introduction.
+        val afterPkr =
+            fsm.onEvent(SharingFsmEvent.FrameReceived(SharingFrames.pairedKeyResult()))
+        assertThat(afterPkr).hasSize(1)
+        val introSend = afterPkr[0] as SharingFsmEffect.SendFrame
+        assertThat(introSend.frame.v1.type).isEqualTo(SharingFrameType.INTRODUCTION)
+        assertThat(introSend.frame.v1.introduction).isEqualTo(introduction)
+        assertThat(fsm.state).isEqualTo(OutboundSharingState.SentIntroduction)
+
+        // Step 3: peer sends RESPONSE{ACCEPT}.
+        val afterAccept =
+            fsm.onEvent(
+                SharingFsmEvent.FrameReceived(
+                    SharingFrames.connectionResponse(ConnectionResponseStatus.ACCEPT),
+                ),
+            )
+        assertThat(afterAccept).hasSize(2)
+        assertThat(afterAccept[0]).isInstanceOf(SharingFsmEffect.ReadyToSendPayloads::class.java)
+        assertThat(afterAccept[1]).isInstanceOf(SharingFsmEffect.Completed::class.java)
+        assertThat(fsm.state).isEqualTo(OutboundSharingState.SendingPayloads)
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+        value = ConnectionResponseStatus::class,
+        names = ["REJECT", "UNKNOWN", "NOT_ENOUGH_SPACE", "TIMED_OUT", "UNSUPPORTED_ATTACHMENT_TYPE"],
+    )
+    fun `non-accept response status surfaces as Rejected with that exact status`(status: ConnectionResponseStatus) {
+        val fsm = driveToSentIntroduction()
+
+        val effects =
+            fsm.onEvent(
+                SharingFsmEvent.FrameReceived(SharingFrames.connectionResponse(status)),
+            )
+
+        assertThat(effects).hasSize(2)
+        val rejected = effects[0] as SharingFsmEffect.Rejected
+        assertThat(rejected.status).isEqualTo(status)
+        assertThat(effects[1]).isInstanceOf(SharingFsmEffect.Cancelled::class.java)
+        assertThat(fsm.state).isEqualTo(OutboundSharingState.Disconnected)
+    }
+
+    @Test
+    fun `user cancel from SentPairedKeyEncryption emits CancelFrame and Cancelled`() {
+        val fsm = newFsm()
+        fsm.start()
+
+        val effects = fsm.onEvent(SharingFsmEvent.UserCancel)
+
+        assertThat(effects).hasSize(2)
+        val send = effects[0] as SharingFsmEffect.SendFrame
+        assertThat(send.frame.v1.type).isEqualTo(SharingFrameType.CANCEL)
+        assertThat(effects[1]).isInstanceOf(SharingFsmEffect.Cancelled::class.java)
+        assertThat(fsm.state).isEqualTo(OutboundSharingState.Disconnected)
+    }
+
+    @Test
+    fun `user cancel from SentIntroduction also emits CancelFrame and Cancelled`() {
+        val fsm = driveToSentIntroduction()
+
+        val effects = fsm.onEvent(SharingFsmEvent.UserCancel)
+
+        assertThat(effects).hasSize(2)
+        val send = effects[0] as SharingFsmEffect.SendFrame
+        assertThat(send.frame.v1.type).isEqualTo(SharingFrameType.CANCEL)
+        assertThat(effects[1]).isInstanceOf(SharingFsmEffect.Cancelled::class.java)
+        assertThat(fsm.state).isEqualTo(OutboundSharingState.Disconnected)
+    }
+
+    @Test
+    fun `peer cancel emits Cancelled with no outbound frame`() {
+        val fsm = newFsm()
+        fsm.start()
+
+        val effects = fsm.onEvent(SharingFsmEvent.FrameReceived(SharingFrames.cancel()))
+
+        assertThat(effects).hasSize(1)
+        assertThat(effects[0]).isInstanceOf(SharingFsmEffect.Cancelled::class.java)
+        assertThat(fsm.state).isEqualTo(OutboundSharingState.Disconnected)
+    }
+
+    @Test
+    fun `misordered RESPONSE before introduction is a protocol error`() {
+        val fsm = newFsm()
+        fsm.start()
+
+        val effects =
+            fsm.onEvent(
+                SharingFsmEvent.FrameReceived(
+                    SharingFrames.connectionResponse(ConnectionResponseStatus.ACCEPT),
+                ),
+            )
+
+        assertThat(effects).hasSize(1)
+        val err = effects[0] as SharingFsmEffect.ProtocolError
+        assertThat(err.reason).contains("PAIRED_KEY_ENCRYPTION")
+        assertThat(fsm.state).isEqualTo(OutboundSharingState.Disconnected)
+    }
+
+    @Test
+    fun `RESPONSE frame with no body is a protocol error`() {
+        val fsm = driveToSentIntroduction()
+
+        val malformed =
+            SharingFrame
+                .newBuilder()
+                .setVersion(SharingFrameVersion.V1)
+                .setV1(
+                    com.google.android.gms.nearby.sharing.Protocol.V1Frame
+                        .newBuilder()
+                        .setType(SharingFrameType.RESPONSE)
+                        .build(),
+                ).build()
+
+        val effects = fsm.onEvent(SharingFsmEvent.FrameReceived(malformed))
+        assertThat(effects).hasSize(1)
+        val err = effects[0] as SharingFsmEffect.ProtocolError
+        assertThat(err.reason).contains("missing connection_response body")
+        assertThat(fsm.state).isEqualTo(OutboundSharingState.Disconnected)
+    }
+
+    @Test
+    fun `UserConsent surfaced to sender FSM is a protocol error`() {
+        val fsm = newFsm()
+        fsm.start()
+
+        val effects = fsm.onEvent(SharingFsmEvent.UserConsent(accept = true))
+
+        assertThat(effects).hasSize(1)
+        val err = effects[0] as SharingFsmEffect.ProtocolError
+        assertThat(err.reason).contains("receiver-only")
+        assertThat(fsm.state).isEqualTo(OutboundSharingState.Disconnected)
+    }
+
+    @Test
+    fun `events after Disconnected return empty list`() {
+        val fsm = newFsm()
+        fsm.start()
+        fsm.onEvent(SharingFsmEvent.UserCancel)
+
+        assertThat(fsm.onEvent(SharingFsmEvent.UserCancel)).isEmpty()
+        assertThat(fsm.onEvent(SharingFsmEvent.FrameReceived(SharingFrames.cancel()))).isEmpty()
+    }
+
+    @Test
+    fun `stray frame in SendingPayloads is a protocol error`() {
+        val fsm = driveToSentIntroduction()
+        fsm.onEvent(
+            SharingFsmEvent.FrameReceived(
+                SharingFrames.connectionResponse(ConnectionResponseStatus.ACCEPT),
+            ),
+        )
+        // Now in SendingPayloads.
+
+        val effects =
+            fsm.onEvent(
+                SharingFsmEvent.FrameReceived(SharingFrames.pairedKeyResult()),
+            )
+        assertThat(effects).hasSize(1)
+        assertThat(effects[0]).isInstanceOf(SharingFsmEffect.ProtocolError::class.java)
+        assertThat(fsm.state).isEqualTo(OutboundSharingState.Disconnected)
+    }
+
+    @Test
+    fun `peer cancel during SendingPayloads cleanly disconnects`() {
+        val fsm = driveToSentIntroduction()
+        fsm.onEvent(
+            SharingFsmEvent.FrameReceived(
+                SharingFrames.connectionResponse(ConnectionResponseStatus.ACCEPT),
+            ),
+        )
+
+        val effects = fsm.onEvent(SharingFsmEvent.FrameReceived(SharingFrames.cancel()))
+        assertThat(effects).hasSize(1)
+        assertThat(effects[0]).isInstanceOf(SharingFsmEffect.Cancelled::class.java)
+        assertThat(fsm.state).isEqualTo(OutboundSharingState.Disconnected)
+    }
+
+    /**
+     * Drives the FSM through PKE / PKR / outbound INTRODUCTION so the
+     * test body starts in [OutboundSharingState.SentIntroduction].
+     */
+    private fun driveToSentIntroduction(): OutboundSharingFsm {
+        val fsm = newFsm()
+        fsm.start()
+        fsm.onEvent(SharingFsmEvent.FrameReceived(SharingFrames.pairedKeyEncryption()))
+        fsm.onEvent(SharingFsmEvent.FrameReceived(SharingFrames.pairedKeyResult()))
+        check(fsm.state == OutboundSharingState.SentIntroduction) {
+            "fixture state setup failed: ${fsm.state}"
+        }
+        return fsm
+    }
+}

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/sharing/SharingFramesTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/sharing/SharingFramesTest.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.sharing
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.security.SecureRandom
+
+/**
+ * Tests for [SharingFrames] — the builders / parser for `Sharing.Nearby.Frame`.
+ *
+ * The FSM treats parsing as fatal-on-failure, so the parse-failure path
+ * is covered here as well as the round-trip happy path. Builder defaults
+ * are also pinned so that a regression that drops `version = V1` (which
+ * stock Quick Share peers reject silently) shows up loudly.
+ */
+class SharingFramesTest {
+    /**
+     * Deterministic [SecureRandom] so [SharingFrames.pairedKeyEncryption]
+     * produces a fixed byte pattern in tests. We only use this for byte
+     * length / non-empty assertions; we never compare against magic
+     * values.
+     */
+    private fun deterministicRandom(): SecureRandom = SecureRandom("test-seed".toByteArray())
+
+    @Test
+    fun `pairedKeyEncryption fills 6 bytes of secret_id_hash and 72 bytes of signed_data by default`() {
+        val frame = SharingFrames.pairedKeyEncryption(secureRandom = deterministicRandom())
+
+        assertThat(frame.version).isEqualTo(SharingFrameVersion.V1)
+        assertThat(frame.v1.type).isEqualTo(SharingFrameType.PAIRED_KEY_ENCRYPTION)
+        assertThat(frame.v1.hasPairedKeyEncryption()).isTrue()
+        assertThat(
+            frame.v1.pairedKeyEncryption.secretIdHash
+                .size(),
+        ).isEqualTo(SharingFrames.DEFAULT_SECRET_ID_HASH_LENGTH)
+        assertThat(
+            frame.v1.pairedKeyEncryption.signedData
+                .size(),
+        ).isEqualTo(SharingFrames.DEFAULT_SIGNED_DATA_LENGTH)
+    }
+
+    @Test
+    fun `pairedKeyEncryption respects custom byte lengths`() {
+        val frame =
+            SharingFrames.pairedKeyEncryption(
+                secureRandom = deterministicRandom(),
+                secretIdHashLength = 10,
+                signedDataLength = 100,
+            )
+        assertThat(
+            frame.v1.pairedKeyEncryption.secretIdHash
+                .size(),
+        ).isEqualTo(10)
+        assertThat(
+            frame.v1.pairedKeyEncryption.signedData
+                .size(),
+        ).isEqualTo(100)
+    }
+
+    @Test
+    fun `pairedKeyEncryption rejects negative byte lengths`() {
+        assertThrows<IllegalArgumentException> {
+            SharingFrames.pairedKeyEncryption(secretIdHashLength = -1)
+        }
+        assertThrows<IllegalArgumentException> {
+            SharingFrames.pairedKeyEncryption(signedDataLength = -1)
+        }
+    }
+
+    @Test
+    fun `pairedKeyResult defaults to UNABLE`() {
+        val frame = SharingFrames.pairedKeyResult()
+        assertThat(frame.v1.type).isEqualTo(SharingFrameType.PAIRED_KEY_RESULT)
+        assertThat(frame.v1.pairedKeyResult.status).isEqualTo(PairedKeyResultStatus.UNABLE)
+    }
+
+    @Test
+    fun `pairedKeyResult honors explicit status`() {
+        val frame = SharingFrames.pairedKeyResult(PairedKeyResultStatus.SUCCESS)
+        assertThat(frame.v1.pairedKeyResult.status).isEqualTo(PairedKeyResultStatus.SUCCESS)
+    }
+
+    @Test
+    fun `connectionResponse wraps the right Status enum value`() {
+        val accept = SharingFrames.connectionResponse(ConnectionResponseStatus.ACCEPT)
+        assertThat(accept.v1.type).isEqualTo(SharingFrameType.RESPONSE)
+        assertThat(accept.v1.connectionResponse.status).isEqualTo(ConnectionResponseStatus.ACCEPT)
+
+        val reject = SharingFrames.connectionResponse(ConnectionResponseStatus.REJECT)
+        assertThat(reject.v1.connectionResponse.status).isEqualTo(ConnectionResponseStatus.REJECT)
+    }
+
+    @Test
+    fun `cancel produces a body-less frame with type=CANCEL`() {
+        val frame = SharingFrames.cancel()
+        assertThat(frame.version).isEqualTo(SharingFrameVersion.V1)
+        assertThat(frame.v1.type).isEqualTo(SharingFrameType.CANCEL)
+        // None of the oneof bodies should be set on a CANCEL frame.
+        assertThat(frame.v1.hasIntroduction()).isFalse()
+        assertThat(frame.v1.hasConnectionResponse()).isFalse()
+        assertThat(frame.v1.hasPairedKeyEncryption()).isFalse()
+        assertThat(frame.v1.hasPairedKeyResult()).isFalse()
+    }
+
+    @Test
+    fun `parse round-trips a frame produced by builders`() {
+        val original = SharingFrames.pairedKeyResult(PairedKeyResultStatus.SUCCESS)
+        val parsed = SharingFrames.parse(original.toByteArray())
+        assertThat(parsed).isEqualTo(original)
+    }
+
+    @Test
+    fun `parse throws SharingFrameParseException for garbage bytes`() {
+        // 0xFF 0xFF would set tag 31 with malformed wire-type bits,
+        // which protobuf rejects.
+        val garbage = byteArrayOf(-1, -1, -1, -1, -1)
+        val ex =
+            assertThrows<SharingFrameParseException> {
+                SharingFrames.parse(garbage)
+            }
+        assertThat(ex.message).contains("Sharing.Nearby.Frame")
+    }
+}

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/sharing/SharingFsmLoopbackTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/sharing/SharingFsmLoopbackTest.kt
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.sharing
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import java.security.SecureRandom
+
+/**
+ * End-to-end loopback exercising both FSMs together.
+ *
+ * The point is to confirm the **two FSMs speak the same wire format**:
+ * an outbound `SendFrame` bytes-encodes, parses back, and is accepted
+ * by the inbound FSM as a legal next event (and vice-versa). The
+ * individual transition tests already cover each FSM in isolation;
+ * this test catches accidental asymmetries — for example, if the
+ * sender ever started emitting a frame type the receiver does not
+ * accept in that state, the loopback would diverge.
+ *
+ * The test simulates the wire by:
+ *  1. Calling `start()` on both FSMs.
+ *  2. Pumping each `SendFrame` effect through `toByteArray()` /
+ *     [SharingFrames.parse] and feeding it back to the peer FSM as a
+ *     [SharingFsmEvent.FrameReceived]. (Round-tripping through bytes
+ *     ensures the FSM only relies on serialized fields, not on
+ *     transient builder state.)
+ *  3. Driving the user-consent decision when the receiver enters
+ *     `WaitingForUserConsent`.
+ *
+ * Both the accept and reject paths are exercised end-to-end.
+ */
+class SharingFsmLoopbackTest {
+    private val introduction =
+        IntroductionFrame
+            .newBuilder()
+            .addFileMetadata(
+                com.google.android.gms.nearby.sharing.Protocol.FileMetadata
+                    .newBuilder()
+                    .setName("loopback.bin")
+                    .setPayloadId(1234L)
+                    .setSize(2048L)
+                    .build(),
+            ).build()
+
+    @Test
+    fun `accept path completes with both FSMs in their post-negotiation states`() {
+        val (inbound, outbound, transcript) = runLoopback(userConsent = true)
+
+        assertThat(inbound.state).isEqualTo(InboundSharingState.ReceivingPayloads)
+        assertThat(outbound.state).isEqualTo(OutboundSharingState.SendingPayloads)
+        assertThat(transcript).contains(SharingFrameType.PAIRED_KEY_ENCRYPTION)
+        assertThat(transcript).contains(SharingFrameType.PAIRED_KEY_RESULT)
+        assertThat(transcript).contains(SharingFrameType.INTRODUCTION)
+        assertThat(transcript).contains(SharingFrameType.RESPONSE)
+        assertThat(transcript).doesNotContain(SharingFrameType.CANCEL)
+    }
+
+    @Test
+    fun `reject path leaves both FSMs Disconnected`() {
+        val (inbound, outbound, transcript) = runLoopback(userConsent = false)
+
+        assertThat(inbound.state).isEqualTo(InboundSharingState.Disconnected)
+        assertThat(outbound.state).isEqualTo(OutboundSharingState.Disconnected)
+        // Reject still travels through a RESPONSE frame.
+        assertThat(transcript).contains(SharingFrameType.RESPONSE)
+    }
+
+    /**
+     * Coroutine-free turn-taking driver. Each iteration:
+     *  - drains the outbound queue from both FSMs,
+     *  - bytes-encodes / decodes each frame,
+     *  - feeds it to the peer FSM,
+     *  - if the inbound FSM has just emitted [SharingFsmEffect.IntroductionReceived],
+     *    delivers the user-consent decision to it.
+     *
+     * Loop bounded by `maxTurns` to fail fast if a state machine ever
+     * fails to terminate.
+     */
+    @Suppress("LoopWithTooManyJumpStatements") // Turn-taking loop is naturally guarded.
+    private fun runLoopback(userConsent: Boolean): LoopbackResult {
+        val rand = SecureRandom("loopback".toByteArray())
+        val inbound = InboundSharingFsm(secureRandom = rand)
+        val outbound = OutboundSharingFsm(introduction = introduction, secureRandom = rand)
+
+        val transcript = mutableListOf<SharingFrameType>()
+        val inboundOutbox = ArrayDeque<SharingFrame>()
+        val outboundOutbox = ArrayDeque<SharingFrame>()
+        var consentDelivered = false
+
+        fun absorbInbound(effects: List<SharingFsmEffect>) {
+            for (e in effects) {
+                if (e is SharingFsmEffect.SendFrame) {
+                    transcript.add(e.frame.v1.type)
+                    inboundOutbox.addLast(e.frame)
+                }
+            }
+        }
+
+        fun absorbOutbound(effects: List<SharingFsmEffect>) {
+            for (e in effects) {
+                if (e is SharingFsmEffect.SendFrame) {
+                    transcript.add(e.frame.v1.type)
+                    outboundOutbox.addLast(e.frame)
+                }
+            }
+        }
+
+        absorbInbound(inbound.start())
+        absorbOutbound(outbound.start())
+
+        val maxTurns = 16
+        repeat(maxTurns) {
+            var progressed = false
+
+            // Inbound's outbox -> outbound FSM.
+            while (inboundOutbox.isNotEmpty()) {
+                progressed = true
+                val frame = inboundOutbox.removeFirst()
+                val parsed = SharingFrames.parse(frame.toByteArray())
+                absorbOutbound(outbound.onEvent(SharingFsmEvent.FrameReceived(parsed)))
+            }
+
+            // Outbound's outbox -> inbound FSM.
+            while (outboundOutbox.isNotEmpty()) {
+                progressed = true
+                val frame = outboundOutbox.removeFirst()
+                val parsed = SharingFrames.parse(frame.toByteArray())
+                val effects = inbound.onEvent(SharingFsmEvent.FrameReceived(parsed))
+                absorbInbound(effects)
+                if (!consentDelivered &&
+                    effects.any { it is SharingFsmEffect.IntroductionReceived }
+                ) {
+                    consentDelivered = true
+                    absorbInbound(inbound.onEvent(SharingFsmEvent.UserConsent(accept = userConsent)))
+                }
+            }
+
+            if (!progressed) return@repeat
+        }
+
+        return LoopbackResult(inbound, outbound, transcript)
+    }
+
+    private data class LoopbackResult(
+        val inbound: InboundSharingFsm,
+        val outbound: OutboundSharingFsm,
+        val transcript: List<SharingFrameType>,
+    )
+}


### PR DESCRIPTION
## Summary

Adds a pure-Kotlin negotiation state machine under `:core-protocol/.../sharing/`
that drives the `Sharing.Nearby.Frame` post-handshake choreography
(PairedKeyEncryption / PairedKeyResult / Introduction / ConnectionResponse /
Cancel) for both receiver and sender roles. Closes #15.

The FSM is **I/O-free** — it is a pure transition function. Inputs:
`FrameReceived`, `UserConsent`, `UserCancel`. Outputs (ordered effect list):
`SendFrame`, `IntroductionReceived`, `ReadyToReceivePayloads`,
`ReadyToSendPayloads`, `Rejected`, `Cancelled`, `Completed`,
`ProtocolError`. The orchestrator (issues #16 / #17 / #22) is responsible
for serializing each `SendFrame` through `PayloadTransferEncoder` and
pushing it through the `SecureChannel`.

## Public surface

- `SharingFrames` — builders for each negotiation frame and a parser
  that surfaces malformed protos as `SharingFrameParseException`.
  `PairedKeyEncryptionFrame` defaults match NearDrop (6-byte
  `secret_id_hash`, 72-byte `signed_data`).
- `SharingFsmEvent` (sealed) — typed inputs.
- `SharingFsmEffect` (sealed) — typed outputs.
- `InboundSharingState` / `OutboundSharingState` — FSM state spaces,
  named to mirror NearDrop's `InboundNearbyConnection.State` /
  `OutboundNearbyConnection.State`.
- `InboundSharingFsm` — receiver role.
- `OutboundSharingFsm` — sender role; takes the prepared
  `IntroductionFrame` at construction.

## Choreography modeled

Receiver: `SentPairedKeyEncryption` -> `SentPairedKeyResult` ->
`ReceivedPairedKeyResult` -> `WaitingForUserConsent` ->
`ReceivingPayloads` (or `Disconnected` on reject / cancel / error).

Sender: `SentPairedKeyEncryption` -> `SentPairedKeyResult` ->
`SentIntroduction` -> `SendingPayloads` (or `Disconnected`).

Cancellation: `UserCancel` emits `SendFrame{CANCEL}` then `Cancelled` and
disconnects. Inbound `Frame{CANCEL}` from any non-terminal state emits
`Cancelled` and disconnects. Post-disconnect events are no-ops
(idempotent shutdown).

Rejection: every `ConnectionResponseFrame.Status` value (`REJECT`,
`UNKNOWN`, `NOT_ENOUGH_SPACE`, `TIMED_OUT`, `UNSUPPORTED_ATTACHMENT_TYPE`)
is surfaced verbatim through `SharingFsmEffect.Rejected` so the UI can
render an accurate cause.

## Tests

36 tests across four files:

- `SharingFramesTest` — builder defaults, custom byte lengths,
  validation, parse round-trip, parse-failure path.
- `InboundSharingFsmTest` — happy path, reject, user cancel from both
  `SentPairedKeyEncryption` and `WaitingForUserConsent`, peer cancel,
  misordered frames, malformed bodies, post-Disconnected idempotency,
  stray frames in `ReceivingPayloads`.
- `OutboundSharingFsmTest` — happy path, all five non-ACCEPT response
  statuses (parameterized), cancel paths, misordered frames, malformed
  bodies, sender-only `UserConsent` rejection.
- `SharingFsmLoopbackTest` — runs both FSMs against each other through
  serialized `toByteArray` / `SharingFrames.parse` round-trips on every
  transmitted frame, validating wire-format symmetry on both accept
  and reject paths.

## Acceptance criteria

- Receiver-side state machine matching `InboundNearbyConnection.State`
  for the negotiation segment (post-UKEY2; pre-UKEY2 states are owned
  by earlier modules).
- Sender-side state machine matching `OutboundNearbyConnection.State`
  for the same segment.
- Misordered frames -> `SharingFsmEffect.ProtocolError` and transition
  to `Disconnected`.
- All five `ConnectionResponseFrame.Status` enum values handled by the
  sender (`Rejected` carries the exact status; UI decides display).

## Out of scope (per issue prompt)

- Wiring to `SecureChannel` and `PayloadAssembler` /
  `PayloadTransferEncoder` (issue #16 / #17).
- Receive consent UI (issue #22).
- Actual file streaming after the FSM signals
  `ReadyTo{Send,Receive}Payloads` (issues #17 / #19 / #23).
