### PR TITLE
feat(ux): surface same-Wi-Fi-network requirement across UX (#85)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,25 @@ Phase 1 is complete. Track the
 [Phase 1 epic](https://github.com/kyujin-cho/WhenVivoMeetsGoogle/issues/1)
 for the full sub-issue list and merged PRs.
 
+## Networking requirements
+
+Phase 1 uses Wi-Fi LAN discovery (mDNS) to find nearby devices:
+
+- **Both the sender and the receiver must be on the same Wi-Fi network**
+  — and on the same VLAN. mDNS multicasts (`_FC9F5ED42C8A._tcp.local.`)
+  do not cross routed subnets, so a typical "Guest" SSID will silently
+  break discovery.
+- The Wi-Fi network must permit IPv4 multicast / mDNS traffic. Some
+  enterprise APs drop multicast frames by default.
+- AP isolation / "client isolation" must be off on the access point.
+- BLE auto-discovery (the "ping nearby devices" pulse that lights up a
+  stock receiver's "Sharing nearby" sheet automatically) is **out of
+  scope for Phase 1** and tracked under Phase 2.
+
+The receiver's persistent notification surfaces the current Wi-Fi SSID
+(`Receiving on "<SSID>"`) so you can verify both ends match without
+leaving the app.
+
 ## Reference material
 
 - Protocol spec: <https://github.com/grishka/NearDrop/blob/master/PROTOCOL.md>

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/onboarding/PermissionsOnboardingActivity.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/onboarding/PermissionsOnboardingActivity.kt
@@ -92,6 +92,13 @@ class PermissionsOnboardingActivity : AppCompatActivity() {
         binding.onboardingGrantButton.setOnClickListener { onGrantClicked() }
         binding.onboardingContinueButton.setOnClickListener { finish() }
         binding.onboardingSettingsButton.setOnClickListener { openAppSettings() }
+        // The same-Wi-Fi-network card (#85) is dismissable so the user
+        // can collapse it after reading. Dismissal is purely visual —
+        // we re-show the card on every onCreate so the requirement
+        // resurfaces if the user revisits onboarding from settings.
+        binding.onboardingNetworkCardDismiss.setOnClickListener {
+            binding.onboardingNetworkCard.visibility = View.GONE
+        }
     }
 
     override fun onSaveInstanceState(outState: Bundle) {

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/send/EmptyPeerHintTimer.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/send/EmptyPeerHintTimer.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.send
+
+/**
+ * Pure-JVM helper for the same-Wi-Fi-network hint card in
+ * [SendActivity] (#85).
+ *
+ * The hint surfaces when the peer list has been empty for at least
+ * [delayMillis] **continuous** milliseconds since the activity started
+ * discovery. Any peer that resolves before the timeout cancels the
+ * hint; if peers later disappear, the hint can re-arm because the
+ * issue's UX guidance is "show after ~3 seconds of empty peer list".
+ *
+ * Once the user dismisses the hint via the card's button it stays
+ * dismissed for the rest of the activity's lifetime — re-arming after
+ * dismissal would defeat the "dismissable" affordance the issue calls
+ * for. [markDismissed] is the one-way latch.
+ *
+ * The helper is intentionally side-effect free: it tracks state but
+ * does not own a coroutine, a `Handler`, or a `View`. Callers schedule
+ * the timeout on whatever scheduler they already have (in the Android
+ * activity case, `lifecycleScope.launch { delay(...) }`) and consult
+ * [shouldShowHint] when the timeout elapses or after every peer-list
+ * change. That keeps the timing logic deterministic in unit tests
+ * without dragging in `Handler`, `Looper`, or Robolectric.
+ *
+ * @param delayMillis minimum milliseconds the peer list must remain
+ *   empty before the hint is allowed to surface. Defaults to
+ *   [DEFAULT_DELAY_MILLIS] (~3 seconds, per the issue body).
+ */
+internal class EmptyPeerHintTimer(
+    private val delayMillis: Long = DEFAULT_DELAY_MILLIS,
+) {
+    /**
+     * Wall-clock-ish timestamp at which the discovery flow started, in
+     * the same time base passed to [shouldShowHint]. `null` until
+     * [start] is called.
+     */
+    private var startTimestamp: Long? = null
+
+    /**
+     * Sticky-once flag: `true` after the user has tapped the dismiss
+     * button on the card. Never resets — re-showing would be noisy.
+     */
+    private var dismissed: Boolean = false
+
+    /**
+     * Begin tracking. Idempotent — repeated calls keep the original
+     * start time so a re-issued discovery flow doesn't push the hint
+     * surfaceing back to "now + delay".
+     *
+     * @param nowMillis current time in the caller's chosen base
+     *   (System.currentTimeMillis or a test clock).
+     */
+    fun start(nowMillis: Long) {
+        if (startTimestamp == null) startTimestamp = nowMillis
+    }
+
+    /**
+     * Mark the hint dismissed by the user. Latches to `true` for the
+     * timer's lifetime — see the class doc for the rationale.
+     */
+    fun markDismissed() {
+        dismissed = true
+    }
+
+    /**
+     * @return `true` when the hint should be visible at [nowMillis]
+     *   given the latest known [peerListEmpty] state. Returns `false`
+     *   if [start] was never called, if the user dismissed the hint,
+     *   if the peer list is non-empty, or if [delayMillis] has not
+     *   yet elapsed since [start].
+     */
+    fun shouldShowHint(
+        nowMillis: Long,
+        peerListEmpty: Boolean,
+    ): Boolean {
+        // All four conditions must hold for the card to surface; we
+        // express them as a single boolean so detekt's ReturnCount
+        // rule stays satisfied without obscuring the intent.
+        val started = startTimestamp
+        return !dismissed &&
+            peerListEmpty &&
+            started != null &&
+            nowMillis - started >= delayMillis
+    }
+
+    /**
+     * Test/debug accessor for the dismissed latch. Not part of the
+     * public contract — exists so unit tests can verify the latch is
+     * sticky without going through [shouldShowHint].
+     */
+    internal fun isDismissed(): Boolean = dismissed
+
+    companion object {
+        /**
+         * Default empty-peer-list timeout. ~3 seconds matches the
+         * issue body's UX guidance and the wording in the runbooks
+         * — long enough that a healthy LAN with a receiver already
+         * advertising surfaces a peer first, short enough that a
+         * misconfigured network produces actionable feedback before
+         * the user gives up and closes the share sheet.
+         */
+        const val DEFAULT_DELAY_MILLIS: Long = 3_000L
+    }
+}

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendActivity.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendActivity.kt
@@ -26,6 +26,7 @@ import io.github.kyujincho.wvmg.protocol.connection.FileSource
 import io.github.kyujincho.wvmg.protocol.connection.OutboundConnection
 import io.github.kyujincho.wvmg.protocol.connection.OutboundConnectionState
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.net.InetAddress
 
@@ -67,6 +68,16 @@ public class SendActivity : AppCompatActivity() {
     private var connectionJob: Job? = null
     private var activeConnection: OutboundConnection? = null
 
+    /**
+     * Tracks whether the same-Wi-Fi-network hint card (#85) has been
+     * shown long enough to count as user-visible. The timer starts on
+     * `onCreate` once we know we have files to share; the card is
+     * surfaced after [EmptyPeerHintTimer.DEFAULT_DELAY_MILLIS] of
+     * continuous empty-peer-list state.
+     */
+    private val emptyPeerHintTimer: EmptyPeerHintTimer = EmptyPeerHintTimer()
+    private var emptyPeerHintJob: Job? = null
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivitySendBinding.inflate(layoutInflater)
@@ -77,6 +88,7 @@ public class SendActivity : AppCompatActivity() {
         binding.sendCancelButton.setOnClickListener { onCancelClicked() }
         binding.sendDoneButton.setOnClickListener { finish() }
         binding.sendShowQrButton.setOnClickListener { onShowQrClicked() }
+        binding.sendNetworkHintDismiss.setOnClickListener { onHintDismissed() }
 
         val parsed = ShareIntentRouter.route(toShareIntent(intent))
         if (parsed == null) {
@@ -96,6 +108,7 @@ public class SendActivity : AppCompatActivity() {
         binding.sendPayloadSummary.text = PayloadSummary.forFiles(this, files)
         binding.sendSubtitle.setText(R.string.send_subtitle_discovering)
         startDiscovery()
+        startEmptyPeerHintTimer()
     }
 
     override fun onDestroy() {
@@ -107,6 +120,7 @@ public class SendActivity : AppCompatActivity() {
         activeConnection?.cancel()
         discoveryJob?.cancel()
         connectionJob?.cancel()
+        emptyPeerHintJob?.cancel()
     }
 
     // -----------------------------------------------------------------
@@ -225,6 +239,44 @@ public class SendActivity : AppCompatActivity() {
         binding.sendSubtitle.setText(
             if (peers.isEmpty()) R.string.send_subtitle_discovering else R.string.send_subtitle_pick_peer,
         )
+        updateEmptyPeerHintVisibility()
+    }
+
+    /**
+     * Start the same-Wi-Fi-network hint timer (#85). After
+     * [EmptyPeerHintTimer.DEFAULT_DELAY_MILLIS] of continuous empty
+     * peer list, re-evaluate visibility — by then either a peer has
+     * shown up (in which case the hint stays hidden) or the timeout
+     * fires and the card surfaces.
+     */
+    private fun startEmptyPeerHintTimer() {
+        emptyPeerHintTimer.start(System.currentTimeMillis())
+        emptyPeerHintJob =
+            lifecycleScope.launch {
+                delay(EmptyPeerHintTimer.DEFAULT_DELAY_MILLIS)
+                updateEmptyPeerHintVisibility()
+            }
+    }
+
+    /**
+     * Re-evaluate the hint card's visibility against the timer + the
+     * current peer list. Called from `renderPeerList` (so a newly
+     * arrived peer hides the card) and from the delayed coroutine
+     * launched in [startEmptyPeerHintTimer] (so the timeout actually
+     * surfaces the card).
+     */
+    private fun updateEmptyPeerHintVisibility() {
+        val show =
+            emptyPeerHintTimer.shouldShowHint(
+                nowMillis = System.currentTimeMillis(),
+                peerListEmpty = peers.isEmpty(),
+            )
+        binding.sendNetworkHint.visibility = if (show) View.VISIBLE else View.GONE
+    }
+
+    private fun onHintDismissed() {
+        emptyPeerHintTimer.markDismissed()
+        binding.sendNetworkHint.visibility = View.GONE
     }
 
     private fun peerLabel(peer: DiscoveredService): String {
@@ -259,8 +311,10 @@ public class SendActivity : AppCompatActivity() {
         // Hide the picker chrome.
         binding.sendPeerList.visibility = View.GONE
         binding.sendEmptyState.visibility = View.GONE
+        binding.sendNetworkHint.visibility = View.GONE
         binding.sendShowQrButton.visibility = View.GONE
         binding.sendStatusPanel.visibility = View.VISIBLE
+        emptyPeerHintJob?.cancel()
 
         binding.sendStatusTarget.text = getString(R.string.send_status_target, peerLabel(peer))
 
@@ -365,6 +419,7 @@ public class SendActivity : AppCompatActivity() {
         binding.sendShowQrButton.visibility = View.GONE
         binding.sendPeerList.visibility = View.GONE
         binding.sendEmptyState.visibility = View.GONE
+        binding.sendNetworkHint.visibility = View.GONE
     }
 
     private fun renderUnsupportedPayload() {
@@ -372,6 +427,7 @@ public class SendActivity : AppCompatActivity() {
         binding.sendSubtitle.text = getString(R.string.send_unsupported)
         binding.sendPeerList.visibility = View.GONE
         binding.sendEmptyState.visibility = View.GONE
+        binding.sendNetworkHint.visibility = View.GONE
         binding.sendShowQrButton.visibility = View.GONE
         binding.sendCancelButton.text = getString(R.string.send_done)
     }

--- a/app/src/main/res/layout/activity_permissions_onboarding.xml
+++ b/app/src/main/res/layout/activity_permissions_onboarding.xml
@@ -71,6 +71,48 @@
             android:layout_marginTop="16dp"
             android:text="@string/onboarding_continue" />
 
+        <!--
+          Same-Wi-Fi-network requirement card (#85). Sits below the
+          permission grid (after the runtime-permission grants) so the
+          user reads the Phase 1 networking requirement before landing
+          in the share flow. Hidden by default and revealed by
+          PermissionsOnboardingActivity once the activity inflates.
+        -->
+        <LinearLayout
+            android:id="@+id/onboarding_network_card"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:background="?android:attr/colorBackgroundFloating"
+            android:orientation="vertical"
+            android:padding="16dp">
+
+            <TextView
+                android:id="@+id/onboarding_network_card_title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/onboarding_network_card_title"
+                android:textAppearance="@style/TextAppearance.AppCompat.Title"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/onboarding_network_card_body"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="@string/onboarding_network_card_body"
+                android:textAppearance="@style/TextAppearance.AppCompat.Body1" />
+
+            <Button
+                android:id="@+id/onboarding_network_card_dismiss"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end"
+                android:layout_marginTop="12dp"
+                android:text="@string/onboarding_network_card_dismiss" />
+
+        </LinearLayout>
+
     </LinearLayout>
 
 </ScrollView>

--- a/app/src/main/res/layout/activity_send.xml
+++ b/app/src/main/res/layout/activity_send.xml
@@ -57,6 +57,49 @@
             android:text="@string/send_empty_state"
             android:textAppearance="@style/TextAppearance.AppCompat.Body1" />
 
+        <!--
+          Same-Wi-Fi-network hint card (#85). Surfaced after ~3 seconds
+          of empty peer list (see EmptyPeerHintTimer) so the user
+          understands why nothing has appeared. Dismissable via the
+          button; once dismissed, stays hidden for the rest of the
+          activity's lifetime.
+        -->
+        <LinearLayout
+            android:id="@+id/send_network_hint"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:background="?android:attr/colorBackgroundFloating"
+            android:orientation="vertical"
+            android:padding="16dp"
+            android:visibility="gone">
+
+            <TextView
+                android:id="@+id/send_network_hint_title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/send_network_hint_title"
+                android:textAppearance="@style/TextAppearance.AppCompat.Subhead"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/send_network_hint_body"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="@string/send_network_hint_body"
+                android:textAppearance="@style/TextAppearance.AppCompat.Body1" />
+
+            <Button
+                android:id="@+id/send_network_hint_dismiss"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end"
+                android:layout_marginTop="8dp"
+                android:text="@string/send_network_hint_dismiss" />
+
+        </LinearLayout>
+
         <Button
             android:id="@+id/send_show_qr_button"
             android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,6 +12,13 @@
     <string name="onboarding_continue_partial">Continue without all permissions</string>
     <string name="onboarding_continue_degraded">Continue without notifications</string>
 
+    <!-- Same-Wi-Fi-network onboarding card (#85). Displayed below the
+         permission rows so the user understands the Phase 1 networking
+         requirement before they land in the share flow. -->
+    <string name="onboarding_network_card_title">Same Wi-Fi network required</string>
+    <string name="onboarding_network_card_body">Phase 1 uses Wi-Fi LAN discovery (mDNS) to find nearby devices. Both the sender and the receiver must be on the same Wi-Fi network. BLE auto-discovery is coming in Phase 2.</string>
+    <string name="onboarding_network_card_dismiss">OK</string>
+
     <!-- NEARBY_WIFI_DEVICES (API 33+). -->
     <string name="permission_nearby_wifi_title">Nearby Wi-Fi devices</string>
     <string name="permission_nearby_wifi_rationale">Required to discover and advertise to other Quick Share devices on the same Wi-Fi network. Quick Share never uses this to determine your physical location.</string>
@@ -30,6 +37,14 @@
     <string name="send_subtitle_discovering">Looking for nearby devices…</string>
     <string name="send_subtitle_pick_peer">Tap a device to send.</string>
     <string name="send_empty_state">No devices nearby yet. Make sure the receiver has Quick Share open and is on the same Wi-Fi network.</string>
+
+    <!-- Same-Wi-Fi-network hint card (#85). Surfaced after a few seconds
+         of empty peer list so the user understands why nothing has
+         appeared. Condensed wording — the full explanation lives in
+         the onboarding card. -->
+    <string name="send_network_hint_title">Same Wi-Fi network required</string>
+    <string name="send_network_hint_body">Phase 1 uses Wi-Fi LAN discovery (mDNS). Both devices must be on the same Wi-Fi network. BLE auto-discovery is coming in Phase 2.</string>
+    <string name="send_network_hint_dismiss">Got it</string>
     <string name="send_show_qr">Show QR</string>
     <string name="send_cancel">Cancel</string>
     <string name="send_done">Done</string>

--- a/app/src/test/kotlin/io/github/kyujincho/wvmg/send/EmptyPeerHintTimerTest.kt
+++ b/app/src/test/kotlin/io/github/kyujincho/wvmg/send/EmptyPeerHintTimerTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.send
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-JVM tests for [EmptyPeerHintTimer], the timing helper for the
+ * same-Wi-Fi-network hint card surfaced by [SendActivity] (#85).
+ *
+ * The class is intentionally side-effect free, so we drive it directly
+ * with synthetic timestamps rather than mocking `Handler` /
+ * `lifecycleScope`. That keeps the timing rules exercised without
+ * dragging in Robolectric just for `delay()` / `Looper`.
+ */
+class EmptyPeerHintTimerTest {
+    @Test
+    fun `hint stays hidden before start is called`() {
+        val timer = EmptyPeerHintTimer(delayMillis = 3_000L)
+        // Even with peerListEmpty true and a "long enough" wall clock,
+        // shouldShowHint must return false until start() runs — the
+        // timer is opt-in to avoid surfacing on activities that never
+        // entered the discovery flow.
+        assertFalse(timer.shouldShowHint(nowMillis = 1_000_000L, peerListEmpty = true))
+    }
+
+    @Test
+    fun `hint stays hidden before delay elapses`() {
+        val timer = EmptyPeerHintTimer(delayMillis = 3_000L)
+        timer.start(nowMillis = 1_000L)
+        // 2_999ms after start is still below the threshold; the card
+        // must remain hidden.
+        assertFalse(timer.shouldShowHint(nowMillis = 1_000L + 2_999L, peerListEmpty = true))
+    }
+
+    @Test
+    fun `hint surfaces after delay elapses with empty peer list`() {
+        val timer = EmptyPeerHintTimer(delayMillis = 3_000L)
+        timer.start(nowMillis = 1_000L)
+        // Exactly at the boundary the hint must surface — boundary
+        // inclusion matters for the coroutine `delay(...)` call site,
+        // which calls back at `start + delay` precisely.
+        assertTrue(timer.shouldShowHint(nowMillis = 1_000L + 3_000L, peerListEmpty = true))
+    }
+
+    @Test
+    fun `hint stays hidden once a peer arrives`() {
+        val timer = EmptyPeerHintTimer(delayMillis = 3_000L)
+        timer.start(nowMillis = 0L)
+        // Even past the delay, a non-empty peer list must keep the
+        // card hidden.
+        assertFalse(timer.shouldShowHint(nowMillis = 10_000L, peerListEmpty = false))
+    }
+
+    @Test
+    fun `hint stays hidden after dismissal`() {
+        val timer = EmptyPeerHintTimer(delayMillis = 3_000L)
+        timer.start(nowMillis = 0L)
+        timer.markDismissed()
+        // After dismissal, even if the threshold and emptiness say
+        // "show", the latch must keep the card hidden.
+        assertFalse(timer.shouldShowHint(nowMillis = 100_000L, peerListEmpty = true))
+        assertTrue(timer.isDismissed())
+    }
+
+    @Test
+    fun `start is idempotent — repeated calls keep the original timestamp`() {
+        val timer = EmptyPeerHintTimer(delayMillis = 3_000L)
+        timer.start(nowMillis = 0L)
+        // A second start at t=2_500 must not push the surface out to
+        // t=2_500+3_000 — the original t=0 anchor stands.
+        timer.start(nowMillis = 2_500L)
+        assertTrue(timer.shouldShowHint(nowMillis = 3_000L, peerListEmpty = true))
+    }
+
+    @Test
+    fun `default delay matches the issue body's three-second guidance`() {
+        // The issue body specifies "after ~3 seconds with no peers".
+        // Lock that contract in so a future tweak goes through code
+        // review.
+        assertTrue(EmptyPeerHintTimer.DEFAULT_DELAY_MILLIS == 3_000L)
+    }
+}

--- a/docs/testing/interop-neardrop-macos.md
+++ b/docs/testing/interop-neardrop-macos.md
@@ -53,6 +53,14 @@ moving on — once the network state changes, wire traces are gone.
 - [ ] Battery saver / data saver disabled. Aggressive Doze can break
       mDNS without producing a clear error.
 
+### Networking requirements
+
+Phase 1 uses Wi-Fi LAN discovery (mDNS), so both devices **must** be on
+the same Wi-Fi network. BLE auto-discovery is Phase 2 and out of scope
+for this runbook. The receiver's persistent notification surfaces the
+current Wi-Fi SSID (`Receiving on "<SSID>"`) — use it to confirm both
+ends match before you start.
+
 ### Network
 
 - [ ] Both devices on the same Wi-Fi SSID **and** the same VLAN. mDNS

--- a/docs/testing/interop-stock-quick-share-android.md
+++ b/docs/testing/interop-stock-quick-share-android.md
@@ -24,6 +24,14 @@ the [Phase 1 epic](https://github.com/kyujin-cho/WhenVivoMeetsGoogle/issues/1).
 
 ## Preconditions
 
+### Networking requirements
+
+Phase 1 uses Wi-Fi LAN discovery (mDNS), so both devices **must** be on
+the same Wi-Fi network. BLE auto-discovery is Phase 2 and out of scope
+for this runbook. The receiver's persistent notification surfaces the
+current Wi-Fi SSID (`Receiving on "<SSID>"`) — use it to confirm both
+ends match before you start each test.
+
 ### Network
 
 - [ ] Both devices are on the **same Wi-Fi SSID and the same VLAN** —

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/CurrentSsidProvider.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/CurrentSsidProvider.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.service.receiver
+
+import android.content.Context
+import android.net.wifi.WifiManager
+
+/**
+ * Look up the device's current Wi-Fi SSID for display in the
+ * receiver's persistent foreground notification (#85).
+ *
+ * ### Why this lives in its own object
+ *
+ * The notification body builder is heavily exercised by unit tests; the
+ * Wi-Fi system service is not unit-testable on a plain JVM. Splitting
+ * the lookup off behind [CurrentSsidProvider] (which the notification
+ * builder consumes via the platform-agnostic [stripSsidQuotes] helper)
+ * keeps the SSID-stripping logic JVM-testable while letting the
+ * Android-only [readCurrentSsid] step stay isolated.
+ *
+ * ### Caveats called out in the issue body
+ *
+ *  - Android wraps the SSID it returns from `WifiManager.connectionInfo`
+ *    in surrounding double quotes. We strip those before display.
+ *  - On API 31+ `WifiManager.getConnectionInfo()` is deprecated and may
+ *    return the literal string `<unknown ssid>` for apps without
+ *    precise location permission. We do **not** request a new permission
+ *    for this nice-to-have surface — callers are expected to handle the
+ *    unknown case gracefully (the notification falls back to a generic
+ *    "Receiving on this network" string).
+ *  - Any exception from the system service (rare, but observed on some
+ *    OEM builds) is treated as "unknown".
+ */
+internal object CurrentSsidProvider {
+    /**
+     * The literal string Android returns from
+     * `WifiManager.connectionInfo.ssid` when the caller is not
+     * authorised to read the SSID. Documented at
+     * `WifiManager.UNKNOWN_SSID`; mirrored here as a constant so the
+     * notification builder doesn't need to depend on the system
+     * service.
+     */
+    internal const val UNKNOWN_SSID: String = "<unknown ssid>"
+
+    /**
+     * Read the current Wi-Fi SSID from the system. Returns `null` when
+     * the SSID is unavailable, redacted, or the caller's permission
+     * grant prevents the system from disclosing it.
+     *
+     * This intentionally suppresses the deprecation warning on
+     * `WifiManager.getConnectionInfo()` — there is no API-level-stable
+     * replacement that doesn't require either `NETWORK_CALLBACK`
+     * acrobatics or new runtime permissions, both of which are
+     * out of scope for the issue's "nice to have, no new permission"
+     * guidance.
+     */
+    @Suppress("DEPRECATION", "TooGenericExceptionCaught")
+    fun readCurrentSsid(context: Context): String? {
+        val wifi =
+            context.applicationContext.getSystemService(Context.WIFI_SERVICE) as? WifiManager
+                ?: return null
+        return try {
+            stripSsidQuotes(wifi.connectionInfo?.ssid)
+        } catch (
+            @Suppress("SwallowedException") t: Throwable,
+        ) {
+            // Some OEM Wi-Fi stacks throw when the device is in a
+            // transient connectivity state (Wi-Fi off mid-call, captive
+            // portal redirect, etc.). The notification surface is
+            // strictly informational; a thrown exception here must not
+            // take the receiver service down.
+            null
+        }
+    }
+
+    /**
+     * Pure-JVM helper for stripping the SSID's surrounding double
+     * quotes and normalising the unknown / blank / null cases.
+     *
+     * Android wraps the textual SSID in matching `"`-delimited quotes
+     * because the field is otherwise an opaque byte sequence (Wi-Fi
+     * SSIDs are arbitrary 0..32-byte strings, not necessarily UTF-8).
+     * We strip those quotes for display since the notification body is
+     * always shown as text.
+     *
+     * Returns `null` for inputs that should fall through to the
+     * generic "Receiving on this network" body — that includes a `null`
+     * input, a blank string, the literal `<unknown ssid>` sentinel, and
+     * a quote-only string (`""`). All other inputs return the
+     * quote-stripped form.
+     */
+    fun stripSsidQuotes(raw: String?): String? {
+        // Pre-strip rejection: blank input, the bare unknown sentinel,
+        // and the quote-only string `""` all bypass the strip step.
+        if (raw.isNullOrBlank() || raw == UNKNOWN_SSID) return null
+        val stripped =
+            if (raw.length >= 2 && raw.startsWith('"') && raw.endsWith('"')) {
+                raw.substring(1, raw.length - 1)
+            } else {
+                raw
+            }
+        // Post-strip rejection: an empty inner value, or the unknown
+        // sentinel coming back wrapped in quotes (observed on some
+        // OEM builds), must fall through to the generic notification
+        // body. A single combined check keeps detekt's ReturnCount
+        // rule satisfied.
+        return stripped.takeUnless { it.isBlank() || it == UNKNOWN_SSID }
+    }
+}

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
@@ -135,6 +135,11 @@ public class ReceiverForegroundService : Service() {
             ReceiverNotification.build(
                 context = this,
                 contentIntent = ReceiverNotification.buildOpenAppIntent(this, openAppTarget),
+                // Surface the current SSID in the persistent
+                // notification (#85). `readCurrentSsid` returns `null`
+                // when the SSID is unavailable / redacted, in which
+                // case the builder falls back to a generic body.
+                ssid = CurrentSsidProvider.readCurrentSsid(this),
             )
         ServiceCompat.startForeground(
             this,

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverNotification.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverNotification.kt
@@ -85,16 +85,22 @@ internal object ReceiverNotification {
      * @param contentIntent a `PendingIntent` opening the app when the
      *   notification is tapped. Constructed by the service so the
      *   builder does not need to know about `MainActivity`.
+     * @param ssid the stripped Wi-Fi SSID to surface in the body, or
+     *   `null` when unavailable. The same-Wi-Fi-network UX (#85)
+     *   appends `Receiving on "<SSID>"` so the user can verify both
+     *   ends match without leaving the app; passing `null` falls back
+     *   to a generic "Receiving on this network" copy.
      */
     fun build(
         context: Context,
         contentIntent: PendingIntent?,
+        ssid: String? = null,
     ): Notification =
         NotificationCompat
             .Builder(context, CHANNEL_ID)
             .setSmallIcon(android.R.drawable.stat_sys_download)
             .setContentTitle(context.getString(R.string.receiver_notification_title))
-            .setContentText(context.getString(R.string.receiver_notification_text))
+            .setContentText(buildContentText(context, ssid))
             .setPriority(NotificationCompat.PRIORITY_LOW)
             .setCategory(NotificationCompat.CATEGORY_SERVICE)
             // Foreground-service notifications are inherently ongoing;
@@ -105,6 +111,23 @@ internal object ReceiverNotification {
             .setSilent(true)
             .setContentIntent(contentIntent)
             .build()
+
+    /**
+     * Pick the notification body string given the current SSID lookup
+     * result. A non-null, non-blank SSID renders as
+     * `Receiving on "<SSID>"`; everything else falls back to the
+     * generic "Receiving on this network" string. Public for unit-test
+     * coverage of the per-state body selection.
+     */
+    internal fun buildContentText(
+        context: Context,
+        ssid: String?,
+    ): String =
+        if (ssid.isNullOrBlank()) {
+            context.getString(R.string.receiver_notification_text_unknown_ssid)
+        } else {
+            context.getString(R.string.receiver_notification_text_with_ssid, ssid)
+        }
 
     /**
      * Build a `PendingIntent` that opens the supplied [target] activity.

--- a/service-android/src/main/res/values/strings.xml
+++ b/service-android/src/main/res/values/strings.xml
@@ -35,6 +35,23 @@
     <string name="receiver_notification_text">Receiving nearby files…</string>
 
     <!--
+      Notification body variant that surfaces the current Wi-Fi SSID
+      (#85). Helps the user verify both ends are on the same network
+      without leaving the app. The %1$s argument is the stripped SSID
+      (Android wraps SSIDs in surrounding double quotes; we strip them
+      before substitution).
+    -->
+    <string name="receiver_notification_text_with_ssid">Receiving on \"%1$s\"</string>
+
+    <!--
+      Fallback body when the SSID is unavailable (for example on API 31+
+      where WifiManager.connectionInfo can return "<unknown ssid>" for
+      apps without ACCESS_FINE_LOCATION). We do not request a new
+      permission for this nice-to-have surface.
+    -->
+    <string name="receiver_notification_text_unknown_ssid">Receiving on this network</string>
+
+    <!--
       Consent notification (#22). Posted when an inbound connection
       reaches `WaitingForUserConsent`. Distinct channel from the
       receiver-foreground notification because it must be high-importance

--- a/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/CurrentSsidProviderTest.kt
+++ b/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/CurrentSsidProviderTest.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.service.receiver
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure-JVM tests for [CurrentSsidProvider.stripSsidQuotes], the helper
+ * that normalises the raw SSID string Android returns from
+ * `WifiManager.connectionInfo.ssid` for use in the receiver's
+ * persistent notification body (#85).
+ *
+ * The Android-only path (`readCurrentSsid`) is not exercised here —
+ * pulling in Robolectric just to mock `WifiManager.getSystemService`
+ * isn't worth it for a one-liner that delegates to this stripper.
+ * The unit tests below lock the stripping contract.
+ */
+class CurrentSsidProviderTest {
+    @Test
+    fun `strips matching surrounding double quotes`() {
+        // The platform consistently wraps the SSID in matching
+        // double quotes. The stripper must remove them so the
+        // notification body shows just the network name.
+        assertThat(CurrentSsidProvider.stripSsidQuotes("\"home-net\"")).isEqualTo("home-net")
+    }
+
+    @Test
+    fun `passes through an unquoted SSID untouched`() {
+        // Some OEM Wi-Fi stacks don't wrap the SSID. Pass-through
+        // must leave such inputs unchanged rather than chopping off
+        // any other character.
+        assertThat(CurrentSsidProvider.stripSsidQuotes("home-net")).isEqualTo("home-net")
+    }
+
+    @Test
+    fun `null input returns null`() {
+        // `WifiManager.connectionInfo` can be null on some Android
+        // versions; the helper must absorb that without throwing.
+        assertThat(CurrentSsidProvider.stripSsidQuotes(null)).isNull()
+    }
+
+    @Test
+    fun `blank input returns null`() {
+        // A blank or whitespace-only SSID is treated as "unknown" so
+        // the notification body falls back to the generic copy.
+        assertThat(CurrentSsidProvider.stripSsidQuotes("")).isNull()
+        assertThat(CurrentSsidProvider.stripSsidQuotes("   ")).isNull()
+    }
+
+    @Test
+    fun `unknown ssid sentinel returns null`() {
+        // API 31+ returns "<unknown ssid>" for callers without
+        // ACCESS_FINE_LOCATION. Issue #85 explicitly chose not to
+        // request a new permission for this nice-to-have; the
+        // stripper must surface the unknown case as null so the
+        // notification falls back gracefully.
+        assertThat(CurrentSsidProvider.stripSsidQuotes("<unknown ssid>")).isNull()
+    }
+
+    @Test
+    fun `quote-wrapped unknown ssid sentinel returns null`() {
+        // A defensive check — some OEM builds have been observed
+        // returning the unknown sentinel inside quotes. Strip first,
+        // then fall through to the unknown-handler.
+        assertThat(CurrentSsidProvider.stripSsidQuotes("\"<unknown ssid>\"")).isNull()
+    }
+
+    @Test
+    fun `empty quoted string returns null`() {
+        // `""` strips to empty; the helper must not feed an empty
+        // string into the notification body.
+        assertThat(CurrentSsidProvider.stripSsidQuotes("\"\"")).isNull()
+    }
+
+    @Test
+    fun `single leading or trailing quote is preserved`() {
+        // Only matching surrounding quotes are stripped. A lone
+        // leading quote indicates a malformed value and must pass
+        // through verbatim — silently dropping the quote could
+        // mask a real bug elsewhere.
+        assertThat(CurrentSsidProvider.stripSsidQuotes("\"home-net")).isEqualTo("\"home-net")
+        assertThat(CurrentSsidProvider.stripSsidQuotes("home-net\"")).isEqualTo("home-net\"")
+    }
+
+    @Test
+    fun `quotes inside the SSID are preserved`() {
+        // SSIDs may technically contain quote characters. After
+        // stripping the surrounding pair the inner quotes must
+        // remain.
+        assertThat(CurrentSsidProvider.stripSsidQuotes("\"home\"net\"")).isEqualTo("home\"net")
+    }
+
+    @Test
+    fun `unicode SSIDs survive stripping`() {
+        // Wi-Fi SSIDs are arbitrary 0..32-byte strings; many OEMs
+        // expose them as UTF-8. Confirm the Kotlin substring slice
+        // doesn't mangle multi-byte characters.
+        assertThat(CurrentSsidProvider.stripSsidQuotes("\"カフェ-Wi-Fi\"")).isEqualTo("カフェ-Wi-Fi")
+    }
+}


### PR DESCRIPTION
## Summary

Closes #85.

Phase 1 relies on mDNS over Wi-Fi LAN, so both peers must be on the same Wi-Fi network for any device to appear. Without an explicit hint, a user trying to share would see "Looking for nearby devices..." indefinitely with no explanation. This PR adds the four UX surfaces called for in the issue.

### What changed

- **Onboarding card** (`PermissionsOnboardingActivity`): a new dismissable card titled "Same Wi-Fi network required" sits below the runtime-permission grid with the full explanation ("Phase 1 uses Wi-Fi LAN discovery (mDNS)... BLE auto-discovery is coming in Phase 2.").
- **Empty-peer-list hint** (`SendActivity`): after ~3 seconds of continuous empty peer list, a condensed hint card surfaces under the picker. Gated by a new pure-JVM `EmptyPeerHintTimer` so the timing rules are unit-testable without Robolectric. Dismissable; latches off once dismissed.
- **Receiver notification SSID** (`ReceiverNotification` / `ReceiverForegroundService`): the persistent foreground notification now appends `Receiving on "<SSID>"`. SSID lookup goes through a new `CurrentSsidProvider` that strips Android's surrounding double quotes and falls back to the generic copy (`Receiving on this network`) when the SSID is unavailable — including the API 31+ `<unknown ssid>` sentinel returned to apps without precise location permission. **No new runtime permission is requested**, in line with the issue's "nice-to-have" guidance.
- **Docs**: README.md and both `docs/testing/` runbooks gain a "Networking requirements" section that calls out the same-Wi-Fi requirement and points at the SSID-bearing notification as a cross-check.

### Tests

- `EmptyPeerHintTimerTest` (pure JVM, JUnit 4): start/dismiss/timeout/peer-arrival state transitions, idempotent `start`, and the default-3s contract.
- `CurrentSsidProviderTest` (pure JVM, JUnit 5 + Truth): quote stripping, blank/null handling, the `<unknown ssid>` sentinel (bare and quote-wrapped), unicode SSIDs, and pass-through for unquoted / partially quoted inputs.
- Existing `AndroidManifestPermissionsTest` is intentionally untouched — no manifest changes were needed.

Verified locally: `./gradlew :app:testDebugUnitTest :service-android:testDebugUnitTest staticAnalysis :app:assembleDebug` all pass.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest :service-android:testDebugUnitTest`
- [x] `./gradlew staticAnalysis`
- [x] `./gradlew :app:assembleDebug`