### PR TITLE
feat: render QR code as a bitmap in ShowQrActivity (#84)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,5 +35,8 @@ jobs:
       - name: Run :core-protocol JVM tests
         run: ./gradlew :core-protocol:test --stacktrace
 
+      - name: Run :app JVM unit tests
+        run: ./gradlew :app:testDebugUnitTest --stacktrace
+
       - name: Assemble debug APK
         run: ./gradlew :app:assembleDebug --stacktrace

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -67,6 +67,12 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.kotlinx.coroutines.android)
 
+    // ZXing core — pure-Java QR encoder used to render the Quick Share QR
+    // URL as a scannable bitmap on ShowQrActivity (#84). Only the encoder
+    // (`QRCodeWriter`) is pulled in; the Android camera/scanner side of
+    // ZXing (`zxing-android-embedded`) is intentionally not used.
+    implementation(libs.zxing.core)
+
     testImplementation(libs.junit4)
     androidTestImplementation(libs.androidx.test.junit)
     androidTestImplementation(libs.androidx.test.espresso.core)

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/send/QrBitmapRenderer.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/send/QrBitmapRenderer.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.send
+
+import android.graphics.Bitmap
+import android.graphics.Color
+
+/**
+ * Android-only adapter that renders the BitMatrix produced by
+ * [QrMatrix.encode] into a [Bitmap] suitable for display in an
+ * `ImageView`.
+ *
+ * This file is deliberately *thin*: all the validation and ZXing wiring
+ * lives in [QrMatrix] (pure JVM, fully testable). The only Android-
+ * specific concern here is allocating the [Bitmap] and blitting the
+ * matrix into it — kept minimal so the Android-only surface is small
+ * enough to be left untested without losing meaningful coverage.
+ *
+ * Performance note: a naive per-cell `setPixel(x, y, color)` loop is
+ * orders of magnitude slower than building an `IntArray` row-by-row and
+ * pushing it via `setPixels(...)` in a single call. For a 800×800
+ * bitmap (typical phone QR display size) the difference is roughly
+ * "imperceptible" vs. "noticeable jank" on mid-range hardware, so we
+ * use the bulk-blit path.
+ */
+public object QrBitmapRenderer {
+    /**
+     * Render [content] as a square QR-code [Bitmap] of [size]×[size]
+     * pixels.
+     *
+     * Dark cells map to [Color.BLACK]; light cells map to [Color.WHITE].
+     * The returned bitmap uses [Bitmap.Config.ARGB_8888] — overkill for
+     * a strictly two-colour image, but it is the most broadly compatible
+     * config and keeps the code straightforward.
+     *
+     * @param content URL or arbitrary string to encode. Must be non-empty.
+     * @param size Edge length of the resulting square bitmap, in pixels.
+     *   Must be strictly positive.
+     * @throws IllegalArgumentException if [content] is empty or [size]
+     *   is non-positive (validated by [QrMatrix.encode]).
+     */
+    public fun render(
+        content: String,
+        size: Int,
+    ): Bitmap {
+        val matrix = QrMatrix.encode(content, size)
+        val width = matrix.width
+        val height = matrix.height
+
+        // Build the pixel buffer in one pass and push it to the bitmap
+        // via a single setPixels(...) call. This is dramatically faster
+        // than per-cell setPixel() — see class docs for the rationale.
+        val pixels = IntArray(width * height)
+        for (y in 0 until height) {
+            val rowOffset = y * width
+            for (x in 0 until width) {
+                pixels[rowOffset + x] = if (matrix.get(x, y)) Color.BLACK else Color.WHITE
+            }
+        }
+
+        val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+        bitmap.setPixels(pixels, 0, width, 0, 0, width, height)
+        return bitmap
+    }
+}

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/send/QrMatrix.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/send/QrMatrix.kt
@@ -39,6 +39,15 @@ public object QrMatrix {
     public val DEFAULT_ERROR_CORRECTION: ErrorCorrectionLevel = ErrorCorrectionLevel.M
 
     /**
+     * Quiet-zone width around the QR symbol, in modules. The QR spec
+     * mandates 4 modules of light margin for reliable decoding by
+     * stock camera apps; this matches ZXing's default but is set
+     * explicitly to keep the decoder-friendly margin visible at this
+     * seam.
+     */
+    private const val QUIET_ZONE_MODULES: Int = 4
+
+    /**
      * Encode [content] as a QR-code [BitMatrix] of the requested pixel
      * dimensions.
      *
@@ -70,10 +79,12 @@ public object QrMatrix {
                 // Quick Share URLs are pure ASCII; pinning the charset
                 // keeps the encoded byte segments deterministic.
                 EncodeHintType.CHARACTER_SET to "UTF-8",
-                // Standard 4-module quiet zone. ZXing defaults to 4
-                // already, but we set it explicitly to make the
-                // decoder-friendly margin visible at this seam.
-                EncodeHintType.MARGIN to 1,
+                // Standard 4-module quiet zone — required by the QR
+                // spec for reliable decoding by stock camera apps. We
+                // set it explicitly rather than relying on the ZXing
+                // default to make the decoder-friendly margin visible
+                // at this seam.
+                EncodeHintType.MARGIN to QUIET_ZONE_MODULES,
             )
 
         return QRCodeWriter().encode(content, BarcodeFormat.QR_CODE, size, size, hints)

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/send/QrMatrix.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/send/QrMatrix.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.send
+
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.EncodeHintType
+import com.google.zxing.common.BitMatrix
+import com.google.zxing.qrcode.QRCodeWriter
+import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel
+
+/**
+ * Pure-JVM half of the QR-bitmap rendering pipeline used by
+ * [ShowQrActivity] (#84).
+ *
+ * Splitting the pipeline into a [BitMatrix]-producing helper (this file,
+ * pure JVM, fully testable on a host JVM) and a separate `BitMatrix → Bitmap`
+ * adapter ([QrBitmapRenderer], Android-only) keeps the testable surface
+ * as wide as possible: argument validation, ZXing wiring, and the chosen
+ * error-correction level can all be exercised without Robolectric.
+ *
+ * The Android-only adapter is intentionally a thin pixel-blit; once the
+ * pure-JVM [encode] step has produced a correct [BitMatrix], the only
+ * thing that can still go wrong on-device is allocating a [Bitmap] of the
+ * right size — and that is well-trodden Android territory.
+ */
+public object QrMatrix {
+    /**
+     * Default ZXing error-correction level used for the Quick Share QR.
+     *
+     * `M` (~15% recovery) is the conventional pick for short URLs shown
+     * on a phone screen — the URL fits well below the version-cap at this
+     * level, and `M` gives the receiver's camera enough redundancy to
+     * decode through glare and modest screen smudging without bloating
+     * the module count.
+     */
+    public val DEFAULT_ERROR_CORRECTION: ErrorCorrectionLevel = ErrorCorrectionLevel.M
+
+    /**
+     * Encode [content] as a QR-code [BitMatrix] of the requested pixel
+     * dimensions.
+     *
+     * @param content The string to encode. Must be non-empty — ZXing
+     *   throws an opaque `WriterException` for empty input, so we
+     *   validate up front for a clearer error.
+     * @param size The desired bitmap edge length in pixels (square).
+     *   Must be strictly positive.
+     * @param errorCorrection Error-correction level. Defaults to
+     *   [DEFAULT_ERROR_CORRECTION].
+     * @return A [BitMatrix] where `matrix[x, y] == true` means the cell
+     *   should be drawn dark (foreground) and `false` means light
+     *   (background).
+     * @throws IllegalArgumentException if [content] is empty or [size]
+     *   is non-positive.
+     */
+    public fun encode(
+        content: String,
+        size: Int,
+        errorCorrection: ErrorCorrectionLevel = DEFAULT_ERROR_CORRECTION,
+    ): BitMatrix {
+        require(content.isNotEmpty()) { "QR content must be non-empty" }
+        require(size > 0) { "QR size must be positive, got $size" }
+
+        val hints =
+            mapOf<EncodeHintType, Any>(
+                // Recovery level — see DEFAULT_ERROR_CORRECTION docs.
+                EncodeHintType.ERROR_CORRECTION to errorCorrection,
+                // Quick Share URLs are pure ASCII; pinning the charset
+                // keeps the encoded byte segments deterministic.
+                EncodeHintType.CHARACTER_SET to "UTF-8",
+                // Standard 4-module quiet zone. ZXing defaults to 4
+                // already, but we set it explicitly to make the
+                // decoder-friendly margin visible at this seam.
+                EncodeHintType.MARGIN to 1,
+            )
+
+        return QRCodeWriter().encode(content, BarcodeFormat.QR_CODE, size, size, hints)
+    }
+}

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/send/ShowQrActivity.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/send/ShowQrActivity.kt
@@ -10,29 +10,24 @@ import androidx.appcompat.app.AppCompatActivity
 import io.github.kyujincho.wvmg.databinding.ActivityShowQrBinding
 import io.github.kyujincho.wvmg.protocol.qr.QrKeyData
 import io.github.kyujincho.wvmg.protocol.qr.QrUrl
+import kotlin.math.min
 
 /**
- * Renders the Quick Share QR-code URL produced by [QrUrl.build] (#20).
+ * Renders the Quick Share QR-code URL produced by [QrUrl.build] (#20)
+ * as a scannable QR bitmap (#84).
  *
- * **Phase 1 stub.** The protocol-side QR-code path (key generation, URL
- * encoding, advertising-token derivation) is fully implemented in
- * `:core-protocol`, but zxing — the standard Android QR-bitmap library
- * — is not yet on the dependency graph. Adding it pulls in ~200 KB of
- * additional code and is out of scope for #24, whose acceptance
- * criteria explicitly say the QR-bitmap renderer can be stubbed as
- * long as the URL is surfaced.
+ * Flow on every screen entry:
  *
- * What we do today:
- *
- *  - Generate a fresh ECDSA P-256 keypair on every screen entry via
- *    [QrKeyData.generate].
+ *  - Generate a fresh ECDSA P-256 keypair via [QrKeyData.generate].
  *  - Build the canonical Quick Share URL with [QrUrl.build].
- *  - Display the URL as monospace selectable text.
+ *  - Encode the URL as a QR-code [android.graphics.Bitmap] via
+ *    [QrBitmapRenderer.render], sized to ~75% of the shorter screen
+ *    edge so it stays square on both portrait and landscape.
+ *  - Surface the URL verbatim as monospace selectable text below the
+ *    bitmap as a copy/paste fallback.
  *
- * What still needs to land before this is production-ready (tracked in
- * a follow-up — see issue #28's wiring scope):
+ * Wiring still pending (tracked separately, see #28's wiring scope):
  *
- *  - Render the URL as an actual QR bitmap (zxing or similar).
  *  - Surface the keypair + advertising token to a discovery layer that
  *    the receiver can match against (the QR-handshake-data
  *    `pairing-token` flow in `:core-protocol`).
@@ -57,10 +52,29 @@ public class ShowQrActivity : AppCompatActivity() {
         val url = QrUrl.build(generated.qrKeyData)
         binding.showQrUrl.text = url
 
-        // Followup #28 will render `url` via zxing (or comparable) once
-        // the dependency graph is updated. See the class-level docs for
-        // the rationale and the wiring scope tracked in #28.
+        // Size the QR bitmap to ~75% of the shorter screen edge so it
+        // stays square and proportionally large in both portrait and
+        // landscape, without crowding the title/URL/button below it.
+        val displayMetrics = resources.displayMetrics
+        val qrSize = (min(displayMetrics.widthPixels, displayMetrics.heightPixels) * QR_SCREEN_FRACTION).toInt()
+
+        val bitmap = QrBitmapRenderer.render(url, qrSize)
+        binding.showQrBitmap.setImageBitmap(bitmap)
+        binding.showQrBitmap.layoutParams =
+            binding.showQrBitmap.layoutParams.apply {
+                width = qrSize
+                height = qrSize
+            }
 
         binding.showQrDone.setOnClickListener { finish() }
+    }
+
+    private companion object {
+        /**
+         * Fraction of the shorter screen edge to use for the QR bitmap.
+         * Per the issue acceptance criteria — "square, ~75% of the
+         * shorter screen edge".
+         */
+        private const val QR_SCREEN_FRACTION: Double = 0.75
     }
 }

