### PR TITLE
feat: add sender BLE service-data advertiser for Phase 2 (#32)

### DIFF
--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendActivity.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendActivity.kt
@@ -23,6 +23,8 @@ import io.github.kyujincho.wvmg.databinding.ItemPeerRowBinding
 import io.github.kyujincho.wvmg.discovery.DiscoveredService
 import io.github.kyujincho.wvmg.discovery.Discovery
 import io.github.kyujincho.wvmg.discovery.DiscoveryEvent
+import io.github.kyujincho.wvmg.discovery.ble.BleAdvertiseHandle
+import io.github.kyujincho.wvmg.discovery.ble.BleAdvertiser
 import io.github.kyujincho.wvmg.protocol.connection.FileSource
 import io.github.kyujincho.wvmg.protocol.connection.OutboundConnection
 import io.github.kyujincho.wvmg.protocol.connection.OutboundConnectionState
@@ -82,6 +84,23 @@ public class SendActivity : AppCompatActivity() {
     private val emptyPeerHintTimer: EmptyPeerHintTimer = EmptyPeerHintTimer()
     private var emptyPeerHintJob: Job? = null
 
+    /**
+     * BLE service-data advertiser (#32). Started alongside mDNS
+     * discovery so receivers' BLE scan loops wake up their mDNS
+     * responders before the user has finished picking a peer. Stopped
+     * when the outbound TCP connection enters [OutboundConnectionState.Handshaking]
+     * (no point continuing to broadcast once the wire link is up) or
+     * on `onDestroy` / cancel.
+     *
+     * Held as a nullable handle because [BleAdvertiser.start] returns
+     * `null` on devices without a peripheral-mode BLE radio, with the
+     * `BLUETOOTH_ADVERTISE` permission revoked, or with Bluetooth
+     * turned off — all of which fall through to the mDNS-only path
+     * per the issue's fallback acceptance criterion.
+     */
+    private var bleAdvertiser: BleAdvertiser? = null
+    private var bleAdvertiseHandle: BleAdvertiseHandle? = null
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivitySendBinding.inflate(layoutInflater)
@@ -113,6 +132,7 @@ public class SendActivity : AppCompatActivity() {
         binding.sendSubtitle.setText(R.string.send_subtitle_discovering)
         startDiscovery()
         startEmptyPeerHintTimer()
+        startBleAdvertise()
     }
 
     override fun onDestroy() {
@@ -125,6 +145,7 @@ public class SendActivity : AppCompatActivity() {
         discoveryJob?.cancel()
         connectionJob?.cancel()
         emptyPeerHintJob?.cancel()
+        stopBleAdvertise()
     }
 
     // -----------------------------------------------------------------
@@ -406,6 +427,10 @@ public class SendActivity : AppCompatActivity() {
                 binding.sendStatusMessage.text = getString(R.string.send_status_target, peerLabel(peer))
             }
             OutboundConnectionState.Handshaking -> {
+                // TCP socket is up — the BLE wake-up pulse has done its
+                // job, stop broadcasting (#32 acceptance: stops as soon
+                // as the TCP connection to a recipient is established).
+                stopBleAdvertise()
                 binding.sendStatusPhase.setText(R.string.send_phase_handshaking)
                 binding.sendPin.visibility = View.GONE
             }
@@ -487,11 +512,57 @@ public class SendActivity : AppCompatActivity() {
             connection.cancel()
             return
         }
+        // Cancel before any peer was selected: stop the BLE pulse now
+        // so we don't waste the radio while finish() tears the activity
+        // down. onDestroy would also catch this, but stopping here keeps
+        // the timing tight for the "stops on user cancel" criterion (#32).
+        stopBleAdvertise()
         finish()
     }
 
     private fun onShowQrClicked() {
         startActivity(Intent(this, ShowQrActivity::class.java))
+    }
+
+    // -----------------------------------------------------------------
+    // BLE service-data pulse (#32)
+    // -----------------------------------------------------------------
+
+    /**
+     * Start the Quick Share BLE service-data advertisement (#32). The
+     * advertisement wakes nearby Quick Share receivers' BLE scan loops,
+     * which in turn enable their mDNS responder so our own discovery can
+     * find them.
+     *
+     * Best-effort: devices without peripheral-mode BLE, devices with
+     * Bluetooth turned off, and devices where the user revoked
+     * `BLUETOOTH_ADVERTISE` after onboarding all flow through the
+     * `null` return path of [BleAdvertiser.start] and are silently
+     * skipped — the mDNS-only discovery path still works for them.
+     */
+    @Suppress("MissingPermission") // Permission re-checked inside BleAdvertiser.start.
+    private fun startBleAdvertise() {
+        val advertiser = BleAdvertiser(applicationContext)
+        bleAdvertiser = advertiser
+        bleAdvertiseHandle = advertiser.start()
+        if (bleAdvertiseHandle == null) {
+            Log.i(BLE_TAG, "BLE pulse not started — falling back to mDNS-only discovery")
+        } else {
+            Log.i(BLE_TAG, "BLE pulse started")
+        }
+    }
+
+    /**
+     * Stop the BLE service-data advertisement if one is active. Called
+     * when the outbound TCP connection lands ([OutboundConnectionState.Handshaking]
+     * onward), when the user cancels, and from `onDestroy` as a final
+     * safety net. Safe to call repeatedly — both the local handle and
+     * the underlying [BleAdvertiseHandle.close] are idempotent.
+     */
+    private fun stopBleAdvertise() {
+        bleAdvertiseHandle?.close()
+        bleAdvertiseHandle = null
+        bleAdvertiser = null
     }
 
     /**
@@ -524,5 +595,10 @@ public class SendActivity : AppCompatActivity() {
 
     private companion object {
         private const val OUTBOUND_TAG: String = "WvmgOutbound"
+
+        // BLE advertise diagnostics share the discovery tag so a single
+        // `adb logcat -s WvmgDiscovery` line surfaces both mDNS and BLE
+        // events on real devices.
+        private const val BLE_TAG: String = "WvmgDiscovery"
     }
 }

--- a/discovery-android/src/main/AndroidManifest.xml
+++ b/discovery-android/src/main/AndroidManifest.xml
@@ -3,10 +3,10 @@
   :discovery-android module manifest.
 
   These permissions are required by the JmDNS publish + browse code wired up
-  in #18. They are declared at the library level so any consuming app
-  automatically inherits them; the umbrella set in :app/AndroidManifest.xml
-  remains authoritative for the runtime-prompt entries (NEARBY_WIFI_DEVICES
-  etc.) added in #26.
+  in #18 plus the BLE service-data advertiser added in #32. They are
+  declared at the library level so any consuming app automatically inherits
+  them; the umbrella set in :app/AndroidManifest.xml remains authoritative
+  for the runtime-prompt entries (NEARBY_WIFI_DEVICES etc.) added in #26.
 
   Compile-time (no runtime prompt):
     * CHANGE_WIFI_MULTICAST_STATE — required to acquire the
@@ -15,12 +15,28 @@
     * ACCESS_WIFI_STATE — needed to obtain WifiManager via getSystemService
       on every API level we support.
 
-  BLE-related runtime permissions for Phase 2 are intentionally omitted.
+  Runtime (gated by tools:targetApi):
+    * BLUETOOTH_ADVERTISE (API 31+) — required by the sender-side BLE
+      service-data pulse (#32) that wakes nearby Quick Share receivers.
+      Onboarding (#31) prompts for the runtime grant; this manifest line
+      makes the requirement library-local so consumers cannot accidentally
+      compile against the BleAdvertiser API without declaring the
+      permission.
+
+  Pre-API-31 devices use the install-time BLUETOOTH / BLUETOOTH_ADMIN
+  legacy permissions declared at :app level (capped with
+  maxSdkVersion=30) — they are not duplicated here to avoid clouding
+  the manifest merger output.
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
+    <uses-permission
+        android:name="android.permission.BLUETOOTH_ADVERTISE"
+        tools:targetApi="31" />
 
 </manifest>

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleAdvertisePayload.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleAdvertisePayload.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.discovery.ble
+
+import java.security.SecureRandom
+
+/**
+ * Composes the 24-byte BLE service-data payload that the sender broadcasts
+ * to wake nearby Quick Share receivers (#32).
+ *
+ * Wire format (per
+ * [PROTOCOL.md](https://github.com/grishka/NearDrop/blob/master/PROTOCOL.md)):
+ *
+ * ```text
+ *   fc 12 8e 01 42 00 00 00 00 00 00 00 00 00 || rand10
+ *   |---------------- 14 fixed bytes ----------------|  |--10--|
+ * ```
+ *
+ * The 14-byte prefix is a literal Quick Share magic. The trailing 10 bytes
+ * are session-scoped randomness — receivers use them to debounce
+ * advertisements from a single sender across short BLE airtime windows.
+ *
+ * This object is pure-JVM (no `android.*` imports) so it is exhaustively
+ * unit-testable. The Android-side advertiser ([BleAdvertiser]) consumes it
+ * and hands the resulting bytes to `BluetoothLeAdvertiser`.
+ */
+public object BleAdvertisePayload {
+    /**
+     * Quick Share BLE service UUID as a 16-bit short UUID. Stock Quick
+     * Share, NearDrop, and Windows Quick Share all use this assigned
+     * number. Wire form on Bluetooth is `0xFE2C`; the 128-bit canonical
+     * form (the UUID receivers compare against in their scan filters) is
+     * derived by substituting it into the Bluetooth Base UUID:
+     * `0000XXXX-0000-1000-8000-00805F9B34FB`.
+     */
+    public const val SERVICE_UUID_SHORT: Int = 0xFE2C
+
+    /**
+     * Canonical 128-bit form of [SERVICE_UUID_SHORT]. Pre-computed so
+     * callers don't have to know the Bluetooth Base UUID format and so
+     * tests can assert against an explicit string.
+     */
+    public const val SERVICE_UUID_128: String = "0000fe2c-0000-1000-8000-00805f9b34fb"
+
+    /**
+     * Total size of the service-data payload in bytes (14 fixed prefix +
+     * 10 random suffix). This must fit alongside the service-UUID field
+     * inside the legacy 31-byte advertising-PDU budget.
+     */
+    public const val PAYLOAD_LEN: Int = 24
+
+    /** Length of the randomness tail. */
+    public const val RANDOM_LEN: Int = 10
+
+    /**
+     * Length of the fixed Quick Share prefix that precedes the randomness.
+     */
+    public const val PREFIX_LEN: Int = PAYLOAD_LEN - RANDOM_LEN // 14
+
+    /**
+     * The 14-byte literal prefix mandated by the protocol. Exposed as a
+     * defensive copy via [prefixBytes] so callers cannot mutate the
+     * canonical bytes.
+     */
+    private val PREFIX: ByteArray =
+        byteArrayOf(
+            0xFC.toByte(),
+            0x12.toByte(),
+            0x8E.toByte(),
+            0x01.toByte(),
+            0x42.toByte(),
+            0x00.toByte(),
+            0x00.toByte(),
+            0x00.toByte(),
+            0x00.toByte(),
+            0x00.toByte(),
+            0x00.toByte(),
+            0x00.toByte(),
+            0x00.toByte(),
+            0x00.toByte(),
+        )
+
+    /** Defensive copy of the canonical 14-byte prefix. */
+    public fun prefixBytes(): ByteArray = PREFIX.copyOf()
+
+    /**
+     * Build a fresh 24-byte payload. The prefix is the canonical Quick
+     * Share magic; the trailing 10 bytes are drawn from [random].
+     *
+     * @param random source of the 10 trailing bytes. Defaults to a fresh
+     *   [SecureRandom]; tests may inject a deterministic [java.util.Random]
+     *   subclass to assert against fixed bytes.
+     */
+    @JvmOverloads
+    public fun build(random: java.util.Random = SecureRandom()): ByteArray {
+        val out = ByteArray(PAYLOAD_LEN)
+        System.arraycopy(PREFIX, 0, out, 0, PREFIX_LEN)
+        val tail = ByteArray(RANDOM_LEN)
+        random.nextBytes(tail)
+        System.arraycopy(tail, 0, out, PREFIX_LEN, RANDOM_LEN)
+        return out
+    }
+
+    /**
+     * Build a payload with the supplied 10-byte randomness tail. Useful
+     * in tests and in scenarios where the caller needs the same random
+     * suffix to be reused (e.g. when re-emitting after a Bluetooth restart
+     * within the same share session).
+     *
+     * @throws IllegalArgumentException if [randomTail] is not exactly
+     *   [RANDOM_LEN] bytes long.
+     */
+    public fun buildWith(randomTail: ByteArray): ByteArray {
+        require(randomTail.size == RANDOM_LEN) {
+            "randomTail must be exactly $RANDOM_LEN bytes, got ${randomTail.size}"
+        }
+        val out = ByteArray(PAYLOAD_LEN)
+        System.arraycopy(PREFIX, 0, out, 0, PREFIX_LEN)
+        System.arraycopy(randomTail, 0, out, PREFIX_LEN, RANDOM_LEN)
+        return out
+    }
+}

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleAdvertiser.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleAdvertiser.kt
@@ -26,6 +26,7 @@ import java.io.Closeable
 import java.security.SecureRandom
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Sender-side BLE advertiser that emits the Quick Share service-data pulse
@@ -67,6 +68,15 @@ public class BleAdvertiser internal constructor(
     private val payloadFactory: () -> ByteArray,
     private val now: () -> Long,
 ) {
+    /**
+     * The currently-live handle, if any. [start] swaps in a new handle
+     * after closing the previous one (re-entrancy guard); [close] paths
+     * use [java.util.concurrent.atomic.AtomicReference.compareAndSet] so
+     * a late `close` from a stale handle doesn't clobber a fresh
+     * advertisement that the same instance opened in the meantime.
+     */
+    private val active: AtomicReference<BleAdvertiseHandleImpl?> = AtomicReference(null)
+
     /**
      * Production constructor. Wires up the Android `BluetoothManager` and
      * a fresh [SecureRandom] for the payload's random tail.
@@ -149,10 +159,6 @@ public class BleAdvertiser internal constructor(
         }
         return advertiser
     }
-
-    private val active: java.util.concurrent.atomic.AtomicReference<BleAdvertiseHandleImpl?> =
-        java.util.concurrent.atomic
-            .AtomicReference(null)
 
     /**
      * Internal indirection over `BluetoothManager.adapter.bluetoothLeAdvertiser`

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleAdvertiser.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleAdvertiser.kt
@@ -1,0 +1,339 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+@file:Suppress("MagicNumber") // Bluetooth API status codes are well-known.
+
+package io.github.kyujincho.wvmg.discovery.ble
+
+import android.Manifest
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothManager
+import android.bluetooth.le.AdvertiseCallback
+import android.bluetooth.le.AdvertiseData
+import android.bluetooth.le.AdvertiseSettings
+import android.bluetooth.le.BluetoothLeAdvertiser
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.ParcelUuid
+import android.util.Log
+import androidx.annotation.RequiresApi
+import androidx.annotation.RequiresPermission
+import androidx.core.content.ContextCompat
+import java.io.Closeable
+import java.security.SecureRandom
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Sender-side BLE advertiser that emits the Quick Share service-data pulse
+ * (#32). Stock Quick Share / NearDrop receivers listen for this 24-byte
+ * payload and, on seeing it, enable their mDNS responder so the sender's
+ * Wi-Fi LAN discovery can find them.
+ *
+ * Lifecycle:
+ *
+ *  1. The caller (typically `SendActivity` after the share intent is
+ *     parsed) constructs a [BleAdvertiser] for an application [Context].
+ *  2. [start] returns a [BleAdvertiseHandle] when the platform accepts the
+ *     advertisement, or `null` when the device cannot advertise (no
+ *     adapter, no peripheral mode, Bluetooth off, missing
+ *     `BLUETOOTH_ADVERTISE` permission, or the platform's
+ *     [BluetoothLeAdvertiser.startAdvertising] callback reports failure).
+ *  3. The handle's [close] stops the advertisement. Closing twice is a
+ *     no-op; the advertiser may be re-`start`ed after close.
+ *
+ * The Quick Share advertisement is intentionally **non-connectable** (we
+ * do not accept GATT connections — we only need the receiver's BLE scan
+ * loop to wake up and start mDNS). This also keeps the payload comfortably
+ * within the legacy 31-byte advertising-PDU budget so we never need
+ * extended-advertising fallbacks.
+ *
+ * Threading: [start] / [close] are safe to call from any thread; the
+ * underlying `BluetoothLeAdvertiser` callbacks fire on the main thread.
+ *
+ * Permissions:
+ *  * API 31+ requires `BLUETOOTH_ADVERTISE` granted at runtime. Onboarding
+ *    requests it (#31), but we still re-check on [start] because the user
+ *    can revoke from Settings. A revoked permission yields `null` rather
+ *    than a [SecurityException].
+ *  * API 24–30 uses the legacy `BLUETOOTH` / `BLUETOOTH_ADMIN` model
+ *    which is install-time and therefore always granted if declared.
+ */
+public class BleAdvertiser internal constructor(
+    private val provider: AdvertiserProvider,
+    private val payloadFactory: () -> ByteArray,
+    private val now: () -> Long,
+) {
+    /**
+     * Production constructor. Wires up the Android `BluetoothManager` and
+     * a fresh [SecureRandom] for the payload's random tail.
+     */
+    public constructor(context: Context) : this(
+        provider = DefaultAdvertiserProvider(context.applicationContext),
+        payloadFactory = { BleAdvertisePayload.build(SecureRandom()) },
+        now = System::currentTimeMillis,
+    )
+
+    /**
+     * Begin advertising. Returns `null` when the platform cannot start —
+     * see class kdoc for the full failure list. Callers should treat
+     * `null` as "BLE pulse unavailable, continue with mDNS-only", per the
+     * issue's fallback acceptance criterion.
+     *
+     * Idempotent within a single instance: calling [start] while a previous
+     * advertisement is still running closes the old handle first.
+     */
+    @RequiresPermission(Manifest.permission.BLUETOOTH_ADVERTISE)
+    public fun start(): BleAdvertiseHandle? {
+        // Re-entrancy: if a prior advertisement is still live, close it
+        // first so we don't leak the BluetoothLeAdvertiser callback.
+        active.getAndSet(null)?.close()
+
+        // Pre-flight check: collapse the "no permission" and "no
+        // advertiser available" branches into a single early-return so
+        // the success path reads top-to-bottom without nested guards.
+        val advertiser = preflight() ?: return null
+
+        val payload = payloadFactory()
+        val settings = buildSettings()
+        val data = buildAdvertiseData(payload)
+
+        val callback = AdvertiseCallbackImpl()
+        return try {
+            advertiser.startAdvertising(settings, data, callback)
+            val handle =
+                BleAdvertiseHandleImpl(
+                    advertiser = advertiser,
+                    callback = callback,
+                    payload = payload,
+                    startedAt = now(),
+                    onClosed = { active.compareAndSet(it, null) },
+                )
+            active.set(handle)
+            Log.i(
+                TAG,
+                "BLE advertise: startAdvertising submitted bytes=" + payload.size +
+                    " uuid=" + BleAdvertisePayload.SERVICE_UUID_128,
+            )
+            handle
+        } catch (
+            // BluetoothLeAdvertiser surfaces a mix of IllegalArgumentException
+            // (payload too large), IllegalStateException (Bluetooth turned
+            // off mid-call), and SecurityException (permission revoked
+            // between checkSelfPermission and startAdvertising). All of
+            // them mean "we couldn't start"; collapse to null + warn.
+            @Suppress("TooGenericExceptionCaught") t: Throwable,
+        ) {
+            Log.w(TAG, "BLE advertise: startAdvertising threw — pulse skipped", t)
+            null
+        }
+    }
+
+    /**
+     * Resolve the platform [BluetoothLeAdvertiser] for this start call,
+     * or `null` if any of the pre-conditions fail (permission revoked,
+     * device has no peripheral mode, Bluetooth turned off). Each failure
+     * is logged so on-device diagnostics still attribute the skip.
+     */
+    private fun preflight(): BluetoothLeAdvertiser? {
+        if (!provider.hasAdvertisePermission()) {
+            Log.w(TAG, "BLE advertise: BLUETOOTH_ADVERTISE not granted — pulse skipped")
+            return null
+        }
+        val advertiser = provider.advertiser()
+        if (advertiser == null) {
+            Log.w(TAG, "BLE advertise: no BluetoothLeAdvertiser available — pulse skipped")
+        }
+        return advertiser
+    }
+
+    private val active: java.util.concurrent.atomic.AtomicReference<BleAdvertiseHandleImpl?> =
+        java.util.concurrent.atomic
+            .AtomicReference(null)
+
+    /**
+     * Internal indirection over `BluetoothManager.adapter.bluetoothLeAdvertiser`
+     * + [ContextCompat.checkSelfPermission]. Lets unit tests substitute
+     * fakes without pulling Robolectric into this module.
+     */
+    internal interface AdvertiserProvider {
+        fun hasAdvertisePermission(): Boolean
+
+        fun advertiser(): BluetoothLeAdvertiser?
+    }
+
+    /**
+     * Production provider. Pulls the adapter + advertiser from the system
+     * `BluetoothManager` on every call so a Bluetooth toggle (off → on) is
+     * picked up the next time [start] runs.
+     */
+    private class DefaultAdvertiserProvider(
+        private val context: Context,
+    ) : AdvertiserProvider {
+        override fun hasAdvertisePermission(): Boolean {
+            // Pre-API-31 devices use the legacy install-time BLUETOOTH /
+            // BLUETOOTH_ADMIN permissions; they are always granted when
+            // declared, so we short-circuit the runtime check.
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return true
+            return checkSPermission()
+        }
+
+        @RequiresApi(Build.VERSION_CODES.S)
+        private fun checkSPermission(): Boolean =
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.BLUETOOTH_ADVERTISE,
+            ) == PackageManager.PERMISSION_GRANTED
+
+        override fun advertiser(): BluetoothLeAdvertiser? {
+            // adapter.bluetoothLeAdvertiser returns null when the adapter
+            // is off, when the device lacks peripheral mode, or when the
+            // chipset's BLE stack hasn't finished initializing yet. All
+            // three map cleanly to "skip the pulse, fall back to mDNS-only".
+            val manager = context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
+            val adapter: BluetoothAdapter? = manager?.adapter
+            return adapter?.bluetoothLeAdvertiser
+        }
+    }
+
+    /**
+     * Default [AdvertiseSettings] for the Quick Share pulse:
+     *   * `LOW_LATENCY` mode — receivers should see us within ~100ms.
+     *   * `TX_POWER_HIGH` — best chance of a wake-up across a typical
+     *     room.
+     *   * `connectable = false` — we never accept GATT connections; this
+     *     keeps the advertising-PDU budget free for the 24-byte service
+     *     data and tells the platform not to allocate a connection window.
+     */
+    private fun buildSettings(): AdvertiseSettings =
+        AdvertiseSettings
+            .Builder()
+            .setAdvertiseMode(AdvertiseSettings.ADVERTISE_MODE_LOW_LATENCY)
+            .setTxPowerLevel(AdvertiseSettings.ADVERTISE_TX_POWER_HIGH)
+            .setConnectable(false)
+            .build()
+
+    /**
+     * Build the [AdvertiseData] with the 16-bit Quick Share service UUID
+     * and the 24-byte service-data payload. The result fits within the
+     * legacy 31-byte advertising budget:
+     *   * 3 bytes for the 16-bit service-UUID list (length+type+UUID),
+     *   * 26 bytes for the service-data (length+type+UUID+24 payload),
+     *   * 2 bytes for flags (auto-added by the platform).
+     */
+    private fun buildAdvertiseData(payload: ByteArray): AdvertiseData {
+        val parcelUuid = ParcelUuid(UUID.fromString(BleAdvertisePayload.SERVICE_UUID_128))
+        return AdvertiseData
+            .Builder()
+            .addServiceUuid(parcelUuid)
+            .addServiceData(parcelUuid, payload)
+            // Skip device name and TX power level — they would push us
+            // over the 31-byte budget and aren't part of the Quick Share
+            // wire spec.
+            .setIncludeDeviceName(false)
+            .setIncludeTxPowerLevel(false)
+            .build()
+    }
+
+    /**
+     * Concrete [BleAdvertiseHandle] backed by a live
+     * `BluetoothLeAdvertiser` callback registration.
+     */
+    private class BleAdvertiseHandleImpl(
+        private val advertiser: BluetoothLeAdvertiser,
+        private val callback: AdvertiseCallbackImpl,
+        override val payload: ByteArray,
+        override val startedAt: Long,
+        private val onClosed: (BleAdvertiseHandleImpl) -> Unit,
+    ) : BleAdvertiseHandle {
+        private val activeFlag = AtomicBoolean(true)
+
+        override val isActive: Boolean get() = activeFlag.get()
+
+        override val lastError: Int? get() = callback.lastError
+
+        override fun close() {
+            if (!activeFlag.compareAndSet(true, false)) return
+            try {
+                advertiser.stopAdvertising(callback)
+                Log.i(TAG, "BLE advertise: stopAdvertising complete")
+            } catch (
+                // stopAdvertising can throw SecurityException if the user
+                // revoked BLUETOOTH_ADVERTISE while we were running, or
+                // IllegalStateException if Bluetooth was turned off
+                // mid-flight. Either way, the advertisement is gone and
+                // there is nothing to recover.
+                @Suppress("TooGenericExceptionCaught") t: Throwable,
+            ) {
+                Log.w(TAG, "BLE advertise: stopAdvertising threw; ignoring", t)
+            }
+            onClosed(this)
+        }
+    }
+
+    /**
+     * Captures the most recent `onStartFailure` error code from
+     * [BluetoothLeAdvertiser]. Callers that surface diagnostics (the
+     * receiver-side BLE scanner test harness, future debug screens) can
+     * read [BleAdvertiseHandle.lastError] to attribute "no peer woke up"
+     * to the platform vs to wire issues.
+     */
+    private class AdvertiseCallbackImpl : AdvertiseCallback() {
+        @Volatile
+        var lastError: Int? = null
+            private set
+
+        override fun onStartSuccess(settingsInEffect: AdvertiseSettings?) {
+            Log.i(TAG, "BLE advertise: onStartSuccess settings=$settingsInEffect")
+        }
+
+        override fun onStartFailure(errorCode: Int) {
+            lastError = errorCode
+            Log.w(TAG, "BLE advertise: onStartFailure code=$errorCode (${describeError(errorCode)})")
+        }
+
+        private fun describeError(code: Int): String =
+            when (code) {
+                ADVERTISE_FAILED_DATA_TOO_LARGE -> "DATA_TOO_LARGE"
+                ADVERTISE_FAILED_TOO_MANY_ADVERTISERS -> "TOO_MANY_ADVERTISERS"
+                ADVERTISE_FAILED_ALREADY_STARTED -> "ALREADY_STARTED"
+                ADVERTISE_FAILED_INTERNAL_ERROR -> "INTERNAL_ERROR"
+                ADVERTISE_FAILED_FEATURE_UNSUPPORTED -> "FEATURE_UNSUPPORTED"
+                else -> "UNKNOWN"
+            }
+    }
+
+    public companion object {
+        /** Shared logcat tag with the rest of the discovery module. */
+        internal const val TAG: String = "WvmgDiscovery"
+    }
+}
+
+/**
+ * Closeable lifecycle handle returned by [BleAdvertiser.start]. Closing the
+ * handle stops the underlying BLE advertisement; subsequent close calls are
+ * no-ops.
+ */
+public interface BleAdvertiseHandle : Closeable {
+    /** True until [close] runs successfully. */
+    public val isActive: Boolean
+
+    /** The 24-byte service-data payload submitted to the platform. */
+    public val payload: ByteArray
+
+    /** `System.currentTimeMillis()` at the moment [BleAdvertiser.start] returned. */
+    public val startedAt: Long
+
+    /**
+     * Most recent `BluetoothLeAdvertiser` `onStartFailure` error code,
+     * or `null` if no failure has been reported. Mirrors
+     * `AdvertiseCallback.ADVERTISE_FAILED_*`.
+     */
+    public val lastError: Int?
+
+    /** Stop the advertisement. Idempotent. */
+    public override fun close()
+}

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleAdvertisePayloadTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleAdvertisePayloadTest.kt
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.discovery.ble
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.Random
+
+/**
+ * Bit-exact tests for the Quick Share BLE service-data payload
+ * composition (#32, PROTOCOL.md).
+ *
+ * The wire format is fixed at:
+ *
+ * ```text
+ *   fc 12 8e 01 42 00 00 00 00 00 00 00 00 00 || rand10
+ * ```
+ *
+ * If any of these assertions fail in CI, stock Quick Share / NearDrop
+ * receivers will silently ignore our advertisement — these tests are
+ * the regression net.
+ */
+class BleAdvertisePayloadTest {
+    @Test
+    fun `payload length matches the protocol-mandated 24 bytes`() {
+        val payload = BleAdvertisePayload.build(deterministicRandom(seed = 1L))
+        assertThat(payload).hasLength(BleAdvertisePayload.PAYLOAD_LEN)
+        assertThat(payload).hasLength(24)
+    }
+
+    @Test
+    fun `prefix is the canonical Quick Share magic`() {
+        // Spec: fc 12 8e 01 42 00 00 00 00 00 00 00 00 00 (14 bytes).
+        val expected =
+            byteArrayOf(
+                0xFC.toByte(),
+                0x12.toByte(),
+                0x8E.toByte(),
+                0x01.toByte(),
+                0x42.toByte(),
+                0x00.toByte(),
+                0x00.toByte(),
+                0x00.toByte(),
+                0x00.toByte(),
+                0x00.toByte(),
+                0x00.toByte(),
+                0x00.toByte(),
+                0x00.toByte(),
+                0x00.toByte(),
+            )
+        assertThat(BleAdvertisePayload.prefixBytes()).isEqualTo(expected)
+    }
+
+    @Test
+    fun `prefixBytes returns a defensive copy`() {
+        val first = BleAdvertisePayload.prefixBytes()
+        first[0] = 0x00
+        val second = BleAdvertisePayload.prefixBytes()
+        // Mutating the returned array must not poison the canonical magic.
+        assertThat(second[0]).isEqualTo(0xFC.toByte())
+    }
+
+    @Test
+    fun `build copies the prefix verbatim into the first 14 bytes`() {
+        val payload = BleAdvertisePayload.build(deterministicRandom(seed = 42L))
+        val head = payload.copyOfRange(0, BleAdvertisePayload.PREFIX_LEN)
+        assertThat(head).isEqualTo(BleAdvertisePayload.prefixBytes())
+    }
+
+    @Test
+    fun `build draws exactly 10 bytes of randomness from the supplied source`() {
+        // Random.nextBytes is the only entropy call — using a counting
+        // wrapper lets us assert on the byte count even with a tiny
+        // deterministic seed.
+        var calls = 0
+        var bytesRead = 0
+        val counting =
+            object : Random(0L) {
+                override fun nextBytes(bytes: ByteArray) {
+                    calls++
+                    bytesRead += bytes.size
+                    super.nextBytes(bytes)
+                }
+            }
+        BleAdvertisePayload.build(counting)
+        assertThat(calls).isEqualTo(1)
+        assertThat(bytesRead).isEqualTo(BleAdvertisePayload.RANDOM_LEN)
+    }
+
+    @Test
+    fun `successive build calls produce different randomness tails`() {
+        // Pull two payloads from a SecureRandom-equivalent source and
+        // assert the random tails differ. A 10-byte collision under a
+        // uniform RNG is ~2^-80, well below any flake threshold.
+        val first = BleAdvertisePayload.build(Random(1L))
+        val second = BleAdvertisePayload.build(Random(2L))
+        val firstTail = first.copyOfRange(BleAdvertisePayload.PREFIX_LEN, first.size)
+        val secondTail = second.copyOfRange(BleAdvertisePayload.PREFIX_LEN, second.size)
+        assertThat(firstTail).isNotEqualTo(secondTail)
+    }
+
+    @Test
+    fun `buildWith places the supplied tail after the prefix`() {
+        val tail = ByteArray(BleAdvertisePayload.RANDOM_LEN) { (0xA0 + it).toByte() }
+        val payload = BleAdvertisePayload.buildWith(tail)
+        assertThat(payload).hasLength(BleAdvertisePayload.PAYLOAD_LEN)
+        assertThat(payload.copyOfRange(0, BleAdvertisePayload.PREFIX_LEN))
+            .isEqualTo(BleAdvertisePayload.prefixBytes())
+        assertThat(payload.copyOfRange(BleAdvertisePayload.PREFIX_LEN, payload.size))
+            .isEqualTo(tail)
+    }
+
+    @Test
+    fun `buildWith rejects a tail of the wrong length`() {
+        // Too short.
+        assertThrows<IllegalArgumentException> {
+            BleAdvertisePayload.buildWith(ByteArray(BleAdvertisePayload.RANDOM_LEN - 1))
+        }
+        // Too long.
+        assertThrows<IllegalArgumentException> {
+            BleAdvertisePayload.buildWith(ByteArray(BleAdvertisePayload.RANDOM_LEN + 1))
+        }
+        // Empty.
+        assertThrows<IllegalArgumentException> {
+            BleAdvertisePayload.buildWith(ByteArray(0))
+        }
+    }
+
+    @Test
+    fun `service uuid short value matches PROTOCOL_md`() {
+        // 0xFE2C is the 16-bit assigned number Google publishes on the
+        // Bluetooth SIG list for Quick Share. Drift here breaks every
+        // existing receiver.
+        assertThat(BleAdvertisePayload.SERVICE_UUID_SHORT).isEqualTo(0xFE2C)
+    }
+
+    @Test
+    fun `service uuid 128 form expands the short uuid into the bluetooth base`() {
+        // The Bluetooth Base UUID is XXXXXXXX-0000-1000-8000-00805F9B34FB
+        // with the 16-bit short UUID slotted into the third / fourth
+        // hex octets. Hand-substituting 0xFE2C yields the constant
+        // BleAdvertisePayload exposes; this test guards against typos.
+        assertThat(BleAdvertisePayload.SERVICE_UUID_128)
+            .isEqualTo("0000fe2c-0000-1000-8000-00805f9b34fb")
+    }
+
+    private fun deterministicRandom(seed: Long): Random = Random(seed)
+}

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleAdvertiserFallbackTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleAdvertiserFallbackTest.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.discovery.ble
+
+import android.bluetooth.le.BluetoothLeAdvertiser
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Fallback-path tests for [BleAdvertiser] (#32 acceptance: "device with
+ * no BluetoothLeAdvertiser → log warning, continue without BLE pulse").
+ *
+ * The happy path (`startAdvertising` succeeds and the
+ * `AdvertiseCallback.onStartSuccess` fires) is exercised manually on
+ * real hardware — see `docs/testing/` — because instantiating a
+ * functioning `BluetoothLeAdvertiser` from a host JVM requires
+ * Robolectric, which the discovery module deliberately does not pull in.
+ *
+ * These tests are JVM-only and target the failure paths that determine
+ * whether the rest of the share UX still works on devices where BLE
+ * advertise is unavailable.
+ */
+class BleAdvertiserFallbackTest {
+    @Test
+    fun `start returns null when permission is denied`() {
+        val advertiser =
+            BleAdvertiser(
+                provider =
+                    object : BleAdvertiser.AdvertiserProvider {
+                        override fun hasAdvertisePermission(): Boolean = false
+
+                        override fun advertiser(): BluetoothLeAdvertiser? =
+                            error("must not be called when permission is denied")
+                    },
+                payloadFactory = { ByteArray(BleAdvertisePayload.PAYLOAD_LEN) },
+                now = { 0L },
+            )
+        val handle = advertiser.start()
+        assertThat(handle).isNull()
+    }
+
+    @Test
+    fun `start returns null when the platform has no BluetoothLeAdvertiser`() {
+        val advertiser =
+            BleAdvertiser(
+                provider =
+                    object : BleAdvertiser.AdvertiserProvider {
+                        override fun hasAdvertisePermission(): Boolean = true
+
+                        // Production code path on devices without
+                        // peripheral mode / with Bluetooth disabled —
+                        // BluetoothAdapter.bluetoothLeAdvertiser is null.
+                        override fun advertiser(): BluetoothLeAdvertiser? = null
+                    },
+                payloadFactory = { ByteArray(BleAdvertisePayload.PAYLOAD_LEN) },
+                now = { 0L },
+            )
+        val handle = advertiser.start()
+        assertThat(handle).isNull()
+    }
+
+    @Test
+    fun `start does not invoke payloadFactory when permission is denied`() {
+        // We don't want to spend entropy / risk an exception in the
+        // payload factory when we already know we can't advertise. This
+        // test pins that ordering so a regression that calls
+        // payloadFactory before the permission check is caught.
+        var built = false
+        val advertiser =
+            BleAdvertiser(
+                provider =
+                    object : BleAdvertiser.AdvertiserProvider {
+                        override fun hasAdvertisePermission(): Boolean = false
+
+                        override fun advertiser(): BluetoothLeAdvertiser? = null
+                    },
+                payloadFactory = {
+                    built = true
+                    ByteArray(BleAdvertisePayload.PAYLOAD_LEN)
+                },
+                now = { 0L },
+            )
+        advertiser.start()
+        assertThat(built).isFalse()
+    }
+
+    @Test
+    fun `start does not invoke payloadFactory when there is no advertiser`() {
+        var built = false
+        val advertiser =
+            BleAdvertiser(
+                provider =
+                    object : BleAdvertiser.AdvertiserProvider {
+                        override fun hasAdvertisePermission(): Boolean = true
+
+                        override fun advertiser(): BluetoothLeAdvertiser? = null
+                    },
+                payloadFactory = {
+                    built = true
+                    ByteArray(BleAdvertisePayload.PAYLOAD_LEN)
+                },
+                now = { 0L },
+            )
+        advertiser.start()
+        assertThat(built).isFalse()
+    }
+}


### PR DESCRIPTION
## Summary

Closes #32. Phase 2 sender-side BLE wake-up pulse so stock Quick Share / NearDrop receivers' BLE scan loops light up their mDNS responder before the user finishes picking a peer.

- Broadcast the 24-byte Quick Share service-data payload (`fc 12 8e 01 42 00 00 00 00 00 00 00 00 00 || rand10`) under service UUID `0xFE2C` whenever `SendActivity` has files to share.
- Non-connectable advertisement, `LOW_LATENCY` mode, `TX_POWER_HIGH`, no device name / TX-power inclusion — fits within the legacy 31-byte advertising PDU.
- Stops on the first transition into `OutboundConnectionState.Handshaking` (i.e. the moment the TCP connection to a recipient is up), on user cancel, and on `onDestroy`.
- Fallbacks: missing `BLUETOOTH_ADVERTISE` permission, Bluetooth off, no peripheral-mode adapter, or `BluetoothLeAdvertiser.startAdvertising` throwing all flow through the `null` return path of `BleAdvertiser.start()` — the share UX continues with mDNS-only discovery.

## Implementation notes

- New code lives under `:discovery-android` in a fresh `discovery.ble` package — keeping it next to the JmDNS publish/browse stack matches the module's stated Phase 2 scope, and `:core-protocol` stays JVM-pure (no `android.*` imports leaked into the protocol module).
- `BleAdvertisePayload` is a pure-Kotlin object with the wire-format constants and a `build(Random)` / `buildWith(ByteArray)` API; exhaustively tested against the bytes mandated by `PROTOCOL.md`.
- `BleAdvertiser` exposes an internal `AdvertiserProvider` seam so unit tests can cover the permission-denied and no-advertiser fallback paths on the host JVM without pulling Robolectric into the module. The happy path is left to the on-device interop checklists under `docs/testing/`.
- `:discovery-android/AndroidManifest.xml` now declares `BLUETOOTH_ADVERTISE` (API 31+ gated) so consumers compile against the new advertiser API only when they explicitly accept the permission. The `:app` umbrella manifest from #31 remains authoritative.

## Test plan

- [x] `./gradlew staticAnalysis` — ktlint + detekt clean across every module.
- [x] `./gradlew :discovery-android:testDebugUnitTest :app:testDebugUnitTest` — 14 new BLE tests pass; existing JVM tests (mDNS publish/browse, manifest regression) still green.
- [x] `./gradlew :app:assembleDebug` — debug APK builds with the new BLE wiring + library-level manifest entry.
- [ ] On-device interop (real Galaxy / Pixel pair, follow-up smoke run): verify `adb logcat -s WvmgDiscovery` surfaces the `BLE advertise: startAdvertising submitted` line on share intent, and `BLE advertise: stopAdvertising complete` once the TCP connection lands.