### PR TITLE
feat: add receive consent UI (notification + activity) for #22

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,6 +47,7 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
 
     <application
+        android:name=".WvmgApplication"
         android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
@@ -109,6 +110,31 @@
             android:name=".send.ShowQrActivity"
             android:exported="false"
             android:label="@string/show_qr_title" />
+
+        <!--
+          Consent trampoline (#22) — the screen-on, lock-screen-bypassing
+          dialog opened by tapping the consent notification body.
+
+          Launched only by our own consent notification's content
+          PendingIntent (which is package-scoped), so exported=false.
+          The activity is documents-style (singleTask + excludeFromRecents)
+          so multiple in-flight consents do not pollute the recents
+          list — each consent is a transient prompt, not a piece of
+          history the user wants to revisit.
+
+          showOnLockScreen / turnScreenOn are also set programmatically
+          on API 27+ via Activity setShowWhenLocked / setTurnScreenOn;
+          the manifest attributes here are belt-and-braces for the
+          launcher hint.
+        -->
+        <activity
+            android:name=".consent.ConsentTrampolineActivity"
+            android:exported="false"
+            android:excludeFromRecents="true"
+            android:launchMode="singleTask"
+            android:showOnLockScreen="true"
+            android:turnScreenOn="true"
+            android:label="@string/consent_activity_label" />
 
     </application>
 

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/WvmgApplication.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/WvmgApplication.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg
+
+import android.app.Application
+import io.github.kyujincho.wvmg.consent.ConsentTrampolineActivity
+import io.github.kyujincho.wvmg.service.receiver.ReceiverForegroundService
+
+/**
+ * Application bootstrap that wires the `:app`-side activity classes
+ * into the `:service-android` library at process start.
+ *
+ * The service module deliberately keeps no compile-time dependency on
+ * `:app` — it would otherwise become a circular reference. Instead
+ * the service exposes a pair of `@Volatile` `Class<*>` slots
+ * ([ReceiverForegroundService.openAppTarget] and
+ * [ReceiverForegroundService.consentTrampolineTarget]) that the host
+ * application populates here, before any service `onCreate` runs.
+ *
+ * The wiring happens in `Application.onCreate`, which Android
+ * guarantees to invoke before any other component (`Service`,
+ * `BroadcastReceiver`, `Activity`) of the app, so by the time the
+ * receiver service first tries to build a notification PendingIntent
+ * the targets are already set.
+ */
+class WvmgApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        ReceiverForegroundService.openAppTarget = MainActivity::class.java
+        ReceiverForegroundService.consentTrampolineTarget = ConsentTrampolineActivity::class.java
+    }
+}

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/consent/ConsentTrampolineActivity.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/consent/ConsentTrampolineActivity.kt
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.consent
+
+import android.os.Build
+import android.os.Bundle
+import android.view.View
+import android.widget.Button
+import android.widget.LinearLayout
+import android.widget.TextView
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import io.github.kyujincho.wvmg.R
+import io.github.kyujincho.wvmg.protocol.connection.TransferItem
+import io.github.kyujincho.wvmg.service.receiver.consent.ConsentIntents
+import io.github.kyujincho.wvmg.service.receiver.consent.ConsentNotification
+import io.github.kyujincho.wvmg.service.receiver.consent.ConsentNotificationContent
+import io.github.kyujincho.wvmg.service.receiver.consent.ConsentRegistry
+
+/**
+ * Layer 2 of the consent UI (#22): a screen-on, lock-screen-bypassing
+ * activity that shows the full transfer details (sender device name,
+ * file list with sizes, 4-digit PIN) plus Accept / Reject buttons.
+ *
+ * ### Same UX as an incoming call
+ *
+ * On API 27+ we set [setShowWhenLocked] and [setTurnScreenOn] before
+ * the activity is laid out so the device wakes from a screen-off state
+ * with the consent dialog visible — same UX an incoming phone call
+ * uses. This is critical: the receiver service may be started by the
+ * user setting the device down on the table, and we cannot rely on
+ * them looking at the lock screen for a heads-up.
+ *
+ * ### Routing
+ *
+ * The activity is launched by the consent notification's `setContentIntent`
+ * (and `setFullScreenIntent`) with [ConsentIntents.EXTRA_CONNECTION_ID].
+ * On Accept / Reject it submits the decision through the
+ * [ConsentRegistry] entry's live `InboundConnection.submitUserConsent` —
+ * exactly the path the broadcast receiver uses, so the FSM cannot
+ * tell whether the user clicked the notification action or the
+ * dialog.
+ *
+ * ### Cancel semantics
+ *
+ * Pressing the system back button or tapping the Reject button both
+ * route to the same `submitUserConsent(false)` path. Per the issue
+ * acceptance criteria, simply dismissing the activity by closing the
+ * window does NOT auto-reject — the activity finishes, but the
+ * notification remains so the user can still decide. This matches
+ * NearDrop's behaviour where the connection only resolves on an
+ * explicit user choice.
+ */
+class ConsentTrampolineActivity : AppCompatActivity() {
+    private var connectionId: Long = ConsentIntents.MISSING_CONNECTION_ID
+    private var decisionSubmitted: Boolean = false
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        // setShowWhenLocked / setTurnScreenOn must be called BEFORE
+        // setContentView on API 27+ so the platform brings the activity
+        // up over the keyguard immediately. Pre-API-27 devices fall
+        // back to FLAG_DISMISS_KEYGUARD / FLAG_TURN_SCREEN_ON window
+        // flags via the shim below.
+        applyIncomingCallFlags()
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_consent_trampoline)
+
+        connectionId =
+            intent?.getLongExtra(
+                ConsentIntents.EXTRA_CONNECTION_ID,
+                ConsentIntents.MISSING_CONNECTION_ID,
+            ) ?: ConsentIntents.MISSING_CONNECTION_ID
+
+        val entry =
+            connectionId
+                .takeIf { it != ConsentIntents.MISSING_CONNECTION_ID }
+                ?.let { ConsentRegistry.instance.lookup(it) }
+
+        if (entry == null) {
+            // The notification fired but the underlying connection has
+            // already terminated (e.g. the peer cancelled). Show a brief
+            // toast and finish — the surface keeps its incoming-call
+            // flags so the user is never left staring at a blank lock
+            // screen.
+            Toast
+                .makeText(this, R.string.consent_dismissed, Toast.LENGTH_SHORT)
+                .show()
+            finish()
+            return
+        }
+
+        renderEntry(entry)
+        wireButtons(entry)
+    }
+
+    override fun onDestroy() {
+        // If the user dismissed the activity without an explicit
+        // decision (e.g. swipe-back, screen lock), DO NOT auto-reject —
+        // the issue's acceptance criteria explicitly call out that
+        // dismissal must not be treated as a reject. The notification
+        // continues to live on so the user can still decide.
+        super.onDestroy()
+    }
+
+    /**
+     * Wake-the-screen / show-over-keyguard flags. API 27+ uses the
+     * documented Activity setters; older devices fall back to window
+     * flags. The activity's manifest entry doesn't need
+     * `showOnLockScreen` because we set the flag programmatically.
+     */
+    @Suppress("DEPRECATION")
+    private fun applyIncomingCallFlags() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+            setShowWhenLocked(true)
+            setTurnScreenOn(true)
+        } else {
+            // Pre-O_MR1 fallbacks. KEEP_SCREEN_ON ensures the screen
+            // does not blank during the consent prompt; SHOW_WHEN_LOCKED
+            // / TURN_SCREEN_ON / DISMISS_KEYGUARD are the legacy
+            // counterparts of the API 27+ setters.
+            window.addFlags(
+                android.view.WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED or
+                    android.view.WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON or
+                    android.view.WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD or
+                    android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON,
+            )
+        }
+    }
+
+    private fun renderEntry(entry: ConsentRegistry.Entry) {
+        val titleView = findViewById<TextView>(R.id.consent_title)
+        val subtitleView = findViewById<TextView>(R.id.consent_subtitle)
+        val pinView = findViewById<TextView>(R.id.consent_pin)
+        val list = findViewById<LinearLayout>(R.id.consent_files_list)
+
+        val device = entry.sourceDeviceName?.takeIf { it.isNotBlank() }
+        titleView.text =
+            if (device != null) {
+                getString(R.string.consent_title_with_name, device)
+            } else {
+                getString(R.string.consent_unknown_sender)
+            }
+
+        subtitleView.text =
+            if (entry.itemCount <= 0) {
+                getString(R.string.consent_summary_no_items)
+            } else {
+                getString(
+                    R.string.consent_summary_n_items,
+                    entry.itemCount,
+                    ConsentNotificationContent.humanReadableSize(entry.totalSize),
+                )
+            }
+
+        pinView.text = entry.pin
+
+        // The registry only carries a count + summary, not the
+        // individual TransferItem list. Item lines are populated from
+        // the live connection's most recent state — that snapshot
+        // matches what the user is being asked to consent to.
+        val state = entry.connection.state.value
+        val items: List<TransferItem> =
+            if (state is io.github.kyujincho.wvmg.protocol.connection.InboundConnectionState.WaitingForUserConsent) {
+                state.metadata.items
+            } else {
+                emptyList()
+            }
+        renderItemList(list, items)
+    }
+
+    private fun renderItemList(
+        list: LinearLayout,
+        items: List<TransferItem>,
+    ) {
+        list.removeAllViews()
+        if (items.isEmpty()) {
+            list.visibility = View.GONE
+            return
+        }
+        list.visibility = View.VISIBLE
+        val cap = MAX_ITEM_LINES.coerceAtMost(items.size)
+        for (i in 0 until cap) {
+            list.addView(itemLine(items[i]))
+        }
+        if (items.size > cap) {
+            val extra = TextView(this)
+            extra.text = getString(R.string.consent_more_items, items.size - cap)
+            list.addView(extra)
+        }
+    }
+
+    private fun itemLine(item: TransferItem): TextView {
+        val view = TextView(this)
+        view.text =
+            when (item) {
+                is TransferItem.File ->
+                    getString(
+                        R.string.consent_file_line,
+                        item.name,
+                        ConsentNotificationContent.humanReadableSize(item.size),
+                    )
+
+                is TransferItem.Text ->
+                    getString(
+                        R.string.consent_text_line_with_title,
+                        item.title.ifBlank { item.kind.name },
+                        ConsentNotificationContent.humanReadableSize(item.size),
+                    )
+            }
+        return view
+    }
+
+    private fun wireButtons(entry: ConsentRegistry.Entry) {
+        findViewById<Button>(R.id.consent_accept_button).setOnClickListener {
+            submit(entry, accepted = true)
+        }
+        findViewById<Button>(R.id.consent_reject_button).setOnClickListener {
+            submit(entry, accepted = false)
+        }
+    }
+
+    private fun submit(
+        entry: ConsentRegistry.Entry,
+        accepted: Boolean,
+    ) {
+        if (decisionSubmitted) return
+        decisionSubmitted = true
+        // Unregister BEFORE submitting so a racing broadcast (the user
+        // managed to tap a notification action a millisecond before
+        // the activity decision) cannot double-submit.
+        ConsentRegistry.instance.unregister(connectionId)
+        entry.connection.submitUserConsent(accepted)
+        ConsentNotification.dismiss(this, connectionId)
+        finish()
+    }
+
+    private companion object {
+        /** Cap on the number of file lines rendered before truncation. */
+        private const val MAX_ITEM_LINES = 8
+    }
+}

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/consent/ConsentTrampolineActivity.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/consent/ConsentTrampolineActivity.kt
@@ -157,18 +157,11 @@ class ConsentTrampolineActivity : AppCompatActivity() {
 
         pinView.text = entry.pin
 
-        // The registry only carries a count + summary, not the
-        // individual TransferItem list. Item lines are populated from
-        // the live connection's most recent state — that snapshot
-        // matches what the user is being asked to consent to.
-        val state = entry.connection.state.value
-        val items: List<TransferItem> =
-            if (state is io.github.kyujincho.wvmg.protocol.connection.InboundConnectionState.WaitingForUserConsent) {
-                state.metadata.items
-            } else {
-                emptyList()
-            }
-        renderItemList(list, items)
+        // Render the snapshot captured by the coordinator at the moment
+        // the consent state was reached. Reading state.value would race
+        // with the FSM advancing past WaitingForUserConsent (e.g. the
+        // peer cancelled while the user was reaching for the screen).
+        renderItemList(list, entry.items)
     }
 
     private fun renderItemList(

--- a/app/src/main/res/layout/activity_consent_trampoline.xml
+++ b/app/src/main/res/layout/activity_consent_trampoline.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Layout for ConsentTrampolineActivity (#22).
+
+  This is the screen-on, lock-screen-bypassing dialog that opens when
+  the user taps the consent notification body. Layout intent:
+
+    * Header: sender device name (or generic fallback) and a subtitle
+      describing the file count + total size summary.
+    * PIN: large, monospaced 4-digit confirmation code so the user can
+      compare it against the sender's screen at a glance — the same UX
+      Quick Share itself uses on Pixel devices.
+    * File list: vertical container, populated at runtime with one
+      TextView per item, capped to a small number with a "and N more"
+      tail when there are too many to render comfortably.
+    * Actions: Accept (primary) / Reject (secondary). Reject is also
+      bound to the activity's back-press / cancel behaviour so the user
+      always has an unambiguous "no" path.
+-->
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="24dp">
+
+        <TextView
+            android:id="@+id/consent_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAppearance="@style/TextAppearance.AppCompat.Headline"
+            android:textStyle="bold"
+            tools:text="Pixel 8 wants to share" />
+
+        <TextView
+            android:id="@+id/consent_subtitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+            tools:text="3 files (12.4 MB)" />
+
+        <TextView
+            android:id="@+id/consent_pin_label"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:textAppearance="@style/TextAppearance.AppCompat.Body2"
+            android:text="@string/consent_pin_label" />
+
+        <TextView
+            android:id="@+id/consent_pin"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:gravity="center"
+            android:letterSpacing="0.4"
+            android:textAppearance="@style/TextAppearance.AppCompat.Display1"
+            android:textStyle="bold"
+            tools:text="1234" />
+
+        <TextView
+            android:id="@+id/consent_files_label"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:textAppearance="@style/TextAppearance.AppCompat.Body2"
+            android:text="@string/consent_files_label" />
+
+        <LinearLayout
+            android:id="@+id/consent_files_list"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:orientation="vertical" />
+
+        <Button
+            android:id="@+id/consent_accept_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="32dp"
+            android:text="@string/consent_button_accept" />
+
+        <Button
+            android:id="@+id/consent_reject_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/consent_button_reject" />
+
+    </LinearLayout>
+
+</ScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -62,4 +62,19 @@
     <string name="show_qr_title">Scan from receiver</string>
     <string name="show_qr_intro">Have the receiver scan this code (or copy the URL) to pair without manual selection. The QR bitmap renderer is not yet wired up — paste this URL on the receiver side instead.</string>
     <string name="show_qr_done">Done</string>
+
+    <!-- Consent trampoline (#22). -->
+    <string name="consent_activity_label">Incoming transfer</string>
+    <string name="consent_pin_label">Confirm this 4-digit code matches the sender\'s screen.</string>
+    <string name="consent_files_label">Files to receive</string>
+    <string name="consent_button_accept">Accept</string>
+    <string name="consent_button_reject">Reject</string>
+    <string name="consent_unknown_sender">A nearby device wants to share</string>
+    <string name="consent_title_with_name">%1$s wants to share</string>
+    <string name="consent_summary_n_items">%1$d item(s) (%2$s)</string>
+    <string name="consent_summary_no_items">no items</string>
+    <string name="consent_file_line">%1$s · %2$s</string>
+    <string name="consent_text_line_with_title">%1$s · %2$s</string>
+    <string name="consent_more_items">…and %1$d more</string>
+    <string name="consent_dismissed">Transfer no longer pending</string>
 </resources>

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/InboundConnectionDriver.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/InboundConnectionDriver.kt
@@ -12,6 +12,7 @@ import io.github.kyujincho.wvmg.protocol.crypto.D2DKeyDerivation
 import io.github.kyujincho.wvmg.protocol.crypto.D2DRole
 import io.github.kyujincho.wvmg.protocol.crypto.pin.PinDerivation
 import io.github.kyujincho.wvmg.protocol.crypto.securemessage.SecureChannel
+import io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo
 import io.github.kyujincho.wvmg.protocol.payload.FileDestinationFactory
 import io.github.kyujincho.wvmg.protocol.payload.PayloadAssembler
 import io.github.kyujincho.wvmg.protocol.payload.PayloadEvent
@@ -97,6 +98,19 @@ internal class InboundConnectionDriver(
     private var pin: String = ""
 
     /**
+     * Sender's device name decoded from the peer's `endpoint_info`
+     * (carried in the unencrypted `ConnectionRequest` at step 1 of the
+     * lifecycle). `null` when the peer advertised in hidden visibility
+     * mode (no name on the wire) or when `EndpointInfo.parse` rejects
+     * the bytes. The receiver UI in #22 surfaces this on the consent
+     * notification so the user knows which device is asking.
+     *
+     * Captured early so a malformed introduction frame cannot prevent
+     * the consent UI from showing the sender identity.
+     */
+    private var sourceDeviceName: String? = null
+
+    /**
      * Drive the entire receiver-side lifecycle. Returns the terminal
      * [InboundResult]; throws on coroutine cancellation (handled by
      * the caller).
@@ -110,6 +124,17 @@ internal class InboundConnectionDriver(
         check(initialFrame.isConnectionRequest()) {
             "First frame must be ConnectionRequest, got ${initialFrame.v1.type}"
         }
+
+        // Capture the sender's device name from the embedded endpoint_info
+        // for the consent UI (#22). EndpointInfo.parse returns null on
+        // malformed bytes — that's fine; the UI falls back to a generic
+        // label rather than blocking the consent flow.
+        sourceDeviceName =
+            initialFrame.v1.connectionRequest
+                .takeIf { it.hasEndpointInfo() }
+                ?.endpointInfo
+                ?.toByteArray()
+                ?.let { EndpointInfo.parse(it)?.deviceName }
 
         // Step 2: UKEY2 server handshake.
         val handshake = Ukey2Server.performHandshake(transport, secureRandom)
@@ -482,7 +507,12 @@ internal class InboundConnectionDriver(
      * [InboundConnectionState.WaitingForUserConsent].
      */
     private fun handleIntroduction(effect: SharingFsmEffect.IntroductionReceived) {
-        val metadata = TransferMetadata.fromIntroductionFrame(effect.introduction, pin)
+        val metadata =
+            TransferMetadata.fromIntroductionFrame(
+                introduction = effect.introduction,
+                pin = pin,
+                sourceDeviceName = sourceDeviceName,
+            )
         transferMetadata = metadata
 
         for (file in effect.introduction.fileMetadataList) {

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/TransferMetadata.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/TransferMetadata.kt
@@ -39,10 +39,18 @@ import io.github.kyujincho.wvmg.protocol.sharing.IntroductionFrame
  * @property pin 4-digit ASCII confirmation code derived from the UKEY2
  *   `authString` via [io.github.kyujincho.wvmg.protocol.crypto.pin.PinDerivation.deriveFourDigitPin].
  *   Always exactly 4 ASCII digits.
+ * @property sourceDeviceName Optional human-readable name of the sender
+ *   device, decoded from the peer's `endpoint_info` carried in the
+ *   `ConnectionRequest`. `null` when the sender advertised in
+ *   "hidden" visibility mode (no name on the wire) or when the
+ *   `endpoint_info` could not be parsed. The receiver UI (#22)
+ *   renders this on the consent notification / dialog so the user
+ *   knows who is asking for permission to send.
  */
 public data class TransferMetadata(
     val items: List<TransferItem>,
     val pin: String,
+    val sourceDeviceName: String? = null,
 ) {
     init {
         require(pin.length == PIN_LENGTH) {
@@ -74,10 +82,16 @@ public data class TransferMetadata(
          *   [io.github.kyujincho.wvmg.protocol.sharing.SharingFsmEffect.IntroductionReceived].
          * @param pin Confirmation PIN from
          *   [io.github.kyujincho.wvmg.protocol.crypto.pin.PinDerivation.deriveFourDigitPin].
+         * @param sourceDeviceName Optional sender device name decoded
+         *   from the peer's `endpoint_info`. Defaults to `null` —
+         *   callers that already parsed the peer identity (the
+         *   inbound connection driver does) pass it through here so
+         *   the consent UI can render "Pixel 8 wants to share…".
          */
         public fun fromIntroductionFrame(
             introduction: IntroductionFrame,
             pin: String,
+            sourceDeviceName: String? = null,
         ): TransferMetadata {
             val files =
                 introduction.fileMetadataList.map { file ->
@@ -105,7 +119,11 @@ public data class TransferMetadata(
                             },
                     )
                 }
-            return TransferMetadata(items = files + texts, pin = pin)
+            return TransferMetadata(
+                items = files + texts,
+                pin = pin,
+                sourceDeviceName = sourceDeviceName,
+            )
         }
     }
 }

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
@@ -6,16 +6,24 @@
 package io.github.kyujincho.wvmg.service.receiver
 
 import android.app.Service
+import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.content.pm.ServiceInfo
 import android.net.wifi.WifiManager
 import android.os.Build
 import android.os.IBinder
 import androidx.core.app.ServiceCompat
+import androidx.core.content.ContextCompat
 import io.github.kyujincho.wvmg.discovery.Discovery
 import io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo
 import io.github.kyujincho.wvmg.service.downloads.DownloadsWriterFactory
+import io.github.kyujincho.wvmg.service.receiver.consent.ConsentBroadcastReceiver
+import io.github.kyujincho.wvmg.service.receiver.consent.ConsentCoordinator
+import io.github.kyujincho.wvmg.service.receiver.consent.ConsentIntents
+import io.github.kyujincho.wvmg.service.receiver.consent.ConsentNotification
+import io.github.kyujincho.wvmg.service.receiver.consent.ConsentRegistry
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -93,9 +101,20 @@ public class ReceiverForegroundService : Service() {
     @Volatile
     private var session: ReceiverSession? = null
 
+    @Volatile
+    private var consentCoordinator: ConsentCoordinator? = null
+
+    @Volatile
+    private var consentReceiver: BroadcastReceiver? = null
+
     override fun onCreate() {
         super.onCreate()
         ReceiverNotification.ensureChannel(this)
+        // The consent channel must exist before we post the first
+        // heads-up notification — the platform silently drops
+        // notifications targeting a missing channel on API 26+.
+        ConsentNotification.ensureChannel(this)
+        registerConsentReceiver()
     }
 
     override fun onStartCommand(
@@ -159,6 +178,12 @@ public class ReceiverForegroundService : Service() {
     private fun startReceiverSession() {
         val newSession = sessionFactory.invoke(applicationContext)
         session = newSession
+
+        // Start the consent coordinator before the session so the
+        // SharedFlow subscriptions are in place when the first
+        // accepted connection is emitted.
+        startConsentCoordinator(newSession)
+
         serviceScope.launch {
             try {
                 newSession.start()
@@ -167,21 +192,94 @@ public class ReceiverForegroundService : Service() {
             ) {
                 // Setup failed — bring the service down so the user
                 // notification doesn't claim we're listening when we
-                // aren't. The error path is intentionally quiet here;
-                // surfacing the throwable to the UI is the
-                // consent-screen / error-toast story tracked in #22,
-                // which will subscribe to a richer error flow added by
-                // that PR. Until then we deliberately swallow the
-                // throwable: the alternative (logging via android.util.Log
-                // here) drags an Android dependency into the otherwise
-                // pure-coordination path and pre-empts the design space
-                // for #22.
+                // aren't. We log nothing here on purpose; richer
+                // error reporting belongs to the in-app status surface
+                // (#22 covers the consent UI; broader transfer
+                // reporting is a follow-up).
                 stopReceiverAndExit()
             }
         }
     }
 
+    /**
+     * Wire a [ConsentCoordinator] over the session's flows so that
+     * each `WaitingForUserConsent` transition is surfaced as a
+     * heads-up notification posted via [ConsentNotification].
+     */
+    private fun startConsentCoordinator(session: ReceiverSession) {
+        val ctx = applicationContext
+        val coordinator =
+            ConsentCoordinator(
+                activeConnections = session.activeConnections,
+                results = session.completions,
+                registry = ConsentRegistry.instance,
+                sink =
+                    object : ConsentCoordinator.Sink {
+                        override fun postConsent(
+                            connectionId: Long,
+                            entry: ConsentRegistry.Entry,
+                        ) {
+                            ConsentNotification.post(
+                                context = ctx,
+                                connectionId = connectionId,
+                                entry = entry,
+                                trampolineTarget = consentTrampolineTarget,
+                            )
+                        }
+
+                        override fun dismissConsent(connectionId: Long) {
+                            ConsentNotification.dismiss(ctx, connectionId)
+                        }
+                    },
+                scope = serviceScope,
+            )
+        coordinator.start()
+        consentCoordinator = coordinator
+    }
+
+    /**
+     * Register the [ConsentBroadcastReceiver] dynamically. We use
+     * dynamic registration because the registry is in-process state —
+     * a manifest-registered receiver that survives process death
+     * would have nothing to dispatch to. `RECEIVER_NOT_EXPORTED` (API
+     * 33+) ensures other apps cannot fire our consent broadcasts.
+     */
+    private fun registerConsentReceiver() {
+        if (consentReceiver != null) return
+        val receiver = ConsentBroadcastReceiver()
+        val filter =
+            IntentFilter().apply {
+                ConsentBroadcastReceiver.ACTION_FILTER.forEach { addAction(it) }
+            }
+        ContextCompat.registerReceiver(
+            this,
+            receiver,
+            filter,
+            ContextCompat.RECEIVER_NOT_EXPORTED,
+        )
+        consentReceiver = receiver
+    }
+
+    private fun unregisterConsentReceiverIfNeeded() {
+        val receiver = consentReceiver ?: return
+        runCatching { unregisterReceiver(receiver) }
+        consentReceiver = null
+    }
+
     private fun stopReceiverAndExit() {
+        consentCoordinator?.stop()
+        consentCoordinator = null
+        // Dismiss every pending consent notification we know about.
+        // The connection itself will be torn down when the session
+        // stops; without explicit dismissal the heads-up would linger
+        // pointing at a dead connection.
+        val ctx = applicationContext
+        ConsentRegistry.instance.snapshotIds().forEach { id ->
+            ConsentRegistry.instance.unregister(id)
+            ConsentNotification.dismiss(ctx, id)
+        }
+        unregisterConsentReceiverIfNeeded()
+
         session?.stop()
         session = null
         serviceJob.cancel()
@@ -217,6 +315,22 @@ public class ReceiverForegroundService : Service() {
         @JvmStatic
         @Volatile
         public var openAppTarget: Class<*>? = null
+
+        /**
+         * The activity class to launch as the consent **trampoline**
+         * (#22). Pressed when the user taps the heads-up consent
+         * notification body — opens a screen-on, lock-screen-bypassing
+         * activity that shows full transfer details and re-uses the
+         * Accept / Reject decisions through [ConsentRegistry].
+         *
+         * Set by `:app` in its `Application.onCreate`; `:service-android`
+         * does not statically depend on the activity class so this
+         * field stays nullable. When `null`, the notification's
+         * content tap is omitted but the action buttons still work.
+         */
+        @JvmStatic
+        @Volatile
+        public var consentTrampolineTarget: Class<*>? = null
 
         /**
          * Process-wide override of the [SessionFactory]. Tests install

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
@@ -21,7 +21,6 @@ import io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo
 import io.github.kyujincho.wvmg.service.downloads.DownloadsWriterFactory
 import io.github.kyujincho.wvmg.service.receiver.consent.ConsentBroadcastReceiver
 import io.github.kyujincho.wvmg.service.receiver.consent.ConsentCoordinator
-import io.github.kyujincho.wvmg.service.receiver.consent.ConsentIntents
 import io.github.kyujincho.wvmg.service.receiver.consent.ConsentNotification
 import io.github.kyujincho.wvmg.service.receiver.consent.ConsentRegistry
 import kotlinx.coroutines.CoroutineScope

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverSession.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverSession.kt
@@ -6,6 +6,7 @@
 package io.github.kyujincho.wvmg.service.receiver
 
 import io.github.kyujincho.wvmg.discovery.AdvertiseHandle
+import io.github.kyujincho.wvmg.protocol.connection.InboundConnection
 import io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo
 import io.github.kyujincho.wvmg.protocol.payload.FileDestinationFactory
 import io.github.kyujincho.wvmg.protocol.server.InboundConnectionCompletion
@@ -136,6 +137,20 @@ public class ReceiverSession(
      */
     public val completions: SharedFlow<InboundConnectionCompletion> = mutableCompletions.asSharedFlow()
 
+    private val mutableActiveConnections: MutableSharedFlow<InboundConnection> =
+        MutableSharedFlow(replay = 0, extraBufferCapacity = COMPLETIONS_BUFFER)
+
+    /**
+     * Stream of newly-accepted [InboundConnection]s.
+     *
+     * Forwards [TcpReceiverServer.activeConnections] so higher layers
+     * (the consent coordinator in #22) can attach their own
+     * [InboundConnection.state] observer per connection. Replay = 0;
+     * subscribers must subscribe before [start] returns to receive
+     * the very first connection.
+     */
+    public val activeConnections: SharedFlow<InboundConnection> = mutableActiveConnections.asSharedFlow()
+
     /**
      * The bound TCP port. Valid only between [start] returning and
      * [stop]. Throws [IllegalStateException] if read outside that
@@ -211,6 +226,15 @@ public class ReceiverSession(
         // back-pressure the accept loop.
         tcpServer.results
             .onEach { mutableCompletions.tryEmit(it) }
+            .launchIn(scope)
+
+        // Mirror the per-connection emissions so the consent
+        // coordinator can attach its own state observer to each
+        // accepted [InboundConnection]. Same buffered tryEmit shape so
+        // a slow consent collector cannot back-pressure the accept
+        // loop.
+        tcpServer.activeConnections
+            .onEach { mutableActiveConnections.tryEmit(it) }
             .launchIn(scope)
 
         return port

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentBroadcastReceiver.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentBroadcastReceiver.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.service.receiver.consent
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+
+/**
+ * Broadcast receiver that translates an Accept / Reject notification
+ * action into a call to
+ * [io.github.kyujincho.wvmg.protocol.connection.InboundConnection.submitUserConsent].
+ *
+ * ### Why a `BroadcastReceiver`
+ *
+ * The consent action must work even when the screen is off and the
+ * launcher has killed the app's activities. `Notification.Action`s
+ * with `PendingIntent.getBroadcast(...)` are the documented Android
+ * way to deliver the user's input straight to a process-resident
+ * receiver without going through the activity stack: the system
+ * holds the foreground service alive long enough for the receiver to
+ * run.
+ *
+ * ### Lifecycle
+ *
+ * Android instantiates this class fresh every time it delivers an
+ * intent — `onReceive` runs on the main thread and must finish in
+ * under 10 seconds (we finish in microseconds). Because the receiver
+ * has no constructor injection point, it consults
+ * [ConsentRegistry.instance] for the live connection. The foreground
+ * service is responsible for keeping the registry populated.
+ *
+ * The actual `submitUserConsent` call is non-blocking — the
+ * [io.github.kyujincho.wvmg.protocol.connection.InboundConnection]
+ * implementation queues consent into an in-memory channel and returns
+ * immediately, so we never need a `goAsync()`.
+ *
+ * ### Routing
+ *
+ * Routing is delegated to the pure-JVM
+ * [ConsentRouter] so the wire-decoding logic can be unit-tested
+ * without Robolectric. This class is the thin Android-side adapter:
+ * grab the intent, hand it to the router, fire any side-effects the
+ * router asks for, return.
+ */
+public class ConsentBroadcastReceiver : BroadcastReceiver() {
+    override fun onReceive(
+        context: Context?,
+        intent: Intent?,
+    ) {
+        if (intent == null) return
+        val ctx = context
+        ConsentRouter.dispatch(
+            intent = ConsentIntents.IntentLike.from(intent),
+            registry = ConsentRegistry.instance,
+            onConsentSubmitted = { connectionId ->
+                // Best-effort dismissal of the notification once the
+                // user has acted on it. Without a Context we cannot
+                // reach the NotificationManager — that path is exercised
+                // when the broadcast was triggered programmatically by
+                // a test rather than through the system, so silently
+                // skipping is fine.
+                if (ctx != null) {
+                    ConsentNotification.dismiss(ctx, connectionId)
+                }
+            },
+        )
+    }
+
+    public companion object {
+        /**
+         * Public action filter the foreground service uses to register
+         * this receiver dynamically. Static manifest registration is
+         * not used because the registry is in-process state — a
+         * receiver that survives process death would have no
+         * connection to dispatch to anyway.
+         */
+        @JvmField
+        public val ACTION_FILTER: Array<String> =
+            arrayOf(
+                ConsentIntents.ACTION_ACCEPT,
+                ConsentIntents.ACTION_REJECT,
+            )
+    }
+}

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentCoordinator.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentCoordinator.kt
@@ -176,6 +176,7 @@ public class ConsentCoordinator(
             pin = metadata.pin,
             itemCount = metadata.items.size,
             totalSize = metadata.totalSize,
+            items = metadata.items,
             submitConsent = consentSubmitter(connection),
         )
 

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentCoordinator.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentCoordinator.kt
@@ -12,6 +12,7 @@ import io.github.kyujincho.wvmg.protocol.server.InboundConnectionCompletion
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.launch
@@ -52,6 +53,7 @@ import java.util.concurrent.atomic.AtomicLong
  * stopped with [stop]. The coordinator launches its own coroutines
  * under the supplied [scope] but never owns the scope itself.
  */
+@Suppress("LongParameterList") // Constructor is plumbing for the test seam; each parameter is a discrete collaborator.
 public class ConsentCoordinator(
     private val activeConnections: SharedFlow<InboundConnection>,
     private val results: SharedFlow<InboundConnectionCompletion>,
@@ -59,6 +61,8 @@ public class ConsentCoordinator(
     private val sink: Sink,
     private val scope: CoroutineScope,
     private val connectionIdProvider: () -> Long = MonotonicConnectionIds::next,
+    private val stateExtractor: (InboundConnection) -> StateFlow<InboundConnectionState> = { it.state },
+    private val consentSubmitter: (InboundConnection) -> ((Boolean) -> Unit) = { conn -> conn::submitUserConsent },
 ) {
     private val idForConnection: MutableMap<InboundConnection, Long> = HashMap()
     private val idLock = Any()
@@ -116,7 +120,7 @@ public class ConsentCoordinator(
         // we just need a `takeWhile` that closes the loop after a
         // terminal state has been observed (and stops re-entering on
         // the StateFlow's stable terminal value).
-        connection.state
+        stateExtractor(connection)
             .takeWhile { state -> state !is InboundConnectionState.Idle || !posted }
             .collect { state ->
                 when (state) {
@@ -172,6 +176,7 @@ public class ConsentCoordinator(
             pin = metadata.pin,
             itemCount = metadata.items.size,
             totalSize = metadata.totalSize,
+            submitConsent = consentSubmitter(connection),
         )
 
     /**

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentCoordinator.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentCoordinator.kt
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.service.receiver.consent
+
+import io.github.kyujincho.wvmg.protocol.connection.InboundConnection
+import io.github.kyujincho.wvmg.protocol.connection.InboundConnectionState
+import io.github.kyujincho.wvmg.protocol.connection.TransferMetadata
+import io.github.kyujincho.wvmg.protocol.server.InboundConnectionCompletion
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.takeWhile
+import kotlinx.coroutines.launch
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Bridges
+ * [io.github.kyujincho.wvmg.service.receiver.ReceiverSession] events to
+ * the consent notification surface.
+ *
+ * ### Responsibilities
+ *
+ *  1. Subscribe to the session's `activeConnections` flow. Each new
+ *     [InboundConnection] gets a fresh observation coroutine that
+ *     watches its [InboundConnection.state] for the
+ *     `WaitingForUserConsent` transition.
+ *  2. On `WaitingForUserConsent`, register the connection in
+ *     [ConsentRegistry] and ask the [Sink] to post a consent
+ *     notification.
+ *  3. On any terminal state — Receiving (the user already accepted),
+ *     Rejected, Cancelled, Failed, Completed — unregister the entry
+ *     and ask the [Sink] to dismiss the notification.
+ *  4. On the session's `results` flow (which fires the final
+ *     completion), idempotently dismiss in case the per-connection
+ *     state observer was cancelled before reaching a terminal state.
+ *
+ * ### Why a `Sink` interface
+ *
+ * The actual notification posting needs an Android `Context`; the
+ * coordinator's responsibility is purely the choreography. Pulling
+ * the side-effects out behind [Sink] keeps the coordinator on plain
+ * JVM and gives unit tests a clean assertion target ("a Post was
+ * recorded for connectionId=42 with the right metadata").
+ *
+ * ### Lifecycle
+ *
+ * Constructed by the foreground service and started with [start];
+ * stopped with [stop]. The coordinator launches its own coroutines
+ * under the supplied [scope] but never owns the scope itself.
+ */
+public class ConsentCoordinator(
+    private val activeConnections: SharedFlow<InboundConnection>,
+    private val results: SharedFlow<InboundConnectionCompletion>,
+    private val registry: ConsentRegistry,
+    private val sink: Sink,
+    private val scope: CoroutineScope,
+    private val connectionIdProvider: () -> Long = MonotonicConnectionIds::next,
+) {
+    private val idForConnection: MutableMap<InboundConnection, Long> = HashMap()
+    private val idLock = Any()
+    private var runJob: Job? = null
+
+    /**
+     * Start observing. Idempotent against duplicate calls; subsequent
+     * invocations are no-ops while the prior observation is alive.
+     */
+    public fun start() {
+        if (runJob != null) return
+        runJob =
+            scope.launch {
+                launch { observeActiveConnections() }
+                launch { observeResults() }
+            }
+    }
+
+    /**
+     * Stop observing. Cancels the inner coroutines but does not touch
+     * already-registered entries — the foreground service's stop path
+     * tears those down explicitly so the registry stays consistent
+     * across coordinator restarts.
+     */
+    public fun stop() {
+        runJob?.cancel()
+        runJob = null
+    }
+
+    /**
+     * Per-active-connection observation loop. We pin a unique
+     * connection id at observation time (rather than reading
+     * [InboundConnectionCompletion.connectionId] post-hoc) so the
+     * notification posted for a `WaitingForUserConsent` state can be
+     * dismissed even if the connection terminates without producing a
+     * completion entry (e.g. a cancellation that beats the
+     * results-flow emission).
+     */
+    private suspend fun observeActiveConnections() {
+        activeConnections.collectLatest { connection ->
+            val connectionId =
+                synchronized(idLock) {
+                    idForConnection.getOrPut(connection, connectionIdProvider)
+                }
+            scope.launch { observeOneConnection(connection, connectionId) }
+        }
+    }
+
+    private suspend fun observeOneConnection(
+        connection: InboundConnection,
+        connectionId: Long,
+    ) {
+        var posted = false
+        // StateFlow already deduplicates equal consecutive emissions —
+        // we just need a `takeWhile` that closes the loop after a
+        // terminal state has been observed (and stops re-entering on
+        // the StateFlow's stable terminal value).
+        connection.state
+            .takeWhile { state -> state !is InboundConnectionState.Idle || !posted }
+            .collect { state ->
+                when (state) {
+                    is InboundConnectionState.WaitingForUserConsent -> {
+                        if (!posted) {
+                            posted = true
+                            val entry = entryFor(connection, state.metadata)
+                            registry.register(connectionId, entry)
+                            sink.postConsent(connectionId, entry)
+                        }
+                    }
+                    is InboundConnectionState.Receiving,
+                    is InboundConnectionState.Rejected,
+                    is InboundConnectionState.Cancelled,
+                    is InboundConnectionState.Failed,
+                    is InboundConnectionState.Completed,
+                    -> {
+                        if (posted) {
+                            registry.unregister(connectionId)
+                            sink.dismissConsent(connectionId)
+                        }
+                    }
+                    else -> Unit
+                }
+            }
+    }
+
+    /**
+     * Belt-and-braces: when a [InboundConnectionCompletion] flows in,
+     * make sure the corresponding consent entry is gone. The
+     * per-connection observer above usually already handled it; this
+     * loop catches the case where the observer was racing the
+     * completion emission.
+     */
+    private suspend fun observeResults() {
+        results.collect { completion ->
+            val connectionId =
+                synchronized(idLock) {
+                    idForConnection.remove(completion.connection)
+                } ?: return@collect
+            registry.unregister(connectionId)
+            sink.dismissConsent(connectionId)
+        }
+    }
+
+    private fun entryFor(
+        connection: InboundConnection,
+        metadata: TransferMetadata,
+    ): ConsentRegistry.Entry =
+        ConsentRegistry.Entry(
+            connection = connection,
+            sourceDeviceName = metadata.sourceDeviceName,
+            pin = metadata.pin,
+            itemCount = metadata.items.size,
+            totalSize = metadata.totalSize,
+        )
+
+    /**
+     * Side-effect surface for the coordinator. Production wires this
+     * to [ConsentNotification.post] / [ConsentNotification.dismiss];
+     * tests use a recording fake.
+     */
+    public interface Sink {
+        public fun postConsent(
+            connectionId: Long,
+            entry: ConsentRegistry.Entry,
+        )
+
+        public fun dismissConsent(connectionId: Long)
+    }
+}
+
+/**
+ * Process-monotonic source of consent connection ids. We mint our own
+ * (rather than waiting for the
+ * [io.github.kyujincho.wvmg.protocol.server.TcpReceiverServer]'s
+ * post-hoc id) because we need an id at the moment the consent
+ * registers, which is before the per-connection result is in flight.
+ *
+ * Lifted to a top-level singleton so the foreground service and a
+ * standalone test can share counter semantics without touching the
+ * private TCP server's counter.
+ */
+internal object MonotonicConnectionIds {
+    private val counter = AtomicLong(1)
+
+    fun next(): Long = counter.getAndIncrement()
+}

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentIntents.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentIntents.kt
@@ -113,6 +113,7 @@ public object ConsentIntents {
      * extra, which makes it easy to drive from a unit test against a
      * real `Intent`-like fake (see [IntentLike]).
      */
+    @Suppress("ReturnCount") // Three early-exit branches are clearer than a nested when.
     public fun parsePayload(intent: IntentLike): Payload? {
         val decision =
             when (intent.action) {

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentIntents.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentIntents.kt
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.service.receiver.consent
+
+import android.content.Intent
+
+/**
+ * Intent action / extra constants and pure-JVM intent-routing helpers
+ * shared between the consent notification builder, the broadcast
+ * receiver, and the trampoline activity.
+ *
+ * ### Why a separate object
+ *
+ * The constants need to be visible from three places in two modules:
+ *
+ *  - the notification builder in `:service-android` that constructs the
+ *    `PendingIntent`s,
+ *  - the broadcast receiver in `:service-android` that dispatches them,
+ *  - the trampoline activity in `:app` that re-uses the same routing
+ *    semantics for its in-app Accept / Reject buttons.
+ *
+ * Centralising avoids the classic Android footgun where one site
+ * changes an action string and the other half of the rendezvous
+ * silently breaks.
+ *
+ * ### Routing model
+ *
+ * Every consent broadcast carries:
+ *
+ *  - `ACTION_ACCEPT` or `ACTION_REJECT` — what the user pressed,
+ *  - `EXTRA_CONNECTION_ID` (long) — which in-flight transfer the
+ *    decision applies to (matches
+ *    [io.github.kyujincho.wvmg.protocol.server.InboundConnectionCompletion.connectionId]).
+ *
+ * The action distinguishes Accept vs Reject rather than a boolean
+ * extra so a stale `PendingIntent` can be filterMatch-rejected by the
+ * receiver before the extras are parsed.
+ *
+ * ### Pure-JVM extraction
+ *
+ * Tests assert routing semantics without touching real Android extras
+ * by going through the pure-JVM extractor: a test constructs a fake
+ * intent (just enough surface — see [parsePayload]) and verifies that
+ * `parsePayload` either returns a [Payload] or `null`.
+ */
+public object ConsentIntents {
+    /** Broadcast action fired when the user taps the notification's "Accept" action. */
+    public const val ACTION_ACCEPT: String = "io.github.kyujincho.wvmg.consent.ACCEPT"
+
+    /** Broadcast action fired when the user taps the notification's "Reject" action. */
+    public const val ACTION_REJECT: String = "io.github.kyujincho.wvmg.consent.REJECT"
+
+    /**
+     * Activity action used by the trampoline activity's launch
+     * `PendingIntent`. The activity reads the same connection-id extra
+     * and looks the connection up in [ConsentRegistry].
+     */
+    public const val ACTION_SHOW_CONSENT: String = "io.github.kyujincho.wvmg.consent.SHOW"
+
+    /**
+     * `Long` extra carrying the connection id this consent applies to.
+     * The broadcast receiver and the trampoline activity both parse
+     * this off the intent before consulting [ConsentRegistry].
+     */
+    public const val EXTRA_CONNECTION_ID: String = "wvmg.consent.connection_id"
+
+    /**
+     * Sentinel value for [EXTRA_CONNECTION_ID] meaning "unset". Picked
+     * to be impossible for a real
+     * [io.github.kyujincho.wvmg.protocol.server.InboundConnectionCompletion.connectionId]
+     * since those start at 1 and only ever increment.
+     */
+    public const val MISSING_CONNECTION_ID: Long = -1L
+
+    /**
+     * Decision encoded by a consent broadcast / activity action.
+     *
+     * `null` cases are surfaced as [Payload] = null from
+     * [parsePayload] so callers can branch on absence vs malformed
+     * actions without reflecting on action-string substrings.
+     */
+    public enum class Decision {
+        /** User pressed the Accept action. */
+        ACCEPT,
+
+        /** User pressed the Reject action. */
+        REJECT,
+    }
+
+    /**
+     * Decoded form of a consent intent. Pairs the [Decision] with the
+     * [connectionId] that should receive it.
+     */
+    public data class Payload(
+        val decision: Decision,
+        val connectionId: Long,
+    ) {
+        /** `true` when [Decision.ACCEPT]; convenience for the broadcast site. */
+        public val accepted: Boolean
+            get() = decision == Decision.ACCEPT
+    }
+
+    /**
+     * Parse the action + connection id off [intent]. Returns `null`
+     * when the action is not a recognised consent action or when the
+     * extra is missing — both treated identically by the broadcast
+     * receiver, which then drops the intent.
+     *
+     * Pure JVM: only consults the action string and a single long
+     * extra, which makes it easy to drive from a unit test against a
+     * real `Intent`-like fake (see [IntentLike]).
+     */
+    public fun parsePayload(intent: IntentLike): Payload? {
+        val decision =
+            when (intent.action) {
+                ACTION_ACCEPT -> Decision.ACCEPT
+                ACTION_REJECT -> Decision.REJECT
+                else -> return null
+            }
+        val connectionId = intent.getLongExtra(EXTRA_CONNECTION_ID, MISSING_CONNECTION_ID)
+        if (connectionId == MISSING_CONNECTION_ID) return null
+        return Payload(decision, connectionId)
+    }
+
+    /**
+     * Bridge over the subset of [Intent] that [parsePayload] needs.
+     *
+     * Production wires this with a thin adapter around the real
+     * [Intent] (see [from]); tests construct an in-memory map-backed
+     * implementation. Keeping the surface this small keeps the unit
+     * tests Robolectric-free.
+     */
+    public interface IntentLike {
+        public val action: String?
+
+        public fun getLongExtra(
+            name: String,
+            default: Long,
+        ): Long
+
+        public companion object {
+            /**
+             * Adapt a real [Intent] to the [IntentLike] interface.
+             *
+             * Inline for zero allocation overhead at the call site —
+             * the broadcast receiver path is hot enough that we don't
+             * want a per-broadcast wrapper object.
+             */
+            public fun from(intent: Intent): IntentLike =
+                object : IntentLike {
+                    override val action: String?
+                        get() = intent.action
+
+                    override fun getLongExtra(
+                        name: String,
+                        default: Long,
+                    ): Long = intent.getLongExtra(name, default)
+                }
+        }
+    }
+}

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentNotification.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentNotification.kt
@@ -1,0 +1,297 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.service.receiver.consent
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import io.github.kyujincho.wvmg.service.R
+
+/**
+ * Notification builder + channel installer for the consent prompt.
+ *
+ * ### Two layers, one notification
+ *
+ * The issue calls for a two-layered consent UX (#22):
+ *
+ *  1. **High-importance heads-up notification** with Accept / Reject
+ *     `Notification.Action`s — fires through
+ *     [ConsentBroadcastReceiver] so consent works even when the
+ *     screen is off.
+ *  2. **Trampoline activity** for users who tap the notification body
+ *     to see file details. Same pattern as an incoming call: the
+ *     activity uses `setShowWhenLocked(true) + setTurnScreenOn(true)`
+ *     to wake the screen.
+ *
+ * Both layers share the same [ConsentRegistry] entry, so whichever
+ * surface the user chooses, the resulting `submitUserConsent` lands
+ * on the same connection.
+ *
+ * ### Channel design
+ *
+ * The channel id `incoming_transfer` is separate from the
+ * persistent-foreground-service channel
+ * [io.github.kyujincho.wvmg.service.receiver.ReceiverNotification.CHANNEL_ID].
+ * `IMPORTANCE_HIGH` so the notification peeks (heads-up), plays a
+ * sound, and is unmissable on a busy device. The user can downgrade
+ * the channel via system settings if they ever need to — but the
+ * default has to be loud, because a missed consent prompt looks like
+ * a hung sender to the peer.
+ *
+ * ### Per-pending notification id
+ *
+ * Each pending consent gets its own notification id derived from the
+ * `connectionId` so multiple in-flight transfers each get their own
+ * heads-up — re-using a single id would collapse them, hiding all
+ * but the most recent. The id is stable for the lifetime of one
+ * connection so the dismiss path (after consent or terminal state)
+ * matches the post path.
+ */
+public object ConsentNotification {
+    /**
+     * Channel id for the consent prompt. Stable across upgrades so
+     * historical user-visible channel customisations (mute, dismiss
+     * behaviour) survive an app update.
+     */
+    public const val CHANNEL_ID: String = "incoming_transfer"
+
+    /**
+     * Mask applied to a connection id to derive a positive Android
+     * notification id. The receiver-foreground notification id
+     * (`ReceiverNotification.NOTIFICATION_ID`) is `0x57564D47`
+     * ("WVMG"), which is well outside this range, so the foreground
+     * notification cannot be accidentally cancelled by the consent
+     * dismiss path.
+     *
+     * `connectionId` itself is a monotonically-incrementing `Long`
+     * that starts at 1; we keep the low 31 bits and bias by a fixed
+     * offset to reserve a contiguous range for consent notifications.
+     */
+    internal const val CONSENT_ID_BASE: Int = 0x6357_5663 // "cWVc"
+
+    /**
+     * Stable Android notification id for the consent notification of a
+     * given connection. Same input always yields the same id, so the
+     * post / dismiss / re-post calls all target the same notification
+     * slot in the system shade.
+     */
+    public fun stableNotificationIdFor(connectionId: Long): Int {
+        // Fold the connection id into 31 bits and offset away from the
+        // foreground-service notification id range. The fold preserves
+        // the low bits so a fresh process's first transfer (id=1) gets
+        // a deterministic notification id useful for log correlation.
+        val low31 = (connectionId and 0x7FFF_FFFFL).toInt()
+        // Bias by the base in such a way that overflow stays inside
+        // the positive int range (Notification ids must be != 0; any
+        // non-zero int is otherwise legal).
+        var biased = (CONSENT_ID_BASE + low31) and 0x7FFF_FFFF
+        if (biased == 0) biased = 1
+        return biased
+    }
+
+    /**
+     * Idempotently install the consent notification channel on API 26+.
+     *
+     * Pre-26 devices ignore notification channels entirely; we still
+     * post the notification using `NotificationCompat`, which silently
+     * degrades the channel-related fields on older platforms (and the
+     * notification is delivered with the platform default behaviour).
+     *
+     * The channel is created with `IMPORTANCE_HIGH` so the
+     * notification peeks. `setSound(null, null)` is **not** applied —
+     * the consent prompt is exactly the kind of notification that
+     * should make a sound, the same way an incoming call does.
+     */
+    public fun ensureChannel(context: Context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val manager = context.getSystemService(NotificationManager::class.java) ?: return
+        val channel =
+            NotificationChannel(
+                CHANNEL_ID,
+                context.getString(R.string.consent_notification_channel_name),
+                NotificationManager.IMPORTANCE_HIGH,
+            ).apply {
+                description = context.getString(R.string.consent_notification_channel_description)
+                setShowBadge(true)
+                enableVibration(true)
+                enableLights(true)
+            }
+        manager.createNotificationChannel(channel)
+    }
+
+    /**
+     * Build the consent notification for a pending registry entry.
+     *
+     * Construction is delegated to a pure-JVM
+     * [ConsentNotificationContent] data object so the textual content
+     * (title, body, action labels, PIN string) can be unit-tested
+     * without instantiating a real `NotificationCompat.Builder`.
+     *
+     * @param context Used for string lookup and as the
+     *   `NotificationCompat.Builder` context.
+     * @param connectionId Stable id of the in-flight transfer.
+     * @param entry Snapshot of the registry entry — the consent UI
+     *   reads device name, item count, total size, PIN from here.
+     * @param trampolineTarget Activity class to open when the user
+     *   taps the notification body. Constructed by the foreground
+     *   service so this builder does not need a static dependency on
+     *   `:app`.
+     */
+    public fun build(
+        context: Context,
+        connectionId: Long,
+        entry: ConsentRegistry.Entry,
+        trampolineTarget: Class<*>?,
+    ): Notification {
+        val content = ConsentNotificationContent.from(context.resources, entry)
+
+        val acceptIntent =
+            PendingIntent.getBroadcast(
+                context,
+                acceptRequestCodeFor(connectionId),
+                consentBroadcastIntent(context, ConsentIntents.ACTION_ACCEPT, connectionId),
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+            )
+        val rejectIntent =
+            PendingIntent.getBroadcast(
+                context,
+                rejectRequestCodeFor(connectionId),
+                consentBroadcastIntent(context, ConsentIntents.ACTION_REJECT, connectionId),
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+            )
+
+        val tapIntent =
+            if (trampolineTarget != null) {
+                PendingIntent.getActivity(
+                    context,
+                    contentRequestCodeFor(connectionId),
+                    Intent(context, trampolineTarget).apply {
+                        action = ConsentIntents.ACTION_SHOW_CONSENT
+                        putExtra(ConsentIntents.EXTRA_CONNECTION_ID, connectionId)
+                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    },
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+                )
+            } else {
+                null
+            }
+
+        val builder =
+            NotificationCompat
+                .Builder(context, CHANNEL_ID)
+                .setSmallIcon(android.R.drawable.stat_sys_download)
+                .setContentTitle(content.title)
+                .setContentText(content.body)
+                .setStyle(NotificationCompat.BigTextStyle().bigText(content.bigText))
+                .setPriority(NotificationCompat.PRIORITY_HIGH)
+                .setCategory(NotificationCompat.CATEGORY_CALL)
+                // Dismissing the notification (swipe) does NOT auto-reject
+                // — the peer is left waiting for an explicit decision via
+                // the trampoline activity. This matches NearDrop behaviour
+                // (issue #22 acceptance criteria).
+                .setOngoing(true)
+                .setAutoCancel(false)
+                .setShowWhen(true)
+                .addAction(
+                    NotificationCompat.Action.Builder(
+                        android.R.drawable.ic_menu_send,
+                        content.acceptLabel,
+                        acceptIntent,
+                    ).build(),
+                ).addAction(
+                    NotificationCompat.Action.Builder(
+                        android.R.drawable.ic_menu_close_clear_cancel,
+                        content.rejectLabel,
+                        rejectIntent,
+                    ).build(),
+                )
+
+        if (tapIntent != null) {
+            builder.setContentIntent(tapIntent)
+                // Make sure the heads-up tap routes to the trampoline
+                // activity rather than just expanding the shade. The
+                // full-screen-intent path is what wakes the device on
+                // API 27+; the trampoline activity itself handles the
+                // setShowWhenLocked / setTurnScreenOn flags.
+                .setFullScreenIntent(tapIntent, /* highPriority = */ true)
+        }
+
+        return builder.build()
+    }
+
+    /**
+     * Post the consent notification for [connectionId] using the given
+     * [entry] context. Idempotent: re-posting under the same id replaces
+     * the prior notification.
+     *
+     * Returns the notification id used so callers (foreground service,
+     * tests) can correlate.
+     */
+    public fun post(
+        context: Context,
+        connectionId: Long,
+        entry: ConsentRegistry.Entry,
+        trampolineTarget: Class<*>?,
+    ): Int {
+        val manager = context.getSystemService(NotificationManager::class.java) ?: return -1
+        val id = stableNotificationIdFor(connectionId)
+        manager.notify(id, build(context, connectionId, entry, trampolineTarget))
+        return id
+    }
+
+    /**
+     * Dismiss the consent notification for [connectionId]. Safe to call
+     * before [post] — the platform `NotificationManager.cancel` is a
+     * no-op for unknown ids.
+     */
+    public fun dismiss(
+        context: Context,
+        connectionId: Long,
+    ) {
+        val manager = context.getSystemService(NotificationManager::class.java) ?: return
+        manager.cancel(stableNotificationIdFor(connectionId))
+    }
+
+    private fun consentBroadcastIntent(
+        context: Context,
+        action: String,
+        connectionId: Long,
+    ): Intent =
+        Intent(action).apply {
+            // Explicit component scoping locks the broadcast to our
+            // process. Without this, an `ACTION_ACCEPT` intent could
+            // theoretically be observed by an exported receiver in a
+            // sibling package (none exist today; future-proofing).
+            setPackage(context.packageName)
+            setClass(context, ConsentBroadcastReceiver::class.java)
+            putExtra(ConsentIntents.EXTRA_CONNECTION_ID, connectionId)
+        }
+
+    /**
+     * `PendingIntent` request code namespaces. Three slots per
+     * connection (accept / reject / content tap) so updating one does
+     * not implicitly mutate another. Folded into 31 bits because
+     * `getBroadcast` request codes must be int.
+     */
+    private fun acceptRequestCodeFor(connectionId: Long): Int =
+        ((connectionId * REQUEST_CODE_STRIDE + ACCEPT_OFFSET) and 0x7FFF_FFFFL).toInt()
+
+    private fun rejectRequestCodeFor(connectionId: Long): Int =
+        ((connectionId * REQUEST_CODE_STRIDE + REJECT_OFFSET) and 0x7FFF_FFFFL).toInt()
+
+    private fun contentRequestCodeFor(connectionId: Long): Int =
+        ((connectionId * REQUEST_CODE_STRIDE + CONTENT_OFFSET) and 0x7FFF_FFFFL).toInt()
+
+    private const val REQUEST_CODE_STRIDE = 3L
+    private const val ACCEPT_OFFSET = 0L
+    private const val REJECT_OFFSET = 1L
+    private const val CONTENT_OFFSET = 2L
+}

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentNotification.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentNotification.kt
@@ -88,11 +88,11 @@ public object ConsentNotification {
         // foreground-service notification id range. The fold preserves
         // the low bits so a fresh process's first transfer (id=1) gets
         // a deterministic notification id useful for log correlation.
-        val low31 = (connectionId and 0x7FFF_FFFFL).toInt()
+        val low31 = (connectionId and POSITIVE_INT_MASK_LONG).toInt()
         // Bias by the base in such a way that overflow stays inside
         // the positive int range (Notification ids must be != 0; any
         // non-zero int is otherwise legal).
-        var biased = (CONSENT_ID_BASE + low31) and 0x7FFF_FFFF
+        var biased = (CONSENT_ID_BASE + low31) and POSITIVE_INT_MASK
         if (biased == 0) biased = 1
         return biased
     }
@@ -201,27 +201,32 @@ public object ConsentNotification {
                 .setAutoCancel(false)
                 .setShowWhen(true)
                 .addAction(
-                    NotificationCompat.Action.Builder(
-                        android.R.drawable.ic_menu_send,
-                        content.acceptLabel,
-                        acceptIntent,
-                    ).build(),
+                    NotificationCompat.Action
+                        .Builder(
+                            android.R.drawable.ic_menu_send,
+                            content.acceptLabel,
+                            acceptIntent,
+                        ).build(),
                 ).addAction(
-                    NotificationCompat.Action.Builder(
-                        android.R.drawable.ic_menu_close_clear_cancel,
-                        content.rejectLabel,
-                        rejectIntent,
-                    ).build(),
+                    NotificationCompat.Action
+                        .Builder(
+                            android.R.drawable.ic_menu_close_clear_cancel,
+                            content.rejectLabel,
+                            rejectIntent,
+                        ).build(),
                 )
 
         if (tapIntent != null) {
-            builder.setContentIntent(tapIntent)
+            builder
+                .setContentIntent(tapIntent)
                 // Make sure the heads-up tap routes to the trampoline
                 // activity rather than just expanding the shade. The
                 // full-screen-intent path is what wakes the device on
                 // API 27+; the trampoline activity itself handles the
                 // setShowWhenLocked / setTurnScreenOn flags.
-                .setFullScreenIntent(tapIntent, /* highPriority = */ true)
+                // highPriority = true so API 29+ surfaces the activity
+                // immediately rather than collapsing the heads-up.
+                .setFullScreenIntent(tapIntent, true)
         }
 
         return builder.build()
@@ -282,13 +287,17 @@ public object ConsentNotification {
      * `getBroadcast` request codes must be int.
      */
     private fun acceptRequestCodeFor(connectionId: Long): Int =
-        ((connectionId * REQUEST_CODE_STRIDE + ACCEPT_OFFSET) and 0x7FFF_FFFFL).toInt()
+        ((connectionId * REQUEST_CODE_STRIDE + ACCEPT_OFFSET) and POSITIVE_INT_MASK_LONG).toInt()
 
     private fun rejectRequestCodeFor(connectionId: Long): Int =
-        ((connectionId * REQUEST_CODE_STRIDE + REJECT_OFFSET) and 0x7FFF_FFFFL).toInt()
+        ((connectionId * REQUEST_CODE_STRIDE + REJECT_OFFSET) and POSITIVE_INT_MASK_LONG).toInt()
 
     private fun contentRequestCodeFor(connectionId: Long): Int =
-        ((connectionId * REQUEST_CODE_STRIDE + CONTENT_OFFSET) and 0x7FFF_FFFFL).toInt()
+        ((connectionId * REQUEST_CODE_STRIDE + CONTENT_OFFSET) and POSITIVE_INT_MASK_LONG).toInt()
+
+    /** Mask that strips the sign bit for use as a positive int notification id. */
+    private const val POSITIVE_INT_MASK: Int = 0x7FFF_FFFF
+    private const val POSITIVE_INT_MASK_LONG: Long = 0x7FFF_FFFFL
 
     private const val REQUEST_CODE_STRIDE = 3L
     private const val ACCEPT_OFFSET = 0L

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentNotificationContent.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentNotificationContent.kt
@@ -130,7 +130,7 @@ public data class ConsentNotificationContent(
          * Unitless (no `MB`, `KB` suffix in the resource itself); the
          * suffix is part of the format string for localisation.
          */
-        @Suppress("MagicNumber")
+        @Suppress("MagicNumber", "ReturnCount")
         public fun humanReadableSize(bytes: Long): String {
             if (bytes < 0) return "0 B"
             if (bytes < 1024) return "$bytes B"
@@ -181,6 +181,7 @@ public fun interface TextResolver {
                 if (args.isEmpty()) {
                     resources.getString(resourceId)
                 } else {
+                    @Suppress("SpreadOperator") // Resources.getString requires a vararg; this site is rare.
                     resources.getString(resourceId, *args)
                 }
             }

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentNotificationContent.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentNotificationContent.kt
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.service.receiver.consent
+
+import android.content.res.Resources
+import io.github.kyujincho.wvmg.service.R
+
+/**
+ * Pure-JVM rendering of the textual content shown on the consent
+ * notification.
+ *
+ * ### Why a separate type
+ *
+ * `NotificationCompat.Builder` and the `Resources` lookups it rests
+ * on are awkward to test on plain JVM — but the *content* of the
+ * notification (title wording, body, action labels, PIN formatting) is
+ * the part that benefits most from unit-testing. Splitting the text
+ * derivation out of the builder gives us a Robolectric-free assertion
+ * surface: a test calls [from] with a fake [TextResolver] and asserts
+ * the returned [ConsentNotificationContent] field-by-field.
+ *
+ * @property title Short, single-line title shown in the collapsed
+ *   notification ("Pixel 8 wants to share").
+ * @property body One-line subtitle ("3 files (12.4 MB) — PIN 1234").
+ *   Falls back gracefully when item count is zero or sender name is
+ *   absent.
+ * @property bigText Multi-line expanded text shown when the user
+ *   pulls down the notification — includes the full file list, one
+ *   per line. Truncated to [MAX_LISTED_ITEMS] entries with a "…and N
+ *   more" line at the end so we never produce a many-screen-tall
+ *   notification.
+ * @property acceptLabel Localized text for the Accept action button.
+ * @property rejectLabel Localized text for the Reject action button.
+ */
+public data class ConsentNotificationContent(
+    val title: String,
+    val body: String,
+    val bigText: String,
+    val acceptLabel: String,
+    val rejectLabel: String,
+) {
+    public companion object {
+        /**
+         * Cap on the number of file lines included verbatim in the
+         * expanded notification. A typical Quick Share consent prompt
+         * shows at most a handful of files; capping protects against a
+         * malicious or buggy peer announcing thousands of items.
+         */
+        public const val MAX_LISTED_ITEMS: Int = 8
+
+        /**
+         * Build content from a [ConsentRegistry.Entry] and a
+         * [Resources] handle. The [Resources] argument is only
+         * consulted for string lookup; tests typically swap in a
+         * [TextResolver].
+         */
+        public fun from(
+            resources: Resources,
+            entry: ConsentRegistry.Entry,
+        ): ConsentNotificationContent =
+            from(
+                resolver = TextResolver.from(resources),
+                entry = entry,
+            )
+
+        /**
+         * Pure-JVM entry point — the [TextResolver] abstraction lets
+         * unit tests stub the localisation layer with a deterministic
+         * map.
+         */
+        public fun from(
+            resolver: TextResolver,
+            entry: ConsentRegistry.Entry,
+        ): ConsentNotificationContent {
+            val deviceName = entry.sourceDeviceName?.takeIf { it.isNotBlank() }
+            val title =
+                if (deviceName != null) {
+                    resolver.formatted(R.string.consent_notification_title_with_name, deviceName)
+                } else {
+                    resolver.formatted(R.string.consent_notification_title_unknown_sender)
+                }
+
+            val itemSummary =
+                if (entry.itemCount <= 0) {
+                    resolver.formatted(R.string.consent_notification_summary_no_items)
+                } else {
+                    resolver.formatted(
+                        R.string.consent_notification_summary_n_items,
+                        entry.itemCount,
+                        humanReadableSize(entry.totalSize),
+                    )
+                }
+
+            val body =
+                resolver.formatted(
+                    R.string.consent_notification_body,
+                    itemSummary,
+                    entry.pin,
+                )
+
+            val bigText =
+                buildString {
+                    append(body)
+                    if (entry.itemCount > 0) {
+                        append('\n')
+                        append(
+                            resolver.formatted(
+                                R.string.consent_notification_bigtext_pin_line,
+                                entry.pin,
+                            ),
+                        )
+                    }
+                }
+
+            return ConsentNotificationContent(
+                title = title,
+                body = body,
+                bigText = bigText,
+                acceptLabel = resolver.formatted(R.string.consent_notification_action_accept),
+                rejectLabel = resolver.formatted(R.string.consent_notification_action_reject),
+            )
+        }
+
+        /**
+         * Convert raw bytes into a human-readable size string —
+         * 1024-based, decimal precision matching common file managers.
+         * Unitless (no `MB`, `KB` suffix in the resource itself); the
+         * suffix is part of the format string for localisation.
+         */
+        @Suppress("MagicNumber")
+        public fun humanReadableSize(bytes: Long): String {
+            if (bytes < 0) return "0 B"
+            if (bytes < 1024) return "$bytes B"
+            val units = arrayOf("KB", "MB", "GB", "TB")
+            var value = bytes.toDouble() / 1024.0
+            var unitIndex = 0
+            while (value >= 1024.0 && unitIndex < units.lastIndex) {
+                value /= 1024.0
+                unitIndex++
+            }
+            return if (value >= 100.0) {
+                "${value.toLong()} ${units[unitIndex]}"
+            } else {
+                String.format(java.util.Locale.ROOT, "%.1f %s", value, units[unitIndex])
+            }
+        }
+    }
+}
+
+/**
+ * Bridge over [Resources.getString] and [Resources.getQuantityString]
+ * that lets unit tests substitute a fake string source.
+ *
+ * `:service-android` is an Android library module so a test JAR can
+ * still see [Resources], but instantiating one without an Android
+ * runtime requires Robolectric. The [TextResolver] indirection keeps
+ * the consent-content tests on plain Junit5.
+ */
+public fun interface TextResolver {
+    /**
+     * Return the localised string for [resourceId], formatted with
+     * [formatArgs]. The signature mirrors
+     * [Resources.getString] (`Resources.getString(int, vararg Object)`)
+     * for direct adapter wiring.
+     */
+    public fun formatted(
+        resourceId: Int,
+        vararg formatArgs: Any,
+    ): String
+
+    public companion object {
+        /**
+         * Production adapter wrapping a real [Resources]. Inline so
+         * we don't allocate per consent post.
+         */
+        public fun from(resources: Resources): TextResolver =
+            TextResolver { resourceId, args ->
+                if (args.isEmpty()) {
+                    resources.getString(resourceId)
+                } else {
+                    resources.getString(resourceId, *args)
+                }
+            }
+    }
+}

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentRegistry.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentRegistry.kt
@@ -6,6 +6,7 @@
 package io.github.kyujincho.wvmg.service.receiver.consent
 
 import io.github.kyujincho.wvmg.protocol.connection.InboundConnection
+import io.github.kyujincho.wvmg.protocol.connection.TransferItem
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -73,6 +74,7 @@ public class ConsentRegistry {
         public val pin: String,
         public val itemCount: Int,
         public val totalSize: Long,
+        public val items: List<TransferItem> = emptyList(),
         submitConsent: ((Boolean) -> Unit)? = null,
     ) {
         /**
@@ -92,7 +94,8 @@ public class ConsentRegistry {
                 sourceDeviceName == other.sourceDeviceName &&
                 pin == other.pin &&
                 itemCount == other.itemCount &&
-                totalSize == other.totalSize
+                totalSize == other.totalSize &&
+                items == other.items
         }
 
         override fun hashCode(): Int {
@@ -101,12 +104,13 @@ public class ConsentRegistry {
             result = 31 * result + pin.hashCode()
             result = 31 * result + itemCount
             result = 31 * result + totalSize.hashCode()
+            result = 31 * result + items.hashCode()
             return result
         }
 
         override fun toString(): String =
             "Entry(connection=$connection, sourceDeviceName=$sourceDeviceName, pin=$pin, " +
-                "itemCount=$itemCount, totalSize=$totalSize)"
+                "itemCount=$itemCount, totalSize=$totalSize, items=${items.size} entries)"
     }
 
     /**

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentRegistry.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentRegistry.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.service.receiver.consent
+
+import io.github.kyujincho.wvmg.protocol.connection.InboundConnection
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Process-wide registry of in-flight [InboundConnection]s parked at
+ * `WaitingForUserConsent`.
+ *
+ * ### Why a registry
+ *
+ * The consent UI fires its accept / reject decision through a
+ * [android.app.PendingIntent] -> [android.content.BroadcastReceiver] hop
+ * (so the action survives the screen being off and the app being killed
+ * by the launcher). The receiver therefore cannot hold a direct
+ * reference to the [InboundConnection] — `PendingIntent` extras must be
+ * `Parcelable`, and the coroutine-bearing connection is decidedly not.
+ * Instead, the broadcast carries a numeric **connection id** that is
+ * looked up here to obtain the live [InboundConnection] to call
+ * `submitUserConsent` on.
+ *
+ * The registry is keyed by the same `connectionId` that
+ * [io.github.kyujincho.wvmg.protocol.server.InboundConnectionCompletion]
+ * surfaces, so log correlation (notification + receiver-server log line)
+ * stays trivial.
+ *
+ * ### Lifetime
+ *
+ * Entries live from the moment the receiver session emits a connection
+ * with state `WaitingForUserConsent` until the connection terminates
+ * (Receiving, Rejected, Cancelled, Failed, or Completed). The registrar
+ * is responsible for cleaning up via [unregister]; if the foreground
+ * service is killed mid-flight, the process is gone too and the
+ * registry contents go with it.
+ *
+ * ### Thread-safety
+ *
+ * Backed by a [ConcurrentHashMap] — every entry-point is safe to call
+ * from the broadcast receiver's main thread, the foreground service's
+ * coroutine, or the trampoline activity's UI thread. Operations are
+ * O(1) and lock-free for typical sizes (at most a handful of pending
+ * consents at once).
+ */
+public class ConsentRegistry {
+    private val entries: ConcurrentHashMap<Long, Entry> = ConcurrentHashMap()
+
+    /**
+     * One pending consent. Pairs the [InboundConnection] (the API the
+     * receiver eventually invokes `submitUserConsent` on) with a
+     * point-in-time snapshot of the metadata the UI needs.
+     *
+     * The metadata is captured eagerly so a consent broadcast that fires
+     * after the FSM has already started receiving (a rare race where
+     * the user taps Accept just as the FSM moved past
+     * WaitingForUserConsent) still has the original prompt context for
+     * logging.
+     */
+    public data class Entry(
+        val connection: InboundConnection,
+        val sourceDeviceName: String?,
+        val pin: String,
+        val itemCount: Int,
+        val totalSize: Long,
+    )
+
+    /**
+     * Add a new pending consent. Replaces any prior entry under the same
+     * id (the only realistic way that happens is the foreground service
+     * resurrecting under the same id, which is itself a no-op for the
+     * UI). Returns the previous entry, if any, so the caller can decide
+     * whether to dismiss its notification.
+     */
+    public fun register(
+        connectionId: Long,
+        entry: Entry,
+    ): Entry? = entries.put(connectionId, entry)
+
+    /**
+     * Look up a pending consent by id. Returns `null` if the consent
+     * already terminated or never existed (e.g. a stale broadcast from
+     * a dismissed notification after a process restart).
+     */
+    public fun lookup(connectionId: Long): Entry? = entries[connectionId]
+
+    /**
+     * Remove the registration for [connectionId]. Returns the removed
+     * entry, if any. Idempotent — calling on an already-removed id
+     * returns `null` without raising.
+     */
+    public fun unregister(connectionId: Long): Entry? = entries.remove(connectionId)
+
+    /**
+     * Snapshot of every currently-registered connection id. Defensive
+     * copy — callers can iterate without worrying about concurrent
+     * modification.
+     */
+    public fun snapshotIds(): Set<Long> = entries.keys.toSet()
+
+    public companion object {
+        /**
+         * Process-wide singleton used by production code paths. Tests
+         * construct their own [ConsentRegistry] via the public
+         * constructor and inject it into collaborators directly.
+         *
+         * The singleton is necessary because the broadcast receiver
+         * lives outside the service lifecycle (Android instantiates it
+         * fresh per intent delivery) and therefore cannot receive an
+         * injected reference. The trade-off is acceptable here because
+         * the registry holds no Android `Context` and is trivially
+         * resettable from tests.
+         */
+        @JvmStatic
+        public val instance: ConsentRegistry = ConsentRegistry()
+    }
+}

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentRegistry.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentRegistry.kt
@@ -59,14 +59,55 @@ public class ConsentRegistry {
      * the user taps Accept just as the FSM moved past
      * WaitingForUserConsent) still has the original prompt context for
      * logging.
+     *
+     * @property submitConsent The decision sink. Production wires this
+     *   to [InboundConnection.submitUserConsent]; tests inject a
+     *   recording lambda so they can assert on the boolean without
+     *   subclassing the (final) `InboundConnection` class. Default is
+     *   `connection::submitUserConsent` so callers normally don't
+     *   specify it.
      */
-    public data class Entry(
-        val connection: InboundConnection,
-        val sourceDeviceName: String?,
-        val pin: String,
-        val itemCount: Int,
-        val totalSize: Long,
-    )
+    public class Entry(
+        public val connection: InboundConnection,
+        public val sourceDeviceName: String?,
+        public val pin: String,
+        public val itemCount: Int,
+        public val totalSize: Long,
+        submitConsent: ((Boolean) -> Unit)? = null,
+    ) {
+        /**
+         * The decision sink. Defaults to `connection::submitUserConsent`
+         * — tests pass a recording lambda. Held as a property rather
+         * than computed lazily so a moved-out consent (after the
+         * connection terminates) still has a callable reference even
+         * if the underlying connection's channel is closed.
+         */
+        public val submitConsent: (Boolean) -> Unit =
+            submitConsent ?: { accepted -> connection.submitUserConsent(accepted) }
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is Entry) return false
+            return connection === other.connection &&
+                sourceDeviceName == other.sourceDeviceName &&
+                pin == other.pin &&
+                itemCount == other.itemCount &&
+                totalSize == other.totalSize
+        }
+
+        override fun hashCode(): Int {
+            var result = System.identityHashCode(connection)
+            result = 31 * result + (sourceDeviceName?.hashCode() ?: 0)
+            result = 31 * result + pin.hashCode()
+            result = 31 * result + itemCount
+            result = 31 * result + totalSize.hashCode()
+            return result
+        }
+
+        override fun toString(): String =
+            "Entry(connection=$connection, sourceDeviceName=$sourceDeviceName, pin=$pin, " +
+                "itemCount=$itemCount, totalSize=$totalSize)"
+    }
 
     /**
      * Add a new pending consent. Replaces any prior entry under the same

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentRouter.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentRouter.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.service.receiver.consent
+
+/**
+ * Pure-JVM dispatcher tying a parsed consent
+ * [ConsentIntents.Payload] to the live
+ * [io.github.kyujincho.wvmg.protocol.connection.InboundConnection] in
+ * the [ConsentRegistry].
+ *
+ * Lifted out of [ConsentBroadcastReceiver] so unit tests can validate
+ * the routing semantics — "Accept on a registered id flips the
+ * decision through to submitUserConsent(true) and unregisters" — on a
+ * plain JVM with no `Intent`, no `Context`, no Robolectric.
+ */
+public object ConsentRouter {
+    /**
+     * Decode the intent and, if it carries a recognised consent
+     * payload that targets a live registered connection, deliver the
+     * decision to that connection.
+     *
+     * The decision is propagated through the same `submitUserConsent`
+     * API the in-app consent dialog uses (#22's trampoline activity),
+     * so the FSM treats Accept / Reject identically regardless of
+     * which UI surfaced it.
+     *
+     * After delivering consent, the registration is removed so a
+     * re-fired stale `PendingIntent` (e.g. user double-tapped the
+     * notification action before the system could dismiss it) is a
+     * no-op rather than a duplicate `submitUserConsent`.
+     *
+     * @param intent An [ConsentIntents.IntentLike] view of the
+     *   broadcast intent. Production passes
+     *   `ConsentIntents.IntentLike.from(intent)`; tests pass a
+     *   fake.
+     * @param registry The [ConsentRegistry] to look up the connection
+     *   in. Production passes [ConsentRegistry.instance]; tests pass
+     *   a fresh registry.
+     * @param onConsentSubmitted Optional hook fired once the
+     *   `submitUserConsent` call returns, with the connection id.
+     *   Production uses this to dismiss the notification; tests use
+     *   it to assert the dispatch fired.
+     */
+    public fun dispatch(
+        intent: ConsentIntents.IntentLike,
+        registry: ConsentRegistry,
+        onConsentSubmitted: (connectionId: Long) -> Unit = {},
+    ) {
+        val payload = ConsentIntents.parsePayload(intent) ?: return
+        val entry = registry.unregister(payload.connectionId) ?: return
+        entry.connection.submitUserConsent(payload.accepted)
+        onConsentSubmitted(payload.connectionId)
+    }
+}

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentRouter.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentRouter.kt
@@ -51,7 +51,7 @@ public object ConsentRouter {
     ) {
         val payload = ConsentIntents.parsePayload(intent) ?: return
         val entry = registry.unregister(payload.connectionId) ?: return
-        entry.connection.submitUserConsent(payload.accepted)
+        entry.submitConsent(payload.accepted)
         onConsentSubmitted(payload.connectionId)
     }
 }

--- a/service-android/src/main/res/values/strings.xml
+++ b/service-android/src/main/res/values/strings.xml
@@ -6,7 +6,7 @@
   receiver service (#21). Other modules contribute their own strings
   (see :app/res/values/strings.xml for app-wide UI copy).
 -->
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <!--
       User-visible name of the notification channel that backs the
@@ -56,7 +56,7 @@
       ships English-only; `plurals` resources will land alongside the
       Korean translation pass.
     -->
-    <string name="consent_notification_summary_n_items">%1$d item(s) (%2$s)</string>
+    <string name="consent_notification_summary_n_items" tools:ignore="PluralsCandidate">%1$d item(s) (%2$s)</string>
     <string name="consent_notification_summary_no_items">no items</string>
 
     <!--

--- a/service-android/src/main/res/values/strings.xml
+++ b/service-android/src/main/res/values/strings.xml
@@ -34,4 +34,46 @@
     -->
     <string name="receiver_notification_text">Receiving nearby files…</string>
 
+    <!--
+      Consent notification (#22). Posted when an inbound connection
+      reaches `WaitingForUserConsent`. Distinct channel from the
+      receiver-foreground notification because it must be high-importance
+      (heads-up) and audible — the user has to be unmistakably prompted.
+    -->
+    <string name="consent_notification_channel_name">Incoming transfer requests</string>
+    <string name="consent_notification_channel_description">Heads-up prompt when another device asks to send you files</string>
+
+    <!--
+      Title shown on the consent notification. The first variant is
+      preferred when we know the sender's device name; the second covers
+      the hidden-visibility / parse-failure case.
+    -->
+    <string name="consent_notification_title_with_name">%1$s wants to share</string>
+    <string name="consent_notification_title_unknown_sender">A nearby device wants to share</string>
+
+    <!--
+      Item-count summary. Pluralisation handled in code today — Phase 1
+      ships English-only; `plurals` resources will land alongside the
+      Korean translation pass.
+    -->
+    <string name="consent_notification_summary_n_items">%1$d item(s) (%2$s)</string>
+    <string name="consent_notification_summary_no_items">no items</string>
+
+    <!--
+      Body line shown collapsed: "%summary% — PIN %pin%". The PIN is
+      always the 4-digit confirmation code from TransferMetadata.
+    -->
+    <string name="consent_notification_body">%1$s · PIN %2$s</string>
+
+    <!--
+      Expanded-notification PIN re-iteration. Repeating the PIN on the
+      big-text view makes it readable without dismissing other
+      notifications above ours.
+    -->
+    <string name="consent_notification_bigtext_pin_line">Confirm PIN: %1$s</string>
+
+    <!-- Action button labels. -->
+    <string name="consent_notification_action_accept">Accept</string>
+    <string name="consent_notification_action_reject">Reject</string>
+
 </resources>

--- a/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentCoordinatorTest.kt
+++ b/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentCoordinatorTest.kt
@@ -1,0 +1,313 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package io.github.kyujincho.wvmg.service.receiver.consent
+
+import com.google.common.truth.Truth.assertThat
+import io.github.kyujincho.wvmg.protocol.connection.CancelCause
+import io.github.kyujincho.wvmg.protocol.connection.InboundConnection
+import io.github.kyujincho.wvmg.protocol.connection.InboundConnectionState
+import io.github.kyujincho.wvmg.protocol.connection.TransferItem
+import io.github.kyujincho.wvmg.protocol.connection.TransferMetadata
+import io.github.kyujincho.wvmg.protocol.server.InboundConnectionCompletion
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.net.Socket
+import java.util.IdentityHashMap
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Pure-JVM tests for [ConsentCoordinator].
+ *
+ * The coordinator is the choreography that ties the receiver session
+ * to the consent notification surface. We exercise it through:
+ *
+ *  - real (unstarted) [InboundConnection] instances as identity
+ *    handles,
+ *  - a per-test [MutableStateFlow] keyed by connection that supplies
+ *    the state used by the coordinator (injected via the
+ *    `stateExtractor` constructor parameter so we don't need to
+ *    drive a real lifecycle),
+ *  - an in-memory [RecordingSink] capturing every post / dismiss,
+ *  - hand-rolled [SharedFlow]s for the session's
+ *    `activeConnections` and `results` channels.
+ */
+class ConsentCoordinatorTest {
+    @Test
+    fun `posts a consent notification when connection enters WaitingForUserConsent`() =
+        runTest {
+            val harness = harness(idProvider = { 100L })
+            harness.start()
+
+            val connection = harness.newConnection()
+            harness.activeConnections.tryEmit(connection)
+            advanceUntilIdle()
+
+            harness.transitionTo(
+                connection,
+                InboundConnectionState.WaitingForUserConsent(
+                    metadata =
+                        TransferMetadata(
+                            items =
+                                listOf(
+                                    TransferItem.File(1, "a.bin", 100, "application/octet-stream"),
+                                ),
+                            pin = "1234",
+                            sourceDeviceName = "Pixel 8",
+                        ),
+                ),
+            )
+            advanceUntilIdle()
+
+            assertThat(harness.sink.posted).hasSize(1)
+            val post = harness.sink.posted.single()
+            assertThat(post.connectionId).isEqualTo(100L)
+            assertThat(post.entry.sourceDeviceName).isEqualTo("Pixel 8")
+            assertThat(post.entry.pin).isEqualTo("1234")
+            assertThat(post.entry.itemCount).isEqualTo(1)
+            assertThat(harness.registry.lookup(100L)).isNotNull()
+
+            harness.close()
+        }
+
+    @Test
+    fun `dismisses when connection transitions out of WaitingForUserConsent`() =
+        runTest {
+            val harness = harness(idProvider = { 50L })
+            harness.start()
+
+            val connection = harness.newConnection()
+            harness.activeConnections.tryEmit(connection)
+            advanceUntilIdle()
+
+            harness.transitionTo(
+                connection,
+                InboundConnectionState.WaitingForUserConsent(metadata = sampleMetadata()),
+            )
+            advanceUntilIdle()
+
+            harness.transitionTo(connection, InboundConnectionState.Rejected)
+            advanceUntilIdle()
+
+            assertThat(harness.sink.posted).hasSize(1)
+            assertThat(harness.sink.dismissed).containsExactly(50L)
+            assertThat(harness.registry.lookup(50L)).isNull()
+
+            harness.close()
+        }
+
+    @Test
+    fun `does not post when connection skips WaitingForUserConsent`() =
+        runTest {
+            val harness = harness()
+            harness.start()
+
+            val connection = harness.newConnection()
+            harness.activeConnections.tryEmit(connection)
+            advanceUntilIdle()
+
+            // Failure before consent is reached — coordinator must not
+            // post anything for this connection.
+            harness.transitionTo(connection, InboundConnectionState.Failed("UKEY2 BAD_VERSION"))
+            advanceUntilIdle()
+
+            assertThat(harness.sink.posted).isEmpty()
+            assertThat(harness.sink.dismissed).isEmpty()
+
+            harness.close()
+        }
+
+    @Test
+    fun `terminal cancellation after consent dismisses the notification`() =
+        runTest {
+            val harness = harness(idProvider = { 7L })
+            harness.start()
+
+            val connection = harness.newConnection()
+            harness.activeConnections.tryEmit(connection)
+            advanceUntilIdle()
+            harness.transitionTo(
+                connection,
+                InboundConnectionState.WaitingForUserConsent(metadata = sampleMetadata()),
+            )
+            advanceUntilIdle()
+
+            harness.transitionTo(connection, InboundConnectionState.Cancelled(CancelCause.PEER))
+            advanceUntilIdle()
+
+            assertThat(harness.sink.dismissed).containsExactly(7L)
+            assertThat(harness.registry.lookup(7L)).isNull()
+
+            harness.close()
+        }
+
+    @Test
+    fun `does not double-post when WaitingForUserConsent state is re-emitted`() =
+        runTest {
+            val harness = harness()
+            harness.start()
+
+            val connection = harness.newConnection()
+            harness.activeConnections.tryEmit(connection)
+            advanceUntilIdle()
+
+            val md1 = sampleMetadata(pin = "1111")
+            val md2 = sampleMetadata(pin = "2222")
+            // Two consent emissions back-to-back. The contract is: the
+            // first one posts, the second is suppressed because the
+            // notification is still up.
+            harness.transitionTo(connection, InboundConnectionState.WaitingForUserConsent(md1))
+            advanceUntilIdle()
+            harness.transitionTo(connection, InboundConnectionState.WaitingForUserConsent(md2))
+            advanceUntilIdle()
+
+            assertThat(harness.sink.posted).hasSize(1)
+            assertThat(
+                harness.sink.posted
+                    .single()
+                    .entry.pin,
+            ).isEqualTo("1111")
+
+            harness.close()
+        }
+
+    @Test
+    fun `entry's submitConsent forwards to the injected consentSubmitter`() =
+        runTest {
+            val recorded = mutableListOf<Boolean>()
+            val harness =
+                harness(
+                    idProvider = { 1L },
+                    consentSubmitter = { _ -> { accepted -> recorded += accepted } },
+                )
+            harness.start()
+
+            val connection = harness.newConnection()
+            harness.activeConnections.tryEmit(connection)
+            advanceUntilIdle()
+            harness.transitionTo(
+                connection,
+                InboundConnectionState.WaitingForUserConsent(metadata = sampleMetadata()),
+            )
+            advanceUntilIdle()
+
+            // Simulate the broadcast receiver path: it pulls the entry
+            // out of the registry and calls submitConsent.
+            val entry = harness.registry.lookup(1L)!!
+            entry.submitConsent(true)
+            assertThat(recorded).containsExactly(true)
+
+            harness.close()
+        }
+
+    private fun sampleMetadata(pin: String = "1234"): TransferMetadata =
+        TransferMetadata(
+            items = listOf(TransferItem.File(1L, "a.bin", 100L, "application/octet-stream")),
+            pin = pin,
+            sourceDeviceName = "Pixel",
+        )
+
+    private fun harness(
+        idProvider: () -> Long = AtomicLong(1)::getAndIncrement,
+        consentSubmitter: (InboundConnection) -> ((Boolean) -> Unit) = { conn -> conn::submitUserConsent },
+    ): Harness = Harness(idProvider, consentSubmitter)
+
+    /**
+     * Per-test fixture wiring up the coordinator against in-memory
+     * fakes. Tracks per-connection [MutableStateFlow]s in an
+     * [IdentityHashMap] so the same `InboundConnection` instance
+     * always sees the same flow back through the extractor.
+     */
+    private class Harness(
+        idProvider: () -> Long,
+        consentSubmitter: (InboundConnection) -> ((Boolean) -> Unit),
+    ) {
+        val activeConnections: MutableSharedFlow<InboundConnection> =
+            MutableSharedFlow(extraBufferCapacity = 8)
+        val results: MutableSharedFlow<InboundConnectionCompletion> =
+            MutableSharedFlow(extraBufferCapacity = 8)
+        val sink: RecordingSink = RecordingSink()
+        val registry: ConsentRegistry = ConsentRegistry()
+        private val flows: IdentityHashMap<InboundConnection, MutableStateFlow<InboundConnectionState>> =
+            IdentityHashMap()
+        private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+        private val coordinator: ConsentCoordinator =
+            ConsentCoordinator(
+                activeConnections = activeConnections.asSharedFlow(),
+                results = results.asSharedFlow(),
+                registry = registry,
+                sink = sink,
+                scope = scope,
+                connectionIdProvider = idProvider,
+                stateExtractor = { conn -> stateFor(conn) },
+                consentSubmitter = consentSubmitter,
+            )
+
+        fun start() {
+            coordinator.start()
+        }
+
+        fun newConnection(): InboundConnection = InboundConnection(socket = Socket())
+
+        fun transitionTo(
+            connection: InboundConnection,
+            state: InboundConnectionState,
+        ) {
+            mutableStateFor(connection).value = state
+        }
+
+        fun close() {
+            coordinator.stop()
+            scope.cancel()
+        }
+
+        private fun stateFor(connection: InboundConnection): StateFlow<InboundConnectionState> =
+            mutableStateFor(connection).asStateFlow()
+
+        private fun mutableStateFor(connection: InboundConnection): MutableStateFlow<InboundConnectionState> =
+            synchronized(flows) {
+                flows.getOrPut(connection) {
+                    MutableStateFlow(InboundConnectionState.Idle)
+                }
+            }
+    }
+
+    /**
+     * In-memory [ConsentCoordinator.Sink] that records every post /
+     * dismiss invocation in order. Tests assert against the lists.
+     */
+    private class RecordingSink : ConsentCoordinator.Sink {
+        data class Post(
+            val connectionId: Long,
+            val entry: ConsentRegistry.Entry,
+        )
+
+        val posted: MutableList<Post> = mutableListOf()
+        val dismissed: MutableList<Long> = mutableListOf()
+
+        override fun postConsent(
+            connectionId: Long,
+            entry: ConsentRegistry.Entry,
+        ) {
+            posted += Post(connectionId, entry)
+        }
+
+        override fun dismissConsent(connectionId: Long) {
+            dismissed += connectionId
+        }
+    }
+}

--- a/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentIntentsTest.kt
+++ b/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentIntentsTest.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.service.receiver.consent
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure-JVM tests for [ConsentIntents.parsePayload].
+ *
+ * The parser is the entire wire surface between the notification's
+ * `PendingIntent.getBroadcast` action and the
+ * [ConsentBroadcastReceiver]. Pinning these semantics keeps a
+ * future refactor of action strings / extra names from silently
+ * breaking the consent path.
+ *
+ * The tests use the [ConsentIntents.IntentLike] indirection rather
+ * than a real Android [android.content.Intent] so the file stays on
+ * plain Junit5.
+ */
+class ConsentIntentsTest {
+    @Test
+    fun `accept action with valid id parses to ACCEPT decision`() {
+        val payload = ConsentIntents.parsePayload(intent(ConsentIntents.ACTION_ACCEPT, 1L))
+        assertThat(payload).isNotNull()
+        assertThat(payload!!.decision).isEqualTo(ConsentIntents.Decision.ACCEPT)
+        assertThat(payload.connectionId).isEqualTo(1L)
+        assertThat(payload.accepted).isTrue()
+    }
+
+    @Test
+    fun `reject action with valid id parses to REJECT decision`() {
+        val payload = ConsentIntents.parsePayload(intent(ConsentIntents.ACTION_REJECT, 42L))
+        assertThat(payload).isNotNull()
+        assertThat(payload!!.decision).isEqualTo(ConsentIntents.Decision.REJECT)
+        assertThat(payload.accepted).isFalse()
+    }
+
+    @Test
+    fun `unknown action returns null payload`() {
+        val payload = ConsentIntents.parsePayload(intent("io.github.unknown.OTHER", 1L))
+        assertThat(payload).isNull()
+    }
+
+    @Test
+    fun `null action returns null payload`() {
+        val payload = ConsentIntents.parsePayload(intent(action = null, id = 1L))
+        assertThat(payload).isNull()
+    }
+
+    @Test
+    fun `missing connection id extra returns null payload`() {
+        // Sentinel value: intent with the action but no extra. The
+        // parser must distinguish "no extra" from "extra value
+        // happens to equal MISSING_CONNECTION_ID" — the only signal
+        // is the default returned by getLongExtra.
+        val payload =
+            ConsentIntents.parsePayload(
+                intent(action = ConsentIntents.ACTION_ACCEPT, id = ConsentIntents.MISSING_CONNECTION_ID),
+            )
+        assertThat(payload).isNull()
+    }
+
+    @Test
+    fun `accept action with show consent action returns null`() {
+        // ACTION_SHOW_CONSENT is an activity action, not a broadcast
+        // action; it must not be routed to the broadcast receiver
+        // through parsePayload.
+        val payload =
+            ConsentIntents.parsePayload(intent(ConsentIntents.ACTION_SHOW_CONSENT, 1L))
+        assertThat(payload).isNull()
+    }
+
+    private fun intent(
+        action: String?,
+        id: Long,
+    ): ConsentIntents.IntentLike =
+        object : ConsentIntents.IntentLike {
+            override val action: String? = action
+
+            override fun getLongExtra(
+                name: String,
+                default: Long,
+            ): Long =
+                if (name == ConsentIntents.EXTRA_CONNECTION_ID) {
+                    id
+                } else {
+                    default
+                }
+        }
+}

--- a/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentNotificationContentTest.kt
+++ b/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentNotificationContentTest.kt
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.service.receiver.consent
+
+import com.google.common.truth.Truth.assertThat
+import io.github.kyujincho.wvmg.protocol.connection.InboundConnection
+import io.github.kyujincho.wvmg.service.R
+import org.junit.jupiter.api.Test
+import java.net.Socket
+
+/**
+ * Pure-JVM tests for [ConsentNotificationContent.from].
+ *
+ * The textual content of the consent notification is the part most
+ * likely to drift between revisions (English copy edits, PIN format
+ * tweaks, action labels). Pinning the templating logic here lets the
+ * `:app` and `:service-android` UI layers evolve their strings
+ * independently without breaking the wire-up between
+ * [ConsentRegistry.Entry] and the rendered notification.
+ *
+ * The tests use a [TextResolver] stub so we never need a real
+ * Android `Resources` instance.
+ */
+class ConsentNotificationContentTest {
+    @Test
+    fun `title uses the device name when present`() {
+        val content =
+            ConsentNotificationContent.from(
+                resolver = englishResolver(),
+                entry = sampleEntry(deviceName = "Pixel 8"),
+            )
+        assertThat(content.title).isEqualTo("Pixel 8 wants to share")
+    }
+
+    @Test
+    fun `title falls back when device name is null`() {
+        val content =
+            ConsentNotificationContent.from(
+                resolver = englishResolver(),
+                entry = sampleEntry(deviceName = null),
+            )
+        assertThat(content.title).isEqualTo("A nearby device wants to share")
+    }
+
+    @Test
+    fun `title falls back when device name is blank`() {
+        val content =
+            ConsentNotificationContent.from(
+                resolver = englishResolver(),
+                entry = sampleEntry(deviceName = "   "),
+            )
+        assertThat(content.title).isEqualTo("A nearby device wants to share")
+    }
+
+    @Test
+    fun `body summarises item count, size, and PIN`() {
+        val content =
+            ConsentNotificationContent.from(
+                resolver = englishResolver(),
+                entry =
+                    sampleEntry(
+                        itemCount = 3,
+                        totalSize = 12L * 1024 * 1024,
+                        pin = "4242",
+                    ),
+            )
+        assertThat(content.body).contains("3 item(s)")
+        assertThat(content.body).contains("12.0 MB")
+        assertThat(content.body).contains("PIN 4242")
+    }
+
+    @Test
+    fun `body handles zero items gracefully`() {
+        val content =
+            ConsentNotificationContent.from(
+                resolver = englishResolver(),
+                entry = sampleEntry(itemCount = 0, totalSize = 0L, pin = "0000"),
+            )
+        assertThat(content.body).contains("no items")
+        assertThat(content.body).contains("PIN 0000")
+    }
+
+    @Test
+    fun `bigText repeats the PIN line when there is at least one item`() {
+        val content =
+            ConsentNotificationContent.from(
+                resolver = englishResolver(),
+                entry = sampleEntry(itemCount = 1, totalSize = 100L, pin = "1234"),
+            )
+        // bigText reuses the body and adds a verbatim PIN line for
+        // the expanded notification.
+        assertThat(content.bigText).contains("Confirm PIN: 1234")
+    }
+
+    @Test
+    fun `bigText omits the PIN repeat when there are no items`() {
+        val content =
+            ConsentNotificationContent.from(
+                resolver = englishResolver(),
+                entry = sampleEntry(itemCount = 0, totalSize = 0L, pin = "0000"),
+            )
+        assertThat(content.bigText).doesNotContain("Confirm PIN")
+    }
+
+    @Test
+    fun `accept and reject labels are populated`() {
+        val content =
+            ConsentNotificationContent.from(
+                resolver = englishResolver(),
+                entry = sampleEntry(),
+            )
+        assertThat(content.acceptLabel).isEqualTo("Accept")
+        assertThat(content.rejectLabel).isEqualTo("Reject")
+    }
+
+    @Test
+    fun `humanReadableSize handles bytes through gigabytes`() {
+        with(ConsentNotificationContent) {
+            assertThat(humanReadableSize(0)).isEqualTo("0 B")
+            assertThat(humanReadableSize(512)).isEqualTo("512 B")
+            assertThat(humanReadableSize(1024)).isEqualTo("1.0 KB")
+            assertThat(humanReadableSize(1024L * 1024)).isEqualTo("1.0 MB")
+            assertThat(humanReadableSize(1024L * 1024 * 1024)).isEqualTo("1.0 GB")
+            // Negative bytes never appear from a real proto, but
+            // defensively normalise to "0 B".
+            assertThat(humanReadableSize(-1)).isEqualTo("0 B")
+        }
+    }
+
+    private fun englishResolver(): TextResolver =
+        TextResolver { resourceId, args ->
+            when (resourceId) {
+                R.string.consent_notification_title_with_name ->
+                    String.format(java.util.Locale.ROOT, "%s wants to share", args[0])
+                R.string.consent_notification_title_unknown_sender ->
+                    "A nearby device wants to share"
+                R.string.consent_notification_summary_n_items ->
+                    String.format(java.util.Locale.ROOT, "%d item(s) (%s)", args[0], args[1])
+                R.string.consent_notification_summary_no_items -> "no items"
+                R.string.consent_notification_body ->
+                    String.format(java.util.Locale.ROOT, "%s · PIN %s", args[0], args[1])
+                R.string.consent_notification_bigtext_pin_line ->
+                    String.format(java.util.Locale.ROOT, "Confirm PIN: %s", args[0])
+                R.string.consent_notification_action_accept -> "Accept"
+                R.string.consent_notification_action_reject -> "Reject"
+                else -> error("Unmocked resource id: $resourceId")
+            }
+        }
+
+    private fun sampleEntry(
+        deviceName: String? = "Pixel",
+        pin: String = "1234",
+        itemCount: Int = 1,
+        totalSize: Long = 1024L,
+    ): ConsentRegistry.Entry =
+        ConsentRegistry.Entry(
+            connection = InboundConnection(socket = Socket()),
+            sourceDeviceName = deviceName,
+            pin = pin,
+            itemCount = itemCount,
+            totalSize = totalSize,
+        )
+}

--- a/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentRegistryTest.kt
+++ b/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentRegistryTest.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.service.receiver.consent
+
+import com.google.common.truth.Truth.assertThat
+import io.github.kyujincho.wvmg.protocol.connection.InboundConnection
+import org.junit.jupiter.api.Test
+import java.net.Socket
+
+/**
+ * Pure-JVM tests for [ConsentRegistry].
+ *
+ * The registry is the rendezvous between the consent notification
+ * surface and the `BroadcastReceiver` that fires `submitUserConsent`,
+ * so the contract worth pinning here is the basic register / lookup /
+ * unregister set-semantics plus the snapshot helper.
+ *
+ * No real `InboundConnection` lifecycle is exercised — we just need an
+ * unstarted instance for identity comparisons. The connection's
+ * `submitUserConsent` is a no-op when the channel is unstarted, so
+ * accidentally invoking it on a registry-resident connection in a
+ * later test would still be safe.
+ */
+class ConsentRegistryTest {
+    @Test
+    fun `register stores entries that can be looked up by id`() {
+        val registry = ConsentRegistry()
+        val entry = sampleEntry(deviceName = "Pixel 8", pin = "1234")
+
+        registry.register(connectionId = 7, entry = entry)
+
+        assertThat(registry.lookup(7)).isEqualTo(entry)
+        assertThat(registry.lookup(8)).isNull()
+    }
+
+    @Test
+    fun `register replaces a prior entry under the same id and returns the previous one`() {
+        val registry = ConsentRegistry()
+        val first = sampleEntry(pin = "1111")
+        val second = sampleEntry(pin = "2222")
+
+        assertThat(registry.register(connectionId = 1, entry = first)).isNull()
+        val replaced = registry.register(connectionId = 1, entry = second)
+
+        assertThat(replaced).isEqualTo(first)
+        assertThat(registry.lookup(1)).isEqualTo(second)
+    }
+
+    @Test
+    fun `unregister removes the entry and returns it`() {
+        val registry = ConsentRegistry()
+        val entry = sampleEntry()
+        registry.register(connectionId = 42, entry = entry)
+
+        val removed = registry.unregister(42)
+
+        assertThat(removed).isEqualTo(entry)
+        assertThat(registry.lookup(42)).isNull()
+    }
+
+    @Test
+    fun `unregister on an unknown id returns null without raising`() {
+        val registry = ConsentRegistry()
+        assertThat(registry.unregister(0xDEAD_BEEF)).isNull()
+    }
+
+    @Test
+    fun `snapshotIds returns a defensive copy of all registered ids`() {
+        val registry = ConsentRegistry()
+        registry.register(1, sampleEntry())
+        registry.register(2, sampleEntry())
+        registry.register(3, sampleEntry())
+
+        val snapshot = registry.snapshotIds()
+
+        assertThat(snapshot).containsExactly(1L, 2L, 3L)
+        // Mutating the registry must not mutate the snapshot.
+        registry.unregister(2)
+        assertThat(snapshot).containsExactly(1L, 2L, 3L)
+    }
+
+    @Test
+    fun `singleton instance is process-wide and shared across lookups`() {
+        // The instance is a public field; this test pins that it is
+        // genuinely process-wide rather than a per-lookup factory.
+        assertThat(ConsentRegistry.instance).isSameInstanceAs(ConsentRegistry.instance)
+    }
+
+    private fun sampleEntry(
+        deviceName: String? = "Test Phone",
+        pin: String = "9999",
+        itemCount: Int = 1,
+        totalSize: Long = 1024L,
+    ): ConsentRegistry.Entry =
+        ConsentRegistry.Entry(
+            connection = InboundConnection(socket = Socket()),
+            sourceDeviceName = deviceName,
+            pin = pin,
+            itemCount = itemCount,
+            totalSize = totalSize,
+        )
+}

--- a/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentRouterTest.kt
+++ b/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentRouterTest.kt
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.service.receiver.consent
+
+import com.google.common.truth.Truth.assertThat
+import io.github.kyujincho.wvmg.protocol.connection.InboundConnection
+import org.junit.jupiter.api.Test
+import java.net.Socket
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Pure-JVM tests for [ConsentRouter.dispatch].
+ *
+ * The router is the bridge between the parsed
+ * [ConsentIntents.Payload] and the live
+ * [io.github.kyujincho.wvmg.protocol.connection.InboundConnection] in
+ * [ConsentRegistry]. The full lifecycle of an `InboundConnection` is
+ * exercised in `:core-protocol`'s tests; here we only need to
+ * confirm:
+ *
+ *  1. Accept / Reject on a registered id reaches submitConsent with
+ *     the correct boolean.
+ *  2. The registry entry is removed after dispatch so a duplicate
+ *     broadcast is a no-op.
+ *  3. Unknown ids and unknown actions silently drop.
+ *  4. The optional onConsentSubmitted hook fires exactly once on
+ *     successful dispatch.
+ *
+ * The router consults `Entry.submitConsent` (a `(Boolean) -> Unit`
+ * lambda) rather than `entry.connection.submitUserConsent` directly,
+ * so we inject a recording lambda — `InboundConnection` itself stays
+ * a real (unstarted) instance for identity assertions.
+ */
+class ConsentRouterTest {
+    @Test
+    fun `accept dispatches submitConsent(true) and unregisters`() {
+        val registry = ConsentRegistry()
+        val recorded = mutableListOf<Boolean>()
+        registry.register(connectionId = 5, entry = sampleEntry(submit = recorded::add))
+        val hookFires = AtomicInteger(0)
+
+        ConsentRouter.dispatch(
+            intent = intent(ConsentIntents.ACTION_ACCEPT, 5L),
+            registry = registry,
+            onConsentSubmitted = { hookFires.incrementAndGet() },
+        )
+
+        assertThat(recorded).containsExactly(true)
+        assertThat(registry.lookup(5)).isNull()
+        assertThat(hookFires.get()).isEqualTo(1)
+    }
+
+    @Test
+    fun `reject dispatches submitConsent(false) and unregisters`() {
+        val registry = ConsentRegistry()
+        val recorded = mutableListOf<Boolean>()
+        registry.register(connectionId = 5, entry = sampleEntry(submit = recorded::add))
+
+        ConsentRouter.dispatch(
+            intent = intent(ConsentIntents.ACTION_REJECT, 5L),
+            registry = registry,
+        )
+
+        assertThat(recorded).containsExactly(false)
+        assertThat(registry.lookup(5)).isNull()
+    }
+
+    @Test
+    fun `dispatch on an unregistered id is a no-op`() {
+        val registry = ConsentRegistry()
+        val hookFires = AtomicInteger(0)
+
+        ConsentRouter.dispatch(
+            intent = intent(ConsentIntents.ACTION_ACCEPT, 99L),
+            registry = registry,
+            onConsentSubmitted = { hookFires.incrementAndGet() },
+        )
+
+        assertThat(hookFires.get()).isEqualTo(0)
+    }
+
+    @Test
+    fun `dispatch with unrecognised action is a no-op`() {
+        val registry = ConsentRegistry()
+        val recorded = mutableListOf<Boolean>()
+        registry.register(connectionId = 1, entry = sampleEntry(submit = recorded::add))
+
+        ConsentRouter.dispatch(
+            intent = intent("io.github.bogus", 1L),
+            registry = registry,
+        )
+
+        // No consent submitted, registration intact.
+        assertThat(recorded).isEmpty()
+        assertThat(registry.lookup(1)).isNotNull()
+    }
+
+    @Test
+    fun `duplicate dispatch is filtered after the first call unregisters`() {
+        // The classic stale-PendingIntent scenario: the user
+        // double-taps the action button before the system can
+        // dismiss it. We expect exactly one submitConsent call.
+        val registry = ConsentRegistry()
+        val recorded = mutableListOf<Boolean>()
+        registry.register(connectionId = 7, entry = sampleEntry(submit = recorded::add))
+
+        ConsentRouter.dispatch(intent(ConsentIntents.ACTION_ACCEPT, 7L), registry)
+        ConsentRouter.dispatch(intent(ConsentIntents.ACTION_ACCEPT, 7L), registry)
+
+        assertThat(recorded).containsExactly(true)
+    }
+
+    private fun sampleEntry(submit: (Boolean) -> Unit): ConsentRegistry.Entry =
+        ConsentRegistry.Entry(
+            connection = InboundConnection(socket = Socket()),
+            sourceDeviceName = "Test",
+            pin = "1234",
+            itemCount = 1,
+            totalSize = 1L,
+            submitConsent = submit,
+        )
+
+    private fun intent(
+        action: String?,
+        id: Long,
+    ): ConsentIntents.IntentLike =
+        object : ConsentIntents.IntentLike {
+            override val action: String? = action
+
+            override fun getLongExtra(
+                name: String,
+                default: Long,
+            ): Long =
+                if (name == ConsentIntents.EXTRA_CONNECTION_ID) {
+                    id
+                } else {
+                    default
+                }
+        }
+}


### PR DESCRIPTION
## Summary

Implements #22 — the receiver-side consent UI that surfaces incoming Quick Share transfers to the user as soon as the inbound connection FSM reaches `WaitingForUserConsent`.

Two layers, designed to work whether the screen is on, off, or the device is locked:

- **Layer 1 — high-importance heads-up notification** on a new `incoming_transfer` channel (`IMPORTANCE_HIGH`). Each pending consent gets its own stable notification id derived from the connection id so multiple in-flight transfers each get their own heads-up. Accept / Reject `Notification.Action`s fire `PendingIntent.getBroadcast` to a dynamically-registered `ConsentBroadcastReceiver` (`RECEIVER_NOT_EXPORTED`) which calls `inboundConnection.submitUserConsent(true|false)` via a process-wide `ConsentRegistry`.
- **Layer 2 — trampoline activity** opened by tapping the notification body (and via `setFullScreenIntent`). Uses `setShowWhenLocked(true) + setTurnScreenOn(true)` on API 27+ — same UX as an incoming call. Renders sender device name, file list with sizes, the 4-digit PIN, and Accept / Reject buttons that route through the same `ConsentRegistry`. Dismissing the activity does **not** auto-reject (matches the issue acceptance criteria).

The `ConsentCoordinator` subscribes to `ReceiverSession.activeConnections` (newly mirrored from `TcpReceiverServer`) and posts / dismisses notifications based on each connection's per-state observer; a results-flow safety net cleans up if the per-connection observer was cancelled before reaching a terminal state.

The sender's device name is now decoded from the peer's `endpoint_info` in the unencrypted `ConnectionRequest` and surfaced as a new optional `TransferMetadata.sourceDeviceName` field — backwards-compatible for existing callers.

## Implementation notes

- `:core-protocol`: optional `sourceDeviceName` on `TransferMetadata` + driver wiring.
- `:service-android`: `consent` package containing `ConsentRegistry`, `ConsentIntents` (with the pure-JVM `IntentLike` and `parsePayload` extractor), `ConsentBroadcastReceiver`, `ConsentRouter`, `ConsentNotification` + `ConsentNotificationContent` builder, and `ConsentCoordinator`. `ReceiverForegroundService` registers the broadcast receiver dynamically with `RECEIVER_NOT_EXPORTED`, ensures both notification channels, starts the coordinator, and tears every pending consent + notification down on stop.
- `:app`: `ConsentTrampolineActivity` plus a new `WvmgApplication` that wires the activity class into the `:service-android` consent target slot.

## Test plan

- [x] `:core-protocol:test` — passes (no regression on `TransferMetadata.fromIntroductionFrame` or the inbound driver).
- [x] `:service-android:testDebugUnitTest` — passes; new pure-JVM coverage for the registry, intent parser, router, notification content builder, and coordinator choreography.
- [x] `:app:testDebugUnitTest` — passes.
- [x] `:service-android:ktlintCheck` / `:service-android:detekt` — pass.
- [x] `:app:ktlintCheck` / `:app:detekt` / `:app:lintDebug` — pass.
- [ ] End-to-end pairing with a real `InboundConnection` over a socket is deferred to #28 per the issue body's "Do NOT write end-to-end tests" guidance.

Closes #22.