--- a/app/src/main/res/layout/activity_show_qr.xml
+++ b/app/src/main/res/layout/activity_show_qr.xml
@@ -1,11 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  QR-code display screen launched from SendActivity (#24 + #20).
+  QR-code display screen launched from SendActivity (#24 + #20 + #84).
 
-  Phase 1 stub: zxing isn't on the dependency graph yet, so we render
-  the QR URL as monospace text. The receiver-side flow that pairs with
-  this URL is not yet wired in (#28 brings the e2e wiring), so the
-  Phase 1 build only needs to surface the URL.
+  Renders the canonical Quick Share QR URL (built by `QrUrl.build`) as a
+  scannable bitmap via ZXing (#84). The URL is also surfaced verbatim as
+  monospace selectable text directly below the bitmap so the user can
+  copy/share it as a fallback when QR scanning is not an option.
+
+  Layout shape: vertical LinearLayout — title, intro, square QR ImageView
+  (~75% of the shorter screen edge, sized programmatically by
+  ShowQrActivity), monospace selectable URL TextView, OK/Done button.
+  Wrapped in a ScrollView so the OK button is always reachable on small
+  screens / large font scales.
 -->
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
@@ -31,6 +37,21 @@
             android:layout_marginTop="8dp"
             android:text="@string/show_qr_intro"
             android:textAppearance="@style/TextAppearance.AppCompat.Body1" />
+
+        <!--
+          Square QR bitmap. Width/height are set programmatically by
+          ShowQrActivity to ~75% of the shorter screen edge. The default
+          values here keep the preview looking sensible in Layout
+          Editor; they are overridden at runtime.
+        -->
+        <ImageView
+            android:id="@+id/show_qr_bitmap"
+            android:layout_width="240dp"
+            android:layout_height="240dp"
+            android:layout_marginTop="24dp"
+            android:layout_gravity="center_horizontal"
+            android:contentDescription="@string/show_qr_image_description"
+            android:background="@android:color/white" />
 
         <TextView
             android:id="@+id/show_qr_url"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,9 +58,10 @@
     <string name="send_status_failure_reason">Reason: %1$s</string>
     <string name="send_status_progress">%1$s of %2$s</string>
 
-    <!-- QR-code (#20) screen. -->
+    <!-- QR-code (#20 + #84) screen. -->
     <string name="show_qr_title">Scan from receiver</string>
-    <string name="show_qr_intro">Have the receiver scan this code (or copy the URL) to pair without manual selection. The QR bitmap renderer is not yet wired up — paste this URL on the receiver side instead.</string>
+    <string name="show_qr_intro">Have the receiver scan this code to pair without manual selection. If their camera cannot read it, copy the URL below as a fallback.</string>
+    <string name="show_qr_image_description">QR code for the Quick Share pairing URL</string>
     <string name="show_qr_done">Done</string>
 
     <!-- Consent trampoline (#22). -->

--- a/app/src/test/kotlin/io/github/kyujincho/wvmg/send/QrMatrixTest.kt
+++ b/app/src/test/kotlin/io/github/kyujincho/wvmg/send/QrMatrixTest.kt
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.send
+
+import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-JVM tests for [QrMatrix].
+ *
+ * The QR-bitmap pipeline used by [ShowQrActivity] (#84) is split into:
+ *
+ *  - [QrMatrix.encode] — pure JVM, returns a ZXing `BitMatrix`. Tested
+ *    here because it is the half that does all the validation, hint
+ *    wiring, and ZXing invocation — i.e. everything that can plausibly
+ *    go wrong on the encode side.
+ *  - [QrBitmapRenderer.render] — Android-only adapter (requires
+ *    `android.graphics.Bitmap`). A thin pixel-blit; left untested
+ *    because the only failure mode is bitmap allocation, which is
+ *    well-trodden Android territory and would require Robolectric to
+ *    exercise on a host JVM.
+ *
+ * We do **not** verify the encoded matrix decodes back to the original
+ * URL: doing so would require running ZXing's decoder against a
+ * camera-style luminance source, which is overkill for verifying that
+ * "we asked ZXing to encode something and it did". The tests below
+ * cover dimensions, argument validation, and that a typical Quick
+ * Share URL doesn't trip the encoder.
+ */
+class QrMatrixTest {
+    /**
+     * Sample URL shaped like the real Quick Share QR URL produced by
+     * [io.github.kyujincho.wvmg.protocol.qr.QrUrl.build]. Length is
+     * representative (~85 chars), so this exercises the encoder at the
+     * payload size we'll see in production.
+     */
+    private val sampleUrl: String =
+        "https://quickshare.google/qrcode#key=" +
+            "AkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQg"
+
+    @Test
+    fun `encode produces a square BitMatrix at the requested size`() {
+        // QR codes are always square; ZXing pads/scales to the requested
+        // dimensions when both are equal and >= the natural module count.
+        val size = 256
+        val matrix = QrMatrix.encode(sampleUrl, size)
+
+        assertEquals(size, matrix.width)
+        assertEquals(size, matrix.height)
+    }
+
+    @Test
+    fun `encode produces a non-blank matrix for a typical URL`() {
+        // A blank matrix would mean ZXing silently returned an empty
+        // canvas. We check that at least one cell is dark — a real QR
+        // code has roughly 50% dark cells, so this is a very loose
+        // sanity gate.
+        val matrix = QrMatrix.encode(sampleUrl, 200)
+
+        var anyDark = false
+        outer@ for (y in 0 until matrix.height) {
+            for (x in 0 until matrix.width) {
+                if (matrix.get(x, y)) {
+                    anyDark = true
+                    break@outer
+                }
+            }
+        }
+        assertTrue("encoded matrix must contain at least one dark cell", anyDark)
+    }
+
+    @Test
+    fun `encode honours a custom error-correction level`() {
+        // Just verify the parameter is plumbed through — encoding under
+        // L vs H usually changes the module count, but at a fixed pixel
+        // size (200) ZXing scales both to the same dimensions, so we
+        // can't verify visually. Instead we make sure both calls succeed
+        // and produce same-sized matrices.
+        val low = QrMatrix.encode(sampleUrl, 200, ErrorCorrectionLevel.L)
+        val high = QrMatrix.encode(sampleUrl, 200, ErrorCorrectionLevel.H)
+
+        assertEquals(200, low.width)
+        assertEquals(200, high.width)
+    }
+
+    @Test
+    fun `encode rejects empty content`() {
+        // ZXing throws WriterException on empty input with an opaque
+        // message. We validate up front so callers get a clearer
+        // IllegalArgumentException with a stable message.
+        val ex =
+            assertThrows(IllegalArgumentException::class.java) {
+                QrMatrix.encode("", 200)
+            }
+        assertTrue(
+            "error message should mention non-empty: ${ex.message}",
+            ex.message?.contains("non-empty") == true,
+        )
+    }
+
+    @Test
+    fun `encode rejects non-positive size`() {
+        // size <= 0 is meaningless — ZXing would also reject it but
+        // with a NegativeArraySizeException or similar. We surface a
+        // proper IAE.
+        assertThrows(IllegalArgumentException::class.java) {
+            QrMatrix.encode(sampleUrl, 0)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            QrMatrix.encode(sampleUrl, -5)
+        }
+    }
+
+    @Test
+    fun `encode is deterministic for identical inputs`() {
+        // Determinism matters: two ShowQrActivity launches with the
+        // same URL (e.g. screen rotation) should render bit-for-bit
+        // identical bitmaps so any framing/contrast tweaks made on the
+        // receiver's camera don't reset between attempts.
+        val first = QrMatrix.encode(sampleUrl, 128)
+        val second = QrMatrix.encode(sampleUrl, 128)
+
+        assertEquals(first.width, second.width)
+        assertEquals(first.height, second.height)
+        for (y in 0 until first.height) {
+            for (x in 0 until first.width) {
+                assertEquals(
+                    "matrix mismatch at ($x,$y)",
+                    first.get(x, y),
+                    second.get(x, y),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `encode handles a long URL without throwing`() {
+        // Sanity check: even at the upper end of plausible Quick Share
+        // URL lengths, the encoder should still produce a valid matrix
+        // (ZXing automatically picks a higher QR version as needed).
+        val longUrl = "https://quickshare.google/qrcode#key=" + "A".repeat(200)
+        val matrix = QrMatrix.encode(longUrl, 256)
+
+        assertEquals(256, matrix.width)
+        assertEquals(256, matrix.height)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,13 @@ tink = "1.15.0"
 # and is the version used by recent third-party Quick Share / NearDrop ports.
 jmdns = "3.5.12"
 
+# ZXing (used by :app to render the Quick Share QR-code URL as a scannable
+# bitmap on the sender's screen, see #84). 3.5.3 is the current stable
+# release of the pure-Java `core` artifact; the Android-flavoured
+# `zxing-android-embedded` is intentionally NOT pulled in because we only
+# need the encoder side (BitMatrix → Bitmap conversion is trivial).
+zxingCore = "3.5.3"
+
 # Testing
 junit4 = "4.13.2"
 junitJupiter = "5.11.3"
@@ -67,6 +74,13 @@ tink-android = { module = "com.google.crypto.tink:tink-android", version.ref = "
 # bits) so the publish/browse logic can also be exercised in unit tests
 # on a host JVM.
 jmdns = { module = "org.jmdns:jmdns", version.ref = "jmdns" }
+
+# ZXing core — pure-Java QR encoder/decoder. Used by :app to render the
+# Quick Share QR URL as a scannable bitmap (#84). Pure JVM (no Android
+# imports) so the BitMatrix-producer half of the rendering pipeline is
+# unit-testable on a host JVM; only the BitMatrix → Bitmap adapter
+# touches Android types.
+zxing-core = { module = "com.google.zxing:core", version.ref = "zxingCore" }
 
 # Testing
 junit4 = { module = "junit:junit", version.ref = "junit4" }


### PR DESCRIPTION
## Summary

Closes #84.

`ShowQrActivity` previously rendered the canonical Quick Share QR URL
(`https://quickshare.google/qrcode#key=...`) as monospace selectable
text only — a stock Android camera could not pair from it. This PR
ships the real bitmap renderer:

- **Vendored ZXing core 3.5.3** via the version catalog (`zxing-core`),
  pulled in as an `implementation` dependency of `:app`. The
  Android-flavoured `zxing-android-embedded` is intentionally not
  used; only the encoder side is needed.
- **Two-stage rendering pipeline** in `:app/.../send/`:
  - `QrMatrix.encode(content, size)` — pure-JVM helper that wraps
    `QRCodeWriter` with explicit hints (error-correction level `M`,
    UTF-8, 4-module quiet zone) and validates input. Fully testable
    on a host JVM.
  - `QrBitmapRenderer.render(content, size)` — Android-only adapter
    that blits the `BitMatrix` into an `ARGB_8888` `Bitmap` via a
    single `setPixels(...)` call.
- **`ShowQrActivity` now renders the bitmap** above the existing
  monospace selectable URL `TextView` (kept as a copy/paste fallback)
  and the OK/Done button. Size is `(min(width, height) * 0.75).toInt()`
  per the issue acceptance criteria.
- **CI runs `:app:testDebugUnitTest`** so the new pure-JVM tests gate
  the build alongside `:core-protocol:test`.

## Implementation notes

The split between `QrMatrix` (pure JVM) and `QrBitmapRenderer`
(Android-only) keeps the testable surface as wide as possible. All
validation and ZXing wiring lives on the JVM-testable side; the
Android-only surface is a thin per-cell pixel-blit. We deliberately
did not pull in Robolectric — `Bitmap` cannot be constructed on a
plain JVM, but the only thing that can still go wrong on-device is
allocating a bitmap of the right size, which is well-trodden Android
territory and a poor target for a unit test.

## Test split

`QrMatrixTest` (pure JVM) covers:
- correct dimensions for the requested size,
- non-blank output for a typical Quick Share URL,
- argument validation (empty content, non-positive size),
- determinism for identical inputs (relevant for screen rotation),
- custom error-correction level plumbing,
- long-URL stability.

We do **not** decode the matrix back to verify the original URL —
that would require a luminance source and ZXing's reader, which is
overkill for a "we asked the encoder to encode something and it did"
gate.