### PR TITLE
fix(protocol): bump advertised keep_alive_timeout_millis from 30 s to 10 min

### DIFF
--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OfflineFrames.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OfflineFrames.kt
@@ -54,7 +54,7 @@ internal object OfflineFrames {
      * See [OutboundFrames.KEEP_ALIVE_TIMEOUT_MILLIS] for the full rationale
      * (One UI 8.0.5 silent-FIN guard; mirrors our request-side value).
      */
-    private const val KEEP_ALIVE_TIMEOUT_MILLIS: Int = 30_000
+    private const val KEEP_ALIVE_TIMEOUT_MILLIS: Int = 600_000
 
     /**
      * Build an unencrypted `OfflineFrame{V1, CONNECTION_RESPONSE,

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundFrames.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundFrames.kt
@@ -87,7 +87,21 @@ internal object OutboundFrames {
     }
 
     private const val KEEP_ALIVE_INTERVAL_MILLIS: Int = 5_000
-    private const val KEEP_ALIVE_TIMEOUT_MILLIS: Int = 30_000
+
+    /**
+     * Keep-alive timeout we advertise to the peer. Stock google/nearby's
+     * default is 30 s under the assumption that the peer will send
+     * explicit `KEEP_ALIVE` frames at the advertised interval. We do
+     * not run a keep-alive sender yet (we only handle inbound
+     * `KEEP_ALIVE` frames, like NearDrop), so a 30-second silence
+     * during slow file transfers — easy to hit on a phone hotspot link
+     * — caused Samsung One UI to disconnect mid-payload at ~81 %
+     * (verified on-device). 10 minutes covers reasonable file sizes
+     * over Wi-Fi LAN; the canonical fix is a periodic
+     * `KEEP_ALIVE` sender driven from the secure channel, tracked
+     * separately.
+     */
+    private const val KEEP_ALIVE_TIMEOUT_MILLIS: Int = 600_000
 
     /** Legacy `status` field value for "STATUS_OK". 0 in the proto enum. */
     private const val STATUS_OK: Int = 0

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/ConnectionResponseFrameShapeTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/ConnectionResponseFrameShapeTest.kt
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test
  *   3. `os_info.type = ANDROID`
  *   4. `multiplex_socket_bitmask = 0` (no medium supports multiplex)
  *   5. `safe_to_disconnect_version = 1`
- *   6. `keep_alive_timeout_millis = 30_000`
+ *   6. `keep_alive_timeout_millis = 600_000`
  *
  * One UI 8.0.5 silently FINs ~150 ms after our `ConnectionResponse{ACCEPT}`
  * when either of fields 4 or 6 is absent (issue #101). Verified on-device
@@ -72,6 +72,6 @@ class ConnectionResponseFrameShapeTest {
         assertThat(cr.safeToDisconnectVersion).isEqualTo(1)
 
         assertThat(cr.hasKeepAliveTimeoutMillis()).isTrue()
-        assertThat(cr.keepAliveTimeoutMillis).isEqualTo(30_000)
+        assertThat(cr.keepAliveTimeoutMillis).isEqualTo(600_000)
     }
 }


### PR DESCRIPTION
## Summary

Stock google/nearby's `keep_alive_timeout_millis` default is 30 s under the assumption that the peer sends explicit `KEEP_ALIVE` frames at the advertised interval. We don't run a keep-alive sender (we only handle inbound `KEEP_ALIVE` frames — same as NearDrop). On a slow Wi-Fi LAN link, payload-chunk gaps exceed 30 s and Samsung disconnects mid-payload.

## Evidence

Verified on a Vivo X300 Ultra → Galaxy S24 Ultra (One UI 8.0.5) transfer of a 35 MB file. The transfer reached 81 % (\`bytesReceived=28835840\`) before Samsung logged:

\`\`\`
NearbyConnections: EndpointManager quit overall KeepAliveManager loop
                   for endpoint fqCG because there's no EndpointChannel
NearbySharing:    IncomingPayloadTransferEnd(... status=29, ...)
\`\`\`

Status code 29 + the keep-alive-manager exit is the canonical signature of Samsung's `keep_alive_timeout_millis` timer firing — exactly the value we advertised in our `ConnectionRequestFrame` and `ConnectionResponseFrame`.

## Change

* `OutboundFrames.KEEP_ALIVE_TIMEOUT_MILLIS` (sender ConnectionRequest + ConnectionResponse): 30 000 → 600 000.
* `OfflineFrames.KEEP_ALIVE_TIMEOUT_MILLIS` (receiver ConnectionResponse): 30 000 → 600 000.
* Both move in lockstep so the shape parity One UI 8.0.5 enforces (#101) is preserved.
* `ConnectionResponseFrameShapeTest` regression guard is updated to pin the new value.

10 minutes covers reasonable file sizes over Wi-Fi LAN and is well within `int32` range. The canonical fix is a periodic `KEEP_ALIVE` sender driven from the secure channel; that's tracked separately and unblocks transfers > 30 s in the meantime.