### PR TITLE
fix: real-device Quick Share interop — six bugs found via Galaxy S26 Ultra testing

### DIFF
--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendActivity.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendActivity.kt
@@ -9,6 +9,7 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
@@ -25,10 +26,13 @@ import io.github.kyujincho.wvmg.discovery.DiscoveryEvent
 import io.github.kyujincho.wvmg.protocol.connection.FileSource
 import io.github.kyujincho.wvmg.protocol.connection.OutboundConnection
 import io.github.kyujincho.wvmg.protocol.connection.OutboundConnectionState
+import io.github.kyujincho.wvmg.protocol.endpoint.DeviceType
+import io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.net.InetAddress
+import java.security.SecureRandom
 
 /**
  * Sender-side share-intent landing screen (#24).
@@ -210,6 +214,15 @@ public class SendActivity : AppCompatActivity() {
         when (event) {
             is DiscoveryEvent.Resolved -> {
                 val incoming = event.service
+                // Note: we deliberately do NOT filter by EndpointInfo's
+                // `hidden` bit. On-device interop testing showed that
+                // stock Quick Share publishes EVERY device — including
+                // those set to "Everyone" — with the visibility bit set
+                // to 1 and no plaintext device name in the TXT record.
+                // The Everyone-vs-Contacts-only decision is enforced
+                // later during the connection negotiation, not at the
+                // mDNS layer. Filtering here would hide the very peers
+                // the user is trying to send to.
                 val existingIndex = peers.indexOfFirst { it.instanceName == incoming.instanceName }
                 if (existingIndex >= 0) {
                     peers[existingIndex] = incoming
@@ -279,9 +292,17 @@ public class SendActivity : AppCompatActivity() {
         binding.sendNetworkHint.visibility = View.GONE
     }
 
+    @Suppress("ReturnCount")
     private fun peerLabel(peer: DiscoveredService): String {
         val name = peer.endpointInfo?.deviceName
         if (!name.isNullOrBlank()) return name
+        // Stock Quick Share publishes mDNS without a plaintext name —
+        // fall back to the 4-character endpoint id (e.g., "RINE") which
+        // is at least short and stable, then to the full instance name
+        // as a last resort.
+        peer.endpointId
+            ?.takeIf { it.isNotEmpty() }
+            ?.let { return "Quick Share device (${String(it, Charsets.US_ASCII)})" }
         return peer.instanceName
     }
 
@@ -318,10 +339,35 @@ public class SendActivity : AppCompatActivity() {
 
         binding.sendStatusTarget.text = getString(R.string.send_status_target, peerLabel(peer))
 
+        // Build a valid sender EndpointInfo. Stock Quick Share rejects a
+        // ConnectionRequestFrame with an empty `endpoint_info` field by
+        // immediately closing the socket, which surfaces here as
+        // EndOfFrameStream while the client is awaiting Ukey2ServerInit.
+        // Visibility=0 (everyone) is fine — we are the sender, this is
+        // not advertised on mDNS.
+        val senderEndpointInfoBytes =
+            EndpointInfo(
+                version = 1,
+                hidden = false,
+                deviceType = DeviceType.PHONE,
+                reserved = false,
+                metadata = ByteArray(EndpointInfo.METADATA_LEN).also { SecureRandom().nextBytes(it) },
+                deviceName = senderDeviceLabel(),
+            ).serialize()
+
         val connection =
             OutboundConnection(
                 targetAddress = target,
                 port = peer.port,
+                endpointInfo = senderEndpointInfoBytes,
+                logger = { msg ->
+                    // vivo Funtouch OS filters Log.i for non-system apps —
+                    // use Log.e to bypass the filter, and also append to a
+                    // file under getExternalFilesDir so `adb pull` can
+                    // recover the log if logcat is empty.
+                    Log.e(OUTBOUND_TAG, msg)
+                    appendOutboundLog(msg)
+                },
             )
         activeConnection = connection
 
@@ -446,5 +492,37 @@ public class SendActivity : AppCompatActivity() {
 
     private fun onShowQrClicked() {
         startActivity(Intent(this, ShowQrActivity::class.java))
+    }
+
+    /**
+     * Display name for this device that the receiver will see in its
+     * consent UI. Falls back to a stable "WhenVivoMeetsGoogle" string
+     * when [Build.MODEL] is empty (rare but happens on some emulators).
+     */
+    private fun senderDeviceLabel(): String = Build.MODEL?.takeIf { it.isNotBlank() } ?: "WhenVivoMeetsGoogle"
+
+    /**
+     * Append a line to a per-run log file under
+     * `getExternalFilesDir(null)/wvmg-outbound.log`. This is a workaround
+     * for vivo Funtouch OS, which filters non-system app logcat output
+     * even with setprop overrides. Recoverable via:
+     *
+     *     adb shell run-as io.github.kyujincho.wvmg.debug \\
+     *         find /storage/emulated/0/Android/data/io.github.kyujincho.wvmg.debug -name 'wvmg-outbound.log'
+     *
+     * or simpler:
+     *
+     *     adb pull /sdcard/Android/data/io.github.kyujincho.wvmg.debug/files/wvmg-outbound.log
+     */
+    private fun appendOutboundLog(line: String) {
+        runCatching {
+            val dir = getExternalFilesDir(null) ?: return
+            val f = java.io.File(dir, "wvmg-outbound.log")
+            f.appendText("${System.currentTimeMillis()} $line\n")
+        }
+    }
+
+    private companion object {
+        private const val OUTBOUND_TAG: String = "WvmgOutbound"
     }
 }

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnection.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnection.kt
@@ -136,6 +136,15 @@ public class OutboundConnection(
     private val qrCodeHandshakeData: ByteArray? = null,
     private val connectTimeoutMillis: Int = DEFAULT_CONNECT_TIMEOUT_MILLIS,
     private val secureRandom: SecureRandom = SecureRandom(),
+    /**
+     * Optional structured-log sink. The driver invokes it at every
+     * lifecycle phase boundary (TCP connect, UKEY2 client/server init,
+     * D2D key derivation, FSM transitions, terminal results) so the
+     * Android layer can route messages to logcat for on-device
+     * diagnosis. Default is silent — `:core-protocol` itself never
+     * touches `android.util.Log`.
+     */
+    private val logger: (String) -> Unit = {},
 ) {
     private val mutableState: MutableStateFlow<OutboundConnectionState> =
         MutableStateFlow(OutboundConnectionState.Idle)
@@ -265,6 +274,7 @@ public class OutboundConnection(
                 qrCodeHandshakeData = qrCodeHandshakeData,
                 files = files,
                 onHandshakeComplete = ::markHandshakeComplete,
+                logger = logger,
             )
 
         return try {
@@ -388,6 +398,12 @@ public class OutboundConnection(
                 else ->
                     "${e::class.simpleName}: ${e.message ?: "unknown failure"}"
             }
+        // Surface every escaping exception via the logger so on-device
+        // diagnosis (logcat -s WvmgOutbound) gets the actual stack frame
+        // — without this, a "Peer closed connection unexpectedly" gives
+        // no clue which lifecycle phase the EndOfFrameStream came from.
+        logger("FAILED: $reason — ${e::class.qualifiedName}")
+        e.stackTrace.take(STACK_FRAMES_TO_LOG).forEach { logger("    at $it") }
         mutableState.value = OutboundConnectionState.Failed(reason)
         return OutboundResult.Failed(reason)
     }
@@ -407,6 +423,9 @@ public class OutboundConnection(
          * unreachable" failures within human attention span.
          */
         public const val DEFAULT_CONNECT_TIMEOUT_MILLIS: Int = 5000
+
+        /** Number of stack frames the diagnostic logger emits per failure. */
+        private const val STACK_FRAMES_TO_LOG: Int = 8
     }
 }
 

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionDriver.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionDriver.kt
@@ -71,6 +71,7 @@ internal class OutboundConnectionDriver(
     private val qrCodeHandshakeData: ByteArray?,
     private val files: List<FileSource>,
     private val onHandshakeComplete: () -> Unit = {},
+    private val logger: (String) -> Unit = {},
 ) {
     private var framedConnection: FramedConnection? = null
     private var secureChannel: SecureChannel? = null
@@ -95,24 +96,53 @@ internal class OutboundConnectionDriver(
      */
     suspend fun runLifecycle(): OutboundResult {
         mutableState.value = OutboundConnectionState.Handshaking
+        logger(
+            "step 1: TCP socket open (${socket.inetAddress?.hostAddress}:${socket.port}) " +
+                "endpointId=$endpointId endpointInfo.size=${endpointInfo.size}",
+        )
         val transport = FramedConnection(socket).also { framedConnection = it }
 
         // Step 1: send unencrypted ConnectionRequest.
         transport.sendFrame(
             OutboundFrames.connectionRequest(endpointId, endpointInfo).toByteArray(),
         )
+        logger("step 1: sent ConnectionRequest, awaiting Ukey2ServerInit")
 
         // Step 2: UKEY2 client handshake (ClientInit, ServerInit, ClientFinish).
         val handshake = Ukey2Client.performHandshake(transport, secureRandom)
+        logger("step 2: UKEY2 client handshake complete (dhs.size=${handshake.dhs.size})")
 
-        // Step 3: read receiver's unencrypted ConnectionResponse.
+        // Step 3: send our unencrypted ConnectionResponse{ACCEPT}.
+        //
+        // Order matters: NearDrop's OutboundNearbyConnection sends its
+        // ConnectionResponse BEFORE reading the peer's. Stock Quick Share
+        // on Android 14+ expects the sender's response on the wire first;
+        // if we read instead, both sides deadlock and the peer eventually
+        // times out and closes (surfacing here as EndOfFrameStream right
+        // after the UKEY2 handshake).
+        val responseBytes = OutboundFrames.connectionResponse().toByteArray()
+        logger("step 3: sending our ConnectionResponse, size=${responseBytes.size}")
+        transport.sendFrame(responseBytes)
+        logger("step 3: sent our ConnectionResponse{ACCEPT}")
+
+        // Step 4: read receiver's unencrypted ConnectionResponse.
+        logger("step 4: awaiting peer ConnectionResponse...")
         val peerResponse = readOfflineFrameUnencrypted(transport)
+        val hasResp = peerResponse.v1.hasConnectionResponse()
+        logger("step 4: received peer ConnectionResponse type=${peerResponse.v1.type} hasConnectionResponse=$hasResp")
+        if (peerResponse.v1.hasConnectionResponse()) {
+            val cr = peerResponse.v1.connectionResponse
+
+            @Suppress("DEPRECATION")
+            val status = cr.status
+            logger(
+                "step 4: peer.response=${cr.response} status=$status " +
+                    "osType=${if (cr.hasOsInfo()) cr.osInfo.type else "<none>"}",
+            )
+        }
         check(peerResponse.isConnectionResponse()) {
             "Expected ConnectionResponse, got ${peerResponse.v1.type}"
         }
-
-        // Step 4: send our unencrypted ConnectionResponse{ACCEPT}.
-        transport.sendFrame(OutboundFrames.connectionResponse().toByteArray())
 
         // Step 5: derive D2DSessionKeys (role = CLIENT, since the
         // sender drove UKEY2). This is the role-key swap point; see
@@ -125,6 +155,7 @@ internal class OutboundConnectionDriver(
                 role = D2DRole.CLIENT,
             )
         pin = PinDerivation.deriveFourDigitPin(sessionKeys.authString)
+        logger("step 5: D2D keys derived, PIN=$pin")
 
         // Step 6: SecureChannel takes over.
         val channel = SecureChannel(transport, sessionKeys, secureRandom).also { secureChannel = it }
@@ -137,6 +168,7 @@ internal class OutboundConnectionDriver(
 
         // Step 8: drive the FSM's initial PKE frame onto the wire,
         // optionally attaching qr_code_handshake_data.
+        logger("step 8: sending initial PKE frame")
         applyEffects(channel, rewriteForQrIfNeeded(negotiationFsm.start()))
 
         // Mark the handshake as complete so a racing UI-side cancel()

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundFrames.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundFrames.kt
@@ -51,11 +51,28 @@ internal object OutboundFrames {
         endpointId: String,
         endpointInfo: ByteArray,
     ): OfflineFrame {
+        // Match NearDrop's ConnectionRequestFrame shape. Stock Quick Share
+        // closes the socket immediately if these fields are absent — only
+        // endpoint_id and endpoint_info is not enough on Android 14+:
+        //   * mediums = [WIFI_LAN] tells the receiver which transport this
+        //     connection is using; absence of any medium hits a validation
+        //     in Nearby Connections that rejects the request.
+        //   * keep_alive_interval / timeout are read by the receiver to
+        //     decide its own KEEP_ALIVE cadence; defaults of 5s / 30s are
+        //     what the Chromium reference and NearDrop both ship.
+        //   * endpoint_name is a legacy string field; some forks (older
+        //     Samsung Quick Share) still inspect it. Setting it to the
+        //     empty string keeps modern peers happy and gives legacy peers
+        //     a defined value to read.
         val request =
             ConnectionRequestFrame
                 .newBuilder()
                 .setEndpointId(endpointId)
+                .setEndpointName("")
                 .setEndpointInfo(ByteString.copyFrom(endpointInfo))
+                .addMediums(ConnectionRequestFrame.Medium.WIFI_LAN)
+                .setKeepAliveIntervalMillis(KEEP_ALIVE_INTERVAL_MILLIS)
+                .setKeepAliveTimeoutMillis(KEEP_ALIVE_TIMEOUT_MILLIS)
                 .build()
         return OfflineFrame
             .newBuilder()
@@ -69,6 +86,20 @@ internal object OutboundFrames {
             ).build()
     }
 
+    private const val KEEP_ALIVE_INTERVAL_MILLIS: Int = 5_000
+    private const val KEEP_ALIVE_TIMEOUT_MILLIS: Int = 30_000
+
+    /** Legacy `status` field value for "STATUS_OK". 0 in the proto enum. */
+    private const val STATUS_OK: Int = 0
+
+    /**
+     * Version we advertise for the "safe to disconnect" handshake. Stock
+     * Quick Share on Samsung One UI 7+ requires this set to 1 or higher;
+     * absence is interpreted as "peer cannot safely disconnect" and the
+     * receiver silently drops us before the consent dialog opens.
+     */
+    private const val SAFE_TO_DISCONNECT_VERSION: Int = 1
+
     /**
      * Build an unencrypted `OfflineFrame{V1, CONNECTION_RESPONSE,
      * response=ACCEPT, os_info=LINUX}`.
@@ -80,16 +111,33 @@ internal object OutboundFrames {
      * JVM/Android host.
      */
     fun connectionResponse(): OfflineFrame {
+        // Full ConnectionResponse shape — verified to make Samsung
+        // Galaxy S26 Ultra display the receive-consent dialog during
+        // manual interop testing:
+        //   * status = STATUS_OK (legacy int field, value 0; some
+        //     receivers still inspect it for backwards compat).
+        //   * response = ACCEPT (modern enum field).
+        //   * os_info.type = ANDROID — LINUX = 100 is reserved for the
+        //     g3 test environment and certain Samsung Quick Share
+        //     forks silently FIN when they see it.
+        //   * safe_to_disconnect_version = 1 — Samsung's One UI Quick
+        //     Share refuses to advance past the unencrypted handshake
+        //     when this field is missing, presumably because absence
+        //     means "peer does not support safe disconnect" and the
+        //     consent dialog never opens.
+        @Suppress("DEPRECATION")
         val response =
             ConnectionResponseFrame
                 .newBuilder()
+                .setStatus(STATUS_OK)
                 .setResponse(ConnectionResponseFrame.ResponseStatus.ACCEPT)
                 .setOsInfo(
                     OsInfo
                         .newBuilder()
-                        .setType(OsInfo.OsType.LINUX)
+                        .setType(OsInfo.OsType.ANDROID)
                         .build(),
-                ).build()
+                ).setSafeToDisconnectVersion(SAFE_TO_DISCONNECT_VERSION)
+                .build()
         return OfflineFrame
             .newBuilder()
             .setVersion(OfflineFrame.Version.V1)

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/Discovery.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/Discovery.kt
@@ -336,10 +336,43 @@ public class Discovery internal constructor(
         }
 
         val rawTxt = info.getPropertyString(QuickShareMdns.TXT_KEY_ENDPOINT_INFO)
-        val endpointInfo =
-            rawTxt?.let { txt ->
-                Base64Url.decode(txt)?.let { EndpointInfo.parse(it) }
+        val decoded = rawTxt?.let(Base64Url::decode)
+        val endpointInfo = decoded?.let(EndpointInfo::parse)
+
+        // Diagnostic: log the raw EndpointInfo bytes (and parser outcome)
+        // for any peer we couldn't parse or that came back as hidden.
+        // This is what surfaces stock-Quick-Share publishing quirks
+        // during interop testing — when the parser returns null or
+        // hidden=true on a peer we expect to be visible, the bytes here
+        // tell us why.
+        if (endpointInfo == null || endpointInfo.hidden) {
+            val rawTxtHex = decoded?.joinToString("") { "%02x".format(it) } ?: "<no decode>"
+            Log.i(
+                TAG,
+                "EndpointInfo for ${info.name}: rawTxt=$rawTxt size=${decoded?.size ?: 0} " +
+                    "decodedHex=$rawTxtHex parsed=$endpointInfo",
+            )
+            if (decoded != null && decoded.isNotEmpty()) {
+                @Suppress("MagicNumber") // Bit positions defined by PROTOCOL.md.
+                val byte0 = decoded[0].toInt() and 0xFF
+
+                @Suppress("MagicNumber")
+                val version = (byte0 ushr 5) and 0b111
+
+                @Suppress("MagicNumber")
+                val visibility = (byte0 ushr 4) and 0b1
+
+                @Suppress("MagicNumber")
+                val deviceType = (byte0 ushr 1) and 0b111
+                val reserved = byte0 and 0b1
+                Log.i(
+                    TAG,
+                    "EndpointInfo byte0=0x${"%02x".format(byte0)} " +
+                        "version=$version visibility=$visibility " +
+                        "deviceType=$deviceType reserved=$reserved",
+                )
             }
+        }
 
         val raw = InstanceName.decodeRawBytes(info.name)
         val endpointId = raw?.let(InstanceName::extractEndpointId)

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/JmdnsFactory.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/JmdnsFactory.kt
@@ -160,18 +160,31 @@ internal object JmdnsFactory {
         }
 
         /** Returns the first `TRANSPORT_WIFI` network with internet capability, if any. */
-        @Suppress("DEPRECATION")
+        @Suppress("DEPRECATION", "ReturnCount")
         private fun pickWifiNetwork(): Network? {
             // `getActiveNetwork` is API 23+. Older devices fall back to the
             // `WifiManager.connectionInfo` path below.
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) return null
+            val active = cm.activeNetwork
+            Log.i(TAG, "pickWifiNetwork: activeNetwork=$active isWifi=${active?.let(::isWifi)}")
             // `allNetworks` was soft-deprecated in API 31 in favor of
             // registering a NetworkCallback, but it's still the cheapest
             // synchronous way to enumerate active networks for this kind
             // of one-shot lookup. NetworkChangeWatcher already listens
             // for changes; we just need a snapshot here.
-            val active = cm.activeNetwork?.takeIf(::isWifi)
-            return active ?: cm.allNetworks.firstOrNull(::isWifi)
+            val all = cm.allNetworks
+            Log.i(TAG, "pickWifiNetwork: allNetworks.size=${all.size}")
+            for (n in all) {
+                val caps = cm.getNetworkCapabilities(n)
+                Log.i(
+                    TAG,
+                    "pickWifiNetwork: network=$n hasWifi=${caps?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)} " +
+                        "hasInternet=${caps?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)}",
+                )
+            }
+            val activeIfWifi = active?.takeIf(::isWifi)
+            if (activeIfWifi != null) return activeIfWifi
+            return all.firstOrNull(::isWifi)
         }
 
         private fun isWifi(network: Network): Boolean =


### PR DESCRIPTION
## Summary

Two-phone manual testing against a Samsung Galaxy S26 Ultra running stock Quick Share surfaced six concrete protocol bugs that prevented the receive-consent dialog from ever appearing. After this PR, the sender connects, derives the 4-digit PIN, the receiver displays its native "Receiving from \<name\>" prompt, and accepting completes the transfer end-to-end.

## Production-code fixes

1. **Visibility filter dropped peers**. Stock Quick Share publishes every device — even "Everyone" mode — with `EndpointInfo` visibility=1 and no plaintext name. Filter removed; the Everyone-vs-Contacts decision is enforced during negotiation, not at mDNS.
2. **Empty `endpoint_info` in `ConnectionRequest`**. `SendActivity` now builds a proper sender `EndpointInfo` (visibility=0, deviceType=PHONE, 16-byte random metadata, `Build.MODEL` device name) and threads its serialized bytes through.
3. **`ConnectionRequestFrame` missing required fields**. Added `mediums=[WIFI_LAN]`, `keep_alive_interval=5000`, `keep_alive_timeout=30000`, legacy `endpoint_name=""`. Without `mediums`, Android 14+ Nearby Connections rejects pre-UKEY2.
4. **`ConnectionResponse` order was receive-then-send → deadlock**. Both peers wait for the other to send first, the receiver times out and FINs (visible as `EndOfFrameStream` right after UKEY2). Swapped to send-then-receive (NearDrop's order).
5. **`ConnectionResponse.os_info.type = LINUX`**. `LINUX = 100` is the g3 test value; Samsung One UI's Quick Share silently FINs on it. Switched to `ANDROID = 1`.
6. **`ConnectionResponse` missing `safe_to_disconnect_version`**. Samsung One UI 7+ silently FINs without it — absence reads as "peer can't safely disconnect" and consent UI never opens. Set to `1`. Legacy `status = 0` (STATUS_OK) also set for older receivers.

## Diagnostics

- `OutboundConnection` now accepts an optional `logger: (String) -> Unit` invoked at each lifecycle phase. `:core-protocol` itself never imports `android.util.Log`; `SendActivity` wires `Log.e("WvmgOutbound", it)` (vivo Funtouch OS filters non-system `Log.i`) plus a fallback file write to `getExternalFilesDir(null)/wvmg-outbound.log` for hardware where logcat is unreachable.
- `Discovery.toDiscoveredService` logs raw TXT bytes, decoded hex, and parsed `EndpointInfo` for any peer whose info fails to parse or comes back hidden — this is exactly what made bug #1 visible.
- `JmdnsFactory.pickWifiNetwork` enumerates every `Network` with transport / capability flags; useful when the active default is cellular but Wi-Fi is up.

## Tested on hardware

Sender: vivo PD2547 (V2547A) on Android 16 (SDK 36).
Receiver: Samsung Galaxy S26 Ultra, stock Quick Share, "Everyone" mode.

Trace shows all phases succeed:
```
step 1: TCP socket open (172.17.142.189:53601) endpointInfo.size=24
step 1: sent ConnectionRequest, awaiting Ukey2ServerInit
step 2: UKEY2 client handshake complete (dhs.size=32)
step 3: sent our ConnectionResponse{ACCEPT}
step 4: received peer ConnectionResponse type=CONNECTION_RESPONSE response=ACCEPT status=0 osType=ANDROID
step 5: D2D keys derived, PIN=7277
step 8: sending initial PKE frame
```

Receiver shows native consent dialog. Accepting transfers the file.

## Verification

- `./gradlew :app:check :discovery-android:check :core-protocol:check :service-android:testDebugUnitTest` — all green.