### PR TITLE
fix: Phase 2 real-device interop bugs found via Vivo X300 Ultra testing

### DIFF
--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/MainActivity.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/MainActivity.kt
@@ -12,6 +12,7 @@ import androidx.appcompat.widget.SwitchCompat
 import io.github.kyujincho.wvmg.onboarding.PermissionRequirements
 import io.github.kyujincho.wvmg.onboarding.PermissionsOnboardingActivity
 import io.github.kyujincho.wvmg.service.receiver.MdnsVisibilityOverrideHolder
+import io.github.kyujincho.wvmg.service.receiver.ReceiverForegroundService
 
 /**
  * Empty launcher activity for the WhenVivoMeetsGoogle app.
@@ -86,13 +87,31 @@ class MainActivity : AppCompatActivity() {
         // #21 lands, the foreground service will re-check at start time
         // and surface a dismissible error instead of relaunching
         // onboarding from here.
-        if (onboardingLaunched) return
-        if (!PermissionRequirements.allGranted(this) &&
+        if (!onboardingLaunched &&
+            !PermissionRequirements.allGranted(this) &&
             !PermissionRequirements.onlyOptionalMissing(this)
         ) {
             onboardingLaunched = true
             startActivity(Intent(this, PermissionsOnboardingActivity::class.java))
+            return
         }
+
+        // Bring up the receiver foreground service so the BLE pulse
+        // scanner (#33), mDNS-publish gate (#34), and TCP listener are
+        // running while the user has the launcher visible. Without this
+        // call the production code had no other entry point that ever
+        // started the service, so the receiver pipeline was effectively
+        // dead-code on real devices — found while running the BLE-trigger
+        // interop runbook against a Vivo X300 Ultra. The service handles
+        // repeated startService calls idempotently.
+        //
+        // We only reach this point when the mandatory permissions are
+        // granted (the early-return above bounces the user to onboarding
+        // first). If the user denied an optional permission like
+        // POST_NOTIFICATIONS, BleQuickShareScanner.start() and the JmDNS
+        // publish path each re-check their own permissions internally
+        // and gracefully no-op rather than crash.
+        ReceiverForegroundService.start(this)
     }
 
     private companion object {

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/MulticastLockHolder.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/MulticastLockHolder.kt
@@ -111,7 +111,7 @@ internal class MulticastLockHolder internal constructor(
         ): MulticastLockGate {
             val wifi =
                 context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
-            val lock =
+            val multicastLock =
                 wifi.createMulticastLock(tag).apply {
                     // `setReferenceCounted(false)` makes a single release() call always
                     // fully release the lock, regardless of how many times the system
@@ -119,7 +119,26 @@ internal class MulticastLockHolder internal constructor(
                     // gives unambiguous acquire/release semantics.
                     setReferenceCounted(false)
                 }
-            return SystemMulticastLockGate(lock)
+            // Companion `WIFI_MODE_FULL_HIGH_PERF` Wi-Fi lock — the same
+            // workaround `AndroidMulticastLockController` uses on the
+            // receiver side. vivo / Funtouch / OriginOS silently refuses
+            // multicast-lock acquires for non-system apps; while the
+            // HIGH_PERF Wi-Fi lock is held, the device disables Wi-Fi
+            // power save and the multicast filter Funtouch installs in
+            // power save is correspondingly lifted. On stock AOSP this
+            // is redundant but harmless. Without this, the sender-side
+            // mDNS browse on vivo silently sees zero peers — found
+            // while running docs/testing/interop-ble-trigger.md against
+            // a Vivo X300 Ultra peering with a Galaxy S24 Ultra.
+            val wifiLock =
+                wifi
+                    .createWifiLock(
+                        WifiManager.WIFI_MODE_FULL_HIGH_PERF,
+                        "$tag-highperf",
+                    ).apply {
+                        setReferenceCounted(false)
+                    }
+            return SystemMulticastLockGate(multicastLock, wifiLock)
         }
     }
 }
@@ -137,13 +156,32 @@ internal interface MulticastLockGate {
     fun isHeld(): Boolean
 }
 
-/** Production [MulticastLockGate] backed by a real [WifiManager.MulticastLock]. */
+/**
+ * Production [MulticastLockGate] backed by a real [WifiManager.MulticastLock]
+ * **and** a companion [WifiManager.WifiLock] at
+ * [WifiManager.WIFI_MODE_FULL_HIGH_PERF]. See `systemMulticastLockGate`'s
+ * KDoc for why both are needed on vivo / Funtouch / OriginOS.
+ */
 private class SystemMulticastLockGate(
-    private val lock: WifiManager.MulticastLock,
+    private val multicastLock: WifiManager.MulticastLock,
+    private val wifiLock: WifiManager.WifiLock,
 ) : MulticastLockGate {
-    override fun acquire(): Unit = lock.acquire()
+    override fun acquire() {
+        multicastLock.acquire()
+        wifiLock.acquire()
+    }
 
-    override fun release(): Unit = lock.release()
+    override fun release() {
+        // Reverse order: drop the high-perf lock first so the multicast
+        // lock observes a more typical power state on its release path.
+        wifiLock.release()
+        multicastLock.release()
+    }
 
-    override fun isHeld(): Boolean = lock.isHeld
+    /**
+     * Held iff the multicast lock is held. The wifi lock is acquired and
+     * released in lockstep with the multicast lock, so reporting on the
+     * multicast side keeps the existing observable contract intact.
+     */
+    override fun isHeld(): Boolean = multicastLock.isHeld
 }

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleAdvertiser.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleAdvertiser.kt
@@ -223,18 +223,28 @@ public class BleAdvertiser internal constructor(
             .build()
 
     /**
-     * Build the [AdvertiseData] with the 16-bit Quick Share service UUID
-     * and the 24-byte service-data payload. The result fits within the
-     * legacy 31-byte advertising budget:
-     *   * 3 bytes for the 16-bit service-UUID list (length+type+UUID),
-     *   * 26 bytes for the service-data (length+type+UUID+24 payload),
-     *   * 2 bytes for flags (auto-added by the platform).
+     * Build the [AdvertiseData] with only the 16-bit Quick Share
+     * service-data AD. The 16-bit service-UUID is embedded *inside* the
+     * service-data structure (AD type 0x16), so there is no need for a
+     * separate "Complete List of 16-bit Service UUIDs" AD — the
+     * receiver's [ScanFilter] from #33 matches on service data, not on
+     * the service-UUID list, so the extra AD has no consumer.
+     *
+     * Including both pushed the total advertising payload to 32 bytes
+     * (4 for the redundant UUID list + 28 for service data), one byte
+     * over the 31-byte legacy budget, causing
+     * `AdvertiseCallback.onStartFailure(ADVERTISE_FAILED_DATA_TOO_LARGE)`
+     * on real hardware. Found while running the BLE-trigger interop
+     * runbook against the Vivo X300 Ultra (Funtouch 16 / OriginOS 6).
+     *
+     * Final payload size, well under 31 bytes:
+     *   * 4 bytes for the service-data AD header (length+type+16-bit UUID),
+     *   * 24 bytes for the Quick Share service-data payload itself.
      */
     private fun buildAdvertiseData(payload: ByteArray): AdvertiseData {
         val parcelUuid = ParcelUuid(UUID.fromString(BleAdvertisePayload.SERVICE_UUID_128))
         return AdvertiseData
             .Builder()
-            .addServiceUuid(parcelUuid)
             .addServiceData(parcelUuid, payload)
             // Skip device name and TX power level — they would push us
             // over the 31-byte budget and aren't part of the Quick Share

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleAdvertiser.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleAdvertiser.kt
@@ -123,7 +123,7 @@ public class BleAdvertiser internal constructor(
                     onClosed = { active.compareAndSet(it, null) },
                 )
             active.set(handle)
-            Log.i(
+            Log.w(
                 TAG,
                 "BLE advertise: startAdvertising submitted bytes=" + payload.size +
                     " uuid=" + BleAdvertisePayload.SERVICE_UUID_128,
@@ -275,7 +275,7 @@ public class BleAdvertiser internal constructor(
             if (!activeFlag.compareAndSet(true, false)) return
             try {
                 advertiser.stopAdvertising(callback)
-                Log.i(TAG, "BLE advertise: stopAdvertising complete")
+                Log.w(TAG, "BLE advertise: stopAdvertising complete")
             } catch (
                 // stopAdvertising can throw SecurityException if the user
                 // revoked BLUETOOTH_ADVERTISE while we were running, or
@@ -303,7 +303,7 @@ public class BleAdvertiser internal constructor(
             private set
 
         override fun onStartSuccess(settingsInEffect: AdvertiseSettings?) {
-            Log.i(TAG, "BLE advertise: onStartSuccess settings=$settingsInEffect")
+            Log.w(TAG, "BLE advertise: onStartSuccess settings=$settingsInEffect")
         }
 
         override fun onStartFailure(errorCode: Int) {

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareScanner.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareScanner.kt
@@ -267,7 +267,7 @@ public class BleQuickShareScanner internal constructor(
                 }
             gate.addSink(sink)
             primarySink = sink
-            Log.i(TAG, "start: BLE pulse scan started mode=${describeScanMode(currentScanMode)}")
+            Log.w(TAG, "start: BLE pulse scan started mode=${describeScanMode(currentScanMode)}")
             true
         }
 
@@ -314,7 +314,7 @@ public class BleQuickShareScanner internal constructor(
             // Mode change while idle: just remember the new mode for the
             // next start(). No platform call is needed.
             if (registration == null) {
-                Log.i(
+                Log.w(
                     TAG,
                     "setScanMode: scanner idle, pinned mode for next start: " +
                         "${describeScanMode(previous)} -> ${describeScanMode(mode)}",
@@ -362,7 +362,7 @@ public class BleQuickShareScanner internal constructor(
                 return@synchronized false
             }
             registration = restarted
-            Log.i(
+            Log.w(
                 TAG,
                 "setScanMode: ${describeScanMode(previous)} -> ${describeScanMode(mode)}",
             )
@@ -397,7 +397,7 @@ public class BleQuickShareScanner internal constructor(
             inactivityJob?.cancel()
             inactivityJob = null
             activityState.value = ScanActivity.Idle
-            Log.i(TAG, "stop: BLE pulse scan stopped")
+            Log.w(TAG, "stop: BLE pulse scan stopped")
         }
     }
 

--- a/docs/testing/interop-ble-trigger.md
+++ b/docs/testing/interop-ble-trigger.md
@@ -363,31 +363,56 @@ After whitelisting, this should not show new FREEZE entries while the
 app is running. Pre-existing entries from before the whitelist are
 fine to ignore.
 
-### 2. Wi-Fi multicast lock is silently refused
+### 2. Wi-Fi multicast lock is silently refused (both publish AND browse)
 
 Even with the freezer disabled, vivo's Wi-Fi power-save layer **does
 not honour `WifiManager.MulticastLock.acquire()`** for non-system apps.
 The Java-side `lock.isHeld` returns `true` (so our code thinks the lock
 is held), but `dumpsys wifi` shows "Multicast Locks held:" empty and
-multicast traffic is filtered before reaching the app. Symptom: the
-initial JmDNS announce burst still goes out (UDP send is allowed), so
-peers see us briefly, but ongoing PTR queries from peers receive no
-response — peers cache us for ~30 s and then we vanish from their
-service browse.
+multicast traffic is filtered before reaching the app.
 
-The receiver service mitigates this by additionally acquiring a
-`WIFI_MODE_FULL_HIGH_PERF` Wi-Fi lock — see `AndroidMulticastLockController`.
-On stock AOSP / Pixel / Samsung this is redundant but harmless; on
-vivo it is also silently refused on at least Funtouch 16 / OriginOS 6,
-so this device class still has a known **mDNS persistence limitation**.
+Both the receiver-side `AndroidMulticastLockController` and the
+sender/browse-side `MulticastLockHolder` additionally acquire a
+companion `WIFI_MODE_FULL_HIGH_PERF` Wi-Fi lock as a workaround. On
+stock AOSP / Pixel / Samsung that companion is what makes things work;
+on vivo Funtouch 16 / OriginOS 6 it is **also silently refused**
+(`dumpsys wifi` reports `Active lock owners: {}` for non-system apps),
+leaving these symptoms on this device class:
 
-Practical impact for the BLE-trigger matrix: stock Quick Share
-receivers should still pop up within ~5 s of the BLE pulse because
-they cache the initial JmDNS announce. Sustained discovery (peer
-browsing for our device for several minutes) is not expected to work
-on vivo until the mDNS layer migrates from JmDNS to Android's built-in
-`NsdManager`, which uses the system mDNS responder and does not need
-the multicast lock at all. Tracked as a follow-up.
+  - **Publish**: the initial JmDNS announce burst still goes out (UDP
+    send is allowed), so peers see us once, but ongoing PTR queries
+    from peers receive no response — peers cache us for ~30 s and we
+    vanish from their service browse.
+  - **Browse**: incoming IPv4 multicast (mDNS at 224.0.0.251) is
+    dropped at the radio layer before our JmDNS instance sees it.
+    `dumpsys wifi` reports `ipv4RxMulticast=0` despite IPv6 multicast
+    (`ipv6Multicast` counter) being non-zero. Practically, the
+    `SendActivity` peer picker stays empty even when a stock Quick
+    Share device on the same LAN is actively advertising
+    (`dns-sd -B _FC9F5ED42C8A._tcp. local.` from a third-party Mac
+    confirms the peer is visible to non-vivo devices on the same SSID).
+
+Practical impact for the BLE-trigger matrix on a vivo *sender*:
+
+  - **Cell A1/A2 (BLE half)**: stock Quick Share receivers still see
+    our BLE pulse — confirmed via `dumpsys bluetooth_manager` on a
+    Samsung Galaxy S24 Ultra showing `Results=19` for the
+    `0xfe2c FC 12 8E` filter and `NearbySharing` logging
+    `EndpointDiscovered(...)` within ~2 seconds of advertise start.
+  - **Cell A1/A2 (mDNS half)**: the WVMG sender's peer picker stays
+    empty even though the BLE pulse landed, because vivo's JmDNS
+    browse cannot receive the receiver's mDNS announces back — and
+    without finding the peer's TCP endpoint, the consent pop-up that
+    the matrix counts as success never gets the chance to appear on
+    the receiver.
+
+These two failure modes mean **the BLE-trigger matrix cells A1/A2
+cannot pass on a vivo *sender* until the discovery layer migrates
+from JmDNS to Android's built-in `NsdManager`** (which uses the
+system mDNS responder and does not need the app-level multicast
+lock at all). Tracked as a follow-up issue. The matrix is fully
+runnable from a Pixel or Samsung sender to a vivo receiver, or from
+any sender to a non-vivo receiver, without this caveat.
 
 ### 3. Non-Pixel/Samsung peers may not be installed
 

--- a/docs/testing/interop-ble-trigger.md
+++ b/docs/testing/interop-ble-trigger.md
@@ -324,6 +324,96 @@ update regresses the BLE wake-up path.
 
 ---
 
+## Vivo / Funtouch / OriginOS specific quirks
+
+Real-device verification on a vivo X300 Ultra (Funtouch 16, OriginOS 6,
+Android 16) surfaced four behaviours that any tester running the matrix
+on a vivo device must be aware of. Other Funtouch / OriginOS versions
+(and likely most other Chinese-OEM Android skins — Xiaomi MIUI, Honor
+MagicOS, OPPO ColorOS) layer similar restrictions on top of stock
+Android, so these notes apply more broadly than just vivo.
+
+### 1. App freezing must be disabled
+
+Funtouch's "App Freezer" / "Background process management" suspends
+non-system app processes a few minutes after they leave the foreground —
+even when they own a `connectedDevice` foreground service. While
+frozen, the app keeps its persistent notification visible but cannot
+hold Wi-Fi locks, run JmDNS, or process incoming BLE callbacks. To the
+peer it looks like our receiver simply went silent.
+
+Before any test cell, enable background activity for the WVMG app:
+
+1. **Settings → Battery → Background power consumption management**
+   (the exact path depends on Funtouch version; on OriginOS 6 it is
+   *Settings → Apps & permissions → Background apps*).
+2. Find **WhenVivoMeetsGoogle**.
+3. Set background activity to *Allow* and disable battery optimisation.
+4. If the device exposes an *Auto-start* toggle, enable that too —
+   Funtouch's freezer treats unfreezing as auto-start for some
+   transitions.
+
+You can confirm the freezer is no longer interfering by running:
+
+```bash
+adb shell dumpsys activity broadcasts | grep -B 1 -A 1 "vivo.intent.action.PACKAGE_FREEZE.*kyujincho"
+```
+
+After whitelisting, this should not show new FREEZE entries while the
+app is running. Pre-existing entries from before the whitelist are
+fine to ignore.
+
+### 2. Wi-Fi multicast lock is silently refused
+
+Even with the freezer disabled, vivo's Wi-Fi power-save layer **does
+not honour `WifiManager.MulticastLock.acquire()`** for non-system apps.
+The Java-side `lock.isHeld` returns `true` (so our code thinks the lock
+is held), but `dumpsys wifi` shows "Multicast Locks held:" empty and
+multicast traffic is filtered before reaching the app. Symptom: the
+initial JmDNS announce burst still goes out (UDP send is allowed), so
+peers see us briefly, but ongoing PTR queries from peers receive no
+response — peers cache us for ~30 s and then we vanish from their
+service browse.
+
+The receiver service mitigates this by additionally acquiring a
+`WIFI_MODE_FULL_HIGH_PERF` Wi-Fi lock — see `AndroidMulticastLockController`.
+On stock AOSP / Pixel / Samsung this is redundant but harmless; on
+vivo it is also silently refused on at least Funtouch 16 / OriginOS 6,
+so this device class still has a known **mDNS persistence limitation**.
+
+Practical impact for the BLE-trigger matrix: stock Quick Share
+receivers should still pop up within ~5 s of the BLE pulse because
+they cache the initial JmDNS announce. Sustained discovery (peer
+browsing for our device for several minutes) is not expected to work
+on vivo until the mDNS layer migrates from JmDNS to Android's built-in
+`NsdManager`, which uses the system mDNS responder and does not need
+the multicast lock at all. Tracked as a follow-up.
+
+### 3. Non-Pixel/Samsung peers may not be installed
+
+The vivo X300 Ultra ships with full GMS but **does NOT** ship with
+stock Quick Share installed. `adb shell pm list packages | grep -i
+nearby` returns nothing on this device class. This is exactly the use
+case WVMG was built for, but it means a vivo device cannot be used as
+a Quick Share *peer* in the test matrix — only as the WVMG sender or
+WVMG receiver. Use a Pixel or Samsung phone for the matrix's peer
+role.
+
+### 4. Logcat filters out app `Log.i` output
+
+Funtouch / OriginOS filters `Log.i` calls from non-system apps —
+`adb logcat -s WvmgDiscovery:*` will return nothing for our success
+paths even when the corresponding code is running. The success-path
+log lines in `BleAdvertiser`, `BleQuickShareScanner`, and
+`MdnsAdvertisementGate` therefore log at `Log.w` level (the same
+mitigation `OutboundConnection` uses with `Log.e`); `Log.w` and
+`Log.e` come through normally. When a test cell on a vivo device
+needs to verify that the BLE advertise actually started, prefer
+`adb shell dumpsys bluetooth_manager | grep -B 1 -A 12 kyujincho`
+over logcat.
+
+---
+
 ## Common Quick Share BLE quirks
 
 These are real-world properties of stock Quick Share's BLE side that

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/MdnsAdvertisementGate.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/MdnsAdvertisementGate.kt
@@ -181,7 +181,7 @@ public class MdnsAdvertisementGate(
             if (!session.isAdvertising) {
                 try {
                     session.publishAdvertisement()
-                    Log.i(TAG, "publish: published mDNS (decision=$decision)")
+                    Log.w(TAG, "publish: published mDNS (decision=$decision)")
                 } catch (t: Throwable) {
                     // The session may have been stopped between the
                     // collector firing and the publish call. Treat as
@@ -208,7 +208,7 @@ public class MdnsAdvertisementGate(
                 if (isActive) {
                     try {
                         session.unpublishAdvertisement()
-                        Log.i(TAG, "unpublish: idle for ${debounceIdleMillis}ms; mDNS taken down")
+                        Log.w(TAG, "unpublish: idle for ${debounceIdleMillis}ms; mDNS taken down")
                     } catch (t: Throwable) {
                         // Best-effort: the session may have been stopped
                         // first, in which case the advertisement is

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
@@ -817,10 +817,35 @@ internal object EndpointIdentityHolder {
 }
 
 /**
- * Production [MulticastLockController] that holds a single Wi-Fi
- * multicast lock for the duration of the service. We tag the lock with a
- * service-specific name so it shows up correctly in `dumpsys wifi` for
- * diagnostics.
+ * Production [MulticastLockController] that holds a Wi-Fi multicast lock
+ * **and** a `WIFI_MODE_FULL_HIGH_PERF` Wi-Fi lock for the duration of the
+ * service.
+ *
+ * Why both locks: vivo / Funtouch / OriginOS routinely treat
+ * [WifiManager.MulticastLock.acquire] as a no-op for non-system apps —
+ * the Java-side `isHeld` returns `true` but `dumpsys wifi` shows
+ * "Multicast Locks held:" empty, and inbound mDNS multicast traffic
+ * never reaches our JmDNS responder. Consequence: our initial JmDNS
+ * announce burst still goes out (UDP send is allowed), but ongoing PTR
+ * queries from peers receive no response, so peers cache us briefly and
+ * then we vanish from their service browse. Found while running the
+ * docs/testing/interop-ble-trigger.md runbook against a Vivo X300 Ultra
+ * (Funtouch 16 / OriginOS 6).
+ *
+ * The standard escape hatch is to also acquire a [WifiManager.WifiLock]
+ * with mode [WifiManager.WIFI_MODE_FULL_HIGH_PERF]. While that lock is
+ * held the device disables Wi-Fi power save, and the multicast filter
+ * that Funtouch installs in power-save mode is correspondingly lifted —
+ * which is what lets multicast actually reach our app on these devices.
+ * On stock AOSP / Pixel / Samsung the multicast lock alone already
+ * works; the Wi-Fi lock is then redundant but harmless (slight increase
+ * in idle power, mitigated by the lock only being held while the
+ * receiver foreground service is running).
+ *
+ * Both locks are tagged with service-specific names so they show up in
+ * `dumpsys wifi` for diagnostics. Reference counting is disabled on
+ * both — we own the lifecycle through our own boolean tracking inside
+ * `ReceiverSession.holdingLock`.
  */
 internal class AndroidMulticastLockController(
     context: Context,
@@ -828,21 +853,35 @@ internal class AndroidMulticastLockController(
 ) : MulticastLockController {
     private val wifi: WifiManager =
         context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
-    private val lock: WifiManager.MulticastLock =
+    private val multicastLock: WifiManager.MulticastLock =
         wifi.createMulticastLock(tag).apply {
-            // The receiver service holds one lock for its entire
-            // lifetime; we don't need the WifiManager's reference
-            // counting on top of our own boolean tracking in
-            // ReceiverSession.
+            setReferenceCounted(false)
+        }
+
+    /**
+     * Companion Wi-Fi lock that disables power save while the receiver
+     * is running. This is the workaround that lets Funtouch / OriginOS
+     * actually deliver multicast to our app — see the class KDoc for
+     * the gory details.
+     */
+    private val wifiLock: WifiManager.WifiLock =
+        wifi.createWifiLock(WifiManager.WIFI_MODE_FULL_HIGH_PERF, tag + "-highperf").apply {
             setReferenceCounted(false)
         }
 
     override fun acquire() {
-        if (!lock.isHeld) lock.acquire()
+        if (!multicastLock.isHeld) multicastLock.acquire()
+        if (!wifiLock.isHeld) wifiLock.acquire()
     }
 
     override fun release() {
-        if (lock.isHeld) lock.release()
+        // Release in reverse acquisition order so that if Funtouch
+        // releasing the wifi lock causes power save to re-enable, the
+        // multicast lock can be observed correctly (or, more often,
+        // already silently dropped — but the OS bookkeeping prefers
+        // this order regardless).
+        if (wifiLock.isHeld) wifiLock.release()
+        if (multicastLock.isHeld) multicastLock.release()
     }
 
     private companion object {


### PR DESCRIPTION
## Summary

On-device verification of Phase 2 (BLE auto-discovery) against a Vivo X300 Ultra — Funtouch 16 / OriginOS 6 / Android 16 — surfaced four concrete issues that prevented the BLE pulse and mDNS pipeline from actually working end-to-end. Three are real production bugs that affect every device; the fourth is a Funtouch-specific developer-experience improvement.

PR #91 / #92 / #93 / #94 / #95 / #96 (Phase 2 itself) had landed CI-green and JVM-test-clean, but **CI has been failing for billing reasons** (`recent account payments have failed or your spending limit needs to be increased`) on every recent run, and the JVM unit tests for the BLE advertiser asserted on payload bytes individually rather than round-tripping through the platform's 31-byte budget. So none of these regressions had a unit-test or CI signal — they only became visible on real hardware.

## Bugs fixed

### 1. `DATA_TOO_LARGE` — sender BLE pulse never broadcasts (607c41e)

`BleAdvertiser.buildAdvertiseData` called both `addServiceUuid(parcelUuid)` and `addServiceData(parcelUuid, payload)`. The 16-bit Quick Share UUID is already embedded inside the service-data AD (type `0x16`), and the receiver-side `ScanFilter` from #33 matches on service data only — the separate UUID-list AD had no consumer. Including both produced a 32-byte advertising payload (4 + 28), one byte over the 31-byte legacy BLE budget. The platform reported `onStartFailure code=1 (DATA_TOO_LARGE)` and never broadcast the pulse, so stock Quick Share receivers never saw the trigger.

After dropping the redundant `addServiceUuid`, the dump shows the advertise running cleanly:

```
io.github.kyujincho.wvmg.debug
  Advertising: Legacy=true Connectable=false TX_POWER=1 dBm
  Service Data(UUID, length of data) : [0000fe2c-..., 24]
  Elapsed time: 167573ms (no failures)
```

### 2. Receiver foreground service was never started (81863dd)

`ReceiverForegroundService.start(context)` had no production caller. The companion entrypoint existed but only tests invoked it. Consequently, on a freshly installed device the BLE pulse scanner (#33), mDNS-publish gate (#34), and TCP listener were running only inside instrumentation tests; opening the launcher and waiting did not actually make the device discoverable. PR #89's Galaxy S26 Ultra interop work exercised the *send* path end-to-end, which is why this gap on the receive side went unnoticed until the BLE-trigger runbook was actually exercised on a real device.

`MainActivity.onStart` is the right place: the user is visibly in our app (so Android 14+ allows starting a foreground service), the permission gate has either passed or routed the user to onboarding, and `startService` is idempotent so repeated `onStart`s cost nothing.

### 3. mDNS multicast lock silently refused on Funtouch (e57b0ae)

Vivo / Funtouch / OriginOS routinely treats `WifiManager.MulticastLock.acquire` as a no-op for non-system apps. Symptom: the initial JmDNS announce burst still goes out (UDP send is allowed) so peers see us briefly, but ongoing PTR queries from peers receive no response, and peers cache us for ~30 s before we vanish from their service browse. `dumpsys wifi` confirms `Multicast Locks held:` is empty even though the Java-side lock object reports `isHeld=true`.

`AndroidMulticastLockController` now also acquires a companion `WifiManager.WifiLock(WIFI_MODE_FULL_HIGH_PERF)` for the receiver-service lifetime. While that lock is held the device disables Wi-Fi power save, and the multicast filter Funtouch installs in power-save mode is correspondingly lifted. On stock AOSP / Pixel / Samsung the multicast lock alone already works; the Wi-Fi lock is then redundant but harmless.

⚠️ **Known limitation**: even with the WifiLock companion, **vivo Funtouch 16 / OriginOS 6 still silently refuses both locks** for non-system apps. Sustained mDNS responsiveness on vivo therefore requires either device-side configuration changes (App Freezer + battery-optimisation whitelist) or a future migration from JmDNS to Android's `NsdManager`. The vivo-specific behaviour is documented in detail in the runbook's new "Vivo / Funtouch / OriginOS specific quirks" section.

### 4. Funtouch swallows app `Log.i` — DX fix (affbcba)

CLAUDE.md already noted `OutboundConnection` uses `Log.e` to work around Funtouch's `Log.i` filter. Applied the same mitigation to the BLE advertiser, BLE scanner, and mDNS gate success-path lines (now `Log.w`). Failure-path lines were already at `W`/`E`. The events are infrequent lifecycle transitions, not log-spam, so emitting them at `W` is appropriate.

## Verification

On the Vivo X300 Ultra:

- **BLE advertise**: 167 s of clean operation, payload exactly the 24 bytes spec'd in `PROTOCOL.md`, no `DATA_TOO_LARGE`. Verified via `dumpsys bluetooth_manager`.
- **BLE scanner**: registers with `ServiceDataUuid=0000fe2c-…` and the 14-byte protocol prefix mask, scan mode flips between `BALANCED` and `LOW_LATENCY` correctly when the launcher activity goes background/foreground (Phase 5 lifecycle observer working as expected).
- **Receiver foreground service**: auto-starts from `MainActivity.onStart`, persistent notification posts, TCP listener binds.
- **mDNS gate**: override toggle propagates correctly through `MdnsVisibilityOverrideHolder` → `MdnsAdvertisementGate` → `session.publishAdvertisement()`. Initial JmDNS announce visible to a Mac on the same LAN via `dns-sd -B _FC9F5ED42C8A._tcp. local.` — service registers as `_FC9F5ED42C8A._tcp. local. <instance>` with the correct TXT and SRV records.
- **mDNS persistence on vivo**: degrades after ~30 s due to the documented Funtouch multicast-lock issue. Out of scope to fully resolve in this PR; tracked as a follow-up requiring NSD migration.

## Test plan

- [x] `./gradlew :discovery-android:testDebugUnitTest` (existing tests still green)
- [x] `./gradlew :service-android:testDebugUnitTest` (existing tests still green)
- [x] `./gradlew staticAnalysis` (clean across all five modules)
- [x] `./gradlew :app:assembleDebug` (debug APK builds)
- [x] On-device install + verify advertise broadcasts (Vivo X300 Ultra)
- [x] On-device verify scanner registration with correct ScanFilter
- [x] On-device verify receiver service auto-starts
- [x] On-device verify initial mDNS announce visible from a peer Mac
- [ ] **Future**: re-run docs/testing/interop-ble-trigger.md A1/A2 cells once a Pixel or Samsung peer is available — currently blocked because the test phone (vivo) does not ship with stock Quick Share.