### PR TITLE
feat(discovery): add receiver BLE pulse scanner (#33)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ CI (`.github/workflows/ci.yml`) runs `staticAnalysis`, `:core-protocol:test`, `:
 Several diagnostic logcat tags are wired up for real-device testing — useful when discovery or transfer behaves differently from JVM tests:
 
 ```bash
-adb logcat -s WvmgDiscovery WvmgSend WvmgOutbound
+adb logcat -s WvmgDiscovery WvmgSend WvmgOutbound WvmgBleScan
 ```
 
 If a manufacturer's logcat filter swallows the app's `Log.i` output (vivo Funtouch OS does this), `OutboundConnection`'s logger uses `Log.e` and also appends to `getExternalFilesDir(null)/wvmg-outbound.log` — pull it with:
@@ -62,7 +62,8 @@ Five Gradle modules. The split is driven by one hard rule: the protocol implemen
                        NO android.* imports. Adding one is a regression — guard in review.
 :core-protocol-test    KAT vectors and shared fixtures. Pure JVM.
 :discovery-android     mDNS publish/browse via JmDNS, multicast lock, network-change watcher.
-                       Android-only; wraps :core-protocol's EndpointInfo.
+                       Phase 2: BLE pulse scanner (BleQuickShareScanner) under
+                       `discovery.ble`. Android-only; wraps :core-protocol's EndpointInfo.
 :service-android       Foreground receiver service (connectedDevice type), MediaStore-backed
                        FileDestinationFactory, consent notification + broadcast receiver.
 :app                   UI: permissions onboarding, share-intent SendActivity, ShowQrActivity,

--- a/discovery-android/src/main/AndroidManifest.xml
+++ b/discovery-android/src/main/AndroidManifest.xml
@@ -3,10 +3,12 @@
   :discovery-android module manifest.
 
   These permissions are required by the JmDNS publish + browse code wired up
-  in #18 plus the BLE service-data advertiser added in #32. They are
-  declared at the library level so any consuming app automatically inherits
-  them; the umbrella set in :app/AndroidManifest.xml remains authoritative
-  for the runtime-prompt entries (NEARBY_WIFI_DEVICES etc.) added in #26.
+  in #18, the BLE service-data advertiser added in #32, and the BLE pulse
+  scanner added in #33. They are declared at the library level so any
+  consuming app automatically inherits them; the umbrella set in
+  :app/AndroidManifest.xml remains authoritative for the runtime-prompt
+  entries (NEARBY_WIFI_DEVICES, BLUETOOTH_ADVERTISE, BLUETOOTH_SCAN, etc.)
+  and is the single place that declares user-visible permission rationales.
 
   Compile-time (no runtime prompt):
     * CHANGE_WIFI_MULTICAST_STATE — required to acquire the
@@ -15,18 +17,23 @@
     * ACCESS_WIFI_STATE — needed to obtain WifiManager via getSystemService
       on every API level we support.
 
-  Runtime (gated by tools:targetApi):
-    * BLUETOOTH_ADVERTISE (API 31+) — required by the sender-side BLE
-      service-data pulse (#32) that wakes nearby Quick Share receivers.
-      Onboarding (#31) prompts for the runtime grant; this manifest line
-      makes the requirement library-local so consumers cannot accidentally
-      compile against the BleAdvertiser API without declaring the
-      permission.
+  Runtime (must be granted by the user on API 31+):
+    * BLUETOOTH_ADVERTISE — required by BleAdvertiser (#32) to broadcast
+      the sender-side BLE service-data pulse that wakes nearby Quick Share
+      receivers. Onboarding (#31) prompts for the runtime grant; this
+      manifest line makes the requirement library-local so consumers cannot
+      accidentally compile against the BleAdvertiser API without declaring
+      the permission.
+    * BLUETOOTH_SCAN — required by BleQuickShareScanner (#33) to listen
+      for sender BLE pulses. neverForLocation tells Android we never
+      derive physical location from BLE scan results, so the platform
+      skips the ACCESS_FINE_LOCATION requirement that would otherwise
+      apply on API 31+.
 
-  Pre-API-31 devices use the install-time BLUETOOTH / BLUETOOTH_ADMIN
-  legacy permissions declared at :app level (capped with
-  maxSdkVersion=30) — they are not duplicated here to avoid clouding
-  the manifest merger output.
+  Legacy (API <= 30 only):
+    * BLUETOOTH / BLUETOOTH_ADMIN — declared with maxSdkVersion=30 so that
+      pre-Android-12 devices still have install-time grants for the BLE
+      scan/advertise APIs while API 31+ devices use the runtime permission.
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
@@ -38,5 +45,17 @@
     <uses-permission
         android:name="android.permission.BLUETOOTH_ADVERTISE"
         tools:targetApi="31" />
+
+    <uses-permission
+        android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation"
+        tools:targetApi="31" />
+
+    <uses-permission
+        android:name="android.permission.BLUETOOTH"
+        android:maxSdkVersion="30" />
+    <uses-permission
+        android:name="android.permission.BLUETOOTH_ADMIN"
+        android:maxSdkVersion="30" />
 
 </manifest>

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareScanner.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareScanner.kt
@@ -1,0 +1,670 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.discovery.ble
+
+import android.Manifest
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothManager
+import android.bluetooth.le.BluetoothLeScanner
+import android.bluetooth.le.ScanCallback
+import android.bluetooth.le.ScanFilter
+import android.bluetooth.le.ScanResult
+import android.bluetooth.le.ScanSettings
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.ParcelUuid
+import android.util.Log
+import androidx.annotation.RequiresPermission
+import androidx.core.content.ContextCompat
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+/**
+ * Quick Share BLE pulse scanner.
+ *
+ * The receiver side of Phase 2's BLE auto-discovery (epic #2). Quick
+ * Share senders advertise a 16-byte BLE service-data payload under
+ * service UUID `0xFE2C` whenever they have something to send (#32).
+ * The first 14 bytes of that payload are pinned by PROTOCOL.md:
+ *
+ * ```
+ * fc 12 8e 01 42 00 00 00 00 00 00 00 00 00
+ * ```
+ *
+ * The trailing two bytes are random and ignored. The scanner uses
+ * `ScanFilter` with a prefix + mask to push the comparison into the
+ * platform — only matching advertisements ever cross the kernel/user
+ * boundary, which keeps power consumption acceptable.
+ *
+ * ### Lifecycle
+ *
+ * The class is designed to be owned by [io.github.kyujincho.wvmg.service.receiver.ReceiverForegroundService].
+ * The service starts the scanner when it comes up and stops it when it
+ * tears down. Callers observe the scanner state through:
+ *
+ *  * [pulses] — a hot [Flow] of every matching [ScanResult]. Suitable
+ *    for diagnostic logging or future "saw a pulse from X" UI.
+ *  * [activity] — a [StateFlow] of [ScanActivity] indicating whether a
+ *    pulse was seen recently. Issue #34 (mDNS gating) consumes this to
+ *    decide whether to publish the receiver's mDNS service.
+ *
+ * The "active" / "idle" transition is driven by a configurable
+ * [inactivityTimeoutMillis] — by default 30 s after the last seen pulse
+ * the scanner reports [ScanActivity.Idle]. The platform scanner itself
+ * keeps running while [start] is in effect; only the activity flag flips
+ * back to idle. A future optimization may stop the platform scan during
+ * idle stretches to save battery, but the issue's acceptance criterion
+ * ("Battery consumption acceptable: in `SCAN_MODE_BALANCED`, BLE scan is
+ * ~10–20 mAh/day") makes the always-on simpler approach acceptable for
+ * Phase 2.
+ *
+ * ### Threading
+ *
+ * `start` and `stop` are safe to call from any thread; they serialize
+ * through a [Mutex] internally. The platform [ScanCallback] fires on
+ * the system's binder thread; we hop straight back into the supplied
+ * [coroutineScope] so consumer callbacks never block the binder pool.
+ *
+ * ### Permissions
+ *
+ * On API 31+ the runtime [Manifest.permission.BLUETOOTH_SCAN] is
+ * required (already requested during onboarding by #31). On API ≤ 30
+ * the install-time [Manifest.permission.BLUETOOTH] +
+ * [Manifest.permission.BLUETOOTH_ADMIN] permissions are sufficient and
+ * the umbrella manifest in `:app` declares them with `maxSdkVersion=30`.
+ *
+ * If the permission is missing, [start] logs a warning and becomes a
+ * no-op — the scanner does not throw because the receiver service must
+ * keep working in mDNS-only mode when BLE is unavailable.
+ *
+ * ### Testability
+ *
+ * [BleScannerGate] abstracts the platform `BluetoothLeScanner` so unit
+ * tests on a plain JVM can drive the lifecycle through a fake. Tests
+ * that need to observe the [activity] flow flip use a
+ * [kotlinx.coroutines.test.TestScope] with a virtual time source.
+ *
+ * @param coroutineScope scope that owns the inactivity-timeout job and
+ *   the hot conversion of [pulses]; cancelling it stops the scanner.
+ * @param gate platform-scanner abstraction; tests inject a fake.
+ * @param permissionChecker checks `BLUETOOTH_SCAN` at start time;
+ *   defaults to a [ContextCompat]-backed implementation.
+ * @param inactivityTimeoutMillis time after the last seen pulse before
+ *   [activity] flips back to [ScanActivity.Idle]. 30 s by default per
+ *   the issue's acceptance criterion.
+ */
+public class BleQuickShareScanner internal constructor(
+    private val coroutineScope: CoroutineScope,
+    private val gate: BleScannerGate,
+    private val permissionChecker: PermissionChecker,
+    private val inactivityTimeoutMillis: Long = DEFAULT_INACTIVITY_TIMEOUT_MILLIS,
+    private val nowMillis: () -> Long = System::currentTimeMillis,
+) {
+    /**
+     * Production constructor. Builds a real [BleScannerGate] over the
+     * platform [BluetoothManager] and a [ContextCompat]-backed
+     * permission checker. Only the application context is retained.
+     */
+    public constructor(
+        context: Context,
+        coroutineScope: CoroutineScope,
+        inactivityTimeoutMillis: Long = DEFAULT_INACTIVITY_TIMEOUT_MILLIS,
+    ) : this(
+        coroutineScope = coroutineScope,
+        gate = AndroidBleScannerGate(context.applicationContext),
+        permissionChecker = AndroidPermissionChecker(context.applicationContext),
+        inactivityTimeoutMillis = inactivityTimeoutMillis,
+    )
+
+    /**
+     * Synchronization guard for [start] / [stop] state transitions.
+     *
+     * We use a plain `synchronized` block instead of a coroutine
+     * `Mutex` so [stop] can run inline from `Service.onDestroy` without
+     * needing a coroutine context — the parent scope is typically about
+     * to be cancelled when stop runs, which would otherwise truncate
+     * any suspend lock. The lock is held only over fast in-memory
+     * state transitions plus a single platform call (`startScan` /
+     * `stopScan`), so contention is negligible in practice.
+     */
+    private val lifecycleLock = Any()
+
+    @Volatile
+    private var registration: BleScannerGate.Registration? = null
+
+    private val activityState: MutableStateFlow<ScanActivity> = MutableStateFlow(ScanActivity.Idle)
+
+    @Volatile
+    private var inactivityJob: Job? = null
+
+    /**
+     * Hot [StateFlow] reporting whether a Quick Share BLE pulse was seen
+     * within [inactivityTimeoutMillis]. Issue #34's mDNS gate subscribes
+     * to this to decide when to publish the receiver advertisement.
+     *
+     * The flow is a cold-to-hot wrapper around an internal mutable
+     * state; subscribers always immediately see the current value and
+     * subsequent transitions until they cancel.
+     */
+    public val activity: StateFlow<ScanActivity> = activityState.asStateFlow()
+
+    private val pulsesSink: MutableSharedFlow<ScanResult> =
+        MutableSharedFlow(replay = 0, extraBufferCapacity = PULSES_BUFFER)
+
+    /**
+     * Hot [Flow] of every matching [ScanResult] received while a scan is
+     * in flight. Subscribers see only pulses that arrive after they
+     * start collecting (no replay) — the scanner is stateless beyond
+     * the inactivity window itself.
+     *
+     * Production builds attach a single [ScanCallback] to the platform
+     * scanner during [start]; that callback both calls [recordPulse]
+     * (to drive the [activity] state machine) and forwards the result
+     * to this shared flow. JVM unit tests use [forTestEmitPulse] to
+     * drive [activity] without instantiating any platform types.
+     */
+    public val pulses: Flow<ScanResult> = pulsesSink.asSharedFlow()
+
+    @Volatile
+    private var primarySink: BleScannerGate.PulseSink? = null
+
+    /**
+     * Begin scanning for Quick Share BLE pulses. Idempotent: if a scan
+     * is already in flight this call is a no-op.
+     *
+     * If `BLUETOOTH_SCAN` is not granted, or if the device has no
+     * Bluetooth LE support / the adapter is disabled, this method logs
+     * the failure and returns without throwing — the receiver service
+     * continues to run in mDNS-only mode.
+     *
+     * @return `true` if the scan is now active (either newly started or
+     *   already in flight), `false` if the scan could not be started.
+     */
+    public fun start(): Boolean =
+        synchronized(lifecycleLock) {
+            if (registration != null) return@synchronized true
+            if (!permissionChecker.hasScanPermission()) {
+                Log.w(TAG, "start: BLUETOOTH_SCAN not granted; skipping BLE pulse scan")
+                return@synchronized false
+            }
+            val started =
+                try {
+                    gate.startScan()
+                } catch (
+                    @Suppress("TooGenericExceptionCaught") t: Throwable,
+                ) {
+                    // Platform throws SecurityException if the runtime permission
+                    // was revoked between the check above and the call, and
+                    // IllegalStateException if Bluetooth is off. Neither is fatal;
+                    // log and let the receiver continue without BLE.
+                    Log.w(TAG, "start: BLE scan failed to start", t)
+                    null
+                }
+            if (started == null) return@synchronized false
+            registration = started
+            val sink =
+                object : BleScannerGate.PulseSink {
+                    override fun onPulse(result: ScanResult) {
+                        recordPulse()
+                        pulsesSink.tryEmit(result)
+                    }
+
+                    override fun onFailed(errorCode: Int) {
+                        Log.w(TAG, "BLE scan failed errorCode=$errorCode")
+                    }
+                }
+            gate.addSink(sink)
+            primarySink = sink
+            Log.i(TAG, "start: BLE pulse scan started")
+            true
+        }
+
+    /**
+     * Stop scanning. Idempotent: calling [stop] when no scan is in
+     * flight is a no-op.
+     */
+    public fun stop() {
+        synchronized(lifecycleLock) {
+            val current = registration ?: return@synchronized
+            primarySink?.let { gate.removeSink(it) }
+            primarySink = null
+            try {
+                current.close()
+            } catch (
+                @Suppress("TooGenericExceptionCaught") t: Throwable,
+            ) {
+                // SecurityException possible if BLUETOOTH_SCAN was revoked at runtime;
+                // the registration is still discarded so the next start() will be clean.
+                Log.w(TAG, "stop: BLE scan close threw", t)
+            }
+            registration = null
+            inactivityJob?.cancel()
+            inactivityJob = null
+            activityState.value = ScanActivity.Idle
+            Log.i(TAG, "stop: BLE pulse scan stopped")
+        }
+    }
+
+    /** True iff a scan is currently in flight. */
+    public val isScanning: Boolean
+        get() = registration != null
+
+    private fun recordPulse() {
+        val now = nowMillis()
+        activityState.value = ScanActivity.Active(lastSeenAtMillis = now)
+        // Refresh the inactivity timer: cancel the in-flight one
+        // (if any) and start a new one. We do not need atomicity
+        // beyond "cancel old, schedule new" because the StateFlow
+        // already serializes value updates.
+        inactivityJob?.cancel()
+        inactivityJob =
+            coroutineScope.launch {
+                delay(inactivityTimeoutMillis)
+                if (isActive) {
+                    val current = activityState.value
+                    if (current is ScanActivity.Active && current.lastSeenAtMillis == now) {
+                        activityState.value = ScanActivity.Idle
+                    }
+                }
+            }
+    }
+
+    /**
+     * Test-only entry point that simulates the platform delivering a
+     * matching pulse. Used by JVM unit tests to drive the inactivity
+     * timeout state machine without standing up a real Bluetooth stack.
+     */
+    internal fun forTestEmitPulse() {
+        recordPulse()
+    }
+
+    public companion object {
+        /** logcat tag for BLE-pulse-related diagnostics. */
+        internal const val TAG: String = "WvmgBleScan"
+
+        /**
+         * 30 s default inactivity window per the acceptance criterion in
+         * issue #33. After the last seen pulse, [activity] flips back to
+         * [ScanActivity.Idle] this many milliseconds later.
+         */
+        public const val DEFAULT_INACTIVITY_TIMEOUT_MILLIS: Long = 30_000L
+
+        /**
+         * Extra buffer for the [pulses] shared flow. A small ring lets
+         * concurrent subscribers and brief consumer back-pressure absorb
+         * a burst of advertisements without dropping pulses on the
+         * floor; 16 was picked as comfortably above typical
+         * `SCAN_MODE_BALANCED` arrival rates.
+         */
+        private const val PULSES_BUFFER: Int = 16
+
+        /**
+         * String form of the Quick Share BLE service UUID per
+         * PROTOCOL.md — the 16-bit short ID `0xFE2C` expanded into the
+         * SIG base UUID. Pin the string here so JVM unit tests, where
+         * [ParcelUuid] is mocked out by AGP, can still verify the wire
+         * value matches the spec.
+         */
+        public const val QUICK_SHARE_SERVICE_UUID_STRING: String =
+            "0000fe2c-0000-1000-8000-00805f9b34fb"
+
+        /**
+         * [ParcelUuid] form of [QUICK_SHARE_SERVICE_UUID_STRING] used
+         * by the platform [ScanFilter] API.
+         */
+        public val QUICK_SHARE_SERVICE_UUID: ParcelUuid
+            get() = ParcelUuid.fromString(QUICK_SHARE_SERVICE_UUID_STRING)
+
+        /**
+         * 14-byte service-data prefix shared by every Quick Share BLE
+         * pulse. The trailing 2 bytes of the 16-byte payload are random
+         * per advertisement and are matched with a zero mask (any value
+         * accepted).
+         *
+         * Returns a fresh copy on each call so callers cannot mutate the
+         * canonical bytes; the array is small and infrequently read so
+         * the copy cost is negligible.
+         */
+        public val SERVICE_DATA_PREFIX: ByteArray
+            get() =
+                byteArrayOf(
+                    0xfc.toByte(),
+                    0x12.toByte(),
+                    0x8e.toByte(),
+                    0x01.toByte(),
+                    0x42.toByte(),
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x00,
+                )
+
+        /**
+         * Mask applied alongside [SERVICE_DATA_PREFIX]. `0xff` for each
+         * pinned prefix byte makes the platform compare it byte-for-byte;
+         * the mask is the same length as the prefix.
+         */
+        public val SERVICE_DATA_MASK: ByteArray
+            get() = ByteArray(SERVICE_DATA_PREFIX.size) { 0xff.toByte() }
+
+        /**
+         * Builds the canonical Quick Share BLE scan filter list.
+         *
+         * Used by [AndroidBleScannerGate] to compose the platform
+         * `startScan` arguments. Exposed (internal) so any future
+         * additional gate implementations stay consistent with the
+         * spec'd prefix + mask without re-deriving them.
+         *
+         * Throws on a JVM unit-test runtime where AGP stubs out
+         * [ScanFilter.Builder] — never call from a JVM test path.
+         */
+        internal fun buildScanFilters(): List<ScanFilter> =
+            listOf(
+                ScanFilter
+                    .Builder()
+                    .setServiceData(
+                        QUICK_SHARE_SERVICE_UUID,
+                        SERVICE_DATA_PREFIX,
+                        SERVICE_DATA_MASK,
+                    ).build(),
+            )
+
+        internal fun buildScanSettings(): ScanSettings =
+            ScanSettings
+                .Builder()
+                .setScanMode(ScanSettings.SCAN_MODE_BALANCED)
+                .setReportDelay(0)
+                .build()
+
+        /**
+         * Test-only factory matching the existing module convention. The
+         * supplied [gate] and [permissionChecker] let JVM unit tests
+         * exercise the lifecycle without instantiating the production
+         * Android wiring.
+         */
+        @JvmStatic
+        internal fun forTesting(
+            coroutineScope: CoroutineScope,
+            gate: BleScannerGate,
+            permissionChecker: PermissionChecker = PermissionChecker { true },
+            inactivityTimeoutMillis: Long = DEFAULT_INACTIVITY_TIMEOUT_MILLIS,
+            nowMillis: () -> Long = System::currentTimeMillis,
+        ): BleQuickShareScanner =
+            BleQuickShareScanner(
+                coroutineScope = coroutineScope,
+                gate = gate,
+                permissionChecker = permissionChecker,
+                inactivityTimeoutMillis = inactivityTimeoutMillis,
+                nowMillis = nowMillis,
+            )
+    }
+}
+
+/**
+ * Coarse activity state surfaced to consumers. Issue #34's mDNS gate
+ * uses this to decide whether to publish the receiver mDNS service.
+ */
+public sealed interface ScanActivity {
+    /** No matching pulse seen within the inactivity window. */
+    public data object Idle : ScanActivity
+
+    /**
+     * A matching pulse has been seen recently. [lastSeenAtMillis] is
+     * the timestamp (per the scanner's clock) of the most recent
+     * matching advertisement. The state automatically flips back to
+     * [Idle] after the configured inactivity timeout elapses.
+     */
+    public data class Active(
+        public val lastSeenAtMillis: Long,
+    ) : ScanActivity
+}
+
+/**
+ * Permission gate consulted by [BleQuickShareScanner.start] before
+ * attempting a platform scan. Lifted to its own interface so JVM tests
+ * can stub it without depending on [ContextCompat].
+ */
+public fun interface PermissionChecker {
+    public fun hasScanPermission(): Boolean
+}
+
+internal class AndroidPermissionChecker(
+    private val context: Context,
+) : PermissionChecker {
+    override fun hasScanPermission(): Boolean {
+        // On API ≤ 30 the install-time BLUETOOTH / BLUETOOTH_ADMIN
+        // permissions are declared in the umbrella manifest and the
+        // runtime check below trivially passes. From API 31+ we need
+        // the runtime BLUETOOTH_SCAN grant.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return true
+        return ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.BLUETOOTH_SCAN,
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+}
+
+/**
+ * Abstract handle over the platform [BluetoothLeScanner]. The real
+ * Android type is final, so we wrap it instead of mocking.
+ *
+ * The gate owns:
+ *   * the platform scan configuration (filter prefix, mask, scan mode),
+ *   * the platform [ScanCallback] subclass (which JVM unit tests cannot
+ *     instantiate because the AGP stub jar lacks bytecode for its
+ *     non-abstract methods).
+ *
+ * Consumers register a [PulseSink] to receive deserialized results — no
+ * AGP-stubbed type ever leaks across the gate boundary, so unit tests
+ * on a plain JVM can drive the scanner end-to-end.
+ */
+public interface BleScannerGate {
+    /**
+     * Begins a Quick-Share-shaped platform scan. Returns a [Registration]
+     * handle whose [Registration.close] stops the platform scan, or
+     * `null` if the scan could not be started (adapter off, no LE
+     * support, etc.).
+     *
+     * The gate is responsible for building the canonical [ScanFilter]
+     * (service UUID `0xFE2C` + 14-byte service-data prefix) and the
+     * [ScanSettings] (`SCAN_MODE_BALANCED`, `reportDelay = 0`) from
+     * the public companions on [BleQuickShareScanner].
+     *
+     * The gate is also responsible for fanning each [ScanResult] out to
+     * every [PulseSink] registered via [addSink].
+     */
+    public fun startScan(): Registration?
+
+    /**
+     * Subscribes a [PulseSink] to receive results from the active scan.
+     * Subsequent matching advertisements are delivered via
+     * [PulseSink.onPulse]; scan failures are delivered via
+     * [PulseSink.onFailed].
+     */
+    public fun addSink(sink: PulseSink)
+
+    /** Removes a sink previously registered via [addSink]. */
+    public fun removeSink(sink: PulseSink)
+
+    /** Token returned from [startScan]; close to stop the underlying scan. */
+    public interface Registration : AutoCloseable {
+        /** Stops the underlying platform scan. Idempotent. */
+        public override fun close()
+    }
+
+    /**
+     * Consumer-side handle for matching pulses. Implementations live
+     * inside [BleQuickShareScanner]; tests provide their own where
+     * needed.
+     */
+    public interface PulseSink {
+        /** Fired for each matching advertisement. */
+        public fun onPulse(result: ScanResult)
+
+        /**
+         * Fired when the platform scanner reports a non-recoverable
+         * failure. The default no-ops; the production scanner logs.
+         */
+        public fun onFailed(errorCode: Int) {
+            // Default: no-op.
+        }
+    }
+}
+
+/**
+ * Production [BleScannerGate] backed by [BluetoothLeScanner]. Owns one
+ * platform scan and fans out [ScanResult]s to a list of subscriber
+ * [BleScannerGate.PulseSink]s — needed because `BluetoothLeScanner`
+ * itself only accepts a single callback per registration but the
+ * scanner has multiple downstream consumers.
+ *
+ * The platform [ScanCallback] is constructed only when needed: the
+ * gate's lifetime is bound to a real Android device, so its instances
+ * never have to survive a JVM unit-test class load.
+ */
+internal class AndroidBleScannerGate(
+    private val context: Context,
+) : BleScannerGate {
+    private val sinks = mutableListOf<BleScannerGate.PulseSink>()
+    private val sinksLock = Any()
+
+    private val rootCallback: ScanCallback by lazy { createRootCallback() }
+
+    private fun createRootCallback(): ScanCallback =
+        object : ScanCallback() {
+            override fun onScanResult(
+                callbackType: Int,
+                result: ScanResult?,
+            ) {
+                if (result == null) return
+                snapshotSinks().forEach { it.onPulse(result) }
+            }
+
+            override fun onBatchScanResults(results: MutableList<ScanResult>?) {
+                if (results.isNullOrEmpty()) return
+                snapshotSinks().forEach { sink ->
+                    results.forEach { sink.onPulse(it) }
+                }
+            }
+
+            override fun onScanFailed(errorCode: Int) {
+                snapshotSinks().forEach { it.onFailed(errorCode) }
+            }
+        }
+
+    @RequiresPermission(Manifest.permission.BLUETOOTH_SCAN)
+    override fun startScan(): BleScannerGate.Registration? {
+        val scanner = resolveScanner() ?: return null
+        scanner.startScan(
+            BleQuickShareScanner.buildScanFilters(),
+            BleQuickShareScanner.buildScanSettings(),
+            rootCallback,
+        )
+        return Registration(scanner)
+    }
+
+    override fun addSink(sink: BleScannerGate.PulseSink) {
+        synchronized(sinksLock) { sinks += sink }
+    }
+
+    override fun removeSink(sink: BleScannerGate.PulseSink) {
+        synchronized(sinksLock) { sinks.remove(sink) }
+    }
+
+    private fun snapshotSinks(): List<BleScannerGate.PulseSink> = synchronized(sinksLock) { sinks.toList() }
+
+    @Suppress("ReturnCount")
+    private fun resolveScanner(): BluetoothLeScanner? {
+        // Each early-return covers a distinct failure mode that the
+        // production logs already differentiate; collapsing them into a
+        // single chained ?: hides the cause when one trips. Suppress
+        // the detekt warning explicitly rather than restructuring.
+        val manager =
+            context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
+                ?: return null
+        val adapter: BluetoothAdapter = manager.adapter ?: return null
+        if (!adapter.isEnabled) return null
+        return adapter.bluetoothLeScanner
+    }
+
+    private inner class Registration(
+        private val scanner: BluetoothLeScanner,
+    ) : BleScannerGate.Registration {
+        @Volatile
+        private var closed: Boolean = false
+
+        @RequiresPermission(Manifest.permission.BLUETOOTH_SCAN)
+        override fun close() {
+            if (closed) return
+            closed = true
+            try {
+                scanner.stopScan(rootCallback)
+            } catch (
+                @Suppress("TooGenericExceptionCaught") t: Throwable,
+            ) {
+                // Adapter may have been turned off after startScan succeeded;
+                // we still want the registration discarded.
+                Log.w(BleQuickShareScanner.TAG, "stopScan threw", t)
+            }
+        }
+    }
+}
+
+/**
+ * Top-level supervisor for the [BleQuickShareScanner] lifecycle. Owns a
+ * private [CoroutineScope] so consumers don't have to wire one up
+ * themselves; cancel by calling [shutdown].
+ *
+ * Receiver services typically construct one of these per session,
+ * call [start] when the foreground service comes up, and call
+ * [shutdown] from `onDestroy`.
+ */
+public class BleScannerHost(
+    context: Context,
+    inactivityTimeoutMillis: Long = BleQuickShareScanner.DEFAULT_INACTIVITY_TIMEOUT_MILLIS,
+) : AutoCloseable {
+    private val supervisor: Job = SupervisorJob()
+    private val scope: CoroutineScope = CoroutineScope(supervisor + Dispatchers.Default)
+
+    public val scanner: BleQuickShareScanner =
+        BleQuickShareScanner(
+            context = context,
+            coroutineScope = scope,
+            inactivityTimeoutMillis = inactivityTimeoutMillis,
+        )
+
+    /** Begins scanning. Safe to call multiple times. */
+    public fun start(): Boolean = scanner.start()
+
+    /** Stops scanning and tears down the owning scope. */
+    public fun shutdown() {
+        scanner.stop()
+        scope.cancel()
+    }
+
+    override fun close() {
+        scanner.stop()
+        scope.cancel()
+    }
+}

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareScanner.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareScanner.kt
@@ -97,11 +97,13 @@ import kotlinx.coroutines.launch
  *
  * [BleScannerGate] abstracts the platform `BluetoothLeScanner` so unit
  * tests on a plain JVM can drive the lifecycle through a fake. Tests
- * that need to observe the [activity] flow flip use a
- * [kotlinx.coroutines.test.TestScope] with a virtual time source.
+ * that need to observe the [activity] flow flip drive the inactivity
+ * timer through `runTest`'s virtual scheduler — see
+ * `BleQuickShareScannerTest`.
  *
- * @param coroutineScope scope that owns the inactivity-timeout job and
- *   the hot conversion of [pulses]; cancelling it stops the scanner.
+ * @param coroutineScope scope that owns the inactivity-timeout
+ *   coroutine. Cancelling the scope only stops the timer — call [stop]
+ *   explicitly to release the platform scan registration.
  * @param gate platform-scanner abstraction; tests inject a fake.
  * @param permissionChecker checks `BLUETOOTH_SCAN` at start time;
  *   defaults to a [ContextCompat]-backed implementation.

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareScannerTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareScannerTest.kt
@@ -1,0 +1,317 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.discovery.ble
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * JVM unit tests for [BleQuickShareScanner].
+ *
+ * The Android `ScanResult` / `BluetoothLeScanner` types are final and not
+ * usable on a plain JVM, so the scanner itself is tested through:
+ *   * `forTestEmitPulse` — drives the activity state machine without
+ *     having to construct a real `ScanResult`.
+ *   * a [FakeBleScannerGate] — counts platform start/stop and tracks
+ *     subscriber callbacks.
+ *
+ * The test runs under [runTest], whose virtual-time scheduler makes the
+ * inactivity timeout (a `delay()` call inside a launched job) deterministic
+ * via `advanceTimeBy` / `advanceUntilIdle`. The scanner attaches its
+ * inactivity-timer job to `backgroundScope`, which `runTest` auto-cancels
+ * when the test body returns.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class BleQuickShareScannerTest {
+    @Test
+    fun `prefix and mask match PROTOCOL spec`() {
+        // Pin the wire bytes — issue #33 cites the spec verbatim and a
+        // regression here would silently break interop with stock
+        // Quick Share senders. Hex-string comparison is more readable
+        // than byte-by-byte assertions and keeps the test failure
+        // message obvious.
+        val hexPrefix = BleQuickShareScanner.SERVICE_DATA_PREFIX.joinToString(separator = "") { "%02x".format(it) }
+        assertThat(hexPrefix).isEqualTo("fc128e014200000000000000" + "0000")
+
+        // Mask is 0xff for every prefix byte — i.e. the platform
+        // compares the entire 14-byte prefix exactly.
+        val hexMask = BleQuickShareScanner.SERVICE_DATA_MASK.joinToString(separator = "") { "%02x".format(it) }
+        assertThat(hexMask).isEqualTo("ffffffffffffffffffffffffffff")
+        assertThat(BleQuickShareScanner.SERVICE_DATA_PREFIX.size).isEqualTo(14)
+        assertThat(BleQuickShareScanner.SERVICE_DATA_MASK.size).isEqualTo(14)
+    }
+
+    @Test
+    fun `service UUID expands to SIG-base form`() {
+        // Quick Share's 16-bit service UUID `0xFE2C` must expand into the
+        // standard SIG base UUID. Pin the string form here (as opposed to
+        // the ParcelUuid object, which is mocked away in AGP unit tests)
+        // so a future refactor cannot silently swap it for a different
+        // namespace.
+        assertThat(BleQuickShareScanner.QUICK_SHARE_SERVICE_UUID_STRING)
+            .isEqualTo("0000fe2c-0000-1000-8000-00805f9b34fb")
+    }
+
+    @Test
+    fun `start without scan permission is a no-op`() =
+        runTest {
+            val gate = FakeBleScannerGate()
+            val scanner =
+                BleQuickShareScanner.forTesting(
+                    coroutineScope = backgroundScope,
+                    gate = gate,
+                    permissionChecker = { false },
+                )
+
+            val started = scanner.start()
+            assertThat(started).isFalse()
+            assertThat(gate.startCount).isEqualTo(0)
+            assertThat(scanner.isScanning).isFalse()
+        }
+
+    @Test
+    fun `start engages the platform scan exactly once`() =
+        runTest {
+            val gate = FakeBleScannerGate()
+            val scanner =
+                BleQuickShareScanner.forTesting(
+                    coroutineScope = backgroundScope,
+                    gate = gate,
+                    permissionChecker = { true },
+                )
+
+            assertThat(scanner.start()).isTrue()
+            assertThat(scanner.start()).isTrue()
+            assertThat(gate.startCount).isEqualTo(1)
+            assertThat(scanner.isScanning).isTrue()
+        }
+
+    @Test
+    fun `start delegates to the gate exactly once when permission is granted`() =
+        runTest {
+            val gate = FakeBleScannerGate()
+            val scanner =
+                BleQuickShareScanner.forTesting(
+                    coroutineScope = backgroundScope,
+                    gate = gate,
+                    permissionChecker = { true },
+                )
+
+            scanner.start()
+
+            // The wire-level filter contents (UUID, service-data prefix,
+            // mask, scan mode = BALANCED, reportDelay = 0) are pinned by
+            // the spec-aligned tests above. Here we only assert that
+            // start did, in fact, hit the gate.
+            assertThat(gate.startCount).isEqualTo(1)
+        }
+
+    @Test
+    fun `stop closes the registration and resets the activity state`() =
+        runTest {
+            val gate = FakeBleScannerGate()
+            // backgroundScope owns the inactivity-timeout job; auto-cancelled by runTest.
+            val scanner =
+                BleQuickShareScanner.forTesting(
+                    coroutineScope = backgroundScope,
+                    gate = gate,
+                    permissionChecker = { true },
+                    nowMillis = { 1_000L },
+                )
+
+            scanner.start()
+            scanner.forTestEmitPulse()
+            advanceUntilIdle()
+            assertThat(scanner.activity.value).isInstanceOf(ScanActivity.Active::class.java)
+
+            scanner.stop()
+            assertThat(gate.stopCount).isEqualTo(1)
+            assertThat(scanner.isScanning).isFalse()
+            assertThat(scanner.activity.value).isEqualTo(ScanActivity.Idle)
+        }
+
+    @Test
+    fun `pulse flips activity to Active and the timestamp matches the clock`() =
+        runTest {
+            val gate = FakeBleScannerGate()
+            var clock = 5_000L
+            val scanner =
+                BleQuickShareScanner.forTesting(
+                    coroutineScope = backgroundScope,
+                    gate = gate,
+                    permissionChecker = { true },
+                    nowMillis = { clock },
+                )
+
+            scanner.start()
+            scanner.forTestEmitPulse()
+            advanceUntilIdle()
+
+            val current = scanner.activity.value
+            assertThat(current).isEqualTo(ScanActivity.Active(lastSeenAtMillis = 5_000L))
+        }
+
+    @Test
+    fun `activity flips back to Idle after the inactivity timeout`() =
+        runTest {
+            val gate = FakeBleScannerGate()
+            val scanner =
+                BleQuickShareScanner.forTesting(
+                    coroutineScope = backgroundScope,
+                    gate = gate,
+                    permissionChecker = { true },
+                    inactivityTimeoutMillis = 30_000L,
+                    nowMillis = { 0L },
+                )
+
+            scanner.start()
+            scanner.forTestEmitPulse()
+            advanceUntilIdle()
+            assertThat(scanner.activity.value).isInstanceOf(ScanActivity.Active::class.java)
+
+            // Just before the deadline — still active.
+            advanceTimeBy(29_999L)
+            assertThat(scanner.activity.value).isInstanceOf(ScanActivity.Active::class.java)
+
+            // At and past the deadline — flips to Idle.
+            advanceTimeBy(2L)
+            advanceUntilIdle()
+            assertThat(scanner.activity.value).isEqualTo(ScanActivity.Idle)
+        }
+
+    @Test
+    fun `back-to-back pulses extend the inactivity window`() =
+        runTest {
+            val gate = FakeBleScannerGate()
+            var clock = 0L
+            val scanner =
+                BleQuickShareScanner.forTesting(
+                    coroutineScope = backgroundScope,
+                    gate = gate,
+                    permissionChecker = { true },
+                    inactivityTimeoutMillis = 30_000L,
+                    nowMillis = { clock },
+                )
+
+            scanner.start()
+            scanner.forTestEmitPulse()
+            advanceUntilIdle()
+
+            // Halfway through the window, another pulse arrives.
+            advanceTimeBy(15_000L)
+            clock = 15_000L
+            scanner.forTestEmitPulse()
+            advanceUntilIdle()
+
+            // Original deadline has now passed but the second pulse
+            // refreshed it — still active.
+            advanceTimeBy(20_000L)
+            advanceUntilIdle()
+            assertThat(scanner.activity.value).isInstanceOf(ScanActivity.Active::class.java)
+
+            // Eventually the second pulse's window expires.
+            advanceTimeBy(11_000L)
+            advanceUntilIdle()
+            assertThat(scanner.activity.value).isEqualTo(ScanActivity.Idle)
+        }
+
+    @Test
+    fun `start when gate refuses to start returns false`() =
+        runTest {
+            val gate = FakeBleScannerGate(refuseStart = true)
+            val scanner =
+                BleQuickShareScanner.forTesting(
+                    coroutineScope = backgroundScope,
+                    gate = gate,
+                    permissionChecker = { true },
+                )
+
+            val started = scanner.start()
+            assertThat(started).isFalse()
+            assertThat(scanner.isScanning).isFalse()
+        }
+
+    @Test
+    fun `stop without an active scan is a no-op`() =
+        runTest {
+            val gate = FakeBleScannerGate()
+            val scanner =
+                BleQuickShareScanner.forTesting(
+                    coroutineScope = backgroundScope,
+                    gate = gate,
+                    permissionChecker = { true },
+                )
+
+            scanner.stop()
+            assertThat(gate.stopCount).isEqualTo(0)
+        }
+
+    @Test
+    fun `activity state flow exposes initial Idle value`() =
+        runTest {
+            val gate = FakeBleScannerGate()
+            val scanner =
+                BleQuickShareScanner.forTesting(
+                    coroutineScope = backgroundScope,
+                    gate = gate,
+                    permissionChecker = { true },
+                )
+
+            // StateFlow contract: collectors immediately see the current
+            // value. Issue #34 relies on this — the mDNS gate must not
+            // miss the initial Idle that says "no pulse yet, do nothing".
+            assertThat(scanner.activity.first()).isEqualTo(ScanActivity.Idle)
+        }
+
+    /**
+     * Pure-JVM stand-in for the platform scanner.
+     *
+     * Records every `startScan` invocation and matching close. The flag
+     * [refuseStart] simulates the production path where the platform
+     * [BluetoothManager] returns `null` (e.g. adapter off) — the gate
+     * returns `null` and the scanner reports the start as failed.
+     *
+     * The fake intentionally does NOT touch the AGP-stubbed `ScanFilter`
+     * / `ScanSettings` types: the production gate
+     * ([AndroidBleScannerGate]) builds those internally so JVM tests
+     * never have to.
+     */
+    private class FakeBleScannerGate(
+        private val refuseStart: Boolean = false,
+    ) : BleScannerGate {
+        var startCount: Int = 0
+            private set
+        var stopCount: Int = 0
+            private set
+        var sinkCount: Int = 0
+            private set
+
+        override fun startScan(): BleScannerGate.Registration? {
+            if (refuseStart) return null
+            startCount++
+            return Registration()
+        }
+
+        override fun addSink(sink: BleScannerGate.PulseSink) {
+            sinkCount++
+        }
+
+        override fun removeSink(sink: BleScannerGate.PulseSink) {
+            sinkCount--
+        }
+
+        private inner class Registration : BleScannerGate.Registration {
+            override fun close() {
+                stopCount++
+            }
+        }
+    }
+}

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
@@ -18,6 +18,7 @@ import android.util.Log
 import androidx.core.app.ServiceCompat
 import androidx.core.content.ContextCompat
 import io.github.kyujincho.wvmg.discovery.Discovery
+import io.github.kyujincho.wvmg.discovery.ble.BleQuickShareScanner
 import io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo
 import io.github.kyujincho.wvmg.service.downloads.DownloadsWriterFactory
 import io.github.kyujincho.wvmg.service.receiver.consent.ConsentBroadcastReceiver
@@ -109,6 +110,9 @@ public class ReceiverForegroundService : Service() {
     @Volatile
     private var consentReceiver: BroadcastReceiver? = null
 
+    @Volatile
+    private var bleScanner: BleQuickShareScanner? = null
+
     override fun onCreate() {
         super.onCreate()
         ReceiverNotification.ensureChannel(this)
@@ -160,9 +164,36 @@ public class ReceiverForegroundService : Service() {
         // just keeps the existing session alive.
         if (session == null) {
             startReceiverSession()
+            startBleScanner()
         }
 
         return START_STICKY
+    }
+
+    /**
+     * Start the Phase 2 BLE pulse scanner (#33). The scanner observes
+     * sender BLE advertisements so a downstream feature (#34, mDNS
+     * gating) can hold off mDNS publish until a matching pulse is
+     * seen. Failures here — `BLUETOOTH_SCAN` not granted, adapter
+     * disabled, no LE support — are non-fatal and logged inside
+     * [BleQuickShareScanner.start]; the receiver continues in
+     * mDNS-only mode.
+     *
+     * Owns the scanner instance so [stopReceiverAndExit] can stop it
+     * symmetrically.
+     */
+    private fun startBleScanner() {
+        if (bleScanner != null) return
+        val scanner =
+            BleQuickShareScanner(
+                context = applicationContext,
+                coroutineScope = serviceScope,
+            )
+        bleScanner = scanner
+        ActiveBleScannerHolder.set(scanner)
+        // start() is idempotent and non-suspending; the receiver service
+        // controls the single scan registration over its lifetime.
+        scanner.start()
     }
 
     override fun onBind(intent: Intent?): IBinder? = null
@@ -325,6 +356,14 @@ public class ReceiverForegroundService : Service() {
         session?.stop()
         session = null
         ActiveDiscoveryHolder.clear()
+
+        // Stop the BLE scanner before cancelling the scope so the
+        // platform `stopScan` actually runs synchronously; otherwise
+        // the registration could outlive the service for a window.
+        bleScanner?.stop()
+        bleScanner = null
+        ActiveBleScannerHolder.clear()
+
         serviceJob.cancel()
         ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE)
         stopSelf()
@@ -502,6 +541,32 @@ public class ReceiverForegroundService : Service() {
 
         /** logcat tag for the diagnostics line — matches the discovery module. */
         private const val DIAGNOSTICS_TAG: String = "WvmgDiscovery"
+    }
+}
+
+/**
+ * Process-wide holder for the active [BleQuickShareScanner] instance.
+ *
+ * Issue #34's mDNS-gating logic needs read-only access to the scanner's
+ * `activity` StateFlow without re-architecting the foreground service
+ * dependency graph. Stashing it on a process-wide holder mirrors
+ * [ActiveDiscoveryHolder]: no behaviour change unless a downstream
+ * caller subscribes; tests that don't construct a real scanner simply
+ * find `null` here.
+ */
+public object ActiveBleScannerHolder {
+    @Volatile
+    private var ref: BleQuickShareScanner? = null
+
+    internal fun set(scanner: BleQuickShareScanner) {
+        ref = scanner
+    }
+
+    /** The active scanner, or `null` if the receiver service is not running. */
+    public fun current(): BleQuickShareScanner? = ref
+
+    internal fun clear() {
+        ref = null
     }
 }
 


### PR DESCRIPTION
## Summary

- Introduces `BleQuickShareScanner` in `:discovery-android/src/main/kotlin/.../ble/`. The scanner installs a single platform `ScanFilter` pinned to PROTOCOL.md's 14-byte service-data prefix at UUID `0xFE2C`, runs in `SCAN_MODE_BALANCED`, and exposes:
  - `pulses: Flow<ScanResult>` — every matching advertisement.
  - `activity: StateFlow<ScanActivity>` — flips to `Idle` after a configurable inactivity window (30 s default per the issue's acceptance criterion).
- `BleScannerGate` abstracts the platform `BluetoothLeScanner` and exposes a Kotlin-only `PulseSink` interface so JVM unit tests never have to instantiate the AGP-stubbed `ScanCallback` class.
- Wired into `ReceiverForegroundService`: starts on service start, stops synchronously in the teardown path. Exposed via `ActiveBleScannerHolder` so the downstream mDNS-gating issue (#34) can subscribe to `activity` without re-architecting the service.
- `:discovery-android` manifest now declares `BLUETOOTH_SCAN` (`neverForLocation`) and the API ≤ 30 legacy `BLUETOOTH` / `BLUETOOTH_ADMIN` permissions; `:app` already declares `BLUETOOTH_SCAN` for the runtime prompt (#31).
- CLAUDE.md updated: the architecture sketch references the new `discovery.ble` package, and the on-device debugging line includes the `WvmgBleScan` logcat tag.

## Test plan

- [x] `./gradlew :discovery-android:testDebugUnitTest` — new `BleQuickShareScannerTest` covers spec-aligned prefix/mask/UUID, permission-denied no-op, idempotent gate calls, inactivity-timeout flip, and back-to-back pulse window extension.
- [x] `./gradlew staticAnalysis` — ktlint + detekt clean across every module.
- [x] `./gradlew :app:testDebugUnitTest :service-android:testDebugUnitTest :core-protocol:test` — full unit-test suite green.
- [x] `./gradlew :app:assembleDebug` — debug APK builds against `compileSdk = 36`.
- [ ] On-device verification (deferred to #34's interop run, when the gate becomes observable end-to-end).

Closes #33.