### PR TITLE
feat(ble): tune scan mode for battery + foreground responsiveness (#35)

### DIFF
--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareScanner.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareScanner.kt
@@ -302,7 +302,12 @@ public class BleQuickShareScanner internal constructor(
      */
     public fun setScanMode(mode: Int): Boolean =
         synchronized(lifecycleLock) {
-            if (mode == currentScanMode && registration != null) return@synchronized true
+            // No-op when the requested mode equals the current one.
+            // Covers both "already scanning at this mode" and "idle and
+            // mode is already the pinned-for-next-start value" — the
+            // latter avoids a noisy "BALANCED -> BALANCED" logcat line
+            // at first observer attach.
+            if (mode == currentScanMode) return@synchronized true
             val previous = currentScanMode
             currentScanMode = mode
 

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareScanner.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareScanner.kt
@@ -74,6 +74,26 @@ import kotlinx.coroutines.launch
  * ~10–20 mAh/day") makes the always-on simpler approach acceptable for
  * Phase 2.
  *
+ * ### Scan-mode tuning (#35)
+ *
+ * The scan registration runs in [ScanSettings.SCAN_MODE_BALANCED] by
+ * default — the documented "low-power, foreground-service-friendly"
+ * mode that Android allows to run continuously without throttling. The
+ * scanner exposes [setScanMode] so the owning foreground service can
+ * temporarily upgrade to [ScanSettings.SCAN_MODE_LOW_LATENCY] while the
+ * user has the app foregrounded (responsiveness matters more than power
+ * during active interaction) and revert back to BALANCED when the app
+ * returns to the background. `setReportDelay(0)` is pinned for both
+ * modes — non-zero delay batches advertisements which is unsuitable for
+ * a near-real-time interactive trigger.
+ *
+ * Switching the scan mode while a scan is in flight tears down the
+ * platform registration and re-registers with the new settings. This is
+ * the platform-recommended pattern (`BluetoothLeScanner.startScan` is
+ * idempotent on the callback identity but takes its `ScanSettings`
+ * snapshot at registration time) and is fast in practice — the kernel
+ * just updates the in-flight scan parameters.
+ *
  * ### Threading
  *
  * `start` and `stop` are safe to call from any thread; they serialize
@@ -150,6 +170,20 @@ public class BleQuickShareScanner internal constructor(
     @Volatile
     private var registration: BleScannerGate.Registration? = null
 
+    /**
+     * Currently-active platform scan mode. Defaults to
+     * [ScanSettings.SCAN_MODE_BALANCED] per the issue #35 acceptance
+     * criterion — the mode that Android allows a foreground service to
+     * run indefinitely without throttling.
+     *
+     * Mutated through [setScanMode] under [lifecycleLock]. Reads outside
+     * the lock are racy in the strict sense but the field is `@Volatile`
+     * and only used as a debug accessor / for the "do nothing if mode
+     * unchanged" early-exit in [setScanMode] itself.
+     */
+    @Volatile
+    private var currentScanMode: Int = ScanSettings.SCAN_MODE_BALANCED
+
     private val activityState: MutableStateFlow<ScanActivity> = MutableStateFlow(ScanActivity.Idle)
 
     @Volatile
@@ -207,7 +241,7 @@ public class BleQuickShareScanner internal constructor(
             }
             val started =
                 try {
-                    gate.startScan()
+                    gate.startScan(currentScanMode)
                 } catch (
                     @Suppress("TooGenericExceptionCaught") t: Throwable,
                 ) {
@@ -233,9 +267,108 @@ public class BleQuickShareScanner internal constructor(
                 }
             gate.addSink(sink)
             primarySink = sink
-            Log.i(TAG, "start: BLE pulse scan started")
+            Log.i(TAG, "start: BLE pulse scan started mode=${describeScanMode(currentScanMode)}")
             true
         }
+
+    /**
+     * Switches the platform scan to the given [ScanSettings] scan-mode
+     * constant. Idempotent — calling with the current mode is a no-op.
+     *
+     * Acceptable values are [ScanSettings.SCAN_MODE_LOW_POWER],
+     * [ScanSettings.SCAN_MODE_BALANCED], and
+     * [ScanSettings.SCAN_MODE_LOW_LATENCY]. Other constants
+     * (`SCAN_MODE_OPPORTUNISTIC` in particular) are intentionally out of
+     * scope: opportunistic mode means "only deliver results that some
+     * other scan would have delivered anyway", and we are the only
+     * BLE scanner in our process.
+     *
+     * If a scan is currently in flight, the platform registration is
+     * torn down and re-registered with the new settings. If no scan is
+     * active, the new mode is simply remembered for the next [start] —
+     * this avoids spurious platform calls when the lifecycle observer
+     * fires before the scanner has been started for the first time.
+     *
+     * Failures during the re-registration are logged but non-fatal: the
+     * receiver service continues without BLE, and the next [start]
+     * attempt will retry.
+     *
+     * @param mode scan mode constant from [ScanSettings].
+     * @return `true` if the scanner ended up running on the requested
+     *   mode (either already running on it, or successfully transitioned
+     *   to it, or the scanner is currently stopped and the mode is now
+     *   pinned for next start). `false` if a re-registration was
+     *   attempted but the platform refused.
+     */
+    public fun setScanMode(mode: Int): Boolean =
+        synchronized(lifecycleLock) {
+            if (mode == currentScanMode && registration != null) return@synchronized true
+            val previous = currentScanMode
+            currentScanMode = mode
+
+            // Mode change while idle: just remember the new mode for the
+            // next start(). No platform call is needed.
+            if (registration == null) {
+                Log.i(
+                    TAG,
+                    "setScanMode: scanner idle, pinned mode for next start: " +
+                        "${describeScanMode(previous)} -> ${describeScanMode(mode)}",
+                )
+                return@synchronized true
+            }
+
+            // Active path: tear down the existing registration and bring
+            // a new one up under the new settings. We deliberately
+            // route through gate.startScan rather than a hypothetical
+            // "update settings in place" call — the platform API does
+            // not expose one and re-registration is the
+            // documented pattern.
+            val sink = primarySink
+            registration?.let { current ->
+                try {
+                    current.close()
+                } catch (
+                    @Suppress("TooGenericExceptionCaught") t: Throwable,
+                ) {
+                    Log.w(TAG, "setScanMode: close of previous registration threw", t)
+                }
+            }
+            registration = null
+
+            val restarted =
+                try {
+                    gate.startScan(mode)
+                } catch (
+                    @Suppress("TooGenericExceptionCaught") t: Throwable,
+                ) {
+                    Log.w(TAG, "setScanMode: re-register at new mode failed", t)
+                    null
+                }
+            if (restarted == null) {
+                // Restart failed — drop the sink registration as well
+                // so the next start() is a clean slate.
+                if (sink != null) gate.removeSink(sink)
+                primarySink = null
+                Log.w(
+                    TAG,
+                    "setScanMode: ${describeScanMode(previous)} -> ${describeScanMode(mode)} " +
+                        "FAILED, scanner is now stopped",
+                )
+                return@synchronized false
+            }
+            registration = restarted
+            Log.i(
+                TAG,
+                "setScanMode: ${describeScanMode(previous)} -> ${describeScanMode(mode)}",
+            )
+            true
+        }
+
+    /** Currently-active platform scan mode. Reflects the value last
+     *  passed to [setScanMode], or [ScanSettings.SCAN_MODE_BALANCED]
+     *  before the first call. Useful for diagnostics / tests. */
+    public val activeScanMode: Int
+        get() = currentScanMode
 
     /**
      * Stop scanning. Idempotent: calling [stop] when no scan is in
@@ -392,12 +525,41 @@ public class BleQuickShareScanner internal constructor(
                     ).build(),
             )
 
-        internal fun buildScanSettings(): ScanSettings =
+        /**
+         * Builds the platform [ScanSettings] for a given scan-mode
+         * constant. Pinned configuration:
+         *
+         *  * `setScanMode` — variable, defaults to BALANCED at the
+         *    scanner level, but switches to LOW_LATENCY while the user
+         *    has the app foregrounded (#35).
+         *  * `setReportDelay(0)` — pinned. Non-zero delay batches
+         *    advertisements which would block the interactive
+         *    "saw a sender" trigger.
+         *
+         * Throws on a JVM unit-test runtime where AGP stubs out
+         * [ScanSettings.Builder] — never call from a JVM test path.
+         */
+        internal fun buildScanSettings(scanMode: Int = ScanSettings.SCAN_MODE_BALANCED): ScanSettings =
             ScanSettings
                 .Builder()
-                .setScanMode(ScanSettings.SCAN_MODE_BALANCED)
+                .setScanMode(scanMode)
                 .setReportDelay(0)
                 .build()
+
+        /**
+         * Human-readable label for the [ScanSettings] scan-mode
+         * constants we care about. Used in logcat lines so a power-tuning
+         * triage can grep `WvmgBleScan setScanMode` and read the
+         * transition without translating integers.
+         */
+        internal fun describeScanMode(mode: Int): String =
+            when (mode) {
+                ScanSettings.SCAN_MODE_OPPORTUNISTIC -> "OPPORTUNISTIC"
+                ScanSettings.SCAN_MODE_LOW_POWER -> "LOW_POWER"
+                ScanSettings.SCAN_MODE_BALANCED -> "BALANCED"
+                ScanSettings.SCAN_MODE_LOW_LATENCY -> "LOW_LATENCY"
+                else -> "UNKNOWN($mode)"
+            }
 
         /**
          * Test-only factory matching the existing module convention. The
@@ -483,20 +645,26 @@ internal class AndroidPermissionChecker(
  */
 public interface BleScannerGate {
     /**
-     * Begins a Quick-Share-shaped platform scan. Returns a [Registration]
-     * handle whose [Registration.close] stops the platform scan, or
-     * `null` if the scan could not be started (adapter off, no LE
-     * support, etc.).
+     * Begins a Quick-Share-shaped platform scan with the given scan
+     * mode. Returns a [Registration] handle whose [Registration.close]
+     * stops the platform scan, or `null` if the scan could not be
+     * started (adapter off, no LE support, etc.).
      *
      * The gate is responsible for building the canonical [ScanFilter]
      * (service UUID `0xFE2C` + 14-byte service-data prefix) and the
-     * [ScanSettings] (`SCAN_MODE_BALANCED`, `reportDelay = 0`) from
+     * [ScanSettings] (`reportDelay = 0`, scan mode = [scanMode]) from
      * the public companions on [BleQuickShareScanner].
      *
      * The gate is also responsible for fanning each [ScanResult] out to
      * every [PulseSink] registered via [addSink].
+     *
+     * @param scanMode one of [ScanSettings.SCAN_MODE_LOW_POWER],
+     *   [ScanSettings.SCAN_MODE_BALANCED], or
+     *   [ScanSettings.SCAN_MODE_LOW_LATENCY]. The scanner uses BALANCED
+     *   by default and switches to LOW_LATENCY while the app is
+     *   foregrounded (#35).
      */
-    public fun startScan(): Registration?
+    public fun startScan(scanMode: Int): Registration?
 
     /**
      * Subscribes a [PulseSink] to receive results from the active scan.
@@ -576,11 +744,11 @@ internal class AndroidBleScannerGate(
         }
 
     @RequiresPermission(Manifest.permission.BLUETOOTH_SCAN)
-    override fun startScan(): BleScannerGate.Registration? {
+    override fun startScan(scanMode: Int): BleScannerGate.Registration? {
         val scanner = resolveScanner() ?: return null
         scanner.startScan(
             BleQuickShareScanner.buildScanFilters(),
-            BleQuickShareScanner.buildScanSettings(),
+            BleQuickShareScanner.buildScanSettings(scanMode),
             rootCallback,
         )
         return Registration(scanner)
@@ -658,6 +826,13 @@ public class BleScannerHost(
 
     /** Begins scanning. Safe to call multiple times. */
     public fun start(): Boolean = scanner.start()
+
+    /**
+     * Switches the platform scan mode. Forwards to
+     * [BleQuickShareScanner.setScanMode]; see that method for the
+     * acceptable [ScanSettings] constants.
+     */
+    public fun setScanMode(mode: Int): Boolean = scanner.setScanMode(mode)
 
     /** Stops scanning and tears down the owning scope. */
     public fun shutdown() {

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareScannerTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareScannerTest.kt
@@ -5,6 +5,7 @@
  */
 package io.github.kyujincho.wvmg.discovery.ble
 
+import android.bluetooth.le.ScanSettings
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
@@ -112,6 +113,120 @@ class BleQuickShareScannerTest {
             // the spec-aligned tests above. Here we only assert that
             // start did, in fact, hit the gate.
             assertThat(gate.startCount).isEqualTo(1)
+        }
+
+    @Test
+    fun `start uses SCAN_MODE_BALANCED by default`() =
+        runTest {
+            // Issue #35 acceptance criterion: the scan registers in
+            // BALANCED mode by default. LOW_LATENCY is opt-in via
+            // setScanMode while the user has the app foregrounded.
+            val gate = FakeBleScannerGate()
+            val scanner =
+                BleQuickShareScanner.forTesting(
+                    coroutineScope = backgroundScope,
+                    gate = gate,
+                    permissionChecker = { true },
+                )
+
+            scanner.start()
+            assertThat(gate.lastScanMode).isEqualTo(ScanSettings.SCAN_MODE_BALANCED)
+            assertThat(scanner.activeScanMode).isEqualTo(ScanSettings.SCAN_MODE_BALANCED)
+        }
+
+    @Test
+    fun `setScanMode while idle pins the mode for the next start`() =
+        runTest {
+            // No platform call should happen until start() runs — we
+            // don't want to thrash the kernel scan registration before
+            // the receiver service has even decided to bring it up.
+            val gate = FakeBleScannerGate()
+            val scanner =
+                BleQuickShareScanner.forTesting(
+                    coroutineScope = backgroundScope,
+                    gate = gate,
+                    permissionChecker = { true },
+                )
+
+            assertThat(scanner.setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)).isTrue()
+            assertThat(gate.startCount).isEqualTo(0)
+            assertThat(scanner.activeScanMode).isEqualTo(ScanSettings.SCAN_MODE_LOW_LATENCY)
+
+            scanner.start()
+            assertThat(gate.lastScanMode).isEqualTo(ScanSettings.SCAN_MODE_LOW_LATENCY)
+        }
+
+    @Test
+    fun `setScanMode while active re-registers with the new mode`() =
+        runTest {
+            // Simulates the foreground -> background transition: the
+            // app comes to the foreground (LOW_LATENCY) and then leaves
+            // it (BALANCED). The scanner should tear down the existing
+            // registration and bring up a new one each time.
+            val gate = FakeBleScannerGate()
+            val scanner =
+                BleQuickShareScanner.forTesting(
+                    coroutineScope = backgroundScope,
+                    gate = gate,
+                    permissionChecker = { true },
+                )
+
+            scanner.start()
+            assertThat(gate.startCount).isEqualTo(1)
+            assertThat(gate.lastScanMode).isEqualTo(ScanSettings.SCAN_MODE_BALANCED)
+
+            assertThat(scanner.setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)).isTrue()
+            assertThat(gate.startCount).isEqualTo(2)
+            assertThat(gate.stopCount).isEqualTo(1)
+            assertThat(gate.lastScanMode).isEqualTo(ScanSettings.SCAN_MODE_LOW_LATENCY)
+            assertThat(scanner.isScanning).isTrue()
+
+            assertThat(scanner.setScanMode(ScanSettings.SCAN_MODE_BALANCED)).isTrue()
+            assertThat(gate.startCount).isEqualTo(3)
+            assertThat(gate.stopCount).isEqualTo(2)
+            assertThat(gate.lastScanMode).isEqualTo(ScanSettings.SCAN_MODE_BALANCED)
+        }
+
+    @Test
+    fun `setScanMode is a no-op when already on the requested mode`() =
+        runTest {
+            val gate = FakeBleScannerGate()
+            val scanner =
+                BleQuickShareScanner.forTesting(
+                    coroutineScope = backgroundScope,
+                    gate = gate,
+                    permissionChecker = { true },
+                )
+
+            scanner.start()
+            assertThat(gate.startCount).isEqualTo(1)
+
+            // Same mode, same registration — no restart should happen.
+            assertThat(scanner.setScanMode(ScanSettings.SCAN_MODE_BALANCED)).isTrue()
+            assertThat(gate.startCount).isEqualTo(1)
+            assertThat(gate.stopCount).isEqualTo(0)
+        }
+
+    @Test
+    fun `setScanMode leaves the scanner stopped if re-register fails`() =
+        runTest {
+            // Once the user has switched on Bluetooth airplane-mode etc,
+            // the platform may refuse a re-register. The scanner must
+            // not pretend to still be scanning in that case.
+            val gate = FlakyBleScannerGate()
+            val scanner =
+                BleQuickShareScanner.forTesting(
+                    coroutineScope = backgroundScope,
+                    gate = gate,
+                    permissionChecker = { true },
+                )
+
+            scanner.start()
+            assertThat(scanner.isScanning).isTrue()
+
+            gate.refuseStart = true
+            assertThat(scanner.setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)).isFalse()
+            assertThat(scanner.isScanning).isFalse()
         }
 
     @Test
@@ -294,9 +409,19 @@ class BleQuickShareScannerTest {
         var sinkCount: Int = 0
             private set
 
-        override fun startScan(): BleScannerGate.Registration? {
+        /**
+         * Most-recently-requested scan mode. `null` until [startScan]
+         * has been called once. Tests assert this to verify that #35's
+         * BALANCED-by-default / LOW_LATENCY-on-foreground policy
+         * actually reaches the platform.
+         */
+        var lastScanMode: Int? = null
+            private set
+
+        override fun startScan(scanMode: Int): BleScannerGate.Registration? {
             if (refuseStart) return null
             startCount++
+            lastScanMode = scanMode
             return Registration()
         }
 
@@ -312,6 +437,32 @@ class BleQuickShareScannerTest {
             override fun close() {
                 stopCount++
             }
+        }
+    }
+
+    /**
+     * [FakeBleScannerGate] variant whose `refuseStart` flag is mutable
+     * so a single test can flip the platform from "scan accepted" to
+     * "scan rejected" mid-flight. Used to exercise the
+     * setScanMode-fails-mid-flight branch of the scanner.
+     */
+    private class FlakyBleScannerGate : BleScannerGate {
+        var refuseStart: Boolean = false
+        var lastScanMode: Int? = null
+            private set
+
+        override fun startScan(scanMode: Int): BleScannerGate.Registration? {
+            if (refuseStart) return null
+            lastScanMode = scanMode
+            return Registration()
+        }
+
+        override fun addSink(sink: BleScannerGate.PulseSink) = Unit
+
+        override fun removeSink(sink: BleScannerGate.PulseSink) = Unit
+
+        private class Registration : BleScannerGate.Registration {
+            override fun close() = Unit
         }
     }
 }

--- a/docs/testing/ble-scan-power.md
+++ b/docs/testing/ble-scan-power.md
@@ -1,0 +1,202 @@
+# Power instrumentation: BLE pulse scanning
+
+This is a manual test runbook for measuring the battery cost of
+WhenVivoMeetsGoogle's Phase 2 BLE pulse scanner (issue #33) running with
+the battery-tuned scan settings introduced in issue #35.
+
+The acceptance criterion in #35 is:
+
+> Measure mAh/hour on a Pixel 7 for a "background scanning, no transfer"
+> hour. Document in the test runbook.
+
+We do not have a real device available in CI, so this document is the
+place where the engineer running the measurement records the result.
+The test setup pins enough of the configuration that two engineers
+running it independently should reach comparable numbers.
+
+## What we are measuring
+
+The scanner runs from inside `ReceiverForegroundService` and uses two
+scan modes:
+
+| App state                           | `ScanSettings` mode          | Notes                                                                 |
+| ----------------------------------- | ---------------------------- | --------------------------------------------------------------------- |
+| Background (default, foreground svc)| `SCAN_MODE_BALANCED`         | The mode Android allows a foreground service to run continuously.     |
+| Foreground (any activity visible)   | `SCAN_MODE_LOW_LATENCY`      | Brief upgrade for responsiveness while the user is actively in-app.   |
+
+`setReportDelay(0)` is pinned for both modes — non-zero delay batches
+advertisements which is unsuitable for an interactive trigger.
+
+The number we want is the **`SCAN_MODE_BALANCED`, no transfer**
+draw — that is the steady state the receiver service spends most of its
+time in, and the one the AC explicitly asks about.
+
+## Preconditions
+
+### Phone (Pixel 7 or comparable)
+
+- [ ] **Pixel 7** running stock Android, ideally a recent stable release
+      (Android 14 / 15). Other devices will not invalidate the test, but
+      record the make/model so the result is comparable.
+- [ ] Battery health > 80 % (Settings → Battery → Battery health).
+      Below 80 %, the discharge profile is no longer representative.
+- [ ] Battery level between 60 % and 90 % at the start of the test.
+      Edge-of-charge regions discharge non-linearly and confound the
+      measurement.
+- [ ] Phone temperature in normal range (no recent gaming / fast charge).
+- [ ] Adaptive Battery, Battery Saver, and per-app battery restrictions
+      OFF for our app.
+- [ ] Bluetooth ON, Wi-Fi ON, screen OFF for the duration of the
+      measurement.
+- [ ] Mobile data toggled OFF if possible — eliminates background
+      cellular activity from the measurement.
+- [ ] The debug build of `:app` installed and granted `BLUETOOTH_SCAN`
+      (the onboarding flow from #31 covers this).
+
+### Workstation
+
+- [ ] `adb` reachable over USB. The phone must NOT be on the charger
+      during the measurement window — `dumpsys battery` reports a
+      derived "discharge rate" that is meaningless while charging.
+      `adb shell dumpsys battery unplug` simulates an unplugged state
+      while keeping USB connected for `adb`.
+
+## Procedure
+
+> All commands assume the worktree root is the current working
+> directory. Substitute your own device serial in `adb -s <serial>` if
+> multiple phones are attached.
+
+### 1. Bring up the receiver
+
+Start the foreground receiver service (the share-intent flow from #24
+also brings the service up; or wire a "stay open" entry in MainActivity):
+
+```bash
+./gradlew :app:installDebug
+adb shell am start -n io.github.kyujincho.wvmg.debug/io.github.kyujincho.wvmg.MainActivity
+# Trigger any flow that calls ReceiverForegroundService.start() —
+# in the current build the share-intent path will do.
+```
+
+Confirm the foreground service is running and the BLE scan started in
+`SCAN_MODE_BALANCED`:
+
+```bash
+adb logcat -d -s WvmgBleScan
+# Expect: "start: BLE pulse scan started mode=BALANCED"
+```
+
+### 2. Establish the baseline
+
+Lock the phone and let the screen turn off. Wait 2 minutes for any
+lingering activity (mDNS announcements, JmDNS settle, Wi-Fi caching) to
+quiesce.
+
+Disconnect the charger but keep the USB lead in for `adb`:
+
+```bash
+adb shell dumpsys battery unplug
+```
+
+Reset the kernel battery counters so the next sample is from a known
+zero:
+
+```bash
+adb shell dumpsys batterystats --reset
+adb shell dumpsys batterystats --enable full-wake-history
+```
+
+### 3. Run the measurement window
+
+Leave the phone undisturbed (locked, screen off, on a flat non-conducting
+surface) for **at least 1 hour**, ideally 2 hours so the measurement
+window is large enough that small noise sources don't dominate.
+
+While the run is in progress, do NOT:
+- Connect any new BLE peripherals to the phone.
+- Send anything to the phone via Quick Share (that would invalidate the
+  "no transfer" condition).
+- Open any other apps that scan BLE.
+
+### 4. Collect the data
+
+After the measurement window completes:
+
+```bash
+adb shell dumpsys batterystats --checkin > batterystats-$(date +%Y%m%d-%H%M).txt
+```
+
+The relevant line in the checkin format is the per-UID `wbl` (wake-lock
++ BLE) breakdown. The package UID is `io.github.kyujincho.wvmg.debug`;
+look up its UID with:
+
+```bash
+adb shell dumpsys package io.github.kyujincho.wvmg.debug | grep userId=
+```
+
+Alternatively, the human-readable form is easier to read:
+
+```bash
+adb shell dumpsys batterystats io.github.kyujincho.wvmg.debug
+```
+
+Look for the `Bluetooth scan results received:` and
+`Bluetooth scan time:` lines. Convert the scan time to mAh using the
+device's published per-mode BLE scan power:
+
+```
+mAh = (scan_time_seconds / 3600) * scan_mode_current_mA
+```
+
+Pixel 7 BLE scan currents (from `power_profile.xml` —
+`adb pull /system/etc/power_profile.xml` for the exact value on your
+firmware):
+
+| Mode          | Current (mA)   |
+| ------------- | -------------- |
+| BALANCED      | _populate from `power_profile.xml`_ |
+| LOW_LATENCY   | _populate from `power_profile.xml`_ |
+| LOW_POWER     | _populate from `power_profile.xml`_ |
+
+### 5. Reconnect the charger and record
+
+```bash
+adb shell dumpsys battery reset
+```
+
+Restore the device to its normal battery state.
+
+## Result template
+
+Fill in this block in the PR or the issue comment when you run the
+measurement on real hardware. **Do not invent numbers.**
+
+```
+Device:           [Pixel 7 / other]
+Android version:  [e.g. Android 14 build TQ3A.230901.001]
+Build:            [git sha / build number of :app]
+Scan mode:        SCAN_MODE_BALANCED
+Test window:      [start ts] -> [end ts] = [duration] minutes
+Battery level:    [start %] -> [end %] = [delta %] absolute
+Battery capacity: [Wh / mAh from spec sheet]
+Per-window draw:  [mAh] / hour
+mAh / hour:       [computed]
+
+Notes:
+  - [unusual conditions, deviations from procedure, etc.]
+```
+
+## Status
+
+- [ ] **TODO — run on real device.** The acceptance criterion in #35
+      requires a Pixel-7-on-real-hardware measurement; no measurement
+      has been recorded yet. Update this section once a result is
+      available.
+
+## See also
+
+- [Interop runbook: NearDrop on macOS](interop-neardrop-macos.md)
+- [Interop runbook: stock Quick Share (Android)](interop-stock-quick-share-android.md)
+- Source: `discovery-android/src/main/.../ble/BleQuickShareScanner.kt` (`buildScanSettings`)
+- Source: `service-android/src/main/.../receiver/ReceiverForegroundService.kt` (`AppLifecycleScanModeObserver`)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,6 +56,12 @@ androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidxAppcompat" }
 androidx-activity-ktx = { module = "androidx.activity:activity-ktx", version.ref = "androidxActivity" }
 androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidxLifecycle" }
+# `lifecycle-process` exposes [androidx.lifecycle.ProcessLifecycleOwner],
+# the singleton LifecycleOwner that tracks "is any activity of this app
+# foreground". The receiver foreground service uses it (#35) to switch
+# the BLE scan mode between BALANCED (background) and LOW_LATENCY
+# (foreground) without inventing a separate process-state mechanism.
+androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "androidxLifecycle" }
 
 # Kotlin coroutines
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }

--- a/service-android/build.gradle.kts
+++ b/service-android/build.gradle.kts
@@ -66,6 +66,10 @@ dependencies {
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
+    // ProcessLifecycleOwner — drives the BLE scan-mode switch between
+    // BALANCED (background) and LOW_LATENCY (foreground) in
+    // ReceiverForegroundService (#35).
+    implementation(libs.androidx.lifecycle.process)
     implementation(libs.kotlinx.coroutines.android)
 
     // Junit Jupiter is the project-wide test runtime. Aligning with

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
@@ -6,6 +6,7 @@
 package io.github.kyujincho.wvmg.service.receiver
 
 import android.app.Service
+import android.bluetooth.le.ScanSettings
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
@@ -13,10 +14,15 @@ import android.content.IntentFilter
 import android.content.pm.ServiceInfo
 import android.net.wifi.WifiManager
 import android.os.Build
+import android.os.Handler
 import android.os.IBinder
+import android.os.Looper
 import android.util.Log
 import androidx.core.app.ServiceCompat
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
 import io.github.kyujincho.wvmg.discovery.Discovery
 import io.github.kyujincho.wvmg.discovery.ble.BleQuickShareScanner
 import io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo
@@ -116,6 +122,21 @@ public class ReceiverForegroundService : Service() {
     @Volatile
     private var mdnsGate: MdnsAdvertisementGate? = null
 
+    /**
+     * Observer attached to [ProcessLifecycleOwner] that switches the
+     * BLE scan mode based on whether the user has the app foregrounded.
+     * `null` while the service is not running; populated by
+     * [startBleScanner] and detached by [stopReceiverAndExit].
+     *
+     * The observer runs on the main thread (per the `ProcessLifecycleOwner`
+     * contract); the [BleQuickShareScanner.setScanMode] call it makes is
+     * synchronized internally and runs the platform call inline, so
+     * blocking the main thread here is bounded by a single
+     * `BluetoothLeScanner.startScan` round-trip.
+     */
+    @Volatile
+    private var processLifecycleObserver: AppLifecycleScanModeObserver? = null
+
     override fun onCreate() {
         super.onCreate()
         ReceiverNotification.ensureChannel(this)
@@ -174,16 +195,27 @@ public class ReceiverForegroundService : Service() {
     }
 
     /**
-     * Start the Phase 2 BLE pulse scanner (#33). The scanner observes
-     * sender BLE advertisements so a downstream feature (#34, mDNS
-     * gating) can hold off mDNS publish until a matching pulse is
-     * seen. Failures here — `BLUETOOTH_SCAN` not granted, adapter
-     * disabled, no LE support — are non-fatal and logged inside
+     * Start the Phase 2 BLE pulse scanner (#33) with the battery-tuned
+     * scan settings from #35. The scanner observes sender BLE
+     * advertisements so a downstream feature (#34, mDNS gating) can
+     * hold off mDNS publish until a matching pulse is seen. Failures
+     * here — `BLUETOOTH_SCAN` not granted, adapter disabled, no LE
+     * support — are non-fatal and logged inside
      * [BleQuickShareScanner.start]; the receiver continues in
      * mDNS-only mode.
      *
-     * Owns the scanner instance so [stopReceiverAndExit] can stop it
-     * symmetrically.
+     * The scan starts in [ScanSettings.SCAN_MODE_BALANCED] (the
+     * documented "low-power, foreground-service-friendly" mode that
+     * Android allows to run continuously without throttling). An
+     * [AppLifecycleScanModeObserver] attached to
+     * [ProcessLifecycleOwner] then upgrades to
+     * [ScanSettings.SCAN_MODE_LOW_LATENCY] while the user has the app
+     * foregrounded — responsiveness matters more than power during
+     * active interaction — and reverts to BALANCED when the app moves
+     * back to the background.
+     *
+     * Owns both the scanner instance and the lifecycle observer so
+     * [stopReceiverAndExit] can tear them down symmetrically.
      */
     private fun startBleScanner() {
         if (bleScanner != null) return
@@ -197,6 +229,32 @@ public class ReceiverForegroundService : Service() {
         // start() is idempotent and non-suspending; the receiver service
         // controls the single scan registration over its lifetime.
         scanner.start()
+
+        // Attach the foreground/background scan-mode observer (#35).
+        // ProcessLifecycleOwner requires its observers to be attached
+        // on the main thread.
+        attachProcessLifecycleObserver(scanner)
+    }
+
+    /**
+     * Add an [AppLifecycleScanModeObserver] to [ProcessLifecycleOwner]
+     * so the scan mode tracks the app's foreground/background state.
+     *
+     * Marshalled onto the main thread because both
+     * `ProcessLifecycleOwner.lifecycle.addObserver` and
+     * `LifecycleOwner` callbacks must run on the main thread per
+     * AndroidX contract. `Service.onStartCommand` is itself called on
+     * the main thread, so this `post` is a no-op when invoked from the
+     * normal lifecycle path — it only exists as a defensive measure
+     * for any future call site that might be migrated off the main
+     * thread.
+     */
+    private fun attachProcessLifecycleObserver(scanner: BleQuickShareScanner) {
+        val observer = AppLifecycleScanModeObserver { mode -> scanner.setScanMode(mode) }
+        processLifecycleObserver = observer
+        runOnMainThread {
+            ProcessLifecycleOwner.get().lifecycle.addObserver(observer)
+        }
     }
 
     override fun onBind(intent: Intent?): IBinder? = null
@@ -375,6 +433,21 @@ public class ReceiverForegroundService : Service() {
         consentReceiver = receiver
     }
 
+    /**
+     * Run [block] on the main thread. If we are already on the main
+     * thread, executes inline; otherwise posts to a [Handler] bound to
+     * [Looper.getMainLooper]. Used to satisfy the `ProcessLifecycleOwner`
+     * "observers must be attached on the main thread" contract from
+     * any future call site.
+     */
+    private fun runOnMainThread(block: () -> Unit) {
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            block()
+        } else {
+            Handler(Looper.getMainLooper()).post(block)
+        }
+    }
+
     private fun unregisterConsentReceiverIfNeeded() {
         val receiver = consentReceiver ?: return
         runCatching { unregisterReceiver(receiver) }
@@ -404,6 +477,18 @@ public class ReceiverForegroundService : Service() {
         session?.stop()
         session = null
         ActiveDiscoveryHolder.clear()
+
+        // Detach the ProcessLifecycleOwner observer first — once the
+        // scanner is stopped, any late foreground/background callback
+        // would just be a no-op on a stopped scanner, but holding the
+        // observer attached past `stopReceiverAndExit` would leak the
+        // service through the global ProcessLifecycleOwner.
+        processLifecycleObserver?.let { observer ->
+            runOnMainThread {
+                ProcessLifecycleOwner.get().lifecycle.removeObserver(observer)
+            }
+        }
+        processLifecycleObserver = null
 
         // Stop the BLE scanner before cancelling the scope so the
         // platform `stopScan` actually runs synchronously; otherwise
@@ -773,4 +858,50 @@ internal class AndroidMulticastLockController(
  */
 public fun interface SessionFactory {
     public fun invoke(context: Context): ReceiverSession
+}
+
+/**
+ * `ProcessLifecycleOwner` observer that switches the BLE scan mode
+ * between [ScanSettings.SCAN_MODE_LOW_LATENCY] (foreground) and
+ * [ScanSettings.SCAN_MODE_BALANCED] (background) per the issue #35
+ * acceptance criterion.
+ *
+ * `ProcessLifecycleOwner` aggregates every activity in the process —
+ * `onStart` fires when the first activity becomes visible, `onStop`
+ * fires `LIFECYCLE_DELAY_MS` (≈700 ms in current AndroidX) after the
+ * last activity goes away. The 700 ms hysteresis is exactly what we
+ * want: rotation, transient activity-to-activity transitions, and
+ * brief pauses for system dialogs do not flap the scan mode.
+ *
+ * The observer is intentionally kept tiny and side-effect-free: its
+ * only job is to translate two lifecycle callbacks into two scan-mode
+ * change requests on the supplied [setScanMode] sink. All locking,
+ * restart, and platform-call logic lives inside the
+ * [BleQuickShareScanner] the sink ultimately targets — that lets unit
+ * tests drive the observer with a recording sink instead of needing a
+ * full scanner standing by.
+ *
+ * Made `internal` so the unit test in `:service-android` can exercise
+ * the lifecycle transitions without instantiating the full foreground
+ * service.
+ *
+ * @param setScanMode callback that applies a [ScanSettings] scan-mode
+ *   constant to the active BLE scanner. Production wires this to
+ *   [BleQuickShareScanner.setScanMode]; tests use a recorder.
+ */
+internal class AppLifecycleScanModeObserver(
+    private val setScanMode: (Int) -> Unit,
+) : DefaultLifecycleObserver {
+    override fun onStart(owner: LifecycleOwner) {
+        // App returned to the foreground: upgrade to LOW_LATENCY for
+        // responsiveness while the user is actively interacting.
+        setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
+    }
+
+    override fun onStop(owner: LifecycleOwner) {
+        // App backgrounded: revert to BALANCED so the foreground
+        // service can run the scan continuously without throttling and
+        // without burning the battery.
+        setScanMode(ScanSettings.SCAN_MODE_BALANCED)
+    }
 }

--- a/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/AppLifecycleScanModeObserverTest.kt
+++ b/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/AppLifecycleScanModeObserverTest.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.service.receiver
+
+import android.bluetooth.le.ScanSettings
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * JVM unit tests for [AppLifecycleScanModeObserver].
+ *
+ * The observer is the glue between `ProcessLifecycleOwner` and the BLE
+ * scan-mode sink (#35). We deliberately do not stand up a real
+ * `ProcessLifecycleOwner` — its singleton requires `androidx.startup`
+ * initialization that is awkward to drive from a JVM test. Instead we
+ * exercise the observer against a synthetic [LifecycleRegistry] /
+ * [LifecycleOwner] pair, the exact two-class collaboration that
+ * `ProcessLifecycleOwner` itself uses.
+ *
+ * Pinned behaviour:
+ *  * `onStart` (app foregrounded)  → sink receives LOW_LATENCY.
+ *  * `onStop`  (app backgrounded) → sink receives BALANCED.
+ *  * Repeated foreground/background transitions translate
+ *    one-for-one to scan-mode change requests, in order.
+ */
+class AppLifecycleScanModeObserverTest {
+    @Test
+    fun `onStart switches the sink to LOW_LATENCY`() {
+        val recorder = ModeRecorder()
+        val observer = AppLifecycleScanModeObserver(recorder::record)
+        val (_, lifecycle) = newOwner()
+        lifecycle.addObserver(observer)
+
+        // ProcessLifecycleOwner's real path is CREATED -> STARTED when
+        // the first activity is foregrounded.
+        lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
+        lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START)
+
+        assertThat(recorder.modes).containsExactly(ScanSettings.SCAN_MODE_LOW_LATENCY)
+    }
+
+    @Test
+    fun `onStop reverts the sink to BALANCED`() {
+        val recorder = ModeRecorder()
+        val observer = AppLifecycleScanModeObserver(recorder::record)
+        val (_, lifecycle) = newOwner()
+        lifecycle.addObserver(observer)
+
+        // Foreground first to put the registry in STARTED, then
+        // background.
+        lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
+        lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START)
+        lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+
+        // Both events fired in the right order: LOW_LATENCY then
+        // BALANCED.
+        assertThat(recorder.modes)
+            .containsExactly(
+                ScanSettings.SCAN_MODE_LOW_LATENCY,
+                ScanSettings.SCAN_MODE_BALANCED,
+            ).inOrder()
+    }
+
+    @Test
+    fun `foreground-background-foreground roundtrip emits all three modes in order`() {
+        // Simulates rotation / multi-task / quick switch — the user
+        // backgrounds and foregrounds repeatedly. Every transition
+        // should produce exactly one scan-mode update so the scanner
+        // tracks the most recent lifecycle event.
+        val recorder = ModeRecorder()
+        val observer = AppLifecycleScanModeObserver(recorder::record)
+        val (_, lifecycle) = newOwner()
+        lifecycle.addObserver(observer)
+
+        lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
+        lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START)
+        lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+        lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START)
+
+        assertThat(recorder.modes)
+            .containsExactly(
+                ScanSettings.SCAN_MODE_LOW_LATENCY,
+                ScanSettings.SCAN_MODE_BALANCED,
+                ScanSettings.SCAN_MODE_LOW_LATENCY,
+            ).inOrder()
+    }
+
+    /**
+     * Build a lifecycle owner / registry pair we can drive manually.
+     * Mirrors the structure `ProcessLifecycleOwner` exposes — owner
+     * holds a single registry; the registry's `addObserver` is what the
+     * production code targets.
+     *
+     * Uses [LifecycleRegistry.createUnsafe] so the registry skips its
+     * "must run on the main thread" enforcement. The default
+     * [LifecycleRegistry] constructor calls
+     * `androidx.arch.core.executor.DefaultTaskExecutor.isMainThread`,
+     * which in turn calls `Looper.getMainLooper()` — un-mocked on the
+     * AGP unit-test runtime, so the regular constructor throws
+     * `RuntimeException("Method getMainLooper not mocked")`.
+     */
+    private fun newOwner(): Pair<LifecycleOwner, LifecycleRegistry> {
+        // Two-step construction: the owner reference is captured first
+        // (lateinit) so the registry can hold it, then the registry is
+        // assigned. `LifecycleRegistry` requires a non-null owner up
+        // front so this dance is unavoidable.
+        lateinit var registry: LifecycleRegistry
+        val owner =
+            object : LifecycleOwner {
+                override val lifecycle: Lifecycle
+                    get() = registry
+            }
+        registry = LifecycleRegistry.createUnsafe(owner)
+        return owner to registry
+    }
+
+    /**
+     * Captures every scan-mode update the observer pushes through the
+     * sink, in the order they arrive. The list is a plain `MutableList`
+     * because the observer always runs synchronously on the same
+     * thread that fires the lifecycle event.
+     */
+    private class ModeRecorder {
+        val modes: MutableList<Int> = mutableListOf()
+
+        fun record(mode: Int) {
+            modes += mode
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements issue #35 — battery-tuned BLE scan settings + foreground-service confirmation.

- The receiver foreground service now drives the BLE pulse scanner's `ScanSettings`:
  - `SCAN_MODE_BALANCED` by default (the documented mode that an Android foreground service can run continuously without throttling).
  - Switches to `SCAN_MODE_LOW_LATENCY` while the user has the app foregrounded (any activity visible), and reverts to `SCAN_MODE_BALANCED` when the app moves back to the background.
  - `setReportDelay(0)` is pinned for both modes — non-zero delay batches advertisements which would block the interactive trigger.
- The foreground/background transition is driven by an `AppLifecycleScanModeObserver` attached to `ProcessLifecycleOwner`. The observer is detached during service teardown so it does not leak the service through the process-wide lifecycle owner.
- The scan still runs entirely from inside `ReceiverForegroundService`, which has been declared with `foregroundServiceType="connectedDevice"` since #21. `ReceiverManifestTest` pins that as a regression guard.

## Power instrumentation

The acceptance criterion in #35 calls for an mAh/hour measurement on a Pixel 7 for a "background scanning, no transfer" hour. No real device is available in this environment, so the procedure has been documented in `docs/testing/ble-scan-power.md` (alongside the existing interop runbooks). The number itself is left as `TODO — run on real device` for the engineer with hardware to fill in.

## Files of note

- `discovery-android/src/main/.../BleQuickShareScanner.kt` — adds `setScanMode(mode)` and parameterizes the `BleScannerGate.startScan` signature.
- `service-android/src/main/.../ReceiverForegroundService.kt` — wires `ProcessLifecycleOwner` -> scanner.
- `service-android/src/test/.../AppLifecycleScanModeObserverTest.kt` — JVM unit test against a synthetic `LifecycleRegistry` (`createUnsafe` to skip main-thread enforcement).
- `discovery-android/src/test/.../BleQuickShareScannerTest.kt` — new cases for default mode, mid-flight switch, no-op on unchanged mode, idle-pin, and refused-restart.
- `gradle/libs.versions.toml`, `service-android/build.gradle.kts` — adds `androidx.lifecycle:lifecycle-process` dependency.
- `docs/testing/ble-scan-power.md` — power-measurement runbook.

Closes #35.

## Test plan

- [x] `./gradlew staticAnalysis`
- [x] `./gradlew :discovery-android:testDebugUnitTest`
- [x] `./gradlew :service-android:testDebugUnitTest`
- [x] `./gradlew :app:testDebugUnitTest`
- [x] `./gradlew :core-protocol:test`
- [x] `./gradlew :app:assembleDebug`
- [ ] Manual: run the procedure in `docs/testing/ble-scan-power.md` on a real Pixel 7 and append the mAh/hour result to the runbook.