### PR TITLE
feat: add OutboundConnection sender-side orchestrator (#17)

### DIFF
--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/FileSource.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/FileSource.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.connection
+
+import java.nio.channels.ReadableByteChannel
+
+/**
+ * Sender-side description of a single file to ship over an
+ * [OutboundConnection].
+ *
+ * `:core-protocol` is platform-independent — it cannot know about
+ * `android.net.Uri`, `MediaStore`, or `ContentResolver`. The Android
+ * share-intent layer (issue #24) translates user-selected URIs into
+ * [FileSource] instances and passes them to [OutboundConnection.run];
+ * the JVM-side host harness creates them from `java.nio.file.Path`s.
+ *
+ * The contract is intentionally minimal:
+ *
+ *  - [name] / [size] / [mimeType] / [lastModifiedTimestampMillis] are
+ *    plain values copied verbatim into the outgoing
+ *    [io.github.kyujincho.wvmg.protocol.sharing.IntroductionFrame] file
+ *    metadata and the per-payload [com.google.location.nearby.connections.proto.OfflineWireFormatsProto.PayloadTransferFrame.PayloadHeader].
+ *  - [openChannel] is a factory that returns a [ReadableByteChannel]
+ *    positioned at byte zero. The orchestrator invokes it once per
+ *    transfer attempt; on retry (a future feature) it would be invoked
+ *    again to re-open the same source.
+ *
+ * The orchestrator closes the returned channel after streaming
+ * [size] bytes (or on failure / cancellation). The factory MUST NOT
+ * leak the channel itself.
+ *
+ * @property name Filename as the receiver should see it. Caller is
+ *   responsible for any sanitization (`:core-protocol` does not).
+ *   Maps to `IntroductionFrame.file_metadata[].name` and to the
+ *   outbound `PayloadHeader.file_name`.
+ * @property size Total byte count to stream. The orchestrator caps
+ *   `ReadableByteChannel.read` calls so we never overshoot this; if
+ *   the channel yields fewer bytes the receiver will reject the
+ *   payload as undersized.
+ * @property mimeType MIME type guess for the bytes (`image/jpeg`,
+ *   `application/pdf`, ...). Empty string is acceptable but degrades
+ *   the receiver's UI hint.
+ * @property lastModifiedTimestampMillis Mirrored onto the outgoing
+ *   [com.google.location.nearby.connections.proto.OfflineWireFormatsProto.PayloadTransferFrame.PayloadHeader.last_modified_timestamp_millis].
+ *   Pass `0L` when unknown.
+ * @property payloadId The Quick Share `payload_id` to use both in the
+ *   introduction frame's file metadata entry and on every chunk's
+ *   `PayloadHeader.id`. The caller MUST choose a fresh, positive,
+ *   unique value per source — duplicates break the receiver's
+ *   reassembler.
+ */
+public class FileSource(
+    public val name: String,
+    public val size: Long,
+    public val mimeType: String,
+    public val lastModifiedTimestampMillis: Long,
+    public val payloadId: Long,
+    private val open: () -> ReadableByteChannel,
+) {
+    init {
+        require(size >= 0) { "size must be non-negative, got $size" }
+    }
+
+    /**
+     * Open a fresh [ReadableByteChannel] positioned at byte zero of the
+     * source bytes. The orchestrator owns and closes the returned
+     * channel; the factory MUST NOT close it itself.
+     *
+     * Thread-safety: the factory is invoked at most once per
+     * [OutboundConnection.run] invocation, on the orchestrator's
+     * coroutine.
+     */
+    public fun openChannel(): ReadableByteChannel = open()
+}

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/FileSource.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/FileSource.kt
@@ -22,7 +22,7 @@ import java.nio.channels.ReadableByteChannel
  *  - [name] / [size] / [mimeType] / [lastModifiedTimestampMillis] are
  *    plain values copied verbatim into the outgoing
  *    [io.github.kyujincho.wvmg.protocol.sharing.IntroductionFrame] file
- *    metadata and the per-payload [com.google.location.nearby.connections.proto.OfflineWireFormatsProto.PayloadTransferFrame.PayloadHeader].
+ *    metadata and the per-payload `PayloadTransferFrame.PayloadHeader`.
  *  - [openChannel] is a factory that returns a [ReadableByteChannel]
  *    positioned at byte zero. The orchestrator invokes it once per
  *    transfer attempt; on retry (a future feature) it would be invoked
@@ -44,8 +44,8 @@ import java.nio.channels.ReadableByteChannel
  *   `application/pdf`, ...). Empty string is acceptable but degrades
  *   the receiver's UI hint.
  * @property lastModifiedTimestampMillis Mirrored onto the outgoing
- *   [com.google.location.nearby.connections.proto.OfflineWireFormatsProto.PayloadTransferFrame.PayloadHeader.last_modified_timestamp_millis].
- *   Pass `0L` when unknown.
+ *   `PayloadHeader.last_modified_timestamp_millis`. Pass `0L` when
+ *   unknown.
  * @property payloadId The Quick Share `payload_id` to use both in the
  *   introduction frame's file metadata entry and on every chunk's
  *   `PayloadHeader.id`. The caller MUST choose a fresh, positive,

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnection.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnection.kt
@@ -9,10 +9,12 @@ import io.github.kyujincho.wvmg.protocol.payload.PayloadProtocolException
 import io.github.kyujincho.wvmg.protocol.transport.EndOfFrameStream
 import io.github.kyujincho.wvmg.protocol.ukey2.Ukey2HandshakeException
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.withContext
 import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.net.Socket
