### PR TITLE
feat(discovery): gate mDNS publish on BLE pulse activity (#34)

### DIFF
--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/MainActivity.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/MainActivity.kt
@@ -8,8 +8,10 @@ package io.github.kyujincho.wvmg
 import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.SwitchCompat
 import io.github.kyujincho.wvmg.onboarding.PermissionRequirements
 import io.github.kyujincho.wvmg.onboarding.PermissionsOnboardingActivity
+import io.github.kyujincho.wvmg.service.receiver.MdnsVisibilityOverrideHolder
 
 /**
  * Empty launcher activity for the WhenVivoMeetsGoogle app.
@@ -18,11 +20,23 @@ import io.github.kyujincho.wvmg.onboarding.PermissionsOnboardingActivity
  * status, and settings screens replace this implementation as the rest
  * of the phase rolls in.
  *
- * The one bit of real logic today is the permissions gate: if any of
- * the runtime permissions Phase 1 needs (#26) is missing on cold start,
- * we send the user to [PermissionsOnboardingActivity] before they see
- * any app UI. Onboarding does not block proceeding when only optional
- * permissions remain denied — see the activity for the policy.
+ * The one bit of real logic today is:
+ *
+ *  - Permissions gate: if any of the runtime permissions Phase 1 needs
+ *    (#26) is missing on cold start, we send the user to
+ *    [PermissionsOnboardingActivity] before they see any app UI.
+ *    Onboarding does not block proceeding when only optional permissions
+ *    remain denied — see the activity for the policy.
+ *  - Always-visible override (#34): a single switch surfaces
+ *    [MdnsVisibilityOverrideHolder.setAlwaysVisible] to the user. When
+ *    enabled, the receiver publishes mDNS unconditionally, bypassing
+ *    the BLE-pulse gate. Useful on devices where BLE scan is
+ *    unavailable (no permission, no LE hardware) or whenever the user
+ *    wants to stay discoverable.
+ *
+ * The override flag is process-wide and lives in memory only. Persisting
+ * the toggle across process death is a follow-up; the in-memory surface
+ * is the minimum #34 needs to ship the override path.
  */
 class MainActivity : AppCompatActivity() {
     /**
@@ -41,6 +55,14 @@ class MainActivity : AppCompatActivity() {
         savedInstanceState?.let {
             onboardingLaunched = it.getBoolean(STATE_ONBOARDING_LAUNCHED, false)
         }
+
+        val switch = findViewById<SwitchCompat>(R.id.main_always_visible_switch)
+        // Reflect the current process-wide value so the toggle is
+        // accurate after a configuration change or activity recreation.
+        switch.isChecked = MdnsVisibilityOverrideHolder.isActive
+        switch.setOnCheckedChangeListener { _, checked ->
+            MdnsVisibilityOverrideHolder.setAlwaysVisible(checked)
+        }
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -50,6 +72,16 @@ class MainActivity : AppCompatActivity() {
 
     override fun onStart() {
         super.onStart()
+        // Re-sync the switch to the holder on every onStart — the
+        // override is process-wide and could have been changed by
+        // another activity (or, in the future, a quick-settings tile)
+        // while we were paused.
+        findViewById<SwitchCompat>(R.id.main_always_visible_switch)?.let {
+            if (it.isChecked != MdnsVisibilityOverrideHolder.isActive) {
+                it.isChecked = MdnsVisibilityOverrideHolder.isActive
+            }
+        }
+
         // Route to onboarding at most once per activity instance. Once
         // #21 lands, the foreground service will re-check at start time
         // and surface a dismissible error instead of relaunching

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,4 +1,39 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<!--
+    Phase 1 / 2 launcher activity layout.
+
+    The launcher is a thin scaffold (the real device list, transfer
+    status, and full settings screens are still tracked elsewhere). The
+    one piece of real UI today is the always-visible override toggle for
+    issue #34 — the user-facing escape hatch that bypasses the BLE-pulse
+    mDNS gate so the receiver works on devices without BLE scan.
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" />
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="24dp">
+
+    <TextView
+        android:id="@+id/main_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/app_name"
+        android:textAppearance="?android:attr/textAppearanceLarge" />
+
+    <androidx.appcompat.widget.SwitchCompat
+        android:id="@+id/main_always_visible_switch"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:text="@string/main_always_visible_title" />
+
+    <TextView
+        android:id="@+id/main_always_visible_subtitle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:text="@string/main_always_visible_subtitle"
+        android:textAppearance="?android:attr/textAppearanceSmall" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,6 +2,13 @@
 <resources>
     <string name="app_name">WhenVivoMeetsGoogle</string>
 
+    <!-- Launcher activity (#34). The "always visible" override lets the
+         user force the receiver to publish mDNS even when no BLE pulse is
+         in flight — useful when BLE scan is unavailable or the user just
+         wants to be discoverable to nearby senders. -->
+    <string name="main_always_visible_title">Always visible</string>
+    <string name="main_always_visible_subtitle">Keep this device discoverable on Wi-Fi even without a Bluetooth pulse from a nearby sender. Turn off to save power; the receiver will only appear briefly while a sender is scanning.</string>
+
     <!-- Permissions onboarding (#26 + #31). -->
     <string name="onboarding_title">App permissions</string>
     <string name="onboarding_intro">Quick Share needs a small set of Android permissions to discover nearby devices over your local Wi-Fi network, to broadcast and listen for short Bluetooth Low Energy pulses that wake nearby Quick Share receivers, and to keep you informed about transfers. Each permission below explains exactly what it is used for.</string>

--- a/service-android/build.gradle.kts
+++ b/service-android/build.gradle.kts
@@ -36,6 +36,21 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
+
+    testOptions {
+        unitTests {
+            // The mDNS gate (#34) and a few other paths in this module
+            // call `android.util.Log.i / Log.w` for structured diagnostics
+            // and observability. Without `returnDefaultValues = true` the
+            // AGP unit-test runtime throws "Method i in android.util.Log
+            // not mocked" from every JVM test that hits a logging path,
+            // which then propagates through generic catch blocks and hides
+            // the real test outcome. Default-values mode returns 0/null
+            // for any unmocked Android API call — safe for our tests
+            // since none of them assert on Log.* output.
+            isReturnDefaultValues = true
+        }
+    }
 }
 
 kotlin {

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/MdnsAdvertisementGate.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/MdnsAdvertisementGate.kt
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.service.receiver
+
+import android.util.Log
+import io.github.kyujincho.wvmg.discovery.ble.ScanActivity
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+/**
+ * Drives the mDNS advertisement lifecycle from BLE pulse activity and
+ * a small set of override flags (issue #34).
+ *
+ * Stock Quick Share does not broadcast mDNS continuously — only while a
+ * sender's BLE pulse is detected. This gate matches that behaviour by
+ * subscribing to:
+ *
+ *  * [bleActivity] — `StateFlow<ScanActivity>` from
+ *    `BleQuickShareScanner` (#33). When the most recent value is
+ *    [ScanActivity.Active] we want to publish.
+ *  * [alwaysVisibleOverride] — sticky user-controlled "always visible"
+ *    toggle. When `true`, we publish unconditionally so the receiver
+ *    works on devices where BLE scan is unavailable (no permission, no
+ *    LE hardware) or where the user simply wants to be discoverable
+ *    while the BLE side is asleep.
+ *  * [qrSessionActive] — when a QR-code-based receive flow is in
+ *    progress (the in-app counterpart to #1.16, hooked into the
+ *    existing #84/#86 QR display path), the gate is bypassed entirely
+ *    and the advertisement stays up. The current build only exposes
+ *    the hook; the QR flow itself toggles it when the relevant code
+ *    lands.
+ *
+ * ### Debounce
+ *
+ * After mDNS goes up, it stays up for at least
+ * [debounceIdleMillis] (default 30 s) to avoid flapping if the BLE
+ * pulse is intermittent. Concretely:
+ *
+ *  * BLE flips Idle → Active: publish immediately, cancel any pending
+ *    unpublish.
+ *  * BLE flips Active → Idle: schedule an unpublish [debounceIdleMillis]
+ *    later.
+ *  * BLE flips back to Active before the timer fires: cancel the timer,
+ *    keep the advertisement up.
+ *  * Override flips on: publish immediately, cancel any pending
+ *    unpublish.
+ *  * Override flips off (and BLE is Idle): schedule an unpublish
+ *    [debounceIdleMillis] later.
+ *
+ * The debounce window is chosen to match #34's acceptance criterion
+ * verbatim.
+ *
+ * ### Concurrency
+ *
+ * The gate runs on a single coroutine launched in [scope]. All the
+ * publish/unpublish state is owned by that coroutine — no locks are
+ * needed beyond the ones [ReceiverSession] already holds internally.
+ *
+ * The gate does **not** own the publish lifecycle past its own scope:
+ * if the receiver service stops, [stop] cancels the gate but leaves the
+ * session to run its own teardown order (which closes any in-flight
+ * AdvertiseHandle as part of its `stop()` path). This keeps the gate's
+ * stop-order trivially safe regardless of which side cancels first.
+ *
+ * @param session the receiver session whose advertisement is gated.
+ * @param bleActivity scanner activity flow sourced from
+ *   `BleQuickShareScanner.activity` via [ActiveBleScannerHolder].
+ * @param alwaysVisibleOverride sticky user-controlled override.
+ * @param qrSessionActive QR-code-flow bypass flag.
+ * @param debounceIdleMillis time after the last "should publish" signal
+ *   before the gate unpublishes the advertisement. 30 s by default per
+ *   issue #34.
+ */
+public class MdnsAdvertisementGate(
+    private val session: ReceiverSession,
+    private val bleActivity: StateFlow<ScanActivity>,
+    private val alwaysVisibleOverride: StateFlow<Boolean>,
+    private val qrSessionActive: StateFlow<Boolean>,
+    private val debounceIdleMillis: Long = DEFAULT_DEBOUNCE_IDLE_MILLIS,
+) {
+    @Volatile
+    private var collectorJob: Job? = null
+
+    @Volatile
+    private var debounceJob: Job? = null
+
+    /**
+     * Begin observing the gating signals on [scope].
+     *
+     * Idempotent: a second call while the gate is already running is a
+     * no-op. Cancelling [scope] (or calling [stop]) tears down the
+     * subscription; the receiver session is unaffected.
+     */
+    public fun start(scope: CoroutineScope) {
+        if (collectorJob != null) return
+        // Re-evaluate the decision whenever any of the three input flows
+        // changes. We collect each flow in its own child coroutine so
+        // the suspending collector doesn't interleave with the
+        // pure-side-effect [apply] body — every state change just
+        // recomputes from the current StateFlow snapshots.
+        //
+        // We deliberately do NOT use [combine] here: in unit tests under
+        // `runTest`, combine's per-source debouncing behaviour interacts
+        // poorly with `StandardTestDispatcher`'s scheduler — the first
+        // emission can be delivered late enough to skip an initial
+        // "publish on already-active state" decision. Three independent
+        // collectors plus a recomputed snapshot keep the dispatch order
+        // explicit and let virtual-time tests reason about it
+        // deterministically.
+        collectorJob =
+            scope.launch {
+                // Force an initial evaluation so the gate's
+                // "publish if currently active" decision applies even
+                // before any of the upstream flows emit a *change*.
+                apply(currentDecision(), scope)
+                launch {
+                    bleActivity.collect { apply(currentDecision(), scope) }
+                }
+                launch {
+                    alwaysVisibleOverride.collect { apply(currentDecision(), scope) }
+                }
+                launch {
+                    qrSessionActive.collect { apply(currentDecision(), scope) }
+                }
+            }
+    }
+
+    private fun currentDecision(): Decision =
+        Decision(
+            bleActive = bleActivity.value is ScanActivity.Active,
+            overrideOn = alwaysVisibleOverride.value,
+            qrActive = qrSessionActive.value,
+        )
+
+    /**
+     * Cancel the gate's coroutines. Idempotent. Does not unpublish — if
+     * an advertisement is in flight at stop time it remains up until
+     * [ReceiverSession.stop] tears it down. (Stopping the gate is not a
+     * user-visible signal; tearing the receiver down is.)
+     */
+    public fun stop() {
+        debounceJob?.cancel()
+        debounceJob = null
+        collectorJob?.cancel()
+        collectorJob = null
+    }
+
+    /**
+     * Apply a [Decision] to the receiver session. Pure side-effect: the
+     * decision either publishes (synchronously, via the session) or
+     * schedules an unpublish on the supplied [scope].
+     */
+    @Suppress("TooGenericExceptionCaught", "ReturnCount")
+    private fun apply(
+        decision: Decision,
+        scope: CoroutineScope,
+    ) {
+        val shouldPublish = decision.bleActive || decision.overrideOn || decision.qrActive
+        if (shouldPublish) {
+            // Cancel any pending unpublish — we're back inside the
+            // "should publish" half of the gate.
+            debounceJob?.cancel()
+            debounceJob = null
+            if (!session.isAdvertising) {
+                try {
+                    session.publishAdvertisement()
+                    Log.i(TAG, "publish: published mDNS (decision=$decision)")
+                } catch (t: Throwable) {
+                    // The session may have been stopped between the
+                    // collector firing and the publish call. Treat as
+                    // benign — the decision will be re-evaluated if the
+                    // session is restarted.
+                    Log.w(TAG, "publish: failed (decision=$decision)", t)
+                }
+            }
+            return
+        }
+
+        // No "should publish" signal active: schedule an unpublish if
+        // the advertisement is currently up. If the timer is already
+        // running we leave it alone — re-arming it would extend the
+        // debounce window unnecessarily. The two early returns plus
+        // the returning `if (shouldPublish)` block above push the
+        // function past detekt's default of 2; suppressed inline since
+        // the alternative (nested if/else) would be harder to read.
+        if (!session.isAdvertising) return
+        if (debounceJob?.isActive == true) return
+        debounceJob =
+            scope.launch {
+                delay(debounceIdleMillis)
+                if (isActive) {
+                    try {
+                        session.unpublishAdvertisement()
+                        Log.i(TAG, "unpublish: idle for ${debounceIdleMillis}ms; mDNS taken down")
+                    } catch (t: Throwable) {
+                        // Best-effort: the session may have been stopped
+                        // first, in which case the advertisement is
+                        // already torn down.
+                        Log.w(TAG, "unpublish: threw", t)
+                    }
+                }
+            }
+    }
+
+    /**
+     * Snapshot of the three input flags. Lifted to a data class so the
+     * collector path is `combine -> distinctUntilChanged -> onEach`
+     * with a value type that has structural equality, instead of a
+     * `Triple<Boolean, Boolean, Boolean>` whose meaning is positional.
+     */
+    private data class Decision(
+        val bleActive: Boolean,
+        val overrideOn: Boolean,
+        val qrActive: Boolean,
+    )
+
+    public companion object {
+        /** logcat tag for gate-related lines. */
+        internal const val TAG: String = "WvmgMdnsGate"
+
+        /**
+         * Default 30 s idle window before the gate unpublishes the
+         * advertisement. Pinned by #34's acceptance criterion: "After
+         * mDNS goes up, it stays up for at least 30 s (debounce) to
+         * avoid flapping if the BLE pulse is intermittent."
+         */
+        public const val DEFAULT_DEBOUNCE_IDLE_MILLIS: Long = 30_000L
+    }
+}

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/MdnsAdvertisementGate.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/MdnsAdvertisementGate.kt
@@ -92,6 +92,16 @@ public class MdnsAdvertisementGate(
     private var debounceJob: Job? = null
 
     /**
+     * Serialises [apply] across the three child collectors so a racing
+     * BLE/override/QR transition cannot interleave the
+     * `session.isAdvertising` check with the publish/schedule write.
+     * Synchronous and held only over fast in-memory state transitions
+     * — the actual `session.publishAdvertisement` / `unpublish` calls
+     * are themselves serialised by the session's internal lock.
+     */
+    private val applyLock: Any = Any()
+
+    /**
      * Begin observing the gating signals on [scope].
      *
      * Idempotent: a second call while the gate is already running is a
@@ -161,7 +171,7 @@ public class MdnsAdvertisementGate(
     private fun apply(
         decision: Decision,
         scope: CoroutineScope,
-    ) {
+    ) = synchronized(applyLock) {
         val shouldPublish = decision.bleActive || decision.overrideOn || decision.qrActive
         if (shouldPublish) {
             // Cancel any pending unpublish — we're back inside the
@@ -210,10 +220,9 @@ public class MdnsAdvertisementGate(
     }
 
     /**
-     * Snapshot of the three input flags. Lifted to a data class so the
-     * collector path is `combine -> distinctUntilChanged -> onEach`
-     * with a value type that has structural equality, instead of a
-     * `Triple<Boolean, Boolean, Boolean>` whose meaning is positional.
+     * Snapshot of the three input flags. Lifted to a data class with
+     * named fields rather than a `Triple<Boolean, Boolean, Boolean>` so
+     * the meaning of each value stays explicit at every call site.
      */
     private data class Decision(
         val bleActive: Boolean,

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
@@ -266,7 +266,12 @@ public class ReceiverForegroundService : Service() {
      * in mDNS-only mode.
      */
     private fun startMdnsGate(activeSession: ReceiverSession) {
+        // Bail out if the service has already been torn down between
+        // session.start() returning and this method running. Without
+        // the running check, a quick start/stop sequence could leak a
+        // gate whose collector keeps a reference to a stopped session.
         if (mdnsGate != null) return
+        if (!activeSession.isRunning) return
         val gate =
             MdnsAdvertisementGate(
                 session = activeSession,

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
@@ -113,6 +113,9 @@ public class ReceiverForegroundService : Service() {
     @Volatile
     private var bleScanner: BleQuickShareScanner? = null
 
+    @Volatile
+    private var mdnsGate: MdnsAdvertisementGate? = null
+
     override fun onCreate() {
         super.onCreate()
         ReceiverNotification.ensureChannel(this)
@@ -225,6 +228,11 @@ public class ReceiverForegroundService : Service() {
         serviceScope.launch {
             try {
                 newSession.start()
+                // Once start() returns successfully the TCP listener is
+                // bound and the multicast lock is held. With the
+                // gated-advertise factory in production, mDNS publish is
+                // not yet up — the gate launched below handles that.
+                startMdnsGate(newSession)
             } catch (
                 @Suppress("SwallowedException") t: Throwable,
             ) {
@@ -243,6 +251,35 @@ public class ReceiverForegroundService : Service() {
         // debug screen. The cadence is intentionally slow (every 10s)
         // so we don't spam logcat in the steady state.
         startDiscoveryDiagnosticsLogger()
+    }
+
+    /**
+     * Construct and launch the [MdnsAdvertisementGate] that drives
+     * [ReceiverSession.publishAdvertisement] / `unpublishAdvertisement`
+     * from BLE pulse activity (#34). Called after [ReceiverSession.start]
+     * returns, so the bound TCP port is already known.
+     *
+     * If [bleScanner] is `null` (BLE failed to start, e.g. permission
+     * denied), the gate observes a never-emitting source — the override
+     * holder remains the only signal that can drive a publish. Users
+     * can still toggle the always-visible override to run the receiver
+     * in mDNS-only mode.
+     */
+    private fun startMdnsGate(activeSession: ReceiverSession) {
+        if (mdnsGate != null) return
+        val gate =
+            MdnsAdvertisementGate(
+                session = activeSession,
+                bleActivity =
+                    bleScanner?.activity
+                        ?: kotlinx.coroutines.flow.MutableStateFlow(
+                            io.github.kyujincho.wvmg.discovery.ble.ScanActivity.Idle,
+                        ),
+                alwaysVisibleOverride = MdnsVisibilityOverrideHolder.activeFlow,
+                qrSessionActive = QrSessionActiveHolder.activeFlow,
+            )
+        gate.start(serviceScope)
+        mdnsGate = gate
     }
 
     /**
@@ -353,6 +390,12 @@ public class ReceiverForegroundService : Service() {
         }
         unregisterConsentReceiverIfNeeded()
 
+        // Stop the gate before the session so its delayed unpublish
+        // coroutine can no longer fire after `session.stop()` has
+        // already torn the AdvertiseHandle down.
+        mdnsGate?.stop()
+        mdnsGate = null
+
         session?.stop()
         session = null
         ActiveDiscoveryHolder.clear()
@@ -455,6 +498,12 @@ public class ReceiverForegroundService : Service() {
                     multicastLock = AndroidMulticastLockController(context),
                     factoryProvider = { DownloadsWriterFactory.create(context) },
                     endpointInfo = identity,
+                    // Issue #34: defer mDNS publish to the
+                    // [MdnsAdvertisementGate] so we only advertise while
+                    // a sender BLE pulse is active (or the user has
+                    // forced visibility on, or a QR session is in
+                    // progress).
+                    advertiseGated = true,
                 )
             }
 
@@ -567,6 +616,74 @@ public object ActiveBleScannerHolder {
 
     internal fun clear() {
         ref = null
+    }
+}
+
+/**
+ * Sticky "always visible" override for the mDNS gate (#34).
+ *
+ * The user surfaces this through the launcher activity (`MainActivity`)
+ * — when toggled on, the receiver publishes mDNS unconditionally even
+ * if no BLE pulse is in flight. Useful on devices where BLE scan is
+ * unavailable (no `BLUETOOTH_SCAN` grant, no LE hardware) or whenever
+ * the user wants to be discoverable regardless of sender activity.
+ *
+ * The flag is process-wide and lives in memory only — it resets across
+ * process death. Persisting the toggle is a follow-up; the in-memory
+ * surface is the minimum #34 needs to ship the override path.
+ *
+ * The gate subscribes to [activeFlow]; UI surfaces (and tests) flip the
+ * value via [setAlwaysVisible].
+ */
+public object MdnsVisibilityOverrideHolder {
+    private val state: kotlinx.coroutines.flow.MutableStateFlow<Boolean> =
+        kotlinx.coroutines.flow.MutableStateFlow(false)
+
+    /**
+     * Hot [kotlinx.coroutines.flow.StateFlow] of the override state.
+     * `true` while the user has forced the receiver to be visible.
+     */
+    public val activeFlow: kotlinx.coroutines.flow.StateFlow<Boolean> = state
+
+    /** Current snapshot value of [activeFlow]. */
+    public val isActive: Boolean
+        get() = state.value
+
+    /** Update the override. Safe to call from any thread. */
+    public fun setAlwaysVisible(active: Boolean) {
+        state.value = active
+    }
+}
+
+/**
+ * QR-code receive-flow bypass for the mDNS gate (#34 acceptance
+ * criterion: "QR-code path overrides this gating entirely — see
+ * #1.16").
+ *
+ * The receiver-side QR-code-driven flow (paired-key over a one-shot
+ * scan) is being implemented in a separate issue; the holder is
+ * exposed now so the gate logic stays correct once that flow lands.
+ * Today the holder is wired to a hot flow with no producers — the
+ * gate consults it but the value is always `false`.
+ */
+public object QrSessionActiveHolder {
+    private val state: kotlinx.coroutines.flow.MutableStateFlow<Boolean> =
+        kotlinx.coroutines.flow.MutableStateFlow(false)
+
+    /** Hot flow signalling whether a QR-code receive session is active. */
+    public val activeFlow: kotlinx.coroutines.flow.StateFlow<Boolean> = state
+
+    /** Current snapshot value of [activeFlow]. */
+    public val isActive: Boolean
+        get() = state.value
+
+    /**
+     * Set the QR-session-active flag. The QR receive flow flips this on
+     * when a scan begins and off when the resulting transfer completes
+     * or is cancelled.
+     */
+    public fun setQrSessionActive(active: Boolean) {
+        state.value = active
     }
 }
 

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverSession.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverSession.kt
@@ -94,6 +94,14 @@ import java.util.concurrent.atomic.AtomicBoolean
  * @property secureRandomProvider Supplies a fresh [SecureRandom] per
  *   accepted connection (UKEY2 keypairs / SecureMessage IVs). Tests
  *   inject a deterministic stub.
+ * @property advertiseGated When `true`, [start] binds the TCP listener
+ *   and acquires the multicast lock but does **not** publish the mDNS
+ *   advertisement. The caller is then responsible for calling
+ *   [publishAdvertisement] / [unpublishAdvertisement] to drive the
+ *   advertise lifecycle externally. Used by [MdnsAdvertisementGate]
+ *   (#34) to bind publish to BLE pulse activity. Defaults to `false`
+ *   for backward-compatibility — `start()` publishes immediately as in
+ *   Phase 1.
  */
 public class ReceiverSession(
     private val tcpServerFactory: TcpServerFactory,
@@ -102,6 +110,7 @@ public class ReceiverSession(
     private val factoryProvider: () -> FileDestinationFactory,
     private val endpointInfo: EndpointInfo,
     private val secureRandomProvider: () -> SecureRandom = { SecureRandom() },
+    private val advertiseGated: Boolean = false,
 ) {
     private val supervisor: Job = SupervisorJob()
 
@@ -208,17 +217,24 @@ public class ReceiverSession(
             throw t
         }
 
-        try {
-            advertiseHandle = advertiser.advertise(endpointInfo, port)
-        } catch (t: Throwable) {
-            // mDNS publish failed. Roll back the listener and the lock.
-            runCatching { tcpServer.stop() }
-            server = null
-            runCatching { multicastLock.release() }
-            holdingLock = false
-            stopped.set(true)
-            scope.cancel()
-            throw t
+        if (!advertiseGated) {
+            // Phase 1 / default behaviour: publish the mDNS advertisement
+            // synchronously during start so peers see us as soon as the
+            // service is up. Issue #34 introduces [advertiseGated] = true
+            // for the BLE-pulse-driven flow, where publish is deferred
+            // until [publishAdvertisement] is called.
+            try {
+                advertiseHandle = advertiser.advertise(endpointInfo, port)
+            } catch (t: Throwable) {
+                // mDNS publish failed. Roll back the listener and the lock.
+                runCatching { tcpServer.stop() }
+                server = null
+                runCatching { multicastLock.release() }
+                holdingLock = false
+                stopped.set(true)
+                scope.cancel()
+                throw t
+            }
         }
 
         // Forward completions onto our SharedFlow. tryEmit is fine because
@@ -255,8 +271,15 @@ public class ReceiverSession(
     public fun stop() {
         if (!stopped.compareAndSet(false, true)) return
 
-        runCatching { advertiseHandle?.close() }
-        advertiseHandle = null
+        // Serialize advertise teardown with any racing publish/unpublish
+        // call: a [MdnsAdvertisementGate] coroutine may invoke
+        // [publishAdvertisement] concurrently with `Service.onDestroy`
+        // calling stop(), and we must not leave an AdvertiseHandle alive
+        // past stop().
+        synchronized(advertiseLock) {
+            runCatching { advertiseHandle?.close() }
+            advertiseHandle = null
+        }
 
         runCatching { server?.stopBlocking() }
         server = null
@@ -275,6 +298,55 @@ public class ReceiverSession(
      */
     public val isRunning: Boolean
         get() = started.get() && !stopped.get()
+
+    /**
+     * Whether an mDNS advertisement is currently published. Used by
+     * [MdnsAdvertisementGate] (#34) to decide whether a publish/unpublish
+     * call would be a no-op.
+     */
+    public val isAdvertising: Boolean
+        get() = advertiseHandle?.isActive == true
+
+    /**
+     * Publish the mDNS advertisement against the bound TCP port. Only
+     * meaningful when the session was constructed with
+     * `advertiseGated = true`. Idempotent: if an advertisement is
+     * already in flight this call is a no-op.
+     *
+     * Thread-safe: serialises with [unpublishAdvertisement] and [stop]
+     * via the same lock so a racing teardown cannot leak a published
+     * advertisement past stop.
+     *
+     * @throws IllegalStateException if the session has not been started
+     *   or has been stopped.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    public fun publishAdvertisement() {
+        synchronized(advertiseLock) {
+            check(started.get()) { "ReceiverSession has not been started" }
+            check(!stopped.get()) { "ReceiverSession has been stopped" }
+            if (advertiseHandle?.isActive == true) return
+            val tcpServer = server ?: error("TCP server is not bound")
+            advertiseHandle = advertiser.advertise(endpointInfo, tcpServer.boundPort)
+        }
+    }
+
+    /**
+     * Unpublish the mDNS advertisement if one is currently in flight.
+     * Idempotent: calling this when no advertisement is published is a
+     * no-op. Other resources (the TCP listener, the multicast lock) are
+     * unaffected — the receiver remains reachable for already-resolved
+     * peers and can be re-published via [publishAdvertisement].
+     */
+    public fun unpublishAdvertisement() {
+        synchronized(advertiseLock) {
+            val handle = advertiseHandle ?: return
+            runCatching { handle.close() }
+            advertiseHandle = null
+        }
+    }
+
+    private val advertiseLock: Any = Any()
 
     public companion object {
         /**

--- a/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/MdnsAdvertisementGateTest.kt
+++ b/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/MdnsAdvertisementGateTest.kt
@@ -1,0 +1,459 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.service.receiver
+
+import com.google.common.truth.Truth.assertThat
+import io.github.kyujincho.wvmg.discovery.AdvertiseHandle
+import io.github.kyujincho.wvmg.discovery.ble.ScanActivity
+import io.github.kyujincho.wvmg.protocol.endpoint.DeviceType
+import io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo
+import io.github.kyujincho.wvmg.protocol.payload.FileDestinationFactory
+import io.github.kyujincho.wvmg.protocol.payload.TempFileDestinationFactory
+import io.github.kyujincho.wvmg.protocol.server.TcpReceiverServer
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.net.InetAddress
+import java.security.SecureRandom
+
+/**
+ * JVM unit tests for [MdnsAdvertisementGate] (#34).
+ *
+ * The gate logic is exercised against:
+ *  * a real (loopback-bound) [TcpReceiverServer] hosted in a
+ *    [ReceiverSession] constructed with `advertiseGated = true`,
+ *  * a [RecordingAdvertiser] that captures publish/unpublish via
+ *    `AdvertiseHandle.close()`,
+ *  * three [MutableStateFlow]s for BLE activity, manual override, and
+ *    QR session — driven directly from the test.
+ *
+ * The 30-second debounce window is exercised via `runTest`'s virtual
+ * scheduler — `advanceTimeBy` lets us cross the threshold deterministically
+ * without sleeping.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class MdnsAdvertisementGateTest {
+    @Test
+    fun `idle activity at boot does not publish`() =
+        runTest {
+            val advertiser = RecordingAdvertiser()
+            val session = startedGatedSession(advertiser = advertiser)
+            val ble = MutableStateFlow<ScanActivity>(ScanActivity.Idle)
+            val override = MutableStateFlow(false)
+            val qr = MutableStateFlow(false)
+
+            val gate =
+                MdnsAdvertisementGate(
+                    session = session,
+                    bleActivity = ble,
+                    alwaysVisibleOverride = override,
+                    qrSessionActive = qr,
+                )
+            gate.start(this)
+            advanceUntilIdle()
+
+            assertThat(advertiser.calls).isEmpty()
+            assertThat(session.isAdvertising).isFalse()
+
+            gate.stop()
+            session.stop()
+        }
+
+    @Test
+    fun `BLE active publishes immediately`() =
+        runTest {
+            val advertiser = RecordingAdvertiser()
+            val session = startedGatedSession(advertiser = advertiser)
+            val ble = MutableStateFlow<ScanActivity>(ScanActivity.Idle)
+            val override = MutableStateFlow(false)
+            val qr = MutableStateFlow(false)
+
+            val gate =
+                MdnsAdvertisementGate(
+                    session = session,
+                    bleActivity = ble,
+                    alwaysVisibleOverride = override,
+                    qrSessionActive = qr,
+                )
+            gate.start(this)
+            advanceUntilIdle()
+
+            ble.value = ScanActivity.Active(lastSeenAtMillis = 1_000L)
+            advanceUntilIdle()
+
+            assertThat(advertiser.calls).hasSize(1)
+            assertThat(session.isAdvertising).isTrue()
+            assertThat(advertiser.calls[0].handle.isActive).isTrue()
+
+            gate.stop()
+            session.stop()
+        }
+
+    @Test
+    fun `BLE active then idle holds publish for 30s before unpublishing`() =
+        runTest {
+            val advertiser = RecordingAdvertiser()
+            val session = startedGatedSession(advertiser = advertiser)
+            val ble = MutableStateFlow<ScanActivity>(ScanActivity.Idle)
+            val override = MutableStateFlow(false)
+            val qr = MutableStateFlow(false)
+
+            val gate =
+                MdnsAdvertisementGate(
+                    session = session,
+                    bleActivity = ble,
+                    alwaysVisibleOverride = override,
+                    qrSessionActive = qr,
+                    debounceIdleMillis = 30_000L,
+                )
+            gate.start(this)
+            advanceUntilIdle()
+
+            ble.value = ScanActivity.Active(lastSeenAtMillis = 1_000L)
+            advanceUntilIdle()
+            assertThat(session.isAdvertising).isTrue()
+
+            // Flip back to idle: the advertisement must remain up for at
+            // least the debounce window. Use `advanceTimeBy` (NOT
+            // `advanceUntilIdle` — that would jump forward to the
+            // debounce timer's scheduled fire time).
+            ble.value = ScanActivity.Idle
+            // First a small advance to flush the StateFlow emission
+            // through the collector so the debounce timer is actually
+            // scheduled.
+            advanceTimeBy(1L)
+            advanceTimeBy(29_998L)
+            assertThat(session.isAdvertising).isTrue()
+
+            // Cross the 30-s threshold — the gate unpublishes.
+            advanceTimeBy(10L)
+            advanceUntilIdle()
+            assertThat(session.isAdvertising).isFalse()
+            assertThat(advertiser.calls[0].handle.isActive).isFalse()
+
+            gate.stop()
+            session.stop()
+        }
+
+    @Test
+    fun `flapping BLE pulse keeps advertisement up`() =
+        runTest {
+            val advertiser = RecordingAdvertiser()
+            val session = startedGatedSession(advertiser = advertiser)
+            val ble = MutableStateFlow<ScanActivity>(ScanActivity.Idle)
+            val override = MutableStateFlow(false)
+            val qr = MutableStateFlow(false)
+
+            val gate =
+                MdnsAdvertisementGate(
+                    session = session,
+                    bleActivity = ble,
+                    alwaysVisibleOverride = override,
+                    qrSessionActive = qr,
+                    debounceIdleMillis = 30_000L,
+                )
+            gate.start(this)
+            advanceUntilIdle()
+
+            ble.value = ScanActivity.Active(lastSeenAtMillis = 1_000L)
+            advanceUntilIdle()
+            assertThat(session.isAdvertising).isTrue()
+
+            // Idle for 20s — within the debounce window. Use
+            // advanceTimeBy (NOT advanceUntilIdle, which would jump to
+            // the debounce timer's scheduled fire time).
+            ble.value = ScanActivity.Idle
+            advanceTimeBy(1L)
+            advanceTimeBy(20_000L)
+            assertThat(session.isAdvertising).isTrue()
+
+            // Active again before the timer fires; the pending unpublish
+            // must be cancelled so a long idle stretch later does not
+            // accidentally tear the advertisement down.
+            ble.value = ScanActivity.Active(lastSeenAtMillis = 21_000L)
+            advanceTimeBy(1L)
+
+            // Wait long enough that, if the original timer were still
+            // armed, it would have fired. With the cancel + new Active
+            // signal, no debounce is in flight, so advanceUntilIdle
+            // doesn't have any pending future-time tasks to consume.
+            advanceTimeBy(15_000L)
+            advanceUntilIdle()
+
+            // Still up: the only AdvertiseHandle is the original one
+            // and it remains active.
+            assertThat(session.isAdvertising).isTrue()
+            assertThat(advertiser.calls).hasSize(1)
+            assertThat(advertiser.calls[0].handle.isActive).isTrue()
+
+            gate.stop()
+            session.stop()
+        }
+
+    @Test
+    fun `manual override forces publish without BLE pulse`() =
+        runTest {
+            val advertiser = RecordingAdvertiser()
+            val session = startedGatedSession(advertiser = advertiser)
+            val ble = MutableStateFlow<ScanActivity>(ScanActivity.Idle)
+            val override = MutableStateFlow(false)
+            val qr = MutableStateFlow(false)
+
+            val gate =
+                MdnsAdvertisementGate(
+                    session = session,
+                    bleActivity = ble,
+                    alwaysVisibleOverride = override,
+                    qrSessionActive = qr,
+                )
+            gate.start(this)
+            advanceUntilIdle()
+            assertThat(session.isAdvertising).isFalse()
+
+            override.value = true
+            advanceUntilIdle()
+            assertThat(session.isAdvertising).isTrue()
+
+            // Override flipped off: gate schedules the debounced unpublish.
+            // advanceUntilIdle would jump to the timer's fire time anyway,
+            // so use it here to deterministically reach the unpublish.
+            override.value = false
+            advanceUntilIdle()
+            assertThat(session.isAdvertising).isFalse()
+
+            gate.stop()
+            session.stop()
+        }
+
+    @Test
+    fun `QR session forces publish and bypasses gating`() =
+        runTest {
+            val advertiser = RecordingAdvertiser()
+            val session = startedGatedSession(advertiser = advertiser)
+            val ble = MutableStateFlow<ScanActivity>(ScanActivity.Idle)
+            val override = MutableStateFlow(false)
+            val qr = MutableStateFlow(false)
+
+            val gate =
+                MdnsAdvertisementGate(
+                    session = session,
+                    bleActivity = ble,
+                    alwaysVisibleOverride = override,
+                    qrSessionActive = qr,
+                )
+            gate.start(this)
+            advanceUntilIdle()
+            assertThat(session.isAdvertising).isFalse()
+
+            qr.value = true
+            advanceUntilIdle()
+            assertThat(session.isAdvertising).isTrue()
+
+            // Even after the configured idle window passes the
+            // advertisement stays up because QR is still active.
+            // No debounce is scheduled (shouldPublish is true), so
+            // advanceUntilIdle has nothing to consume past current time.
+            advanceTimeBy(60_000L)
+            advanceUntilIdle()
+            assertThat(session.isAdvertising).isTrue()
+
+            qr.value = false
+            advanceUntilIdle()
+            assertThat(session.isAdvertising).isFalse()
+
+            gate.stop()
+            session.stop()
+        }
+
+    @Test
+    fun `override stays publish when BLE goes idle`() =
+        runTest {
+            val advertiser = RecordingAdvertiser()
+            val session = startedGatedSession(advertiser = advertiser)
+            val ble = MutableStateFlow<ScanActivity>(ScanActivity.Idle)
+            val override = MutableStateFlow(true)
+            val qr = MutableStateFlow(false)
+
+            val gate =
+                MdnsAdvertisementGate(
+                    session = session,
+                    bleActivity = ble,
+                    alwaysVisibleOverride = override,
+                    qrSessionActive = qr,
+                )
+            gate.start(this)
+            advanceUntilIdle()
+            assertThat(session.isAdvertising).isTrue()
+
+            // BLE flips active then idle; advertisement must stay up
+            // because the override is still true.
+            ble.value = ScanActivity.Active(lastSeenAtMillis = 1_000L)
+            advanceUntilIdle()
+            ble.value = ScanActivity.Idle
+            advanceTimeBy(60_000L)
+            advanceUntilIdle()
+            assertThat(session.isAdvertising).isTrue()
+
+            gate.stop()
+            session.stop()
+        }
+
+    @Test
+    fun `gate stop does not unpublish in-flight advertisement`() =
+        runTest {
+            val advertiser = RecordingAdvertiser()
+            val session = startedGatedSession(advertiser = advertiser)
+            val ble = MutableStateFlow<ScanActivity>(ScanActivity.Active(lastSeenAtMillis = 1_000L))
+            val override = MutableStateFlow(false)
+            val qr = MutableStateFlow(false)
+
+            val gate =
+                MdnsAdvertisementGate(
+                    session = session,
+                    bleActivity = ble,
+                    alwaysVisibleOverride = override,
+                    qrSessionActive = qr,
+                )
+            gate.start(this)
+            advanceUntilIdle()
+            assertThat(session.isAdvertising).isTrue()
+
+            gate.stop()
+            advanceUntilIdle()
+            // Stopping the gate does not in itself tear the advertisement
+            // down; the session's stop() owns that order.
+            assertThat(session.isAdvertising).isTrue()
+
+            session.stop()
+            assertThat(session.isAdvertising).isFalse()
+        }
+
+    @Test
+    fun `gate start is idempotent`() =
+        runTest {
+            val advertiser = RecordingAdvertiser()
+            val session = startedGatedSession(advertiser = advertiser)
+            val ble = MutableStateFlow<ScanActivity>(ScanActivity.Active(lastSeenAtMillis = 1_000L))
+            val override = MutableStateFlow(false)
+            val qr = MutableStateFlow(false)
+
+            val gate =
+                MdnsAdvertisementGate(
+                    session = session,
+                    bleActivity = ble,
+                    alwaysVisibleOverride = override,
+                    qrSessionActive = qr,
+                )
+            gate.start(this)
+            gate.start(this)
+            advanceUntilIdle()
+
+            // Only one publish call regardless of how many times start()
+            // was invoked.
+            assertThat(advertiser.calls).hasSize(1)
+
+            gate.stop()
+            session.stop()
+        }
+
+    // --------------------------------------------------------------
+    // Helpers
+    // --------------------------------------------------------------
+
+    /**
+     * Build a [ReceiverSession] configured with `advertiseGated = true`,
+     * start it (so the TCP listener binds), and return it ready for the
+     * gate to drive publish/unpublish against.
+     */
+    private fun startedGatedSession(advertiser: RecordingAdvertiser): ReceiverSession {
+        val session =
+            ReceiverSession(
+                tcpServerFactory =
+                    object : TcpServerFactory {
+                        override fun create(
+                            scope: CoroutineScope,
+                            factoryProvider: () -> FileDestinationFactory,
+                            secureRandomProvider: () -> SecureRandom,
+                        ): TcpReceiverServer =
+                            TcpReceiverServer(
+                                parentScope = scope,
+                                factoryProvider = factoryProvider,
+                                secureRandomProvider = secureRandomProvider,
+                                bindAddress = InetAddress.getLoopbackAddress(),
+                            )
+                    },
+                advertiser = advertiser,
+                multicastLock =
+                    object : MulticastLockController {
+                        override fun acquire() = Unit
+
+                        override fun release() = Unit
+                    },
+                factoryProvider = { TempFileDestinationFactory() },
+                endpointInfo = sampleEndpointInfo(),
+                advertiseGated = true,
+            )
+        runBlocking { session.start() }
+        return session
+    }
+
+    private fun sampleEndpointInfo(): EndpointInfo =
+        EndpointInfo(
+            version = 1,
+            hidden = false,
+            deviceType = DeviceType.PHONE,
+            reserved = false,
+            metadata = ByteArray(EndpointInfo.METADATA_LEN) { it.toByte() },
+            deviceName = "Gate Test",
+            tlvRecords = emptyList(),
+        )
+
+    /**
+     * Recording [DiscoveryAdvertiser] that captures every advertise call
+     * and produces a fake [AdvertiseHandle] tracking active state. Same
+     * shape as the recorder in [ReceiverSessionTest] but lifted here as
+     * a top-level fixture rather than a private inner class so the gate
+     * tests can extend it if needed.
+     */
+    private class RecordingAdvertiser : DiscoveryAdvertiser {
+        data class Call(
+            val endpointInfo: EndpointInfo,
+            val port: Int,
+            val handle: FakeAdvertiseHandle,
+        )
+
+        val calls: MutableList<Call> = mutableListOf()
+
+        override fun advertise(
+            endpointInfo: EndpointInfo,
+            port: Int,
+        ): AdvertiseHandle {
+            val handle = FakeAdvertiseHandle(port = port)
+            calls += Call(endpointInfo, port, handle)
+            return handle
+        }
+    }
+
+    private class FakeAdvertiseHandle(
+        override val port: Int,
+        override val instanceName: String = "wvmg-gate-test",
+    ) : AdvertiseHandle {
+        @Volatile
+        private var active: Boolean = true
+
+        override val isActive: Boolean
+            get() = active
+
+        override fun close() {
+            active = false
+        }
+    }
+}

--- a/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverSessionTest.kt
+++ b/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverSessionTest.kt
@@ -255,6 +255,83 @@ class ReceiverSessionTest {
         }
 
     @Test
+    fun `advertiseGated start does not publish until publishAdvertisement is called`() =
+        runBlocking {
+            val advertiser = RecordingAdvertiser()
+            val session =
+                makeSession(
+                    advertiser = advertiser,
+                    advertiseGated = true,
+                )
+
+            session.start()
+            assertThat(advertiser.calls).isEmpty()
+            assertThat(session.isAdvertising).isFalse()
+
+            session.publishAdvertisement()
+            assertThat(advertiser.calls).hasSize(1)
+            assertThat(session.isAdvertising).isTrue()
+            assertThat(advertiser.calls[0].port).isEqualTo(session.boundPort)
+
+            // Idempotent: a second call with the advertisement up does
+            // not double-publish.
+            session.publishAdvertisement()
+            assertThat(advertiser.calls).hasSize(1)
+
+            session.unpublishAdvertisement()
+            assertThat(session.isAdvertising).isFalse()
+            assertThat(advertiser.calls[0].handle.isActive).isFalse()
+
+            // Re-publish after an unpublish opens a fresh handle.
+            session.publishAdvertisement()
+            assertThat(advertiser.calls).hasSize(2)
+
+            session.stop()
+        }
+
+    @Test
+    fun `unpublishAdvertisement is a no-op when nothing is published`() =
+        runBlocking {
+            val advertiser = RecordingAdvertiser()
+            val session =
+                makeSession(
+                    advertiser = advertiser,
+                    advertiseGated = true,
+                )
+
+            session.start()
+            session.unpublishAdvertisement()
+            session.unpublishAdvertisement()
+            assertThat(advertiser.calls).isEmpty()
+
+            session.stop()
+        }
+
+    @Test
+    fun `publishAdvertisement throws before start`() {
+        val session = makeSession(advertiseGated = true)
+        assertThrows<IllegalStateException> { session.publishAdvertisement() }
+    }
+
+    @Test
+    fun `stop tears down a gated advertisement`() =
+        runBlocking {
+            val advertiser = RecordingAdvertiser()
+            val session =
+                makeSession(
+                    advertiser = advertiser,
+                    advertiseGated = true,
+                )
+
+            session.start()
+            session.publishAdvertisement()
+            assertThat(session.isAdvertising).isTrue()
+
+            session.stop()
+            assertThat(advertiser.calls.map { it.handle.isActive }).containsExactly(false)
+        }
+
+    @Test
     fun `default tcp server factory binds on all interfaces`() =
         runBlocking {
             // A smoke test for the TcpServerFactory.default() helper —
@@ -287,6 +364,7 @@ class ReceiverSessionTest {
         advertiser: DiscoveryAdvertiser = RecordingAdvertiser(),
         endpointInfo: EndpointInfo = sampleEndpointInfo(),
         factoryProvider: () -> FileDestinationFactory = { TempFileDestinationFactory() },
+        advertiseGated: Boolean = false,
     ): ReceiverSession =
         ReceiverSession(
             tcpServerFactory =
@@ -307,6 +385,7 @@ class ReceiverSessionTest {
             multicastLock = locks,
             factoryProvider = factoryProvider,
             endpointInfo = endpointInfo,
+            advertiseGated = advertiseGated,
         )
 
     private fun sampleEndpointInfo(name: String = "Test Device"): EndpointInfo =
@@ -374,6 +453,7 @@ class ReceiverSessionTest {
         override val port: Int,
         override val instanceName: String = "wvmg-test-instance",
     ) : AdvertiseHandle {
+        @Volatile
         private var active: Boolean = true
 
         override val isActive: Boolean


### PR DESCRIPTION
## Summary

Closes #34. Stock Quick Share only broadcasts mDNS while a sender's BLE pulse is detected — this PR matches that behaviour, saving Wi-Fi/CPU and respecting users who don't want to be visible.

- Introduces `MdnsAdvertisementGate` (pure-JVM coordinator) that subscribes to `BleQuickShareScanner.activity` (#33), a sticky user-controlled "always visible" override, and a QR-session bypass hook.
- Refactors `ReceiverSession` with an `advertiseGated` flag and new `publishAdvertisement` / `unpublishAdvertisement` methods so the gate can drive publish externally.
- Wires `MdnsVisibilityOverrideHolder` + `QrSessionActiveHolder` as process-wide singletons (mirrors `ActiveBleScannerHolder` from #33), with a single `SwitchCompat` on `MainActivity` for the user-facing always-visible toggle.
- 30-s idle debounce in the gate per the issue's acceptance criterion (`After mDNS goes up, it stays up for at least 30 s`).
- `ReceiverForegroundService` constructs the gate after `ReceiverSession.start()` returns and tears it down before `session.stop()` so the delayed unpublish coroutine cannot fire after the `AdvertiseHandle` is closed.

## Acceptance criteria mapping

- [x] Receiver service maintains an `mdnsActive` decision toggled by BLE scan callbacks (`MdnsAdvertisementGate.apply`).
- [x] mDNS publish call goes out only when `mdnsActive=true` (gated `ReceiverSession`, default factory now sets `advertiseGated = true`).
- [x] After mDNS goes up, it stays up for at least 30 s (debounce) — `DEFAULT_DEBOUNCE_IDLE_MILLIS`, covered by `BLE active then idle holds publish for 30s before unpublishing` and the flapping test.
- [x] Manual override: user can force-enable visibility from the app UI — `MainActivity` switch toggles `MdnsVisibilityOverrideHolder`.
- [x] QR-code path overrides the gate entirely — `QrSessionActiveHolder` exposed for the in-progress receiver QR-code flow (#1.16) to flip when it lands.

## Test plan

- [x] `./gradlew :service-android:testDebugUnitTest` — all green (114 tests).
- [x] `./gradlew :app:assembleDebug` — APK builds.
- [x] `./gradlew staticAnalysis` — ktlint + detekt across every module.
- [ ] On-device smoke test: confirm mDNS only goes up while a sender BLE pulse is in flight (deferred to integration testing).