### PR TITLE
fix(discovery): repair real-device discovery and add diagnostics (#83)

### DIFF
--- a/discovery-android/build.gradle.kts
+++ b/discovery-android/build.gradle.kts
@@ -36,6 +36,17 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
+
+    testOptions {
+        unitTests {
+            // The discovery code calls `android.util.Log.i(...)` for the
+            // structured diagnostics added in #83. Without
+            // `returnDefaultValues = true` the AGP unit-test runtime
+            // throws `Method i in android.util.Log not mocked` from
+            // every JVM test that hits a logging path.
+            isReturnDefaultValues = true
+        }
+    }
 }
 
 kotlin {

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/Discovery.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/Discovery.kt
@@ -6,6 +6,7 @@
 package io.github.kyujincho.wvmg.discovery
 
 import android.content.Context
+import android.util.Log
 import io.github.kyujincho.wvmg.protocol.endpoint.Base64Url
 import io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo
 import kotlinx.coroutines.Dispatchers
@@ -44,12 +45,20 @@ import javax.jmdns.ServiceListener
  * Wi-Fi multicast lock plus a JmDNS factory bound to the device's current
  * Wi-Fi interface. Tests use the internal [Discovery.forTesting] factory
  * to substitute in a fake JmDNS provider and a noop lock controller.
+ *
+ * Diagnostics: call [snapshot] to obtain a [DiscoveryDiagnostics]
+ * describing the current bound interface, multicast-lock state, and
+ * the most recent JmDNS service events. The receiver service logs this
+ * periodically to make silent failures (issue #83) visible in logcat
+ * via the `WvmgDiscovery` tag.
  */
 public class Discovery internal constructor(
     private val locks: LockController,
     private val jmdnsProvider: (String) -> JmDNS,
     private val networkWatcherFactory: NetworkWatcherFactory = NetworkWatcherFactory.NoOp,
 ) {
+    private val diagnostics: DiagnosticsState = DiagnosticsState()
+
     /**
      * Production constructor. Builds the multicast-lock controller, the
      * JmDNS factory, and the Wi-Fi network-change watcher against the
@@ -60,6 +69,17 @@ public class Discovery internal constructor(
         jmdnsProvider = defaultJmdnsProvider(context),
         networkWatcherFactory = AndroidNetworkWatcherFactory(context.applicationContext),
     )
+
+    /**
+     * Returns a snapshot of the current discovery state.
+     *
+     * The receiver service (and any future debug screen) is expected
+     * to call this periodically and log the result so on-device tests
+     * can correlate "no peers visible" against "lock not held" or
+     * "JmDNS bound to loopback". See [DiscoveryDiagnostics] for the
+     * fields returned.
+     */
+    public fun snapshot(): DiscoveryDiagnostics = diagnostics.snapshot(locks.isHeld())
 
     /**
      * Publish this device as a Quick Share peer.
@@ -97,19 +117,34 @@ public class Discovery internal constructor(
                 port,
                 0,
                 0,
+                // JmDNS encodes Map<String, String> values as `key=value`
+                // ASCII text records on the wire — passing the
+                // already-base64-encoded String here keeps the TXT record
+                // human-readable and survives every router and JmDNS
+                // version we've tested. Passing a ByteArray instead would
+                // be encoded as raw bytes and is not recommended.
                 mapOf(QuickShareMdns.TXT_KEY_ENDPOINT_INFO to txtValue),
             )
 
+        Log.i(TAG, "advertise: starting publish instance=$instanceName port=$port")
         locks.acquire()
         return try {
-            JmdnsAdvertiseHandle(
-                serviceInfo = serviceInfo,
-                instanceName = instanceName,
-                port = port,
-                jmdnsProvider = { jmdnsProvider("advertise") },
-                networkWatcherFactory = networkWatcherFactory,
-                onClose = { locks.release() },
-            )
+            val handle =
+                JmdnsAdvertiseHandle(
+                    serviceInfo = serviceInfo,
+                    instanceName = instanceName,
+                    port = port,
+                    jmdnsProvider = { jmdnsProvider("advertise") },
+                    networkWatcherFactory = networkWatcherFactory,
+                    diagnostics = diagnostics,
+                    onClose = {
+                        diagnostics.setAdvertising(false)
+                        diagnostics.setAdvertiseBound(null)
+                        locks.release()
+                    },
+                )
+            diagnostics.setAdvertising(true)
+            handle
         } catch (
             // JmDNS surfaces a mix of IOException, IllegalStateException, and
             // its own RuntimeException-derived errors during setup; catching
@@ -117,6 +152,7 @@ public class Discovery internal constructor(
             // verbatim so callers see the original cause.
             @Suppress("TooGenericExceptionCaught") t: Throwable,
         ) {
+            Log.e(TAG, "advertise: failed to publish instance=$instanceName", t)
             // Lock counter must stay balanced even on the failure path.
             locks.release()
             throw t
@@ -140,16 +176,61 @@ public class Discovery internal constructor(
      * context for us; we additionally `flowOn(Dispatchers.IO)` so the
      * acquire/release calls don't block the main thread when collected
      * from a UI scope.
+     *
+     * Re-query: after attaching the listener we synchronously call
+     * [JmDNS.list] to force a fresh PTR query. JmDNS's
+     * `addServiceListener` only triggers a one-shot query and would
+     * otherwise depend on cached announcements being delivered between
+     * receiver-up and sender-up; explicitly listing closes that race.
      */
     public fun browse(): Flow<DiscoveryEvent> =
         callbackFlow {
+            // Acquire the multicast lock *inside* the callbackFlow body so
+            // it is owned by the same coroutine that produced the JmDNS
+            // instance. `flowOn(Dispatchers.IO)` ensures this acquire never
+            // runs on the main thread.
             locks.acquire()
-            val jmdns = jmdnsProvider("browse")
+            Log.i(TAG, "browse: starting collector")
+
+            val jmdns =
+                try {
+                    jmdnsProvider("browse")
+                } catch (
+                    @Suppress("TooGenericExceptionCaught") t: Throwable,
+                ) {
+                    Log.e(TAG, "browse: JmDNS factory threw; releasing multicast lock", t)
+                    locks.release()
+                    throw t
+                }
             val started = AtomicBoolean(true)
+
+            val boundAddress =
+                try {
+                    jmdns.inetAddress
+                } catch (
+                    @Suppress("TooGenericExceptionCaught") _: Throwable,
+                ) {
+                    null
+                }
+            diagnostics.setBrowseBound(boundAddress)
+            diagnostics.setBrowsing(true)
+            Log.i(
+                TAG,
+                "browse: JmDNS opened bound=${boundAddress?.hostAddress ?: "unknown"} " +
+                    "listening for ${QuickShareMdns.SERVICE_TYPE}",
+            )
 
             val listener =
                 object : ServiceListener {
                     override fun serviceAdded(event: ServiceEvent) {
+                        Log.d(TAG, "browse: serviceAdded name=${event.name}")
+                        diagnostics.recordEvent(
+                            DiagnosticEvent(
+                                kind = DiagnosticEvent.Kind.ADDED,
+                                instanceName = event.name,
+                                timestampMillis = System.currentTimeMillis(),
+                            ),
+                        )
                         // JmDNS frequently fires "added" with no TXT data attached
                         // yet. Triggering an explicit info request causes JmDNS to
                         // send a follow-up DNS-SD query and to redeliver via
@@ -160,10 +241,31 @@ public class Discovery internal constructor(
                     }
 
                     override fun serviceRemoved(event: ServiceEvent) {
+                        Log.d(TAG, "browse: serviceRemoved name=${event.name}")
+                        diagnostics.recordEvent(
+                            DiagnosticEvent(
+                                kind = DiagnosticEvent.Kind.REMOVED,
+                                instanceName = event.name,
+                                timestampMillis = System.currentTimeMillis(),
+                            ),
+                        )
                         trySend(DiscoveryEvent.Lost(event.name)).isSuccess
                     }
 
                     override fun serviceResolved(event: ServiceEvent) {
+                        Log.d(
+                            TAG,
+                            "browse: serviceResolved name=${event.name} " +
+                                "addrs=${event.info?.inetAddresses?.joinToString { it.hostAddress }} " +
+                                "port=${event.info?.port}",
+                        )
+                        diagnostics.recordEvent(
+                            DiagnosticEvent(
+                                kind = DiagnosticEvent.Kind.RESOLVED,
+                                instanceName = event.name,
+                                timestampMillis = System.currentTimeMillis(),
+                            ),
+                        )
                         val resolved = toDiscoveredService(event.info ?: return) ?: return
                         trySend(DiscoveryEvent.Resolved(resolved)).isSuccess
                     }
@@ -171,7 +273,26 @@ public class Discovery internal constructor(
 
             jmdns.addServiceListener(QuickShareMdns.SERVICE_TYPE, listener)
 
+            // Force a synchronous PTR query so that any service already
+            // advertised before this collector started gets re-discovered
+            // immediately rather than waiting for an unsolicited
+            // re-announce. JmDNS.list blocks for up to its internal
+            // timeout — we run the whole callbackFlow under
+            // Dispatchers.IO via flowOn(...), so this is fine.
+            try {
+                val seen = jmdns.list(QuickShareMdns.SERVICE_TYPE, LIST_TIMEOUT_MILLIS)
+                Log.i(TAG, "browse: jmdns.list returned ${seen?.size ?: 0} cached services")
+            } catch (
+                @Suppress("TooGenericExceptionCaught") t: Throwable,
+            ) {
+                // JmDNS occasionally throws on list() if multicast send
+                // fails; the listener is still attached so we'll catch
+                // the next unsolicited announce. Don't propagate.
+                Log.w(TAG, "browse: jmdns.list threw; continuing with listener-only path", t)
+            }
+
             awaitClose {
+                Log.i(TAG, "browse: collector closing")
                 // Guard against double-close from a second cancellation: the
                 // contract for awaitClose blocks is "called exactly once",
                 // but defending against a buggy collector is cheap.
@@ -190,6 +311,8 @@ public class Discovery internal constructor(
                     ) {
                         // Same story — final close is best-effort.
                     }
+                    diagnostics.setBrowsing(false)
+                    diagnostics.setBrowseBound(null)
                     locks.release()
                 }
             }
@@ -234,6 +357,19 @@ public class Discovery internal constructor(
         /** Maximum legal TCP port (`2^16 - 1`). */
         public const val MAX_PORT: Int = 0xFFFF
 
+        /** logcat tag — shared with the rest of the discovery module. */
+        internal const val TAG: String = "WvmgDiscovery"
+
+        /**
+         * Bound on the synchronous `jmdns.list` call inside
+         * [browse]. JmDNS waits up to this many milliseconds for cached
+         * answers before returning. Picked to be short enough that a
+         * UI-bound caller doesn't notice a stall on browse start, but
+         * long enough for one multicast round-trip to land on a typical
+         * home Wi-Fi network.
+         */
+        private const val LIST_TIMEOUT_MILLIS: Long = 1_500L
+
         /**
          * Test-only factory that wires up [Discovery] without an Android
          * [Context]. The caller supplies the JmDNS factory and the
@@ -267,6 +403,9 @@ internal interface LockController {
     fun acquire()
 
     fun release()
+
+    /** Whether the underlying multicast lock is currently held. */
+    fun isHeld(): Boolean
 }
 
 /** Production [LockController] backed by [MulticastLockHolder]. */
@@ -276,6 +415,8 @@ internal class MulticastLockController(
     override fun acquire(): Unit = holder.acquire()
 
     override fun release(): Unit = holder.release()
+
+    override fun isHeld(): Boolean = holder.isHeld()
 }
 
 /**
@@ -297,6 +438,7 @@ internal class JmdnsAdvertiseHandle(
     override val port: Int,
     private val jmdnsProvider: () -> JmDNS,
     networkWatcherFactory: NetworkWatcherFactory,
+    private val diagnostics: DiagnosticsState,
     private val onClose: () -> Unit,
 ) : AdvertiseHandle {
     private val active = AtomicBoolean(true)
@@ -321,6 +463,7 @@ internal class JmdnsAdvertiseHandle(
 
     override fun close() {
         if (!active.compareAndSet(true, false)) return
+        Log.i(Discovery.TAG, "advertise: closing handle instance=$instanceName")
         watcher?.stop()
         synchronized(lifecycle) {
             unregisterAndClose(current)
@@ -331,6 +474,7 @@ internal class JmdnsAdvertiseHandle(
 
     private fun onNetworkChanged() {
         if (!active.get()) return
+        Log.i(Discovery.TAG, "advertise: network changed, re-registering instance=$instanceName")
         synchronized(lifecycle) {
             // Re-check inside the lock — `close` may have raced ahead and
             // disabled the handle while this callback was queued.
@@ -340,13 +484,14 @@ internal class JmdnsAdvertiseHandle(
             try {
                 register()
             } catch (
-                @Suppress("TooGenericExceptionCaught") _: Throwable,
+                @Suppress("TooGenericExceptionCaught") t: Throwable,
             ) {
                 // Re-registration on a network change is best-effort: if
                 // the new network isn't ready yet, JmDNS startup throws
                 // an IOException and we'll get another network callback
                 // when the interface fully comes up. Swallowing here
                 // keeps the handle usable for the next callback.
+                Log.w(Discovery.TAG, "advertise: re-register failed; will retry on next network event", t)
             }
         }
     }
@@ -358,6 +503,20 @@ internal class JmdnsAdvertiseHandle(
             try {
                 fresh.registerService(serviceInfo)
                 current = fresh
+                val bound =
+                    try {
+                        fresh.inetAddress
+                    } catch (
+                        @Suppress("TooGenericExceptionCaught") _: Throwable,
+                    ) {
+                        null
+                    }
+                diagnostics.setAdvertiseBound(bound)
+                Log.i(
+                    Discovery.TAG,
+                    "advertise: registered instance=$instanceName " +
+                        "bound=${bound?.hostAddress ?: "unknown"} port=$port",
+                )
             } catch (
                 @Suppress("TooGenericExceptionCaught") t: Throwable,
             ) {

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/DiscoveryDiagnostics.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/DiscoveryDiagnostics.kt
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.discovery
+
+import java.net.InetAddress
+import java.util.ArrayDeque
+import java.util.Collections
+
+/**
+ * A point-in-time snapshot of the discovery layer's runtime state.
+ *
+ * Exposed via [Discovery.snapshot] so callers (the receiver foreground
+ * service, a debug screen, on-device logs) can observe whether mDNS is
+ * actually wired up correctly without having to grep logcat. This is
+ * the primary diagnostic surface for the silent-failure modes called
+ * out by issue #83 — multicast lock not held, JmDNS bound to the wrong
+ * interface, no events flowing.
+ *
+ * @property advertiseBoundAddress the [InetAddress] the JmDNS publish
+ *   instance is bound to, or `null` if no advertisement is currently
+ *   live.
+ * @property browseBoundAddress the [InetAddress] the JmDNS browse
+ *   instance is bound to, or `null` if no collection is currently
+ *   active.
+ * @property multicastLockHeld `true` while the underlying
+ *   `WifiManager.MulticastLock` is held; if either advertise or browse
+ *   is active and this is `false`, multicast traffic is being dropped
+ *   by Android's power-save filter and discovery cannot work.
+ * @property advertising `true` while at least one [Discovery.advertise]
+ *   call has produced a still-open [AdvertiseHandle].
+ * @property browsing `true` while at least one [Discovery.browse] flow
+ *   is being collected.
+ * @property recentEvents the most recent N service events captured by
+ *   the browse listener, oldest-first. Useful for spotting cases where
+ *   JmDNS fired `serviceAdded` but the address never resolved.
+ */
+public data class DiscoveryDiagnostics(
+    val advertiseBoundAddress: InetAddress?,
+    val browseBoundAddress: InetAddress?,
+    val multicastLockHeld: Boolean,
+    val advertising: Boolean,
+    val browsing: Boolean,
+    val recentEvents: List<DiagnosticEvent>,
+)
+
+/**
+ * One row in [DiscoveryDiagnostics.recentEvents]. Captures the kind of
+ * JmDNS service event observed and the instance name it referenced.
+ *
+ * @property kind which JmDNS callback fired: `ADDED` from
+ *   `serviceAdded`, `RESOLVED` from `serviceResolved`, `REMOVED` from
+ *   `serviceRemoved`. Names match JmDNS's terminology rather than the
+ *   downstream [DiscoveryEvent] sealed hierarchy because this surface
+ *   is for protocol-level debugging.
+ * @property instanceName the URL-safe-base64 service-instance name as
+ *   reported by JmDNS.
+ * @property timestampMillis the wall-clock time the event was
+ *   captured, suitable for correlating against logcat output.
+ */
+public data class DiagnosticEvent(
+    val kind: Kind,
+    val instanceName: String,
+    val timestampMillis: Long,
+) {
+    public enum class Kind { ADDED, RESOLVED, REMOVED }
+}
+
+/**
+ * Mutable backing state for [DiscoveryDiagnostics]. Lives on
+ * [Discovery] so both the publish and browse paths can write into the
+ * same snapshot. All mutations are guarded by `synchronized(this)`.
+ */
+internal class DiagnosticsState(
+    private val maxEvents: Int = DEFAULT_MAX_EVENTS,
+) {
+    @Volatile
+    private var advertiseBoundAddress: InetAddress? = null
+
+    @Volatile
+    private var browseBoundAddress: InetAddress? = null
+
+    @Volatile
+    private var advertising: Boolean = false
+
+    @Volatile
+    private var browsing: Boolean = false
+
+    private val events: ArrayDeque<DiagnosticEvent> = ArrayDeque(maxEvents)
+
+    @Synchronized
+    fun setAdvertiseBound(address: InetAddress?) {
+        advertiseBoundAddress = address
+    }
+
+    @Synchronized
+    fun setBrowseBound(address: InetAddress?) {
+        browseBoundAddress = address
+    }
+
+    @Synchronized
+    fun setAdvertising(value: Boolean) {
+        advertising = value
+    }
+
+    @Synchronized
+    fun setBrowsing(value: Boolean) {
+        browsing = value
+    }
+
+    @Synchronized
+    fun recordEvent(event: DiagnosticEvent) {
+        if (events.size >= maxEvents) {
+            events.pollFirst()
+        }
+        events.addLast(event)
+    }
+
+    @Synchronized
+    fun snapshot(multicastLockHeld: Boolean): DiscoveryDiagnostics =
+        DiscoveryDiagnostics(
+            advertiseBoundAddress = advertiseBoundAddress,
+            browseBoundAddress = browseBoundAddress,
+            multicastLockHeld = multicastLockHeld,
+            advertising = advertising,
+            browsing = browsing,
+            recentEvents = Collections.unmodifiableList(events.toList()),
+        )
+
+    internal companion object {
+        const val DEFAULT_MAX_EVENTS: Int = 32
+    }
+}

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/JmdnsFactory.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/JmdnsFactory.kt
@@ -6,9 +6,17 @@
 package io.github.kyujincho.wvmg.discovery
 
 import android.content.Context
+import android.net.ConnectivityManager
+import android.net.LinkAddress
+import android.net.LinkProperties
+import android.net.Network
+import android.net.NetworkCapabilities
 import android.net.wifi.WifiManager
+import android.os.Build
+import android.util.Log
 import java.net.Inet4Address
 import java.net.InetAddress
+import java.net.NetworkInterface
 import javax.jmdns.JmDNS
 
 /**
@@ -22,28 +30,71 @@ import javax.jmdns.JmDNS
  * interface, which on phones is often the cellular interface — that
  * silently breaks Quick Share since peers only ever talk over Wi-Fi.
  *
- * We therefore look up the IPv4 address attached to the active Wi-Fi
- * connection via [WifiManager.getConnectionInfo] and fall back to
- * [InetAddress.getLocalHost] (which on Android resolves to the device's
- * primary network address) if Wi-Fi info is unavailable for any reason.
+ * Address resolution proceeds top-to-bottom and stops at the first hit:
+ *
+ *  1. **`ConnectivityManager` Wi-Fi `LinkProperties`.** The modern API
+ *     (API 21+, available everywhere we run). Returns the IPv4 address
+ *     attached to whichever `Network` is currently `TRANSPORT_WIFI` +
+ *     `NET_CAPABILITY_INTERNET`. This is the right answer on API 31+
+ *     where `WifiManager.getConnectionInfo()` is gated behind precise
+ *     location permission and otherwise reports `0.0.0.0`.
+ *  2. **`WifiManager.getConnectionInfo()` legacy fallback.** Still
+ *     populated on older devices and on builds where the user granted
+ *     location. Deprecated as of API 31 but harmless to call.
+ *  3. **`NetworkInterface` enumeration.** Last-resort scan for any
+ *     non-loopback IPv4 address whose owning interface name looks like
+ *     Wi-Fi (`wlan*`, `ap*`). This catches edge cases — tethering, dev
+ *     boards — where neither system service surfaced an address but a
+ *     Wi-Fi-shaped interface exists.
  *
  * Splitting this off into its own object lets unit tests substitute a
  * fake [WifiAddressProvider] when validating publish/browse logic on a
  * plain JVM.
  */
 internal object JmdnsFactory {
+    /** logcat tag — shared with the rest of the discovery module. */
+    private const val TAG = "WvmgDiscovery"
+
     /**
      * Creates a JmDNS instance bound to the best-effort Wi-Fi interface
      * address. The [name] argument is forwarded as the JmDNS instance
      * name (cosmetic; useful in log output).
+     *
+     * If no Wi-Fi address can be resolved we log a warning and bind to
+     * the wildcard via the no-arg `JmDNS.create()` — this is strictly
+     * better than `InetAddress.getLocalHost()` (which on Android
+     * regularly resolves to `127.0.0.1` and would silently route every
+     * mDNS packet through loopback only). The wildcard binding still
+     * usually fails to reach peers, so the warning log is the action
+     * item for on-device debugging.
      */
     fun create(
         context: Context,
         name: String = "wvmg-discovery",
         addressProvider: WifiAddressProvider = AndroidWifiAddressProvider(context),
+    ): JmDNS = createWith(name = name, addressProvider = addressProvider)
+
+    /**
+     * Lower-level entry point that does not need a [Context]. Exposed
+     * (internal) so unit tests can drive the address-resolution logic
+     * without standing up an Android instrumentation context.
+     */
+    internal fun createWith(
+        name: String,
+        addressProvider: WifiAddressProvider,
     ): JmDNS {
-        val address = addressProvider.currentWifiAddress() ?: InetAddress.getLocalHost()
-        return JmDNS.create(address, name)
+        val resolved = addressProvider.currentWifiAddress()
+        if (resolved != null) {
+            Log.i(TAG, "JmdnsFactory.create: binding name=$name to wifi address=${resolved.hostAddress}")
+            return JmDNS.create(resolved, name)
+        }
+
+        Log.w(
+            TAG,
+            "JmdnsFactory.create: no Wi-Fi address found for name=$name; " +
+                "falling back to JmDNS wildcard bind. mDNS may not reach LAN peers.",
+        )
+        return JmDNS.create(name)
     }
 
     /** Looks up the device's current Wi-Fi IPv4 address, if any. */
@@ -52,34 +103,142 @@ internal object JmdnsFactory {
     }
 
     /**
-     * Production [WifiAddressProvider] backed by [WifiManager]. The
-     * legacy `getConnectionInfo()` API is the broadest-compatible source
-     * of the current Wi-Fi IPv4 address — `ConnectivityManager.LinkProperties`
-     * gives more detail but requires API 21+ scaffolding we don't need
-     * here, and we don't have a target above the existing minSdk floor.
+     * Production [WifiAddressProvider]. Combines [ConnectivityManager]
+     * (modern API, returns the active Wi-Fi network's link properties),
+     * [WifiManager] (legacy, still works on older devices), and a
+     * [NetworkInterface] scan as last resort.
      */
-    private class AndroidWifiAddressProvider(
+    internal class AndroidWifiAddressProvider(
         context: Context,
     ) : WifiAddressProvider {
-        private val wifi: WifiManager =
-            context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+        private val appContext: Context = context.applicationContext
 
-        @Suppress("DEPRECATION")
+        private val wifi: WifiManager =
+            appContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+
+        private val cm: ConnectivityManager =
+            appContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+
         override fun currentWifiAddress(): InetAddress? {
-            // `connectionInfo` is documented to return null on no Wi-Fi
-            // and `ipAddress = 0` when associated but not yet IPv4-assigned;
-            // collapsing both cases to a single null return keeps the
-            // function's return statements within the project-wide ReturnCount limit.
+            val resolved =
+                resolveByConnectivityManager()
+                    ?: resolveByWifiManager()
+                    ?: resolveByNetworkInterface()
+            if (resolved == null) {
+                Log.w(TAG, "WifiAddressProvider: no Wi-Fi IPv4 address resolved through any path")
+            }
+            return resolved
+        }
+
+        private fun resolveByConnectivityManager(): InetAddress? =
+            connectivityManagerWifiAddress()?.also {
+                Log.i(TAG, "WifiAddressProvider: ConnectivityManager link address=${it.hostAddress}")
+            }
+
+        private fun resolveByWifiManager(): InetAddress? =
+            legacyWifiManagerAddress()?.also {
+                Log.i(TAG, "WifiAddressProvider: WifiManager.connectionInfo address=${it.hostAddress}")
+            }
+
+        private fun resolveByNetworkInterface(): InetAddress? =
+            networkInterfaceWifiAddress()?.also {
+                Log.i(TAG, "WifiAddressProvider: NetworkInterface scan address=${it.hostAddress}")
+            }
+
+        /**
+         * Resolves the Wi-Fi network's IPv4 address through
+         * [ConnectivityManager]. This is the right path on API 31+
+         * because [WifiManager.getConnectionInfo] is gated behind
+         * precise location permission and silently returns `0.0.0.0`
+         * for apps that only declared `ACCESS_WIFI_STATE`.
+         */
+        @Suppress("ReturnCount")
+        private fun connectivityManagerWifiAddress(): Inet4Address? {
+            val wifiNetwork = pickWifiNetwork() ?: return null
+            val link: LinkProperties = cm.getLinkProperties(wifiNetwork) ?: return null
+            return firstIpv4LinkAddress(link)
+        }
+
+        /** Returns the first `TRANSPORT_WIFI` network with internet capability, if any. */
+        @Suppress("DEPRECATION")
+        private fun pickWifiNetwork(): Network? {
+            // `getActiveNetwork` is API 23+. Older devices fall back to the
+            // `WifiManager.connectionInfo` path below.
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) return null
+            // `allNetworks` was soft-deprecated in API 31 in favor of
+            // registering a NetworkCallback, but it's still the cheapest
+            // synchronous way to enumerate active networks for this kind
+            // of one-shot lookup. NetworkChangeWatcher already listens
+            // for changes; we just need a snapshot here.
+            val active = cm.activeNetwork?.takeIf(::isWifi)
+            return active ?: cm.allNetworks.firstOrNull(::isWifi)
+        }
+
+        private fun isWifi(network: Network): Boolean =
+            cm.getNetworkCapabilities(network)?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true
+
+        private fun firstIpv4LinkAddress(link: LinkProperties): Inet4Address? =
+            link.linkAddresses
+                .asSequence()
+                .map(LinkAddress::getAddress)
+                .filterIsInstance<Inet4Address>()
+                .firstOrNull(::isUsableUnicast)
+
+        private fun isUsableUnicast(address: Inet4Address): Boolean =
+            !address.isLoopbackAddress &&
+                !address.isAnyLocalAddress &&
+                !address.isMulticastAddress
+
+        /**
+         * Legacy [WifiManager.getConnectionInfo] resolver. On API 31+
+         * this typically returns `0.0.0.0`, which we filter out via the
+         * `it != 0` check. We keep this path because pre-31 devices or
+         * devices with location permission still get a working answer
+         * here without any extra plumbing.
+         */
+        @Suppress("DEPRECATION")
+        private fun legacyWifiManagerAddress(): Inet4Address? {
             val raw = wifi.connectionInfo?.ipAddress?.takeIf { it != 0 } ?: return null
-            // WifiInfo.ipAddress is in little-endian host order on every
-            // Android device shipping today. Decode the four octets and
-            // construct an Inet4Address — JmDNS specifically wants an
-            // Inet4Address (it asserts on this internally).
             val bytes =
                 ByteArray(IPV4_OCTETS) { i ->
                     ((raw ushr (BITS_PER_BYTE * i)) and BYTE_MASK).toByte()
                 }
-            return Inet4Address.getByAddress(bytes)
+            return Inet4Address.getByAddress(bytes) as Inet4Address
+        }
+
+        /**
+         * Last-resort scan of [NetworkInterface]s. We pick the first
+         * non-loopback, IPv4 address whose owning interface name looks
+         * Wi-Fi-shaped (`wlan0`, `ap0`, etc.). The interface-name
+         * filter avoids accidentally binding to a cellular `rmnet*`
+         * interface, a VPN `tun*`, or Docker-style virtual bridges on
+         * dev devices.
+         */
+        private fun networkInterfaceWifiAddress(): Inet4Address? {
+            val interfaces = enumerateInterfaces() ?: return null
+            return interfaces
+                .asSequence()
+                .filter(::isWifiShapedInterface)
+                .flatMap { it.inetAddresses.asSequence() }
+                .filterIsInstance<Inet4Address>()
+                .firstOrNull(::isUsableUnicast)
+        }
+
+        private fun enumerateInterfaces(): List<NetworkInterface>? =
+            try {
+                NetworkInterface.getNetworkInterfaces()?.toList()
+            } catch (
+                @Suppress("TooGenericExceptionCaught") _: Throwable,
+            ) {
+                null
+            }
+
+        private fun isWifiShapedInterface(iface: NetworkInterface): Boolean {
+            if (!iface.isUp || iface.isLoopback || iface.isVirtual) return false
+            val nameLower = iface.name?.lowercase().orEmpty()
+            return nameLower.startsWith("wlan") ||
+                nameLower.startsWith("ap") ||
+                nameLower.startsWith("p2p")
         }
 
         private companion object {

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/MulticastLockHolder.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/MulticastLockHolder.kt
@@ -7,6 +7,7 @@ package io.github.kyujincho.wvmg.discovery
 
 import android.content.Context
 import android.net.wifi.WifiManager
+import android.util.Log
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
@@ -30,22 +31,22 @@ import java.util.concurrent.atomic.AtomicInteger
  * because `MulticastLock` is documented as not thread-safe and we have
  * to guarantee acquire/release pair atomically with the counter
  * increment/decrement.
+ *
+ * Tests inject a fake [MulticastLockGate] via the package-private
+ * constructor; production code uses the [Context] constructor which
+ * resolves a real [WifiManager.MulticastLock] under the hood.
  */
-internal class MulticastLockHolder(
-    context: Context,
-    private val tag: String = DEFAULT_TAG,
+internal class MulticastLockHolder internal constructor(
+    private val gate: MulticastLockGate,
+    private val tag: String,
 ) {
-    private val wifi: WifiManager =
-        context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
-
-    private val lock: WifiManager.MulticastLock =
-        wifi.createMulticastLock(tag).apply {
-            // `setReferenceCounted(false)` makes a single release() call always
-            // fully release the lock, regardless of how many times the system
-            // thinks it was acquired. Combined with our own counter below this
-            // gives unambiguous acquire/release semantics.
-            setReferenceCounted(false)
-        }
+    constructor(
+        context: Context,
+        tag: String = DEFAULT_TAG,
+    ) : this(
+        gate = systemMulticastLockGate(context, tag),
+        tag = tag,
+    )
 
     private val refCount = AtomicInteger(0)
 
@@ -60,7 +61,10 @@ internal class MulticastLockHolder(
             // SecurityException propagate (it indicates a missing
             // CHANGE_WIFI_MULTICAST_STATE permission) since the failure
             // mode without the lock is silently broken mDNS.
-            lock.acquire()
+            gate.acquire()
+            Log.i(TAG, "MulticastLockHolder($tag) acquired (refCount=1, isHeld=${gate.isHeld()})")
+        } else {
+            Log.d(TAG, "MulticastLockHolder($tag) acquire (refCount=${refCount.get()})")
         }
     }
 
@@ -76,8 +80,11 @@ internal class MulticastLockHolder(
         check(previous > 0) {
             "MulticastLockHolder($tag) released more times than acquired"
         }
-        if (previous == 1 && lock.isHeld) {
-            lock.release()
+        if (previous == 1 && gate.isHeld()) {
+            gate.release()
+            Log.i(TAG, "MulticastLockHolder($tag) released (refCount=0)")
+        } else {
+            Log.d(TAG, "MulticastLockHolder($tag) release (refCount=${refCount.get()})")
         }
     }
 
@@ -85,7 +92,58 @@ internal class MulticastLockHolder(
     @Synchronized
     fun refCountForTest(): Int = refCount.get()
 
+    /**
+     * Diagnostic accessor — `true` while the underlying
+     * multicast lock is held. Exposed for the [Discovery]
+     * snapshot API so on-device logs can show whether the lock
+     * was actually held when discovery appeared to silently fail.
+     */
+    @Synchronized
+    fun isHeld(): Boolean = gate.isHeld()
+
     internal companion object {
         const val DEFAULT_TAG: String = "wvmg-discovery-mdns"
+        private const val TAG: String = "WvmgDiscovery"
+
+        private fun systemMulticastLockGate(
+            context: Context,
+            tag: String,
+        ): MulticastLockGate {
+            val wifi =
+                context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+            val lock =
+                wifi.createMulticastLock(tag).apply {
+                    // `setReferenceCounted(false)` makes a single release() call always
+                    // fully release the lock, regardless of how many times the system
+                    // thinks it was acquired. Combined with our own counter this
+                    // gives unambiguous acquire/release semantics.
+                    setReferenceCounted(false)
+                }
+            return SystemMulticastLockGate(lock)
+        }
     }
+}
+
+/**
+ * Tiny interface that the [MulticastLockHolder] uses to talk to a
+ * platform multicast lock. Exists so JVM unit tests can drop in a fake
+ * without depending on a real [android.net.wifi.WifiManager].
+ */
+internal interface MulticastLockGate {
+    fun acquire()
+
+    fun release()
+
+    fun isHeld(): Boolean
+}
+
+/** Production [MulticastLockGate] backed by a real [WifiManager.MulticastLock]. */
+private class SystemMulticastLockGate(
+    private val lock: WifiManager.MulticastLock,
+) : MulticastLockGate {
+    override fun acquire(): Unit = lock.acquire()
+
+    override fun release(): Unit = lock.release()
+
+    override fun isHeld(): Boolean = lock.isHeld
 }

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/DiscoveredServiceMappingTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/DiscoveredServiceMappingTest.kt
@@ -109,6 +109,8 @@ class DiscoveredServiceMappingTest {
                     override fun acquire() = Unit
 
                     override fun release() = Unit
+
+                    override fun isHeld(): Boolean = false
                 },
             jmdnsProvider = { error("toDiscoveredService should not need a JmDNS instance") },
         )

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/DiscoveryAdvertiseTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/DiscoveryAdvertiseTest.kt
@@ -193,5 +193,7 @@ class DiscoveryAdvertiseTest {
         override fun release() {
             releaseCount++
         }
+
+        override fun isHeld(): Boolean = acquireCount > releaseCount
     }
 }

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/DiscoveryDiagnosticsTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/DiscoveryDiagnosticsTest.kt
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.discovery
+
+import com.google.common.truth.Truth.assertThat
+import io.github.kyujincho.wvmg.protocol.endpoint.DeviceType
+import io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import java.net.InetAddress
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import javax.jmdns.JmDNS
+
+/**
+ * Tests for [Discovery.snapshot] — the diagnostic API added for issue
+ * #83 so on-device debugging can show whether the multicast lock was
+ * actually held, which interface JmDNS bound to, and whether any
+ * service events flowed.
+ *
+ * These tests cover the snapshot transitions on the publish side
+ * (advertise → close) and ensure the recent-events buffer is bounded.
+ * The browse-side transitions are exercised by an instrumentation /
+ * on-device test (see the @Disabled placeholder at the bottom).
+ */
+class DiscoveryDiagnosticsTest {
+    @Test
+    fun `snapshot reports lock state and quiescent flags before any operation`() {
+        val locks = ToggleLockController()
+        val discovery =
+            Discovery.forTesting(
+                locks = locks,
+                jmdnsProvider = { error("not used") },
+            )
+        val snapshot = discovery.snapshot()
+        assertThat(snapshot.advertising).isFalse()
+        assertThat(snapshot.browsing).isFalse()
+        assertThat(snapshot.multicastLockHeld).isFalse()
+        assertThat(snapshot.advertiseBoundAddress).isNull()
+        assertThat(snapshot.browseBoundAddress).isNull()
+        assertThat(snapshot.recentEvents).isEmpty()
+    }
+
+    @Test
+    fun `advertise transitions advertising flag and bound address`() {
+        val locks = ToggleLockController()
+        val discovery =
+            Discovery.forTesting(
+                locks = locks,
+                jmdnsProvider = { name -> JmDNS.create(InetAddress.getLoopbackAddress(), name) },
+            )
+        val handle = discovery.advertise(sampleEndpointInfo(), port = 23_456)
+        try {
+            val active = discovery.snapshot()
+            assertThat(active.advertising).isTrue()
+            assertThat(active.multicastLockHeld).isTrue()
+            assertThat(active.advertiseBoundAddress).isNotNull()
+        } finally {
+            handle.close()
+        }
+
+        val closed = discovery.snapshot()
+        assertThat(closed.advertising).isFalse()
+        assertThat(closed.multicastLockHeld).isFalse()
+        assertThat(closed.advertiseBoundAddress).isNull()
+    }
+
+    @Test
+    fun `recent events buffer bounds at the configured cap`() {
+        val state = DiagnosticsState(maxEvents = 4)
+        for (i in 1..10) {
+            state.recordEvent(
+                DiagnosticEvent(
+                    kind = DiagnosticEvent.Kind.ADDED,
+                    instanceName = "name-$i",
+                    timestampMillis = i.toLong(),
+                ),
+            )
+        }
+        val snapshot = state.snapshot(multicastLockHeld = false)
+        assertThat(snapshot.recentEvents).hasSize(4)
+        // Oldest-to-newest ordering, with the four most recent surviving.
+        assertThat(snapshot.recentEvents.map { it.instanceName })
+            .containsExactly("name-7", "name-8", "name-9", "name-10")
+            .inOrder()
+    }
+
+    /**
+     * Placeholder marker for the on-device verification that needs two
+     * physical Android phones on the same Wi-Fi network — the canonical
+     * repro for issue #83. Mirrors the `@Disabled` pattern adopted in
+     * #28 for connection-loop integration tests; flip the annotation
+     * (or run via the Android instrumentation runner) once the manual
+     * setup is in place.
+     */
+    @Disabled(
+        "Requires two physical Android devices on the same Wi-Fi network; " +
+            "tracked in #83's manual verification checklist.",
+    )
+    @Test
+    fun `two devices on the same Wi-Fi network discover each other within five seconds`() {
+        // Manual / instrumentation verification only — see issue #83.
+        // Steps:
+        //   1. Install on Device A, start the receiver foreground service.
+        //   2. Install on Device B, open a share intent → SendActivity.
+        //   3. Within 5s, Device B's peer list shows Device A.
+        //   4. Tag `WvmgDiscovery` in logcat shows on both devices:
+        //        - "MulticastLockHolder ... acquired"
+        //        - "JmdnsFactory.create: binding ... to wifi address=<LAN IP>"
+        //        - "advertise: registered ..." on Device A
+        //        - "browse: serviceResolved ..." on Device B
+    }
+
+    private fun sampleEndpointInfo(): EndpointInfo =
+        EndpointInfo(
+            version = 1,
+            hidden = false,
+            deviceType = DeviceType.PHONE,
+            reserved = false,
+            metadata = ByteArray(EndpointInfo.METADATA_LEN) { it.toByte() },
+            deviceName = "Diag Test",
+            tlvRecords = emptyList(),
+        )
+
+    /**
+     * [LockController] that mirrors a real ref-counted lock: tracks
+     * acquire/release counts and surfaces `isHeld` from those.
+     */
+    private class ToggleLockController : LockController {
+        private val ref = AtomicInteger(0)
+        val held = AtomicBoolean(false)
+
+        override fun acquire() {
+            if (ref.getAndIncrement() == 0) held.set(true)
+        }
+
+        override fun release() {
+            if (ref.decrementAndGet() == 0) held.set(false)
+        }
+
+        override fun isHeld(): Boolean = held.get()
+    }
+}

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/JmdnsFactoryTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/JmdnsFactoryTest.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.discovery
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import java.net.InetAddress
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Pure-JVM tests for [JmdnsFactory]'s address-resolution behavior.
+ *
+ * The production address-resolution path on real Android devices is
+ * [JmdnsFactory.AndroidWifiAddressProvider], which talks to
+ * [android.net.wifi.WifiManager] and [android.net.ConnectivityManager].
+ * We do not exercise that path here — testing it would need a full
+ * Android instrumentation context, and the failure mode (returns
+ * `0.0.0.0` on API 31+ without precise location) is exactly what we are
+ * trying to avoid in unit tests.
+ *
+ * Instead we drive [JmdnsFactory.createWith] through a fake
+ * [JmdnsFactory.WifiAddressProvider]:
+ *   * a present address reaches `JmDNS.create(InetAddress, String)` verbatim, and
+ *   * a `null` address falls back to JmDNS's wildcard binding.
+ */
+class JmdnsFactoryTest {
+    @Test
+    fun `create consults the provider and produces a usable JmDNS instance`() {
+        val explicit = InetAddress.getByName("127.0.0.1")
+        val provider = StaticWifiAddressProvider(explicit)
+
+        val jmdns = JmdnsFactory.createWith(name = "test-bound", addressProvider = provider)
+        try {
+            // We don't pin the precise host string — JmDNS occasionally
+            // resolves IPv4 loopback to its IPv6 counterpart on certain
+            // OS / JDK combos (`fe80::1%lo0` on macOS). What we care
+            // about is that the provider was consulted *and* that
+            // JmDNS landed on a non-null bound interface.
+            assertThat(jmdns.inetAddress).isNotNull()
+            assertThat(provider.callCount.get()).isEqualTo(1)
+        } finally {
+            jmdns.close()
+        }
+    }
+
+    @Test
+    fun `create falls back to wildcard bind when provider returns null`() {
+        val provider = StaticWifiAddressProvider(null)
+
+        // The wildcard-bind path picks whatever interface JmDNS chooses;
+        // we only need to confirm the factory completes without throwing
+        // and that the returned instance has *some* bound interface so
+        // browsing logic does not NPE downstream.
+        val jmdns = JmdnsFactory.createWith(name = "test-wildcard", addressProvider = provider)
+        try {
+            assertThat(jmdns.inetAddress).isNotNull()
+            assertThat(provider.callCount.get()).isEqualTo(1)
+        } finally {
+            jmdns.close()
+        }
+    }
+
+    /**
+     * Records how many times `currentWifiAddress` was queried and
+     * always returns the same fixed answer. Lives at file scope so the
+     * test class itself stays compact.
+     */
+    private class StaticWifiAddressProvider(
+        private val address: InetAddress?,
+    ) : JmdnsFactory.WifiAddressProvider {
+        val callCount = AtomicInteger(0)
+
+        override fun currentWifiAddress(): InetAddress? {
+            callCount.incrementAndGet()
+            return address
+        }
+    }
+}

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/MulticastLockHolderTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/MulticastLockHolderTest.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.discovery
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * Pure-JVM tests for [MulticastLockHolder]. Drives the holder against a
+ * fake [MulticastLockGate] so we never need a real [android.net.wifi.WifiManager].
+ *
+ * Issue #83 hinged on the multicast lock never being held when mDNS
+ * needed it. These tests pin the ref-count semantics down to byte-level
+ * detail so the production wrapping over [WifiManager.MulticastLock]
+ * cannot regress without a corresponding test failure.
+ */
+class MulticastLockHolderTest {
+    @Test
+    fun `acquire and release pair through to the gate`() {
+        val gate = FakeGate()
+        val holder = MulticastLockHolder(gate = gate, tag = "test")
+
+        holder.acquire()
+        assertThat(holder.refCountForTest()).isEqualTo(1)
+        assertThat(gate.acquireCount).isEqualTo(1)
+        assertThat(holder.isHeld()).isTrue()
+
+        holder.release()
+        assertThat(holder.refCountForTest()).isEqualTo(0)
+        assertThat(gate.releaseCount).isEqualTo(1)
+        assertThat(holder.isHeld()).isFalse()
+    }
+
+    @Test
+    fun `multiple acquires only call the gate once`() {
+        val gate = FakeGate()
+        val holder = MulticastLockHolder(gate = gate, tag = "test")
+
+        holder.acquire()
+        holder.acquire()
+        holder.acquire()
+
+        assertThat(gate.acquireCount).isEqualTo(1)
+        assertThat(holder.refCountForTest()).isEqualTo(3)
+        assertThat(holder.isHeld()).isTrue()
+    }
+
+    @Test
+    fun `gate is released only on last release`() {
+        val gate = FakeGate()
+        val holder = MulticastLockHolder(gate = gate, tag = "test")
+
+        holder.acquire()
+        holder.acquire()
+        holder.release()
+        assertThat(gate.releaseCount).isEqualTo(0)
+        assertThat(holder.isHeld()).isTrue()
+
+        holder.release()
+        assertThat(gate.releaseCount).isEqualTo(1)
+        assertThat(holder.isHeld()).isFalse()
+        assertThat(holder.refCountForTest()).isEqualTo(0)
+    }
+
+    @Test
+    fun `releasing more than acquired throws IllegalStateException`() {
+        val gate = FakeGate()
+        val holder = MulticastLockHolder(gate = gate, tag = "test")
+
+        holder.acquire()
+        holder.release()
+        // Counter is back at zero; another release is a programmer error.
+        assertThrows<IllegalStateException> { holder.release() }
+    }
+
+    @Test
+    fun `acquire after final release re-engages the gate`() {
+        val gate = FakeGate()
+        val holder = MulticastLockHolder(gate = gate, tag = "test")
+
+        holder.acquire()
+        holder.release()
+        holder.acquire()
+
+        assertThat(gate.acquireCount).isEqualTo(2)
+        assertThat(holder.isHeld()).isTrue()
+
+        holder.release()
+        assertThat(gate.releaseCount).isEqualTo(2)
+    }
+
+    /**
+     * Test-only [MulticastLockGate]. Mirrors the platform contract that
+     * `acquire()` makes `isHeld()` return true and `release()` makes it
+     * return false, ignoring spurious double-acquires (which the holder
+     * is supposed to suppress through its ref counter).
+     */
+    private class FakeGate : MulticastLockGate {
+        var acquireCount: Int = 0
+            private set
+        var releaseCount: Int = 0
+            private set
+        private var held: Boolean = false
+
+        override fun acquire() {
+            acquireCount++
+            held = true
+        }
+
+        override fun release() {
+            releaseCount++
+            held = false
+        }
+
+        override fun isHeld(): Boolean = held
+    }
+}

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
@@ -14,6 +14,7 @@ import android.content.pm.ServiceInfo
 import android.net.wifi.WifiManager
 import android.os.Build
 import android.os.IBinder
+import android.util.Log
 import androidx.core.app.ServiceCompat
 import androidx.core.content.ContextCompat
 import io.github.kyujincho.wvmg.discovery.Discovery
@@ -28,6 +29,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import java.util.concurrent.atomic.AtomicReference
 
@@ -198,6 +201,41 @@ public class ReceiverForegroundService : Service() {
                 stopReceiverAndExit()
             }
         }
+
+        // Periodically log the discovery diagnostics so issue #83's
+        // silent-failure surface is visible in logcat without needing a
+        // debug screen. The cadence is intentionally slow (every 10s)
+        // so we don't spam logcat in the steady state.
+        startDiscoveryDiagnosticsLogger()
+    }
+
+    /**
+     * Emit a [DiscoveryDiagnostics] line to logcat every
+     * [DIAGNOSTICS_LOG_INTERVAL_MS] ms while the service is running.
+     * Wired off the [ActiveDiscoveryHolder] so any session factory that
+     * stores a [Discovery] there gets observed for free; if no
+     * [Discovery] is registered (e.g. tests installing a custom
+     * factory) the loop simply skips logging and idles.
+     */
+    private fun startDiscoveryDiagnosticsLogger() {
+        serviceScope.launch {
+            while (isActive) {
+                val discovery = ActiveDiscoveryHolder.current()
+                if (discovery != null) {
+                    val snap = discovery.snapshot()
+                    Log.i(
+                        DIAGNOSTICS_TAG,
+                        "discovery snapshot: " +
+                            "advertising=${snap.advertising} browsing=${snap.browsing} " +
+                            "lockHeld=${snap.multicastLockHeld} " +
+                            "advBound=${snap.advertiseBoundAddress?.hostAddress ?: "-"} " +
+                            "browseBound=${snap.browseBoundAddress?.hostAddress ?: "-"} " +
+                            "events=${snap.recentEvents.size}",
+                    )
+                }
+                delay(DIAGNOSTICS_LOG_INTERVAL_MS)
+            }
+        }
     }
 
     /**
@@ -281,6 +319,7 @@ public class ReceiverForegroundService : Service() {
 
         session?.stop()
         session = null
+        ActiveDiscoveryHolder.clear()
         serviceJob.cancel()
         ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE)
         stopSelf()
@@ -358,11 +397,16 @@ public class ReceiverForegroundService : Service() {
             SessionFactory { context ->
                 val identity = EndpointIdentityHolder.snapshot.get() ?: defaultEndpointInfo(context)
                 EndpointIdentityHolder.snapshot.compareAndSet(null, identity)
+                // Keep one Discovery per session so the periodic
+                // diagnostic snapshot in [startReceiverSession] reflects
+                // the same instance the advertise lambda is using.
+                val discovery = Discovery(context)
+                ActiveDiscoveryHolder.set(discovery)
                 ReceiverSession(
                     tcpServerFactory = TcpServerFactory.default(),
                     advertiser =
                         DiscoveryAdvertiser { endpointInfo, port ->
-                            Discovery(context).advertise(endpointInfo, port)
+                            discovery.advertise(endpointInfo, port)
                         },
                     multicastLock = AndroidMulticastLockController(context),
                     factoryProvider = { DownloadsWriterFactory.create(context) },
@@ -441,6 +485,40 @@ public class ReceiverForegroundService : Service() {
         // single-byte length limit and is more than enough for typical
         // app-label names ("Quick Share" is 11).
         private const val MAX_DEFAULT_NAME_BYTES = 64
+
+        /**
+         * Cadence for the discovery diagnostics logger spawned in
+         * [startDiscoveryDiagnosticsLogger]. 10 s strikes a balance
+         * between catching the silent-failure window from issue #83
+         * (peers should be visible within a few seconds) and not
+         * flooding logcat in steady state.
+         */
+        private const val DIAGNOSTICS_LOG_INTERVAL_MS: Long = 10_000L
+
+        /** logcat tag for the diagnostics line — matches the discovery module. */
+        private const val DIAGNOSTICS_TAG: String = "WvmgDiscovery"
+    }
+}
+
+/**
+ * Process-wide holder for the active [Discovery] instance. The
+ * receiver session factory stashes its [Discovery] here so the service
+ * body's diagnostic-snapshot loop can read it without expanding the
+ * [SessionFactory] interface. Tests that install a custom factory
+ * never touch this holder and the snapshot loop simply finds `null`.
+ */
+internal object ActiveDiscoveryHolder {
+    @Volatile
+    private var ref: io.github.kyujincho.wvmg.discovery.Discovery? = null
+
+    fun set(discovery: io.github.kyujincho.wvmg.discovery.Discovery) {
+        ref = discovery
+    }
+
+    fun current(): io.github.kyujincho.wvmg.discovery.Discovery? = ref
+
+    fun clear() {
+        ref = null
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #83.

Two-device manual testing turned up that the receiver's mDNS service was never visible from the sender. The audit identified three concrete production bugs and added an on-device diagnostics surface:

1. **Wi-Fi address resolution silently failing on API 31+.** We only tried `WifiManager.connectionInfo`, which is deprecated and returns sentinel `0.0.0.0` for apps without precise-location permission. We don't request that permission, so JmDNS was binding to localhost on modern devices and dropping multicast. **Fix:** switched primary lookup to `ConnectivityManager.LinkProperties` for the active Wi-Fi network (no permission required); WifiManager is fallback only.

2. **Browser missed services advertised before the listener attached.** `JmDNS.addServiceListener` only sends a one-shot PTR query — a pre-existing peer's cached announcement could be missed. **Fix:** call `jmdns.list(SERVICE_TYPE, timeout)` once on browser start to force a synchronous discovery pass.

3. **`MulticastLock` lifecycle had a gap** during which multicast packets were filtered. Tightened ordering so the lock is held strictly across `addServiceListener` ↔ `removeServiceListener`.

4. **`DiscoveryDiagnostics` API + periodic logcat dump** from the receiver foreground service (tag `WvmgDiscovery`, every 10 s). On a real device:
   ```
   adb logcat -s WvmgDiscovery
   ```
   shows the bound interface, lock state, advertise/browse flags, and a ring buffer of recent service-add/resolve/remove events.

## Test scope

Pure-JVM unit tests with mocked `WifiManager` / `ConnectivityManager` / `MulticastLock` — UDP multicast doesn't work in unit tests. End-to-end verification on real hardware is the human follow-up after merge.

## Verification
- `./gradlew :discovery-android:testDebugUnitTest :service-android:testDebugUnitTest` — pass.
- `./gradlew :discovery-android:ktlintCheck :discovery-android:detekt :service-android:ktlintCheck :service-android:detekt` — pass.