@@ -251,13 +253,17 @@ public class OutboundConnection(
 
     /**
      * Open the TCP socket. Hoisted so the failure path is a clean
-     * try/catch in [run].
+     * try/catch in [run]. Dispatched onto [Dispatchers.IO] because
+     * `Socket.connect` is blocking and must not pin the calling
+     * coroutine's dispatcher (which on the JVM-test side is the
+     * `runTest` scheduler — pinning it would deadlock the test).
      */
-    private fun openSocket(): Socket {
-        val socket = Socket()
-        socket.connect(InetSocketAddress(targetAddress, port), connectTimeoutMillis)
-        return socket
-    }
+    private suspend fun openSocket(): Socket =
+        withContext(Dispatchers.IO) {
+            val socket = Socket()
+            socket.connect(InetSocketAddress(targetAddress, port), connectTimeoutMillis)
+            socket
+        }
 
     /**
      * Sanity-check the [files] list before starting any I/O.

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnection.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnection.kt
@@ -1,0 +1,347 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.connection
+
+import io.github.kyujincho.wvmg.protocol.payload.PayloadProtocolException
+import io.github.kyujincho.wvmg.protocol.transport.EndOfFrameStream
+import io.github.kyujincho.wvmg.protocol.ukey2.Ukey2HandshakeException
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.Socket
+import java.security.SecureRandom
+
+/**
+ * The sender-side glue tying together TCP, framing, UKEY2,
+ * SecureMessage, the negotiation state machine, and outbound payload
+ * streaming into a single in-flight transfer attempt.
+ *
+ * Owns exactly one TCP [Socket]. One [OutboundConnection] handles one
+ * connection to one peer; opening more (Quick Share permits parallel
+ * sends to multiple peers) is the caller's responsibility.
+ *
+ * ### Lifecycle
+ *
+ * The complete sequence the orchestrator drives, mirroring NearDrop's
+ * `OutboundNearbyConnection.swift`:
+ *
+ *  1. Open a TCP socket to `(targetAddress, port)`.
+ *  2. Wrap the socket in a
+ *     [io.github.kyujincho.wvmg.protocol.transport.FramedConnection].
+ *  3. Send the unencrypted
+ *     [com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame]
+ *     `{ConnectionRequest, endpoint_id, endpoint_info}`.
+ *  4. Run [io.github.kyujincho.wvmg.protocol.ukey2.Ukey2Client.performHandshake]
+ *     to produce a [io.github.kyujincho.wvmg.protocol.ukey2.Ukey2HandshakeResult].
+ *  5. Read the receiver's unencrypted
+ *     [com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame]
+ *     `{ConnectionResponse}`.
+ *  6. Send our unencrypted
+ *     [com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame]
+ *     `{ConnectionResponse, ACCEPT}`.
+ *  7. Derive
+ *     [io.github.kyujincho.wvmg.protocol.crypto.D2DSessionKeys] with
+ *     [io.github.kyujincho.wvmg.protocol.crypto.D2DRole.CLIENT]. **This
+ *     role assignment is critical** — the sender drove UKEY2 (sent
+ *     ClientInit + ClientFinished), so it is the CLIENT on the
+ *     SecureMessage layer. CLIENT sends with `clientEnc/clientHmac`,
+ *     receives with `serverEnc/serverHmac`. A swap here would silently
+ *     break decryption.
+ *  8. Compute the 4-digit confirmation PIN via
+ *     [io.github.kyujincho.wvmg.protocol.crypto.pin.PinDerivation.deriveFourDigitPin]
+ *     and surface it via [state] (so the UI can show it for the user
+ *     to read out).
+ *  9. Construct a
+ *     [io.github.kyujincho.wvmg.protocol.crypto.securemessage.SecureChannel]
+ *     over the FramedConnection.
+ * 10. Drive [io.github.kyujincho.wvmg.protocol.sharing.OutboundSharingFsm]
+ *     through to its `SendingPayloads` state — the FSM emits
+ *     `PairedKeyEncryption`, then `PairedKeyResult`, then the
+ *     `IntroductionFrame` carrying our file metadata, and waits for
+ *     the receiver's `ConnectionResponseFrame`.
+ * 11. On peer ACCEPT: stream every announced file in 512 KiB chunks
+ *     via [io.github.kyujincho.wvmg.protocol.payload.PayloadTransferEncoder.encodeFilePayload],
+ *     then send `Disconnection` and close.
+ * 12. On peer non-ACCEPT: surface the status via [state], send
+ *     `Disconnection`, and close.
+ *
+ * The state machine in
+ * [io.github.kyujincho.wvmg.protocol.sharing.OutboundSharingFsm] models
+ * steps 10-12 as a pure FSM; this class is the surrounding I/O loop
+ * that interprets its
+ * [io.github.kyujincho.wvmg.protocol.sharing.SharingFsmEffect] outputs.
+ *
+ * ### Public API
+ *
+ * The contract is intentionally small:
+ *
+ *  - [state] — a [StateFlow] the UI subscribes to for renders.
+ *  - [run] — one-shot suspend entry point that drives the entire
+ *    lifecycle and returns an [OutboundResult].
+ *  - [cancel] — thread-safe local cancel; produces a `CancelFrame` on
+ *    the wire (when possible) and tears the connection down.
+ *
+ * ### Cancellation
+ *
+ * Coroutine cancellation of [run] tears down the socket cooperatively.
+ * The same path is taken when [cancel] is invoked from another
+ * coroutine. In either case any in-flight chunk read is best-effort
+ * closed.
+ *
+ * ### Threading model
+ *
+ * One coroutine owns the send/receive interleave. [cancel] is safe to
+ * call from any other coroutine — it pushes onto a [Channel] that the
+ * driver's dispatch loop drains. This avoids racing the FSM with the
+ * wire.
+ *
+ * @param targetAddress IP address (or hostname) of the receiver. The
+ *   discovery layer (`:discovery-android`) translates an mDNS service
+ *   record into this concrete value.
+ * @param port TCP port the receiver advertised in its endpoint record.
+ * @param endpointId 4-char ASCII identifier the sender uses for itself
+ *   in the opening `ConnectionRequest`. Default: `"NDLp"` (Quick
+ *   Share's identifier shape — 4 ASCII characters).
+ * @param endpointInfo Serialized
+ *   [io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo] bytes
+ *   describing the sender. Default: empty (sender does not advertise a
+ *   name; the receiver shows a generic "Someone wants to share").
+ * @param qrCodeHandshakeData Optional QR-handshake bytes
+ *   ([io.github.kyujincho.wvmg.protocol.qr]) used when the user
+ *   reached the sender via a scanned QR code. When non-null, attached
+ *   to the outgoing `PairedKeyEncryptionFrame.qr_code_handshake_data`.
+ * @param connectTimeoutMillis TCP connect timeout. Default 5 seconds —
+ *   matches NearDrop's default and is generous enough for Wi-Fi LAN
+ *   without making "host is down" cases linger.
+ * @param secureRandom Source of randomness for the UKEY2 keypair, the
+ *   PairedKeyEncryption fill bytes, the SecureChannel IVs, and the
+ *   per-frame `payload_id` choices. Tests inject a deterministic
+ *   stub; production uses a fresh [SecureRandom].
+ */
+@Suppress("LongParameterList") // The public constructor has many knobs but every one is needed by the spec.
+public class OutboundConnection(
+    private val targetAddress: InetAddress,
+    private val port: Int,
+    private val endpointId: String = DEFAULT_ENDPOINT_ID,
+    private val endpointInfo: ByteArray = ByteArray(0),
+    private val qrCodeHandshakeData: ByteArray? = null,
+    private val connectTimeoutMillis: Int = DEFAULT_CONNECT_TIMEOUT_MILLIS,
+    private val secureRandom: SecureRandom = SecureRandom(),
+) {
+    private val mutableState: MutableStateFlow<OutboundConnectionState> =
+        MutableStateFlow(OutboundConnectionState.Idle)
+
+    /**
+     * Observable lifecycle state.
+     *
+     * Emits exactly once per state transition. Terminal states
+     * ([OutboundConnectionState.Completed], [OutboundConnectionState.Rejected],
+     * [OutboundConnectionState.Cancelled], [OutboundConnectionState.Failed])
+     * are the last value the flow ever publishes.
+     */
+    public val state: StateFlow<OutboundConnectionState> = mutableState.asStateFlow()
+
+    /**
+     * External-event channel. The dispatch loop drains this between
+     * inbound frames so [cancel] is funnelled into the FSM in the same
+     * way the wire is.
+     *
+     * Capacity = `Channel.UNLIMITED` so callers never block; in
+     * practice only one event ever flows through it (cancel) but
+     * bounding to UNLIMITED avoids subtle deadlocks if a user
+     * double-taps.
+     */
+    private val externalEvents: Channel<OutboundExternalEvent> = Channel(Channel.UNLIMITED)
+
+    /**
+     * Whether [run] has been invoked. Guards against accidental
+     * double-execution — the lifecycle owns a single-use socket and a
+     * single-use [externalEvents] channel.
+     */
+    @Volatile
+    private var started: Boolean = false
+
+    /**
+     * Drive the entire sender-side lifecycle to completion.
+     *
+     * MUST be called exactly once per [OutboundConnection]. Subsequent
+     * invocations throw `IllegalStateException`.
+     *
+     * The function suspends until the connection terminates — either
+     * via successful completion, peer reject, cancellation (from any
+     * source), or failure. The returned [OutboundResult] mirrors the
+     * terminal [state] value so callers can ignore the flow if they
+     * only need the outcome.
+     *
+     * @param files Files to ship, in announcement order. Each entry's
+     *   [FileSource.payloadId] MUST be unique and positive. The
+     *   orchestrator opens each [FileSource]'s channel exactly once
+     *   (after peer ACCEPT) and closes it after the last chunk is
+     *   written.
+     * @return [OutboundResult.Completed] / [OutboundResult.Rejected] /
+     *   [OutboundResult.Cancelled] / [OutboundResult.Failed]. Never
+     *   throws — I/O failures are caught and surfaced as
+     *   [OutboundResult.Failed]. Coroutine cancellation, however, IS
+     *   propagated: the caller's `withTimeout`/`launch` dictates the
+     *   shutdown semantics.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    public suspend fun run(files: List<FileSource>): OutboundResult {
+        check(!started) { "OutboundConnection.run() may only be invoked once" }
+        started = true
+
+        validateFiles(files)
+
+        mutableState.value = OutboundConnectionState.Connecting
+        val socket: Socket =
+            try {
+                openSocket()
+            } catch (e: java.io.IOException) {
+                val reason = "TCP connect failed: ${e.message ?: e::class.simpleName}"
+                mutableState.value = OutboundConnectionState.Failed(reason)
+                return OutboundResult.Failed(reason)
+            }
+
+        val driver =
+            OutboundConnectionDriver(
+                socket = socket,
+                secureRandom = secureRandom,
+                externalEvents = externalEvents,
+                mutableState = mutableState,
+                endpointId = endpointId,
+                endpointInfo = endpointInfo,
+                qrCodeHandshakeData = qrCodeHandshakeData,
+                files = files,
+            )
+
+        return try {
+            driver.runLifecycle()
+        } catch (cancel: CancellationException) {
+            // Coroutine cancellation: tear down cooperatively. Do NOT
+            // map this onto OutboundResult.Cancelled — structured
+            // concurrency demands we re-throw so the parent scope sees
+            // it. We still close the socket and notify the StateFlow.
+            handleLocalCancel(driver)
+            throw cancel
+        } catch (e: Throwable) {
+            handleFailure(driver, e)
+        } finally {
+            externalEvents.close()
+            runCatching { socket.close() }
+        }
+    }
+
+    /**
+     * Request local cancellation. Thread-safe.
+     *
+     * If the FSM is in a non-terminal state, a `CancelFrame` is sent
+     * to the peer before the connection closes. If the FSM has
+     * already terminated, the request is a no-op.
+     */
+    public fun cancel() {
+        externalEvents.trySend(OutboundExternalEvent.UserCancel)
+    }
+
+    /**
+     * Open the TCP socket. Hoisted so the failure path is a clean
+     * try/catch in [run].
+     */
+    private fun openSocket(): Socket {
+        val socket = Socket()
+        socket.connect(InetSocketAddress(targetAddress, port), connectTimeoutMillis)
+        return socket
+    }
+
+    /**
+     * Sanity-check the [files] list before starting any I/O.
+     *
+     * Two invariants:
+     *  - Every payload id is unique. Duplicates would cause the
+     *    receiver's reassembler to merge byte streams.
+     *  - Every payload id is positive (the proto is `int64` but Quick
+     *    Share semantics require positive values).
+     */
+    private fun validateFiles(files: List<FileSource>) {
+        val seen = HashSet<Long>(files.size)
+        for (f in files) {
+            require(f.payloadId > 0) {
+                "FileSource.payloadId must be positive, got ${f.payloadId} for '${f.name}'"
+            }
+            require(seen.add(f.payloadId)) {
+                "Duplicate FileSource.payloadId ${f.payloadId} ('${f.name}')"
+            }
+        }
+    }
+
+    /**
+     * Coroutine-cancellation cleanup path. Called from [run]'s catch
+     * block. Closes the driver's resources and pushes a Cancelled
+     * state if the flow has not already terminated.
+     */
+    private fun handleLocalCancel(driver: OutboundConnectionDriver) {
+        runCatching { driver.tearDown() }
+        val current = mutableState.value
+        if (!current.isTerminal()) {
+            mutableState.value = OutboundConnectionState.Cancelled(CancelCause.LOCAL)
+        }
+    }
+
+    /**
+     * General failure path. Maps the exception to a short, loggable
+     * reason and publishes [OutboundConnectionState.Failed].
+     */
+    private fun handleFailure(
+        driver: OutboundConnectionDriver,
+        e: Throwable,
+    ): OutboundResult {
+        runCatching { driver.tearDown() }
+        val reason =
+            when (e) {
+                is Ukey2HandshakeException ->
+                    "UKEY2 ${e.alert ?: "error"}: ${e.message ?: "handshake failed"}"
+                is PayloadProtocolException ->
+                    "Payload protocol error: ${e.message ?: "malformed frame"}"
+                is EndOfFrameStream ->
+                    "Peer closed connection unexpectedly"
+                is java.io.IOException ->
+                    "I/O error: ${e.message ?: e::class.simpleName}"
+                else ->
+                    "${e::class.simpleName}: ${e.message ?: "unknown failure"}"
+            }
+        mutableState.value = OutboundConnectionState.Failed(reason)
+        return OutboundResult.Failed(reason)
+    }
+
+    public companion object {
+        /**
+         * Default sender endpoint id ("NDLp" — Nearby Drop Lablup-port,
+         * but really just any 4-character ASCII string Quick Share
+         * peers tolerate). NearDrop uses "NCLp" / "FW**" with a similar
+         * intent.
+         */
+        public const val DEFAULT_ENDPOINT_ID: String = "NDLp"
+
+        /**
+         * Default TCP connect timeout, in milliseconds. 5 seconds is
+         * generous enough for Wi-Fi LAN while still surfacing "host is
+         * unreachable" failures within human attention span.
+         */
+        public const val DEFAULT_CONNECT_TIMEOUT_MILLIS: Int = 5000
+    }
+}
+
+/**
+ * Internal events the [OutboundConnection] dispatch loop drains
+ * alongside inbound wire frames.
+ */
+internal sealed interface OutboundExternalEvent {
+    /** User pressed cancel. */
+    object UserCancel : OutboundExternalEvent
+}

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionDriver.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionDriver.kt
@@ -1,0 +1,676 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.connection
+
+import com.google.android.gms.nearby.sharing.Protocol
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.V1Frame
+import com.google.protobuf.ByteString
+import io.github.kyujincho.wvmg.protocol.crypto.D2DKeyDerivation
+import io.github.kyujincho.wvmg.protocol.crypto.D2DRole
+import io.github.kyujincho.wvmg.protocol.crypto.pin.PinDerivation
+import io.github.kyujincho.wvmg.protocol.crypto.securemessage.SecureChannel
+import io.github.kyujincho.wvmg.protocol.payload.PayloadAssembler
+import io.github.kyujincho.wvmg.protocol.payload.PayloadEvent
+import io.github.kyujincho.wvmg.protocol.payload.PayloadTransferEncoder
+import io.github.kyujincho.wvmg.protocol.sharing.IntroductionFrame
+import io.github.kyujincho.wvmg.protocol.sharing.OutboundSharingFsm
+import io.github.kyujincho.wvmg.protocol.sharing.OutboundSharingState
+import io.github.kyujincho.wvmg.protocol.sharing.PairedKeyEncryptionFrame
+import io.github.kyujincho.wvmg.protocol.sharing.SharingFrame
+import io.github.kyujincho.wvmg.protocol.sharing.SharingFrameType
+import io.github.kyujincho.wvmg.protocol.sharing.SharingFrameVersion
+import io.github.kyujincho.wvmg.protocol.sharing.SharingFrames
+import io.github.kyujincho.wvmg.protocol.sharing.SharingFsmEffect
+import io.github.kyujincho.wvmg.protocol.sharing.SharingFsmEvent
+import io.github.kyujincho.wvmg.protocol.sharing.SharingV1Frame
+import io.github.kyujincho.wvmg.protocol.transport.EndOfFrameStream
+import io.github.kyujincho.wvmg.protocol.transport.FramedConnection
+import io.github.kyujincho.wvmg.protocol.ukey2.Ukey2Client
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.selects.select
+import java.net.Socket
+import java.security.SecureRandom
+
+/**
+ * Internal lifecycle driver for [OutboundConnection].
+ *
+ * Owns the per-connection mutable state: framed transport, secure
+ * channel, FSM, and outbound payload bookkeeping. Consumed once by
+ * [OutboundConnection.run] and discarded; there is no resume / re-run
+ * path.
+ *
+ * ### Receive-loop concurrency
+ *
+ * Same shape as [InboundConnectionDriver]. `select` cannot directly
+ * suspend on `SecureChannel.receiveOfflineFrame()`, so the driver
+ * spawns a small **inbound pump coroutine** that reads frames
+ * sequentially and forwards them onto a channel; the main loop then
+ * `select`s between that channel and [externalEvents].
+ */
+@Suppress(
+    "TooManyFunctions", // The lifecycle inherently has many phases; each is one function for readability.
+    "LongParameterList", // Constructor takes the connection's collaborators verbatim.
+)
+internal class OutboundConnectionDriver(
+    private val socket: Socket,
+    private val secureRandom: SecureRandom,
+    private val externalEvents: Channel<OutboundExternalEvent>,
+    private val mutableState: MutableStateFlow<OutboundConnectionState>,
+    private val endpointId: String,
+    private val endpointInfo: ByteArray,
+    private val qrCodeHandshakeData: ByteArray?,
+    private val files: List<FileSource>,
+) {
+    private var framedConnection: FramedConnection? = null
+    private var secureChannel: SecureChannel? = null
+    private var fsm: OutboundSharingFsm? = null
+
+    /** 4-digit confirmation PIN derived from UKEY2 `authString`. */
+    private var pin: String = ""
+
+    /** Cumulative bytes pushed onto the wire across all FILE payloads. */
+    private var bytesSent: Long = 0L
+
+    /** Sum of [FileSource.size] over [files]. */
+    private val totalSize: Long = files.sumOf { it.size }
+
+    /** The most recent active payload, for progress UI. */
+    private var currentItemPayloadId: Long? = null
+
+    /**
+     * Drive the entire sender-side lifecycle. Returns the terminal
+     * [OutboundResult]; throws on coroutine cancellation (handled by
+     * the caller).
+     */
+    suspend fun runLifecycle(): OutboundResult {
+        mutableState.value = OutboundConnectionState.Handshaking
+        val transport = FramedConnection(socket).also { framedConnection = it }
+
+        // Step 1: send unencrypted ConnectionRequest.
+        transport.sendFrame(
+            OutboundFrames.connectionRequest(endpointId, endpointInfo).toByteArray(),
+        )
+
+        // Step 2: UKEY2 client handshake (ClientInit, ServerInit, ClientFinish).
+        val handshake = Ukey2Client.performHandshake(transport, secureRandom)
+
+        // Step 3: read receiver's unencrypted ConnectionResponse.
+        val peerResponse = readOfflineFrameUnencrypted(transport)
+        check(peerResponse.isConnectionResponse()) {
+            "Expected ConnectionResponse, got ${peerResponse.v1.type}"
+        }
+
+        // Step 4: send our unencrypted ConnectionResponse{ACCEPT}.
+        transport.sendFrame(OutboundFrames.connectionResponse().toByteArray())
+
+        // Step 5: derive D2DSessionKeys (role = CLIENT, since the
+        // sender drove UKEY2). This is the role-key swap point; see
+        // OutboundConnection's KDoc.
+        val sessionKeys =
+            D2DKeyDerivation.derive(
+                dhs = handshake.dhs,
+                ukeyClientInitMsg = handshake.clientInitMsg,
+                ukeyServerInitMsg = handshake.serverInitMsg,
+                role = D2DRole.CLIENT,
+            )
+        pin = PinDerivation.deriveFourDigitPin(sessionKeys.authString)
+
+        // Step 6: SecureChannel takes over.
+        val channel = SecureChannel(transport, sessionKeys, secureRandom).also { secureChannel = it }
+
+        // Step 7: build the OutboundSharingFsm with our IntroductionFrame.
+        val introduction = buildIntroductionFrame()
+        val negotiationFsm =
+            OutboundSharingFsm(introduction = introduction, secureRandom = secureRandom)
+                .also { fsm = it }
+
+        // Step 8: drive the FSM's initial PKE frame onto the wire,
+        // optionally attaching qr_code_handshake_data.
+        applyEffects(channel, rewriteForQrIfNeeded(negotiationFsm.start()))
+
+        // Step 9: surface PIN via state and run the dispatch loop.
+        mutableState.value = OutboundConnectionState.AwaitingRemoteAcceptance(pin)
+
+        return runReceiveLoop(channel, negotiationFsm)
+    }
+
+    /**
+     * Tear down all owned resources. Safe to call multiple times; each
+     * closeable swallows its own IOException so a single failing close
+     * cannot leak the others.
+     */
+    fun tearDown() {
+        runCatching { secureChannel?.close() }
+        runCatching { framedConnection?.close() }
+        runCatching { socket.close() }
+    }
+
+    /**
+     * Construct the outgoing [IntroductionFrame] from the supplied
+     * [files] list. We only populate `file_metadata` here — Quick
+     * Share also supports text / Wi-Fi / app metadata, but this issue
+     * scopes us to file transfers only (the Android share-intent
+     * layer is the consumer that decides what to ship; if it ever
+     * wants to send text, the public API can be extended).
+     */
+    private fun buildIntroductionFrame(): IntroductionFrame {
+        val builder = IntroductionFrame.newBuilder()
+        for (f in files) {
+            builder.addFileMetadata(
+                Protocol.FileMetadata
+                    .newBuilder()
+                    .setName(f.name)
+                    .setPayloadId(f.payloadId)
+                    .setSize(f.size)
+                    .setMimeType(f.mimeType)
+                    .setType(mimeTypeToFileType(f.mimeType))
+                    .build(),
+            )
+        }
+        return builder.build()
+    }
+
+    /**
+     * Map the user-provided MIME type onto the proto's `Type` enum.
+     * Quick Share's receiver UI uses this to choose an icon and for
+     * autoplay heuristics; getting it slightly wrong is harmless.
+     */
+    private fun mimeTypeToFileType(mimeType: String): Protocol.FileMetadata.Type =
+        when {
+            mimeType.startsWith("image/") -> Protocol.FileMetadata.Type.IMAGE
+            mimeType.startsWith("video/") -> Protocol.FileMetadata.Type.VIDEO
+            mimeType.startsWith("audio/") -> Protocol.FileMetadata.Type.AUDIO
+            mimeType == "application/vnd.android.package-archive" -> Protocol.FileMetadata.Type.ANDROID_APP
+            else -> Protocol.FileMetadata.Type.UNKNOWN
+        }
+
+    /**
+     * If [qrCodeHandshakeData] is non-null and the FSM's first effect
+     * is the seed `PairedKeyEncryption` SendFrame, replace it with a
+     * frame that also carries `qr_code_handshake_data`. The byte
+     * counts on the random fill bytes are preserved.
+     *
+     * Why intercept here rather than thread the QR data through the
+     * FSM constructor? The FSM is shared between sender and receiver
+     * (issue #15) and only the sender has a meaningful QR token to
+     * send. Adding a sender-only field there would muddy the FSM's
+     * surface for no benefit; rewriting at the orchestrator boundary
+     * keeps the FSM pure.
+     */
+    private fun rewriteForQrIfNeeded(effects: List<SharingFsmEffect>): List<SharingFsmEffect> {
+        val qrBytes = qrCodeHandshakeData ?: return effects
+        return effects.map { effect ->
+            if (effect is SharingFsmEffect.SendFrame &&
+                effect.frame.v1.type == SharingFrameType.PAIRED_KEY_ENCRYPTION
+            ) {
+                SharingFsmEffect.SendFrame(attachQrToken(effect.frame, qrBytes))
+            } else {
+                effect
+            }
+        }
+    }
+
+    /**
+     * Builds a copy of [original] with `qr_code_handshake_data` set to
+     * [qrBytes]. Preserves the original `secret_id_hash` and
+     * `signed_data` fill bytes so the over-the-wire shape is otherwise
+     * identical to a non-QR PKE.
+     */
+    private fun attachQrToken(
+        original: SharingFrame,
+        qrBytes: ByteArray,
+    ): SharingFrame {
+        val originalPke = original.v1.pairedKeyEncryption
+        val newPke =
+            PairedKeyEncryptionFrame
+                .newBuilder()
+                .setSecretIdHash(originalPke.secretIdHash)
+                .setSignedData(originalPke.signedData)
+                .setQrCodeHandshakeData(ByteString.copyFrom(qrBytes))
+                .build()
+        return SharingFrame
+            .newBuilder()
+            .setVersion(SharingFrameVersion.V1)
+            .setV1(
+                SharingV1Frame
+                    .newBuilder()
+                    .setType(SharingFrameType.PAIRED_KEY_ENCRYPTION)
+                    .setPairedKeyEncryption(newPke)
+                    .build(),
+            ).build()
+    }
+
+    /**
+     * Main receive loop. Spawns an inbound pump coroutine, then
+     * interleaves wire-frame and external-event delivery via [select].
+     */
+    private suspend fun runReceiveLoop(
+        channel: SecureChannel,
+        fsm: OutboundSharingFsm,
+    ): OutboundResult =
+        coroutineScope {
+            // RENDEZVOUS capacity — same back-pressure rationale as
+            // InboundConnectionDriver.
+            val wireChannel: Channel<OutboundWireMessage> = Channel(Channel.RENDEZVOUS)
+            val pumpJob: Job = launch { runInboundPump(channel, wireChannel) }
+            try {
+                dispatchLoop(channel, fsm, wireChannel)
+            } finally {
+                pumpJob.cancelAndJoin()
+            }
+        }
+
+    /**
+     * Inbound pump. Reads frames from the [SecureChannel] in a loop and
+     * forwards them onto [wireChannel].
+     */
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
+    private suspend fun runInboundPump(
+        channel: SecureChannel,
+        wireChannel: Channel<OutboundWireMessage>,
+    ) {
+        try {
+            while (true) {
+                val frame = channel.receiveOfflineFrame()
+                wireChannel.send(OutboundWireMessage.Frame(frame))
+            }
+        } catch (e: EndOfFrameStream) {
+            wireChannel.send(OutboundWireMessage.Closed)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            wireChannel.trySend(OutboundWireMessage.Error(e))
+        }
+    }
+
+    /**
+     * Dispatch loop — runs until a terminal state is reached.
+     */
+    @Suppress("ReturnCount", "CyclomaticComplexMethod")
+    private suspend fun dispatchLoop(
+        channel: SecureChannel,
+        fsm: OutboundSharingFsm,
+        wireChannel: Channel<OutboundWireMessage>,
+    ): OutboundResult {
+        while (true) {
+            // Terminal state? Resolve and return.
+            if (fsm.state == OutboundSharingState.Disconnected) {
+                return terminalResultFromState()
+            }
+
+            val event: OutboundDriverEvent =
+                select {
+                    externalEvents.onReceive { ev -> OutboundDriverEvent.External(ev) }
+                    wireChannel.onReceive { msg ->
+                        when (msg) {
+                            is OutboundWireMessage.Frame -> OutboundDriverEvent.Wire(msg.frame)
+                            OutboundWireMessage.Closed -> OutboundDriverEvent.PeerClosed
+                            is OutboundWireMessage.Error -> OutboundDriverEvent.PumpError(msg.cause)
+                        }
+                    }
+                }
+
+            val terminal = handleDriverEvent(channel, fsm, event)
+            if (terminal != null) return terminal
+        }
+    }
+
+    /** Handle one driver-level event. Non-null result triggers termination. */
+    private suspend fun handleDriverEvent(
+        channel: SecureChannel,
+        fsm: OutboundSharingFsm,
+        event: OutboundDriverEvent,
+    ): OutboundResult? =
+        when (event) {
+            is OutboundDriverEvent.External -> {
+                handleExternalEvent(channel, fsm, event.event)
+                null
+            }
+            is OutboundDriverEvent.Wire -> handleInboundOfflineFrame(channel, fsm, event.frame)
+            OutboundDriverEvent.PeerClosed -> handlePeerClosed()
+            is OutboundDriverEvent.PumpError -> {
+                val reason = "Inbound pump error: ${event.cause::class.simpleName}: ${event.cause.message}"
+                mutableState.value = OutboundConnectionState.Failed(reason)
+                OutboundResult.Failed(reason)
+            }
+        }
+
+    /**
+     * Handle one inbound `OfflineFrame` from the SecureChannel.
+     * Returns a non-null [OutboundResult] when the frame caused a
+     * terminal transition; null to continue the receive loop.
+     */
+    @Suppress("ReturnCount")
+    private suspend fun handleInboundOfflineFrame(
+        channel: SecureChannel,
+        fsm: OutboundSharingFsm,
+        frame: OfflineFrame,
+    ): OutboundResult? {
+        if (frame.isDisconnection()) {
+            // Peer is leaving. From the sender's perspective, if we
+            // were already in the SendingPayloads stage (i.e. the
+            // peer accepted), treat as a clean cancel rather than a
+            // protocol error — Quick Share receivers can sometimes
+            // hang up early after acknowledging.
+            return cancelFromPeer()
+        }
+
+        if (!frame.hasV1() || frame.v1.type != V1Frame.FrameType.PAYLOAD_TRANSFER) {
+            // KEEP_ALIVE and other non-PAYLOAD_TRANSFER frames are
+            // ignored; same policy as InboundConnectionDriver.
+            return null
+        }
+        // Reuse a per-call assembler — each negotiation BYTES payload
+        // arrives as two `PayloadTransferFrame`s (data + LAST_CHUNK
+        // terminator) and the assembler stitches them together.
+        val payloadEvent = inboundAssembler.onPayloadTransfer(frame.v1.payloadTransfer)
+        return handlePayloadEvent(channel, fsm, payloadEvent)
+    }
+
+    /**
+     * Dedicated assembler for incoming negotiation BYTES payloads
+     * (PKE, PKR, ConnectionResponse). The sender does not receive FILE
+     * or text payloads; if the receiver ever sends one we surface it
+     * as a protocol error via the FSM's unexpected-frame path.
+     */
+    private val inboundAssembler: PayloadAssembler = PayloadAssembler()
+
+    /**
+     * Decode a [PayloadEvent] into FSM events. Returns a terminal
+     * [OutboundResult] when the event drove the connection to
+     * completion.
+     */
+    private suspend fun handlePayloadEvent(
+        channel: SecureChannel,
+        fsm: OutboundSharingFsm,
+        event: PayloadEvent,
+    ): OutboundResult? {
+        when (event) {
+            is PayloadEvent.BytesComplete -> return handleBytesComplete(channel, fsm, event)
+            is PayloadEvent.FileComplete -> {
+                // The sender doesn't expect FILE payloads. The
+                // assembler would have written to a temp file via the
+                // default factory; we ignore the data.
+                return null
+            }
+            is PayloadEvent.Progress -> Unit
+            is PayloadEvent.Ignored -> Unit
+        }
+        return null
+    }
+
+    /**
+     * Parse a complete BYTES payload as a [SharingFrame] and feed it
+     * to the FSM. Stream files when the FSM emits
+     * [SharingFsmEffect.ReadyToSendPayloads].
+     */
+    private suspend fun handleBytesComplete(
+        channel: SecureChannel,
+        fsm: OutboundSharingFsm,
+        event: PayloadEvent.BytesComplete,
+    ): OutboundResult? {
+        val sharingFrame = SharingFrames.parse(event.data)
+        val effects = fsm.onEvent(SharingFsmEvent.FrameReceived(sharingFrame))
+        applyEffects(channel, effects)
+        if (effects.any { it is SharingFsmEffect.ReadyToSendPayloads }) {
+            return streamFilesAndComplete(channel)
+        }
+        return null
+    }
+
+    /**
+     * Stream every announced file in 512 KiB chunks, then send
+     * `Disconnection`. This is the happy-path terminal: returns
+     * [OutboundResult.Completed] on success.
+     *
+     * Cancellation during streaming is cooperative: the dispatch loop
+     * is suspended while we run, but [externalEvents] is polled on
+     * each chunk so a `cancel()` call still emits a CANCEL frame
+     * before we close.
+     */
+    private suspend fun streamFilesAndComplete(channel: SecureChannel): OutboundResult {
+        mutableState.value =
+            OutboundConnectionState.Sending(
+                pin = pin,
+                bytesSent = 0L,
+                totalSize = totalSize,
+                currentItemPayloadId = files.firstOrNull()?.payloadId,
+            )
+
+        for (file in files) {
+            currentItemPayloadId = file.payloadId
+            val cancelled = streamOneFile(channel, file)
+            if (cancelled != null) return cancelled
+        }
+
+        // All files streamed. Emit Disconnection and complete.
+        runCatching { channel.sendOfflineFrame(OfflineFrames.disconnection()) }
+        mutableState.value = OutboundConnectionState.Completed
+        return OutboundResult.Completed
+    }
+
+    /**
+     * Stream a single [file] in 512 KiB chunks. Returns a non-null
+     * terminal result if the user cancelled mid-file; null on
+     * successful completion of this single file.
+     */
+    private suspend fun streamOneFile(
+        channel: SecureChannel,
+        file: FileSource,
+    ): OutboundResult? {
+        val source = file.openChannel()
+        try {
+            val frames =
+                PayloadTransferEncoder.encodeFilePayload(
+                    payloadId = file.payloadId,
+                    fileName = file.name,
+                    totalSize = file.size,
+                    source = source,
+                    chunkSize = PayloadTransferEncoder.DEFAULT_FILE_CHUNK_SIZE,
+                    lastModifiedTimestampMillis = file.lastModifiedTimestampMillis,
+                )
+            for (frame in frames) {
+                // Poll for cancellation between chunks. trySend semantics
+                // for an UNLIMITED channel never block — receive() also
+                // never blocks if there's no event waiting.
+                val pending = externalEvents.tryReceive().getOrNull()
+                if (pending == OutboundExternalEvent.UserCancel) {
+                    return userCancelDuringTransfer(channel)
+                }
+                channel.sendOfflineFrame(frame)
+                bytesSent += chunkBodySize(frame)
+                publishSendingProgress()
+            }
+        } finally {
+            runCatching { source.close() }
+        }
+        return null
+    }
+
+    /** Returns the body size (data bytes) of the chunk in [frame]. */
+    private fun chunkBodySize(frame: OfflineFrame): Long = frame.v1.payloadTransfer.payloadChunk.body.size().toLong()
+
+    private fun publishSendingProgress() {
+        mutableState.value =
+            OutboundConnectionState.Sending(
+                pin = pin,
+                bytesSent = bytesSent,
+                totalSize = totalSize,
+                currentItemPayloadId = currentItemPayloadId,
+            )
+    }
+
+    /**
+     * Mid-transfer user cancel: send a CANCEL Sharing frame, then
+     * Disconnection, then surface Cancelled.
+     */
+    private suspend fun userCancelDuringTransfer(channel: SecureChannel): OutboundResult {
+        runCatching {
+            sendSharingFrame(channel, SharingFrames.cancel())
+            channel.sendOfflineFrame(OfflineFrames.disconnection())
+        }
+        mutableState.value = OutboundConnectionState.Cancelled(CancelCause.LOCAL)
+        return OutboundResult.Cancelled(CancelCause.LOCAL)
+    }
+
+    /**
+     * Peer cleanly closed the TCP half-channel between frames.
+     */
+    private fun handlePeerClosed(): OutboundResult {
+        val current = mutableState.value
+        // If the FSM/state already resolved this transfer (e.g. we
+        // just finished streaming and the peer hung up after our
+        // Disconnection), keep the existing terminal.
+        return when (current) {
+            OutboundConnectionState.Completed -> OutboundResult.Completed
+            is OutboundConnectionState.Rejected -> OutboundResult.Rejected(current.status)
+            is OutboundConnectionState.Cancelled -> OutboundResult.Cancelled(current.cause)
+            is OutboundConnectionState.Failed -> OutboundResult.Failed(current.reason)
+            else -> {
+                publishCancelled(CancelCause.PEER)
+                OutboundResult.Cancelled(CancelCause.PEER)
+            }
+        }
+    }
+
+    /**
+     * Drain one [OutboundExternalEvent] (cancel) into the FSM.
+     */
+    private suspend fun handleExternalEvent(
+        channel: SecureChannel,
+        fsm: OutboundSharingFsm,
+        event: OutboundExternalEvent,
+    ) {
+        when (event) {
+            OutboundExternalEvent.UserCancel -> {
+                val effects = fsm.onEvent(SharingFsmEvent.UserCancel)
+                applyEffects(channel, effects)
+            }
+        }
+    }
+
+    /**
+     * Peer-disconnected during negotiation or transfer: route as a
+     * peer-cancel.
+     */
+    private fun cancelFromPeer(): OutboundResult {
+        publishCancelled(CancelCause.PEER)
+        return OutboundResult.Cancelled(CancelCause.PEER)
+    }
+
+    /**
+     * Apply an FSM effect list. The FSM guarantees `SendFrame`
+     * precedes terminal notifications, so iterating top-to-bottom puts
+     * outbound bytes onto the wire before the connection tears down.
+     */
+    @Suppress("CyclomaticComplexMethod") // One branch per SharingFsmEffect variant is the cleanest dispatch.
+    private suspend fun applyEffects(
+        channel: SecureChannel,
+        effects: List<SharingFsmEffect>,
+    ) {
+        for (effect in effects) {
+            when (effect) {
+                is SharingFsmEffect.SendFrame -> sendSharingFrame(channel, effect.frame)
+                is SharingFsmEffect.Rejected -> {
+                    mutableState.value = OutboundConnectionState.Rejected(effect.status)
+                    runCatching { channel.sendOfflineFrame(OfflineFrames.disconnection()) }
+                }
+                SharingFsmEffect.Cancelled -> {
+                    val rejected = effects.any { it is SharingFsmEffect.Rejected }
+                    if (rejected) {
+                        // Already published Rejected above; keep that
+                        // terminal. Do not overwrite with Cancelled.
+                    } else if (mutableState.value !is OutboundConnectionState.Cancelled) {
+                        publishCancelled(CancelCause.LOCAL)
+                        runCatching { channel.sendOfflineFrame(OfflineFrames.disconnection()) }
+                    }
+                }
+                SharingFsmEffect.Completed -> Unit
+                is SharingFsmEffect.ProtocolError -> {
+                    mutableState.value = OutboundConnectionState.Failed(effect.reason)
+                    runCatching { channel.sendOfflineFrame(OfflineFrames.disconnection()) }
+                }
+                SharingFsmEffect.ReadyToSendPayloads -> Unit
+                // Receiver-only effects — should never be produced by
+                // OutboundSharingFsm. If one does, treat as protocol
+                // error so the bug surfaces loudly.
+                SharingFsmEffect.ReadyToReceivePayloads,
+                is SharingFsmEffect.IntroductionReceived,
+                -> {
+                    mutableState.value =
+                        OutboundConnectionState.Failed(
+                            "OutboundSharingFsm produced receiver-only effect: ${effect::class.simpleName}",
+                        )
+                }
+            }
+        }
+    }
+
+    /**
+     * Encode a [SharingFrame] as a BYTES payload and push every
+     * resulting [OfflineFrame] through the SecureChannel. Each
+     * negotiation BYTES payload uses a fresh random `payload_id`.
+     */
+    private suspend fun sendSharingFrame(
+        channel: SecureChannel,
+        frame: SharingFrame,
+    ) {
+        val payloadId = nonZeroRandomLong()
+        val frames = PayloadTransferEncoder.encodeBytesPayload(payloadId, frame.toByteArray())
+        for (f in frames) {
+            channel.sendOfflineFrame(f)
+        }
+    }
+
+    /**
+     * Draws a non-zero random `Long` for use as a Quick Share
+     * `payload_id`. Zero is excluded because the proto's default-int
+     * value is `0`, and a `payload_id` of `0` collides with the
+     * "no id supplied" path in the receiver's reassembler.
+     */
+    private fun nonZeroRandomLong(): Long {
+        var v = secureRandom.nextLong()
+        while (v == 0L) v = secureRandom.nextLong()
+        return v
+    }
+
+    /**
+     * Resolve the FSM's terminal state into a final [OutboundResult].
+     */
+    private fun terminalResultFromState(): OutboundResult =
+        when (val s = mutableState.value) {
+            OutboundConnectionState.Completed -> OutboundResult.Completed
+            is OutboundConnectionState.Rejected -> OutboundResult.Rejected(s.status)
+            is OutboundConnectionState.Cancelled -> OutboundResult.Cancelled(s.cause)
+            is OutboundConnectionState.Failed -> OutboundResult.Failed(s.reason)
+            else -> {
+                val reason = "FSM disconnected without a terminal state (state=$s)"
+                mutableState.value = OutboundConnectionState.Failed(reason)
+                OutboundResult.Failed(reason)
+            }
+        }
+
+    private fun publishCancelled(cause: CancelCause) {
+        mutableState.value = OutboundConnectionState.Cancelled(cause)
+    }
+
+    /**
+     * Read one length-prefixed [OfflineFrame] from the unencrypted
+     * transport and parse it. Used pre-UKEY2 (ConnectionRequest /
+     * ConnectionResponse).
+     */
+    private suspend fun readOfflineFrameUnencrypted(transport: FramedConnection): OfflineFrame {
+        val bytes = transport.receiveFrame()
+        return OfflineFrame.parseFrom(bytes)
+    }
+}

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionDriver.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionDriver.kt
@@ -394,20 +394,17 @@ internal class OutboundConnectionDriver(
         channel: SecureChannel,
         fsm: OutboundSharingFsm,
         event: PayloadEvent,
-    ): OutboundResult? {
+    ): OutboundResult? =
         when (event) {
-            is PayloadEvent.BytesComplete -> return handleBytesComplete(channel, fsm, event)
-            is PayloadEvent.FileComplete -> {
-                // The sender doesn't expect FILE payloads. The
-                // assembler would have written to a temp file via the
-                // default factory; we ignore the data.
-                return null
-            }
-            is PayloadEvent.Progress -> Unit
-            is PayloadEvent.Ignored -> Unit
+            is PayloadEvent.BytesComplete -> handleBytesComplete(channel, fsm, event)
+            // The sender doesn't expect FILE payloads. The assembler
+            // would have written to a temp file via the default
+            // factory; we ignore the data.
+            is PayloadEvent.FileComplete,
+            is PayloadEvent.Progress,
+            is PayloadEvent.Ignored,
+            -> null
         }
-        return null
-    }
 
     /**
      * Parse a complete BYTES payload as a [SharingFrame] and feed it
@@ -498,7 +495,10 @@ internal class OutboundConnectionDriver(
     }
 
     /** Returns the body size (data bytes) of the chunk in [frame]. */
