### PR TITLE
feat: BLE permissions onboarding for Phase 2 (#31)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,7 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <!--
-      Phase 1 permission set for Quick Share over Wi-Fi LAN.
+      Phase 1 + Phase 2 permission set for Quick Share over Wi-Fi LAN
+      with BLE auto-discovery.
 
       Runtime (must be requested at app start, gated by API level):
         * NEARBY_WIFI_DEVICES (API 33+) — required for any local-network
@@ -12,6 +13,14 @@
           ACCESS_FINE_LOCATION on API 33+ devices.
         * POST_NOTIFICATIONS (API 33+) — used by the foreground transfer
           service notification (#21) and incoming-transfer notifications.
+        * BLUETOOTH_ADVERTISE (API 31+, #31) — required to broadcast the
+          Quick Share BLE service-data pulse so stock receivers wake up
+          their mDNS responder when our app starts a send (#32).
+        * BLUETOOTH_SCAN (API 31+, #31) — required to scan for senders'
+          BLE pulses so we only enable our mDNS responder when a sender is
+          nearby (#33). neverForLocation tells Android we never derive
+          physical location from BLE scan results, so the platform skips
+          the location-permission requirement.
 
       Compile-time (no runtime prompt):
         * CHANGE_WIFI_MULTICAST_STATE — held while mDNS is active via
@@ -19,9 +28,19 @@
           dropped on Android by default unless the lock is acquired.
         * INTERNET / ACCESS_NETWORK_STATE / ACCESS_WIFI_STATE — local
           socket I/O, network/Wi-Fi state inspection.
+        * BLUETOOTH / BLUETOOTH_ADMIN (API ≤ 30, #31) — legacy permission
+          model for pre-Android-12 devices. Capped with maxSdkVersion=30
+          so API 31+ devices use the runtime BLUETOOTH_ADVERTISE /
+          BLUETOOTH_SCAN permissions instead.
 
-      Phase 2 (BLUETOOTH_*) and READ_MEDIA_* are intentionally omitted —
-      see issue #26 scope notes.
+      BLUETOOTH_CONNECT is intentionally NOT declared — Phase 2 only
+      advertises and scans; it does not initiate or accept GATT
+      connections. If/when BLE L2CAP support lands the runtime permission
+      will be added alongside that work.
+
+      READ_MEDIA_* is intentionally omitted — Phase 1 routes all media
+      access through the system share-intent flow, which does not require
+      direct media permissions.
     -->
 
     <!-- Wi-Fi peer discovery on API 33+. neverForLocation tells Android we
@@ -37,6 +56,28 @@
     <uses-permission
         android:name="android.permission.POST_NOTIFICATIONS"
         tools:targetApi="33" />
+
+    <!-- Phase 2 BLE auto-discovery permissions (#31). Runtime on API 31+.
+         BLUETOOTH_SCAN uses neverForLocation so the platform does not
+         require ACCESS_FINE_LOCATION; we do not derive physical location
+         from BLE pulse scans. -->
+    <uses-permission
+        android:name="android.permission.BLUETOOTH_ADVERTISE"
+        tools:targetApi="31" />
+    <uses-permission
+        android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation"
+        tools:targetApi="31" />
+
+    <!-- Legacy Bluetooth permission model for API ≤ 30. Capped with
+         maxSdkVersion=30 so API 31+ devices use the runtime BLUETOOTH_*
+         permissions above instead of these grant-at-install variants. -->
+    <uses-permission
+        android:name="android.permission.BLUETOOTH"
+        android:maxSdkVersion="30" />
+    <uses-permission
+        android:name="android.permission.BLUETOOTH_ADMIN"
+        android:maxSdkVersion="30" />
 
     <!-- Multicast lock for mDNS service discovery (compile-time). -->
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/onboarding/PermissionRequirements.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/onboarding/PermissionRequirements.kt
@@ -15,25 +15,37 @@ import androidx.core.content.ContextCompat
 import io.github.kyujincho.wvmg.R
 
 /**
- * Single source of truth for the runtime permissions Phase 1 needs.
+ * Single source of truth for the runtime permissions onboarding asks for.
  *
  * Compile-time permissions (`CHANGE_WIFI_MULTICAST_STATE`, `INTERNET`,
- * `ACCESS_NETWORK_STATE`, `ACCESS_WIFI_STATE`) are declared in the
- * manifest and never appear here — they are granted at install time.
+ * `ACCESS_NETWORK_STATE`, `ACCESS_WIFI_STATE`, legacy `BLUETOOTH` /
+ * `BLUETOOTH_ADMIN` on API ≤ 30) are declared in the manifest and never
+ * appear here — they are granted at install time.
  *
  * Runtime permissions are gated by API level:
  *   * `NEARBY_WIFI_DEVICES` and `POST_NOTIFICATIONS` only exist on API 33+.
- *     On older devices they are simply absent from this list and the
- *     onboarding screen reports them as automatically granted, since
- *     pre-33 platforms either rely on different permissions (legacy
- *     Wi-Fi discovery does not need NEARBY_WIFI_DEVICES) or post
- *     notifications without a prompt.
+ *   * `BLUETOOTH_ADVERTISE` and `BLUETOOTH_SCAN` only exist on API 31+ — on
+ *     API ≤ 30 the legacy install-time `BLUETOOTH` / `BLUETOOTH_ADMIN`
+ *     permissions cover the same capabilities, so we skip the runtime
+ *     prompt entirely on those devices.
+ *
+ * Each requirement is classified as **mandatory** or **optional**:
+ *   * Mandatory denials gate the app's primary discovery path.
+ *     Currently `NEARBY_WIFI_DEVICES` is the only mandatory permission —
+ *     without it Phase 1 cannot run mDNS discovery at all.
+ *   * Optional denials let the app run in a degraded mode. Today that
+ *     means missing notifications (silent transfers) or missing BLE
+ *     auto-discovery (mDNS-only fallback per #31's acceptance criteria).
+ *
+ * Onboarding is allowed to complete with optional-only denials; the
+ * service-start gate re-checks at runtime so the user can grant later
+ * via system Settings without revisiting onboarding.
  */
 internal object PermissionRequirements {
     /**
      * Describes a single runtime permission for the onboarding UI: the
      * Android permission identifier plus user-facing copy explaining
-     * **why** the app needs it.
+     * **why** the app needs it, and whether denying it blocks the app.
      */
     internal data class Requirement(
         val permission: String,
@@ -41,22 +53,55 @@ internal object PermissionRequirements {
         @StringRes val rationaleRes: Int,
         @StringRes val grantedRes: Int,
         @StringRes val deniedRes: Int,
+        /**
+         * If true, denying this permission still lets onboarding finish
+         * (the app falls back to a degraded mode). If false, onboarding
+         * keeps the user on this screen until the permission is granted
+         * or the user explicitly chooses "continue without".
+         */
+        val optional: Boolean,
     )
 
     /**
      * The set of runtime permissions that need to be requested on the
-     * **current** device. Empty on API < 33 — Phase 1 has no runtime
-     * permissions on those devices.
+     * **current** device. Empty on devices with API < 31 that don't run
+     * any runtime-permissioned features (currently impossible because
+     * minSdk is 24 and we have no runtime permissions for API 24–30).
      */
-    internal fun requirementsFor(): List<Requirement> =
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            tiramisuRequirements()
-        } else {
-            emptyList()
+    internal fun requirementsFor(): List<Requirement> {
+        val result = mutableListOf<Requirement>()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            result += blePermissions()
         }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            result += tiramisuPermissions()
+        }
+        return result
+    }
+
+    @RequiresApi(Build.VERSION_CODES.S)
+    private fun blePermissions(): List<Requirement> =
+        listOf(
+            Requirement(
+                permission = Manifest.permission.BLUETOOTH_ADVERTISE,
+                titleRes = R.string.permission_bluetooth_advertise_title,
+                rationaleRes = R.string.permission_bluetooth_advertise_rationale,
+                grantedRes = R.string.permission_status_granted,
+                deniedRes = R.string.permission_status_optional_denied_ble,
+                optional = true,
+            ),
+            Requirement(
+                permission = Manifest.permission.BLUETOOTH_SCAN,
+                titleRes = R.string.permission_bluetooth_scan_title,
+                rationaleRes = R.string.permission_bluetooth_scan_rationale,
+                grantedRes = R.string.permission_status_granted,
+                deniedRes = R.string.permission_status_optional_denied_ble,
+                optional = true,
+            ),
+        )
 
     @RequiresApi(Build.VERSION_CODES.TIRAMISU)
-    private fun tiramisuRequirements(): List<Requirement> =
+    private fun tiramisuPermissions(): List<Requirement> =
         listOf(
             Requirement(
                 permission = Manifest.permission.NEARBY_WIFI_DEVICES,
@@ -64,6 +109,7 @@ internal object PermissionRequirements {
                 rationaleRes = R.string.permission_nearby_wifi_rationale,
                 grantedRes = R.string.permission_status_granted,
                 deniedRes = R.string.permission_status_denied,
+                optional = false,
             ),
             Requirement(
                 permission = Manifest.permission.POST_NOTIFICATIONS,
@@ -71,6 +117,7 @@ internal object PermissionRequirements {
                 rationaleRes = R.string.permission_notifications_rationale,
                 grantedRes = R.string.permission_status_granted,
                 deniedRes = R.string.permission_status_optional_denied,
+                optional = true,
             ),
         )
 
@@ -89,26 +136,26 @@ internal object PermissionRequirements {
             }
 
     /**
-     * True when every runtime permission Phase 1 asks for has been
+     * True when every runtime permission onboarding asks for has been
      * granted (or is not applicable to the current API level).
      */
     internal fun allGranted(context: Context): Boolean = missingPermissions(context).isEmpty()
 
     /**
      * True when the only outstanding permissions are non-blocking ones
-     * (currently just `POST_NOTIFICATIONS`). The service can run in
-     * degraded mode in that case — see issue #26 acceptance criteria.
+     * (`POST_NOTIFICATIONS` and the BLE permissions). The service can
+     * run in degraded mode in that case — see issue #26 / #31 acceptance
+     * criteria. Returns false when no permissions are missing (use
+     * [allGranted] to detect that case).
      */
     internal fun onlyOptionalMissing(context: Context): Boolean {
-        val missing = missingPermissions(context)
+        val missing = missingPermissions(context).toSet()
         if (missing.isEmpty()) return false
-        return missing.all { it == OPTIONAL_POST_NOTIFICATIONS }
+        val optionalSet =
+            requirementsFor()
+                .filter(Requirement::optional)
+                .map(Requirement::permission)
+                .toSet()
+        return missing.all(optionalSet::contains)
     }
-
-    /**
-     * `Manifest.permission.POST_NOTIFICATIONS` exists only on API 33+.
-     * Holding the literal string as a constant keeps the comparison in
-     * [onlyOptionalMissing] safe to call on every API level.
-     */
-    private const val OPTIONAL_POST_NOTIFICATIONS = "android.permission.POST_NOTIFICATIONS"
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,9 +2,9 @@
 <resources>
     <string name="app_name">WhenVivoMeetsGoogle</string>
 
-    <!-- Permissions onboarding (#26). -->
+    <!-- Permissions onboarding (#26 + #31). -->
     <string name="onboarding_title">App permissions</string>
-    <string name="onboarding_intro">Quick Share needs a small set of Android permissions to discover nearby devices over your local Wi-Fi network and to keep you informed about transfers. Each permission below explains exactly what it is used for.</string>
+    <string name="onboarding_intro">Quick Share needs a small set of Android permissions to discover nearby devices over your local Wi-Fi network, to broadcast and listen for short Bluetooth Low Energy pulses that wake nearby Quick Share receivers, and to keep you informed about transfers. Each permission below explains exactly what it is used for.</string>
     <string name="onboarding_empty_state">Your device does not require any runtime permissions for Phase 1. You are all set.</string>
     <string name="onboarding_grant_button">Grant permissions</string>
     <string name="onboarding_open_settings">Open app settings</string>
@@ -27,10 +27,19 @@
     <string name="permission_notifications_title">Notifications</string>
     <string name="permission_notifications_rationale">Used to show the foreground transfer service indicator and to alert you about incoming files. Without this permission, transfers still work but you will not be notified about them.</string>
 
+    <!-- BLUETOOTH_ADVERTISE (API 31+, #31). -->
+    <string name="permission_bluetooth_advertise_title">Bluetooth advertising</string>
+    <string name="permission_bluetooth_advertise_rationale">Used to broadcast a short Bluetooth Low Energy pulse so nearby Quick Share receivers wake up automatically when you start a send. Without this permission, sends still work but the receiver may need to manually open Quick Share first.</string>
+
+    <!-- BLUETOOTH_SCAN (API 31+, #31). -->
+    <string name="permission_bluetooth_scan_title">Nearby Bluetooth devices</string>
+    <string name="permission_bluetooth_scan_rationale">Used to listen for nearby Quick Share senders so this device wakes up its receiver only when needed. Quick Share never uses this to determine your physical location.</string>
+
     <!-- Permission status labels. -->
     <string name="permission_status_granted">Granted</string>
     <string name="permission_status_denied">Required - not granted</string>
     <string name="permission_status_optional_denied">Optional - not granted (degraded mode)</string>
+    <string name="permission_status_optional_denied_ble">Optional - not granted (mDNS-only mode)</string>
 
     <!-- Share-intent (#24) sender flow. -->
     <string name="send_activity_label">Send via Quick Share</string>

--- a/app/src/test/kotlin/io/github/kyujincho/wvmg/AndroidManifestPermissionsTest.kt
+++ b/app/src/test/kotlin/io/github/kyujincho/wvmg/AndroidManifestPermissionsTest.kt
@@ -11,14 +11,17 @@ import org.junit.Test
 import java.io.File
 
 /**
- * Manifest-level regression test for the Phase 1 permission set (#26).
+ * Manifest-level regression test for the Phase 1 + Phase 2 permission
+ * set (#26, #31).
  *
  * We read `app/src/main/AndroidManifest.xml` as a plain text file rather
  * than going through the Android build system. The intent is to catch
  * accidental drift — for example, someone removing the
- * `neverForLocation` flag, or adding a Phase 2 permission ahead of
- * schedule — without paying the cost of pulling Robolectric into the
- * `:app` module just for this one test.
+ * `neverForLocation` flag from `BLUETOOTH_SCAN` (which would force the
+ * platform to also require `ACCESS_FINE_LOCATION`), or accidentally
+ * declaring a runtime permission we explicitly chose to skip — without
+ * paying the cost of pulling Robolectric into the `:app` module just
+ * for this one test.
  *
  * The CI job `:app:test` runs this on every PR.
  */
@@ -33,16 +36,13 @@ class AndroidManifestPermissionsTest {
 
     @Test
     fun `nearby wifi devices declared with neverForLocation flag`() {
-        assertTrue(
-            "NEARBY_WIFI_DEVICES permission must be declared",
-            manifest.contains("android.permission.NEARBY_WIFI_DEVICES"),
-        )
+        val block = usesPermissionBlockFor("android.permission.NEARBY_WIFI_DEVICES")
         // The neverForLocation flag tells Android we do not derive
         // physical location from peer scans; without it the platform
         // requires ACCESS_FINE_LOCATION on top of NEARBY_WIFI_DEVICES.
         assertTrue(
             "NEARBY_WIFI_DEVICES must use neverForLocation",
-            manifest.contains("android:usesPermissionFlags=\"neverForLocation\""),
+            block.contains("android:usesPermissionFlags=\"neverForLocation\""),
         )
     }
 
@@ -69,22 +69,62 @@ class AndroidManifestPermissionsTest {
     }
 
     @Test
-    fun `phase 2 permissions are not declared in phase 1`() {
-        // Bluetooth permissions belong to Phase 2 (BLE auto-discovery).
-        // Declaring them now would surface unnecessary install-time
-        // permission warnings to users — guard against that here.
-        val phase2Forbidden =
-            listOf(
-                "android.permission.BLUETOOTH_SCAN",
-                "android.permission.BLUETOOTH_ADVERTISE",
-                "android.permission.BLUETOOTH_CONNECT",
-            )
-        for (permission in phase2Forbidden) {
-            assertFalse(
-                "$permission must NOT be declared in Phase 1",
-                manifest.contains(permission),
-            )
-        }
+    fun `bluetooth advertise declared for phase 2 ble auto-discovery`() {
+        // BLUETOOTH_ADVERTISE is required (API 31+) so we can broadcast
+        // the Quick Share BLE service-data pulse that wakes nearby
+        // receivers (#31 / #32). It does not need neverForLocation —
+        // that flag is only meaningful for SCAN.
+        assertTrue(
+            "BLUETOOTH_ADVERTISE must be declared",
+            manifest.contains("android.permission.BLUETOOTH_ADVERTISE"),
+        )
+    }
+
+    @Test
+    fun `bluetooth scan declared with neverForLocation flag`() {
+        // BLUETOOTH_SCAN must use neverForLocation; without it the
+        // platform forces the user to also grant ACCESS_FINE_LOCATION,
+        // which we explicitly avoid for our scan-pulse-only use case
+        // (#31 / #33).
+        val block = usesPermissionBlockFor("android.permission.BLUETOOTH_SCAN")
+        assertTrue(
+            "BLUETOOTH_SCAN must use neverForLocation",
+            block.contains("android:usesPermissionFlags=\"neverForLocation\""),
+        )
+    }
+
+    @Test
+    fun `legacy bluetooth permissions are capped at api 30`() {
+        // Pre-API-31 devices use the install-time BLUETOOTH /
+        // BLUETOOTH_ADMIN model. We still need them declared so the app
+        // works on API 24–30, but they must be capped with
+        // maxSdkVersion=30 so API 31+ devices use the runtime variants
+        // exclusively (otherwise the install-time grant is silently
+        // applied alongside the runtime permission, which confuses
+        // some manufacturers' permission auditors).
+        val legacyBluetooth = usesPermissionBlockFor("android.permission.BLUETOOTH")
+        assertTrue(
+            "Legacy BLUETOOTH must declare android:maxSdkVersion=\"30\"",
+            legacyBluetooth.contains("android:maxSdkVersion=\"30\""),
+        )
+        val legacyBluetoothAdmin = usesPermissionBlockFor("android.permission.BLUETOOTH_ADMIN")
+        assertTrue(
+            "Legacy BLUETOOTH_ADMIN must declare android:maxSdkVersion=\"30\"",
+            legacyBluetoothAdmin.contains("android:maxSdkVersion=\"30\""),
+        )
+    }
+
+    @Test
+    fun `bluetooth connect is not declared yet`() {
+        // BLUETOOTH_CONNECT is only needed when initiating or accepting
+        // GATT connections — Phase 2 only advertises and scans, so
+        // declaring CONNECT today would surface a permission prompt the
+        // app does not need. Guard against accidentally pulling it in
+        // before BLE L2CAP support lands.
+        assertFalse(
+            "BLUETOOTH_CONNECT must NOT be declared until BLE L2CAP support lands",
+            manifest.contains("android.permission.BLUETOOTH_CONNECT"),
+        )
     }
 
     @Test
@@ -177,5 +217,34 @@ class AndroidManifestPermissionsTest {
             "ShowQrActivity must declare android:exported=\"false\"",
             qrBlock.contains("android:exported=\"false\""),
         )
+    }
+
+    /**
+     * Returns the substring of the manifest that holds the single
+     * `<uses-permission>` element for [permission], from `<uses-permission`
+     * up to (but excluding) the closing `/>`. Used to scope per-permission
+     * flag assertions (e.g. neverForLocation, maxSdkVersion) so they can
+     * tell which `<uses-permission>` element they are actually inspecting.
+     *
+     * Fails the calling test if the permission is not found at all.
+     */
+    private fun usesPermissionBlockFor(permission: String): String {
+        val needle = "android:name=\"$permission\""
+        assertTrue(
+            "$permission must be declared",
+            manifest.contains(needle),
+        )
+        // Walk back from the name attribute to the opening tag, then
+        // forward to the closing slash. Self-closing `<uses-permission .../>`
+        // tags are the only shape we use for these declarations, so this
+        // boundary works even when several permissions live next to one
+        // another in the file.
+        val nameIndex = manifest.indexOf(needle)
+        val openIndex = manifest.lastIndexOf("<uses-permission", nameIndex)
+        val closeIndex = manifest.indexOf("/>", nameIndex)
+        check(openIndex >= 0 && closeIndex > openIndex) {
+            "Could not locate <uses-permission .../> block for $permission"
+        }
+        return manifest.substring(openIndex, closeIndex)
     }
 }


### PR DESCRIPTION
## Summary

Implements [#31](https://github.com/kyujin-cho/WhenVivoMeetsGoogle/issues/31) — the runtime / install-time permission scaffolding that subsequent Phase 2 issues (#32 sender BLE advertise, #33 receiver BLE scan, #34 mDNS gating, #35 battery-tuned scan) depend on.

### Manifest

- `BLUETOOTH_ADVERTISE` (API 31+, runtime) — broadcast the Quick Share BLE service-data pulse so stock receivers wake up automatically when our app starts a send.
- `BLUETOOTH_SCAN` with `usesPermissionFlags="neverForLocation"` (API 31+, runtime) — scan for senders' BLE pulses without forcing the platform to also require `ACCESS_FINE_LOCATION`.
- Legacy `BLUETOOTH` / `BLUETOOTH_ADMIN` with `android:maxSdkVersion="30"` so the app still works on the pre-Android-12 install-time permission model but API 31+ devices use the runtime variants exclusively.
- `BLUETOOTH_CONNECT` is intentionally **not** declared. Phase 2 only advertises and scans; we do not initiate or accept GATT connections. The runtime permission can be added later if/when BLE L2CAP support lands.

### Onboarding UI / logic

- `PermissionRequirements` gains a per-`Requirement` `optional` flag and the BLE entries are gated to API 31+. Denials of optional permissions (notifications, BLE) let onboarding complete in degraded / mDNS-only mode, matching the acceptance criterion: *"Service refuses to enable BLE features if denied; falls back to mDNS-only mode."*
- New `strings.xml` entries explain each BLE permission in plain language, including the "never derives physical location" reassurance for the scan permission.
- Onboarding intro copy was extended to mention the BLE pulse so the user reads about it before the system prompt appears.

### Tests

- `AndroidManifestPermissionsTest` was reshaped: the old "phase 2 permissions are not declared" guard was inverted into per-permission assertions that verify `BLUETOOTH_ADVERTISE` is declared, `BLUETOOTH_SCAN` carries `neverForLocation`, legacy `BLUETOOTH` / `BLUETOOTH_ADMIN` are capped at API 30, and `BLUETOOTH_CONNECT` remains absent.
- A new helper (`usesPermissionBlockFor`) scopes the flag assertions to the matching `<uses-permission>` element so each permission's flags are verified independently rather than relying on a global `manifest.contains(...)` check.

### Acceptance criteria

- [x] Onboarding screen requests these permissions with rationale.
- [x] Service refuses to enable BLE features if denied; falls back to mDNS-only mode (BLE entries are marked optional, so onboarding completes; subsequent Phase 2 issues will read the `PackageManager` grant state at runtime before turning on advertise/scan).
- [x] `usesPermissionFlags="neverForLocation"` is set on `BLUETOOTH_SCAN`, so location permission is never prompted.

## Verification

- `./gradlew staticAnalysis` — passes.
- `./gradlew :app:testDebugUnitTest` — passes (manifest regression suite updated).
- `./gradlew :app:assembleDebug` — APK builds with merged manifest carrying the new permissions.

## Test plan

- [ ] On API 31+ device: launch the app and confirm the BLE permission rows appear with their rationales.
- [ ] Deny the BLE permissions and confirm the "Continue without all permissions" wording surfaces (optional-only denials).
- [ ] Accept the BLE permissions and confirm `PackageManager.checkPermission` returns `PERMISSION_GRANTED` for both `BLUETOOTH_ADVERTISE` and `BLUETOOTH_SCAN` from a quick logcat dump.
- [ ] Pre-API-31 device (or `--target sdk-30` emulator): confirm onboarding does **not** prompt for BLE permissions because the legacy install-time variants cover them.