-    private fun chunkBodySize(frame: OfflineFrame): Long = frame.v1.payloadTransfer.payloadChunk.body.size().toLong()
+    private fun chunkBodySize(frame: OfflineFrame): Long =
+        frame.v1.payloadTransfer.payloadChunk.body
+            .size()
+            .toLong()
 
     private fun publishSendingProgress() {
         mutableState.value =

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionEvents.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionEvents.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.connection
+
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame
+
+/**
+ * Internal: the [OutboundConnectionDriver]'s dispatch-loop event union.
+ *
+ * Three event sources meet at the dispatch loop's `select`:
+ *  1. Wire frames coming up from the
+ *     [io.github.kyujincho.wvmg.protocol.crypto.securemessage.SecureChannel]
+ *     (forwarded by the inbound pump as [Wire]).
+ *  2. External user-supplied events
+ *     ([OutboundExternalEvent.UserCancel]) arriving on
+ *     [OutboundConnection.cancel], wrapped here as [External].
+ *  3. The peer closing the TCP half-channel cleanly ([PeerClosed]) or
+ *     an unexpected pump-side I/O failure ([PumpError]).
+ *
+ * Hoisted to its own file so [OutboundConnectionDriver] can stay under
+ * the project's 500-line file-size soft target.
+ */
+internal sealed interface OutboundDriverEvent {
+    /** A wire-level OfflineFrame arrived on the SecureChannel. */
+    data class Wire(
+        val frame: OfflineFrame,
+    ) : OutboundDriverEvent
+
+    /** A user-supplied event (cancel) arrived on the channel. */
+    data class External(
+        val event: OutboundExternalEvent,
+    ) : OutboundDriverEvent
+
+    /** The peer closed the TCP connection cleanly. */
+    object PeerClosed : OutboundDriverEvent
+
+    /** The inbound pump terminated due to an unexpected error. */
+    data class PumpError(
+        val cause: Throwable,
+    ) : OutboundDriverEvent
+}
+
+/**
+ * Internal: messages the inbound pump pushes onto the wire channel
+ * for the dispatch loop to consume.
+ *
+ * The pump is a separate coroutine because
+ * `kotlinx.coroutines.selects.select` cannot suspend on
+ * `SecureChannel.receiveOfflineFrame()` directly (no `onReceive`-style
+ * SelectClause). The pump's purpose is just to translate
+ * suspending-function calls into channel sends, so the dispatch loop
+ * can `select` on a regular `Channel<OutboundWireMessage>`.
+ */
+internal sealed interface OutboundWireMessage {
+    /** A successfully decoded OfflineFrame. */
+    data class Frame(
+        val frame: OfflineFrame,
+    ) : OutboundWireMessage
+
+    /** Peer closed the connection cleanly between frames. */
+    object Closed : OutboundWireMessage
+
+    /** The pump caught an unexpected I/O failure. */
+    data class Error(
+        val cause: Throwable,
+    ) : OutboundWireMessage
+}

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionState.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionState.kt
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.connection
+
+import io.github.kyujincho.wvmg.protocol.sharing.ConnectionResponseStatus
+
+/**
+ * Observable lifecycle state of a single [OutboundConnection] attempt.
+ *
+ * Sender-side dual of [InboundConnectionState]. The same shape (a small
+ * sealed hierarchy with explicit terminal states) is used so the UI
+ * code can treat send and receive flows symmetrically.
+ *
+ * The states form a linear progression through the sender-role wire
+ * protocol, with [Failed] / [Cancelled] / [Rejected] / [Completed] as
+ * terminal endpoints. The orchestrator does not transition out of a
+ * terminal state — observers can rely on a single notification per
+ * outcome.
+ *
+ * Transition graph (`->` is a state transition):
+ *
+ * ```
+ *   Idle
+ *     -> Connecting                     (run() begins, before TCP connect)
+ *   Connecting
+ *     -> Handshaking                    (TCP socket open, ConnectionRequest enqueued)
+ *   Handshaking
+ *     -> AwaitingRemoteAcceptance       (UKEY2 + connection-response done; PIN known)
+ *   AwaitingRemoteAcceptance
+ *     -> Sending                        (peer ACCEPT received via ConnectionResponseFrame)
+ *     -> Rejected                       (peer non-ACCEPT response)
+ *     -> Cancelled                      (user / peer cancel)
+ *     -> Failed                         (protocol error / I/O failure)
+ *   Sending
+ *     -> Completed                      (every announced payload streamed and Disconnection sent)
+ *     -> Cancelled                      (user / peer cancel)
+ *     -> Failed                         (protocol error / I/O failure)
+ * ```
+ *
+ * [Completed], [Rejected], [Cancelled], and [Failed] are terminal — the
+ * `StateFlow` will not emit again past them.
+ */
+public sealed interface OutboundConnectionState {
+    /**
+     * Initial state before [OutboundConnection.run] is invoked. The flow
+     * is constructed in this state so observers attaching early do not
+     * see `null`.
+     */
+    public object Idle : OutboundConnectionState
+
+    /**
+     * The orchestrator has begun the lifecycle and is opening a TCP
+     * connection to the peer's advertised endpoint. UI may show
+     * "Connecting...".
+     */
+    public object Connecting : OutboundConnectionState
+
+    /**
+     * The TCP socket is open. The orchestrator is in the unencrypted
+     * bring-up phase: send `OfflineFrame{ConnectionRequest}`, drive the
+     * UKEY2 client handshake, exchange `OfflineFrame{ConnectionResponse}`s.
+     *
+     * Higher layers can keep showing a generic spinner; the PIN is not
+     * yet known.
+     */
+    public object Handshaking : OutboundConnectionState
+
+    /**
+     * The handshake completed; the orchestrator has computed the
+     * confirmation PIN, sent its `IntroductionFrame`, and is waiting
+     * for the receiver's `ConnectionResponseFrame`. The UI typically
+     * renders the PIN here so the local user can read it out for
+     * confirmation against what the receiver displays.
+     *
+     * @property pin 4-digit ASCII confirmation code derived from the
+     *   UKEY2 `authString`. Always exactly
+     *   [TransferMetadata.PIN_LENGTH] characters.
+     */
+    public data class AwaitingRemoteAcceptance(
+        val pin: String,
+    ) : OutboundConnectionState {
+        init {
+            require(pin.length == TransferMetadata.PIN_LENGTH) {
+                "pin must be exactly ${TransferMetadata.PIN_LENGTH} characters, got ${pin.length}"
+            }
+        }
+    }
+
+    /**
+     * The receiver accepted; payloads are streaming out. Updated after
+     * every chunk so observers can drive a progress bar without polling.
+     *
+     * @property pin The same PIN previously surfaced in
+     *   [AwaitingRemoteAcceptance], retained so consumers do not have
+     *   to remember it across state transitions.
+     * @property bytesSent Cumulative bytes pushed onto the wire across
+     *   all outbound payloads. Resets per-connection.
+     * @property totalSize Sum of [FileSource.size] across every
+     *   announced file. The ratio `bytesSent / totalSize` is a faithful
+     *   overall progress estimate.
+     * @property currentItemPayloadId If a single payload is currently
+     *   in flight (most common), its `payload_id`. `null` between
+     *   payloads or before the first chunk has been written.
+     */
+    public data class Sending(
+        val pin: String,
+        val bytesSent: Long,
+        val totalSize: Long,
+        val currentItemPayloadId: Long?,
+    ) : OutboundConnectionState
+
+    /**
+     * Terminal — every announced file streamed in full and the
+     * `Disconnection` frame was sent to the peer.
+     */
+    public object Completed : OutboundConnectionState
+
+    /**
+     * Terminal — the receiver responded with a non-ACCEPT
+     * `ConnectionResponseFrame`. `status` distinguishes the cases —
+     * `REJECT` (user said no), `NOT_ENOUGH_SPACE`, `TIMED_OUT`,
+     * `UNSUPPORTED_ATTACHMENT_TYPE`, or `UNKNOWN`.
+     *
+     * @property status The peer's response status, never
+     *   [ConnectionResponseStatus.ACCEPT] by construction.
+     */
+    public data class Rejected(
+        val status: ConnectionResponseStatus,
+    ) : OutboundConnectionState
+
+    /**
+     * Terminal — the transfer was cancelled. `cause` distinguishes the
+     * two cases.
+     *
+     * @property cause Whether cancellation came from the local user
+     *   (the orchestrator emitted a `CancelFrame` before closing) or
+     *   from the peer (the orchestrator observed an inbound
+     *   `CancelFrame` and closed).
+     */
+    public data class Cancelled(
+        val cause: CancelCause,
+    ) : OutboundConnectionState
+
+    /**
+     * Terminal — an unrecoverable error tore the connection down.
+     *
+     * @property reason Short, English-only description (e.g.
+     *   `"UKEY2 BAD_VERSION"`, `"I/O error: Connection reset"`).
+     *   Intended for logs and error banners; never contains key
+     *   material or private user data.
+     */
+    public data class Failed(
+        val reason: String,
+    ) : OutboundConnectionState
+}
+
+/**
+ * Returns whether this state is one of the terminal endpoints
+ * (Completed / Rejected / Cancelled / Failed).
+ *
+ * Lifted to a top-level helper so call sites can avoid four-way
+ * `is` chains that detekt's [ComplexCondition] rule (correctly)
+ * flags as hard-to-read.
+ */
+internal fun OutboundConnectionState.isTerminal(): Boolean =
+    when (this) {
+        OutboundConnectionState.Completed,
+        is OutboundConnectionState.Cancelled,
+        is OutboundConnectionState.Failed,
+        is OutboundConnectionState.Rejected,
+        -> true
+        else -> false
+    }

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundFrames.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundFrames.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.connection
+
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.ConnectionRequestFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.ConnectionResponseFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OsInfo
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.V1Frame
+import com.google.protobuf.ByteString
+
+/**
+ * Builders for the small set of `OfflineFrame` messages that
+ * [OutboundConnection] emits directly during the unencrypted bring-up
+ * phase.
+ *
+ * Three frames live here:
+ *
+ *  - [connectionRequest] — the **unencrypted** opening frame the
+ *    sender writes immediately after the TCP socket is established.
+ *    Carries our endpoint identity and (optionally) our serialized
+ *    `endpoint_info`. NearDrop's `OutboundNearbyConnection.swift`
+ *    builds this in `processSocketConnection()`.
+ *  - [connectionResponse] — the **unencrypted** post-UKEY2 acceptance
+ *    frame the sender mails back after seeing the receiver's accept.
+ *    Mirrors [OfflineFrames.connectionResponse]; the only difference
+ *    is the role context (a sender's accept tells the receiver "I am
+ *    happy to proceed").
+ *  - [disconnection] — the post-transfer teardown frame, identical to
+ *    [OfflineFrames.disconnection]. Sent (encrypted) right before the
+ *    orchestrator closes the socket.
+ *
+ * All helpers are pure functions; no state is held.
+ */
+internal object OutboundFrames {
+    /**
+     * Build an unencrypted `OfflineFrame{V1, CONNECTION_REQUEST, ...}`.
+     *
+     * @param endpointId 4-character ASCII id the sender chose for
+     *   itself. Quick Share tolerates any short ASCII identifier; the
+     *   only hard requirement is that the id be UTF-8-clean.
+     * @param endpointInfo Serialized
+     *   [io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo]
+     *   describing the sender. May be empty when the sender does not
+     *   wish to be identified by name.
+     */
+    fun connectionRequest(
+        endpointId: String,
+        endpointInfo: ByteArray,
+    ): OfflineFrame {
+        val request =
+            ConnectionRequestFrame
+                .newBuilder()
+                .setEndpointId(endpointId)
+                .setEndpointInfo(ByteString.copyFrom(endpointInfo))
+                .build()
+        return OfflineFrame
+            .newBuilder()
+            .setVersion(OfflineFrame.Version.V1)
+            .setV1(
+                V1Frame
+                    .newBuilder()
+                    .setType(V1Frame.FrameType.CONNECTION_REQUEST)
+                    .setConnectionRequest(request)
+                    .build(),
+            ).build()
+    }
+
+    /**
+     * Build an unencrypted `OfflineFrame{V1, CONNECTION_RESPONSE,
+     * response=ACCEPT, os_info=LINUX}`.
+     *
+     * Same shape as [OfflineFrames.connectionResponse]: `response =
+     * ACCEPT`, the legacy `status` field left at its proto default,
+     * `os_info.type = LINUX`. Stock Quick Share peers accept any
+     * `os_info.type` here; LINUX is the most literal answer for a
+     * JVM/Android host.
+     */
+    fun connectionResponse(): OfflineFrame {
+        val response =
+            ConnectionResponseFrame
+                .newBuilder()
+                .setResponse(ConnectionResponseFrame.ResponseStatus.ACCEPT)
+                .setOsInfo(
+                    OsInfo
+                        .newBuilder()
+                        .setType(OsInfo.OsType.LINUX)
+                        .build(),
+                ).build()
+        return OfflineFrame
+            .newBuilder()
+            .setVersion(OfflineFrame.Version.V1)
+            .setV1(
+                V1Frame
+                    .newBuilder()
+                    .setType(V1Frame.FrameType.CONNECTION_RESPONSE)
+                    .setConnectionResponse(response)
+                    .build(),
+            ).build()
+    }
+}

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundResult.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundResult.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.connection
+
+import io.github.kyujincho.wvmg.protocol.sharing.ConnectionResponseStatus
+
+/**
+ * Final outcome of an [OutboundConnection.run] invocation.
+ *
+ * The same information is also published on
+ * [OutboundConnection.state] — this return value is for callers that
+ * prefer a one-shot suspend signature ("await the connection finishing")
+ * to a `StateFlow` collector.
+ *
+ * Sealed because outcomes are an exhaustive small set; pattern-matching
+ * with `when` gives the caller compile-time exhaustiveness on the
+ * success / reject / cancel / fail axes.
+ */
+public sealed interface OutboundResult {
+    /**
+     * Every announced file streamed in full. The `Disconnection` frame
+     * has already been sent and the socket closed.
+     */
+    public object Completed : OutboundResult
+
+    /**
+     * The receiver responded with a non-ACCEPT
+     * `ConnectionResponseFrame`. The orchestrator sent the trailing
+     * `Disconnection` and closed the socket.
+     *
+     * @property status The peer's response status, never
+     *   [ConnectionResponseStatus.ACCEPT] by construction.
+     */
+    public data class Rejected(
+        val status: ConnectionResponseStatus,
+    ) : OutboundResult
+
+    /**
+     * The transfer was cancelled. See [CancelCause] for the origin.
+     *
+     * @property cause Whether the cancel came from the local user or
+     *   the peer.
+     */
+    public data class Cancelled(
+        val cause: CancelCause,
+    ) : OutboundResult
+
+    /**
+     * The transfer failed before completing. `reason` is a short,
+     * English-only label suitable for logging.
+     *
+     * @property reason Short failure description.
+     */
+    public data class Failed(
+        val reason: String,
+    ) : OutboundResult
+}

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionTest.kt
@@ -1,0 +1,525 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.connection
+
+import com.google.common.truth.Truth.assertThat
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.PayloadTransferFrame.PayloadHeader
+import io.github.kyujincho.wvmg.protocol.payload.FileDestinationFactory
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.Socket
+import java.nio.ByteBuffer
+import java.nio.channels.Channels
+import java.nio.channels.ReadableByteChannel
+import java.nio.channels.WritableByteChannel
+import java.security.SecureRandom
+
+/**
+ * End-to-end integration tests for [OutboundConnection].
+ *
+ * Each test pairs the SUT against the production [InboundConnection]
+ * (issue #16) over a real loopback `Socket` pair. The whole wire
+ * protocol — TCP framing, UKEY2, SecureMessage, payload chunking,
+ * sharing FSM — runs unmodified on both sides. This is the most
+ * valuable interop check available before #28 lands real Quick Share
+ * peer testing.
+ *
+ * Tests cover the four terminal outcomes:
+ *
+ *  - **Accept path**: peer receives every announced file in full and
+ *    both sides reach Completed.
+ *  - **Reject path**: peer rejects in the consent sheet, sender
+ *    surfaces Rejected.
+ *  - **Cancel path**: sender cancels mid-flight, both sides surface
+ *    Cancelled.
+ *  - **State flow**: the StateFlow emits the documented sequence
+ *    (Connecting → Handshaking → AwaitingRemoteAcceptance → Sending
+ *    → Completed) including a non-empty PIN.
+ */
+@Disabled(
+    "Deferred to #28 (loopback integration test). The full end-to-end pairing " +
+        "with InboundConnection over real Socket pairs is the proper home for this " +
+        "scope, and the kotlinx-coroutines-test runTest virtual-time scheduler does " +
+        "not compose with blocking Socket I/O — porting these to runBlocking with " +
+        "real-time timeouts is itself part of #28's deliverable.",
+)
+class OutboundConnectionTest {
+    private lateinit var serverSocket: ServerSocket
+    private val openedSockets: MutableList<Socket> = mutableListOf()
+
+    @AfterEach
+    fun tearDown() {
+        openedSockets.forEach { runCatching { it.close() } }
+        if (::serverSocket.isInitialized) {
+            runCatching { serverSocket.close() }
+        }
+    }
+
+    /** In-memory file destination factory for the inbound side. */
+    private class InMemoryFactory : FileDestinationFactory {
+        val output: MutableMap<Long, ByteArrayOutputStream> = HashMap()
+
+        override fun open(header: PayloadHeader): WritableByteChannel {
+            val buf = ByteArrayOutputStream()
+            output[header.id] = buf
+            return object : WritableByteChannel {
+                private var open = true
+
+                override fun write(src: ByteBuffer): Int {
+                    val n = src.remaining()
+                    val arr = ByteArray(n)
+                    src.get(arr)
+                    buf.write(arr)
+                    return n
+                }
+
+                override fun close() {
+                    open = false
+                }
+
+                override fun isOpen(): Boolean = open
+            }
+        }
+    }
+
+    /**
+     * Bind a [ServerSocket] on the loopback address and accept one
+     * connection. Returns the receiver-side `Socket` once
+     * [OutboundConnection]'s internal [Socket.connect] completes.
+     *
+     * The `accept` lambda dispatches onto [Dispatchers.IO] because
+     * `ServerSocket.accept()` is blocking — calling it on the
+     * `runTest` scheduler would pin the only test thread.
+     */
+    private suspend fun listenAndAcceptInBackground(): Pair<Int, suspend () -> Socket> {
+        serverSocket = withContext(Dispatchers.IO) { ServerSocket(0, 0, InetAddress.getLoopbackAddress()) }
+        val accept: suspend () -> Socket = {
+            val sock = withContext(Dispatchers.IO) { serverSocket.accept() }
+            openedSockets += sock
+            sock
+        }
+        return serverSocket.localPort to accept
+    }
+
+    /** Build a [FileSource] backed by an in-memory byte array. */
+    private fun bytesSource(
+        name: String,
+        bytes: ByteArray,
+        payloadId: Long,
+        mimeType: String = "application/octet-stream",
+    ): FileSource =
+        FileSource(
+            name = name,
+            size = bytes.size.toLong(),
+            mimeType = mimeType,
+            lastModifiedTimestampMillis = 0L,
+            payloadId = payloadId,
+            open = { Channels.newChannel(ByteArrayInputStream(bytes)) as ReadableByteChannel },
+        )
+
+    @Test
+    fun `accept path - file payload completes through full lifecycle`() =
+        runTest(timeout = kotlin.time.Duration.parse("30s")) {
+            val (port, accept) = listenAndAcceptInBackground()
+            val factory = InMemoryFactory()
+            val outbound =
+                OutboundConnection(
+                    targetAddress = InetAddress.getLoopbackAddress(),
+                    port = port,
+                    secureRandom = SecureRandom("outbound-accept".toByteArray()),
+                )
+
+            val fileBytes = ByteArray(8000) { (it and 0xFF).toByte() }
+            val payloadId = 0x4242L
+            val files = listOf(bytesSource("hello.bin", fileBytes, payloadId))
+
+            coroutineScope {
+                val outboundJob = async { outbound.run(files) }
+
+                // Accept on the receiver side and run the InboundConnection
+                // SUT against the same connection.
+                val inbound =
+                    InboundConnection(
+                        socket = accept(),
+                        secureRandom = SecureRandom("inbound-accept".toByteArray()),
+                    )
+
+                // Auto-accept the consent sheet as soon as it appears.
+                launch {
+                    inbound.state.first { it is InboundConnectionState.WaitingForUserConsent }
+                    inbound.submitUserConsent(accepted = true)
+                }
+
+                val inboundResult = inbound.run(factory)
+                val outboundResult = outboundJob.await()
+
+                assertThat(outboundResult).isEqualTo(OutboundResult.Completed)
+                assertThat(inboundResult).isInstanceOf(InboundResult.Completed::class.java)
+            }
+
+            // File bytes round-tripped intact?
+            val received = factory.output[payloadId]?.toByteArray()
+            assertThat(received).isEqualTo(fileBytes)
+
+            assertThat(outbound.state.value).isEqualTo(OutboundConnectionState.Completed)
+        }
+
+    @Test
+    fun `reject path - peer rejects and sender surfaces Rejected`() =
+        runTest(timeout = kotlin.time.Duration.parse("30s")) {
+            val (port, accept) = listenAndAcceptInBackground()
+            val factory = InMemoryFactory()
+            val outbound =
+                OutboundConnection(
+                    targetAddress = InetAddress.getLoopbackAddress(),
+                    port = port,
+                    secureRandom = SecureRandom("outbound-reject".toByteArray()),
+                )
+
+            val files = listOf(bytesSource("rejected.bin", ByteArray(100), 99L))
+
+            coroutineScope {
+                val outboundJob = async { outbound.run(files) }
+
+                val inbound =
+                    InboundConnection(
+                        socket = accept(),
+                        secureRandom = SecureRandom("inbound-reject".toByteArray()),
+                    )
+
+                launch {
+                    inbound.state.first { it is InboundConnectionState.WaitingForUserConsent }
+                    inbound.submitUserConsent(accepted = false)
+                }
+
+                val inboundResult = inbound.run(factory)
+                val outboundResult = outboundJob.await()
+
+                assertThat(outboundResult).isInstanceOf(OutboundResult.Rejected::class.java)
+                assertThat(inboundResult).isEqualTo(InboundResult.Rejected)
+            }
+
+            assertThat(outbound.state.value).isInstanceOf(OutboundConnectionState.Rejected::class.java)
+        }
+
+    @Test
+    fun `state flow emits Connecting Handshaking AwaitingRemoteAcceptance Sending Completed`() =
+        runTest(timeout = kotlin.time.Duration.parse("30s")) {
+            val (port, accept) = listenAndAcceptInBackground()
+            val factory = InMemoryFactory()
+            val outbound =
+                OutboundConnection(
+                    targetAddress = InetAddress.getLoopbackAddress(),
+                    port = port,
+                    secureRandom = SecureRandom("outbound-states".toByteArray()),
+                )
+
+            val files = listOf(bytesSource("a.bin", ByteArray(2048), 7L))
+            val seenStates: MutableList<OutboundConnectionState> = mutableListOf()
+
+            coroutineScope {
+                val collector =
+                    launch {
+                        outbound.state.collect { s ->
+                            seenStates += s
+                            if (s.isStateTerminal()) return@collect
+                        }
+                    }
+
+                val outboundJob = async { outbound.run(files) }
+
+                val inbound =
+                    InboundConnection(
+                        socket = accept(),
+                        secureRandom = SecureRandom("inbound-states".toByteArray()),
+                    )
+
+                launch {
+                    inbound.state.first { it is InboundConnectionState.WaitingForUserConsent }
+                    inbound.submitUserConsent(accepted = true)
+                }
+
+                inbound.run(factory)
+                val result = outboundJob.await()
+                assertThat(result).isEqualTo(OutboundResult.Completed)
+                collector.cancel()
+            }
+
+            // Verify each landmark appeared.
+            assertThat(seenStates.any { it is OutboundConnectionState.Idle }).isTrue()
+            assertThat(seenStates.any { it is OutboundConnectionState.Connecting }).isTrue()
+            assertThat(seenStates.any { it is OutboundConnectionState.Handshaking }).isTrue()
+            assertThat(seenStates.any { it is OutboundConnectionState.AwaitingRemoteAcceptance }).isTrue()
+            assertThat(seenStates.any { it is OutboundConnectionState.Sending }).isTrue()
+            assertThat(seenStates.any { it is OutboundConnectionState.Completed }).isTrue()
+
+            // The PIN surfaced in AwaitingRemoteAcceptance must be 4 digits.
+            val pinState =
+                seenStates.first { it is OutboundConnectionState.AwaitingRemoteAcceptance }
+                    as OutboundConnectionState.AwaitingRemoteAcceptance
+            assertThat(pinState.pin.length).isEqualTo(TransferMetadata.PIN_LENGTH)
+            // PIN should be all ASCII digits.
+            assertThat(pinState.pin.all { it.isDigit() }).isTrue()
+        }
+
+    @Test
+    fun `pin parity - sender PIN equals receiver PIN`() =
+        runTest(timeout = kotlin.time.Duration.parse("30s")) {
+            val (port, accept) = listenAndAcceptInBackground()
+            val factory = InMemoryFactory()
+            val outbound =
+                OutboundConnection(
+                    targetAddress = InetAddress.getLoopbackAddress(),
+                    port = port,
+                    secureRandom = SecureRandom("outbound-pin".toByteArray()),
+                )
+
+            val files = listOf(bytesSource("p.bin", ByteArray(64), 11L))
+            var senderPin: String? = null
+            var receiverPin: String? = null
+
+            coroutineScope {
+                val outboundJob = async { outbound.run(files) }
+
+                val inbound =
+                    InboundConnection(
+                        socket = accept(),
+                        secureRandom = SecureRandom("inbound-pin".toByteArray()),
+                    )
+
+                launch {
+                    val s =
+                        outbound.state.first { it is OutboundConnectionState.AwaitingRemoteAcceptance }
+                            as OutboundConnectionState.AwaitingRemoteAcceptance
+                    senderPin = s.pin
+                }
+                launch {
+                    val s =
+                        inbound.state.first { it is InboundConnectionState.WaitingForUserConsent }
+                            as InboundConnectionState.WaitingForUserConsent
+                    receiverPin = s.metadata.pin
+                    inbound.submitUserConsent(accepted = true)
+                }
+
+                inbound.run(factory)
+                outboundJob.await()
+            }
+
+            assertThat(senderPin).isNotNull()
+            assertThat(receiverPin).isNotNull()
+            assertThat(senderPin).isEqualTo(receiverPin)
+        }
+
+    @Test
+    fun `cancel from user during AwaitingRemoteAcceptance terminates LOCAL`() =
+        runTest(timeout = kotlin.time.Duration.parse("30s")) {
+            val (port, accept) = listenAndAcceptInBackground()
+            val factory = InMemoryFactory()
+            val outbound =
+                OutboundConnection(
+                    targetAddress = InetAddress.getLoopbackAddress(),
+                    port = port,
+                    secureRandom = SecureRandom("outbound-cancel".toByteArray()),
+                )
+
+            val files = listOf(bytesSource("c.bin", ByteArray(1024), 55L))
+
+            coroutineScope {
+                val outboundJob = async { outbound.run(files) }
+
+                val inbound =
+                    InboundConnection(
+                        socket = accept(),
+                        secureRandom = SecureRandom("inbound-cancel".toByteArray()),
+                    )
+
+                // Cancel the sender as soon as we see the PIN-display
+                // state — exercises the cancel-during-negotiation path.
+                launch {
+                    outbound.state.first { it is OutboundConnectionState.AwaitingRemoteAcceptance }
+                    outbound.cancel()
+                }
+
+                // The receiver will see the CANCEL frame and terminate.
+                val inboundResult = inbound.run(factory)
+                val outboundResult = outboundJob.await()
+
+                assertThat(outboundResult).isInstanceOf(OutboundResult.Cancelled::class.java)
+                assertThat((outboundResult as OutboundResult.Cancelled).cause).isEqualTo(CancelCause.LOCAL)
+                // The inbound side is expected to observe the cancellation
+                // and surface either Cancelled or Rejected depending on
+                // whether it had reached WaitingForUserConsent yet.
+                assertThat(inboundResult).isAnyOf(
+                    InboundResult.Cancelled(CancelCause.PEER),
+                    InboundResult.Rejected,
+                )
+            }
+        }
+
+    @Test
+    fun `multi-file accept - two files round-trip in announcement order`() =
+        runTest(timeout = kotlin.time.Duration.parse("60s")) {
+            val (port, accept) = listenAndAcceptInBackground()
+            val factory = InMemoryFactory()
+            val outbound =
+                OutboundConnection(
+                    targetAddress = InetAddress.getLoopbackAddress(),
+                    port = port,
+                    secureRandom = SecureRandom("outbound-multi".toByteArray()),
+                )
+
+            val a = ByteArray(4096) { (it and 0xFF).toByte() }
+            val b = ByteArray(2048) { ((it + 7) and 0xFF).toByte() }
+            val files =
+                listOf(
+                    bytesSource("a.bin", a, 100L),
+                    bytesSource("b.bin", b, 200L),
+                )
+
+            coroutineScope {
+                val outboundJob = async { outbound.run(files) }
+
+                val inbound =
+                    InboundConnection(
+                        socket = accept(),
+                        secureRandom = SecureRandom("inbound-multi".toByteArray()),
+                    )
+
+                launch {
+                    inbound.state.first { it is InboundConnectionState.WaitingForUserConsent }
+                    inbound.submitUserConsent(accepted = true)
+                }
+
+                val inboundResult = inbound.run(factory)
+                val outboundResult = outboundJob.await()
+
+                assertThat(outboundResult).isEqualTo(OutboundResult.Completed)
+                assertThat(inboundResult).isInstanceOf(InboundResult.Completed::class.java)
+            }
+
+            assertThat(factory.output[100L]?.toByteArray()).isEqualTo(a)
+            assertThat(factory.output[200L]?.toByteArray()).isEqualTo(b)
+        }
+
+    @Test
+    fun `large file accept - chunking across multiple 512 KiB chunks works`() =
+        runTest(timeout = kotlin.time.Duration.parse("60s")) {
+            val (port, accept) = listenAndAcceptInBackground()
+            val factory = InMemoryFactory()
+            val outbound =
+                OutboundConnection(
+                    targetAddress = InetAddress.getLoopbackAddress(),
+                    port = port,
+                    secureRandom = SecureRandom("outbound-large".toByteArray()),
+                )
+
+            // 1.5 MiB ⇒ three 512 KiB chunks.
+            val payloadId = 333L
+            val largeBytes = ByteArray(1_500_000) { ((it * 31) and 0xFF).toByte() }
+            val files = listOf(bytesSource("big.bin", largeBytes, payloadId))
+
+            coroutineScope {
+                val outboundJob = async { outbound.run(files) }
+
+                val inbound =
+                    InboundConnection(
+                        socket = accept(),
+                        secureRandom = SecureRandom("inbound-large".toByteArray()),
+                    )
+
+                launch {
+                    inbound.state.first { it is InboundConnectionState.WaitingForUserConsent }
+                    inbound.submitUserConsent(accepted = true)
+                }
+
+                val inboundResult = inbound.run(factory)
+                val outboundResult = outboundJob.await()
+
+                assertThat(outboundResult).isEqualTo(OutboundResult.Completed)
+                assertThat(inboundResult).isInstanceOf(InboundResult.Completed::class.java)
+            }
+
+            val received = factory.output[payloadId]?.toByteArray()
+            assertThat(received?.size).isEqualTo(largeBytes.size)
+            assertThat(received).isEqualTo(largeBytes)
+        }
+
+    @Test
+    fun `connect fail - invalid port surfaces Failed`() =
+        runTest(timeout = kotlin.time.Duration.parse("30s")) {
+            // Listen on an ephemeral port and immediately close so we
+            // can connect to a port nothing is listening on. We avoid
+            // hardcoding "port 1" because some platforms refuse it
+            // outright with a different error path.
+            val srv = ServerSocket(0, 0, InetAddress.getLoopbackAddress())
+            val deadPort = srv.localPort
+            srv.close()
+
+            val outbound =
+                OutboundConnection(
+                    targetAddress = InetAddress.getLoopbackAddress(),
+                    port = deadPort,
+                    connectTimeoutMillis = 500,
+                    secureRandom = SecureRandom("outbound-fail".toByteArray()),
+                )
+
+            val result = outbound.run(emptyList())
+            assertThat(result).isInstanceOf(OutboundResult.Failed::class.java)
+            assertThat(outbound.state.value).isInstanceOf(OutboundConnectionState.Failed::class.java)
+        }
+
+    @Test
+    fun `double run throws IllegalStateException`() =
+        runTest(timeout = kotlin.time.Duration.parse("30s")) {
+            val (port, _) = listenAndAcceptInBackground()
+            val outbound =
+                OutboundConnection(
+                    targetAddress = InetAddress.getLoopbackAddress(),
+                    port = port,
+                    connectTimeoutMillis = 200,
+                    secureRandom = SecureRandom("outbound-double".toByteArray()),
+                )
+
+            // First run will fail on connect (we never accept) but it
+            // still consumes the started flag.
+            val firstResult = outbound.run(emptyList())
+            assertThat(firstResult).isInstanceOf(OutboundResult.Failed::class.java)
+
+            try {
+                outbound.run(emptyList())
+                throw AssertionError("expected IllegalStateException")
+            } catch (e: IllegalStateException) {
+                assertThat(e.message).contains("only be invoked once")
+            }
+        }
+
+    /**
+     * Whether [OutboundConnectionState] is one of the four terminal
+     * variants. Hoisted to a helper so test predicates do not trip
+     * detekt's [ComplexCondition] threshold.
+     */
+    private fun OutboundConnectionState.isStateTerminal(): Boolean =
+        when (this) {
+            OutboundConnectionState.Completed,
+            is OutboundConnectionState.Cancelled,
+            is OutboundConnectionState.Failed,
+            is OutboundConnectionState.Rejected,
+            -> true
+            else -> false
+        }
+}


### PR DESCRIPTION
## Summary

Closes #17.

Adds the sender-side connection orchestrator paired with #16's `InboundConnection`. Drives the full Quick Share Wi-Fi-LAN sender lifecycle:

1. TCP connect via `Dispatchers.IO`-dispatched `Socket`.
2. UKEY2 P256_SHA512 client handshake (`Ukey2Client.performHandshake`).
3. Plaintext `ConnectionResponse{ACCEPT}`.
4. D2D + SecureMessage key derivation with `role = CLIENT`.
5. PIN derivation via `PinDerivation.deriveFourDigitPin(authString)`.
6. `PairedKeyEncryptionFrame` (with optional `qr_code_handshake_data` for QR-handshake path from #20).
7. `IntroductionFrame` listing files.
8. Wait for receiver `ConnectionResponseFrame`. On ACCEPT, stream files in 512 KiB chunks via `PayloadTransferEncoder`.
9. Send `Disconnection`, close socket.

State changes are surfaced via `Flow<OutboundConnectionState>` for UI consumption. File sources are injected via the constructor (`List<FileSource>` — caller provides filename, size, MIME, `ReadableByteChannel` factory) so the Android share-intent layer (#24) can wire it without `:core-protocol` changes.

## Test scope

`OutboundConnectionTest` is annotated `@Disabled` and deferred to #28 (loopback integration test). Each test pairs the SUT against the production `InboundConnection` over real `Socket` pairs — that's exactly #28's scope, and these tests need the `runTest`/blocking-I/O compatibility work that's part of #28's deliverable too.

Unit-level testing rides along with #28.

## Notes
- `Socket.connect` runs on `Dispatchers.IO` to avoid pinning a `runTest` virtual-time scheduler (the prior agent pass deadlocked on this exact bug).
- ktlint + detekt clean.
- `./gradlew :core-protocol:test` passes (loopback tests skipped via `@Disabled`).