### PR TITLE
fix: random UKEY2 failures (P-256 sign byte) + Galaxy interop hardening

### DIFF
--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendActivity.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendActivity.kt
@@ -18,6 +18,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import io.github.kyujincho.wvmg.R
+import io.github.kyujincho.wvmg.service.receiver.OutboundSessionActiveHolder
 import io.github.kyujincho.wvmg.databinding.ActivitySendBinding
 import io.github.kyujincho.wvmg.databinding.ItemPeerRowBinding
 import io.github.kyujincho.wvmg.discovery.DiscoveredService
@@ -103,6 +104,16 @@ public class SendActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // Veto receiver-side mDNS publish for the duration of this
+        // activity. When WVMG concurrently publishes its receiver-side
+        // mDNS record AND opens an outbound `OutboundConnection` to the
+        // same peer, Samsung One UI 8.0.5's GMS Nearby caches state for
+        // our endpoint from the discovered WIFI_LAN service and then
+        // fails `securegcm::UKey2Handshake::ParseHandshakeMessage` on
+        // our incoming `client_finished` (verified ~73-267 ms after the
+        // peer writes server_init). Pausing the gate for the lifetime
+        // of `SendActivity` clears that race window.
+        OutboundSessionActiveHolder.setOutboundSessionActive(true)
         binding = ActivitySendBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
@@ -146,6 +157,10 @@ public class SendActivity : AppCompatActivity() {
         connectionJob?.cancel()
         emptyPeerHintJob?.cancel()
         stopBleAdvertise()
+        // Lift the gate veto so the receiver-side mDNS record can come
+        // back up if any of the gate's existing publish signals
+        // (BLE pulse, always-visible override, QR session) call for it.
+        OutboundSessionActiveHolder.setOutboundSessionActive(false)
     }
 
     // -----------------------------------------------------------------
@@ -235,27 +250,76 @@ public class SendActivity : AppCompatActivity() {
         when (event) {
             is DiscoveryEvent.Resolved -> {
                 val incoming = event.service
-                // Note: we deliberately do NOT filter by EndpointInfo's
-                // `hidden` bit. On-device interop testing showed that
-                // stock Quick Share publishes EVERY device — including
-                // those set to "Everyone" — with the visibility bit set
-                // to 1 and no plaintext device name in the TXT record.
-                // The Everyone-vs-Contacts-only decision is enforced
-                // later during the connection negotiation, not at the
-                // mDNS layer. Filtering here would hide the very peers
-                // the user is trying to send to.
-                val existingIndex = peers.indexOfFirst { it.instanceName == incoming.instanceName }
-                if (existingIndex >= 0) {
-                    peers[existingIndex] = incoming
+                // Dedup by primary address + port, NOT by mDNS instance
+                // name. Stock Quick Share rotates instance names rapidly
+                // for privacy and frequently publishes multiple records
+                // simultaneously (e.g., one with the friendly name and
+                // one without) — captured on a Galaxy S24 Ultra, all
+                // pointing at the same TCP listener. Keying on instance
+                // name leaves the picker with several rows for the same
+                // device, some of them stale, and tapping a stale row
+                // intermittently triggers a silent UKEY2 FIN on the peer
+                // (its current internal state no longer matches the
+                // older instance ID baked into the row).
+                //
+                // We deliberately do NOT filter by EndpointInfo's
+                // `hidden` bit. Stock peers publish every device — even
+                // "Everyone" mode — with visibility=1 and no plaintext
+                // name; the Everyone-vs-Contacts-only decision happens
+                // during the connection negotiation, not at the mDNS
+                // layer. Filtering here would hide the very peers the
+                // user is trying to send to.
+                val key = peerDedupKey(incoming)
+                if (key == null) {
+                    // Defensive: if the resolved record has no usable
+                    // address (rare; the discovery layer normally drops
+                    // these earlier), fall back to instance-name dedup
+                    // so the row at least appears.
+                    val ix = peers.indexOfFirst { it.instanceName == incoming.instanceName }
+                    if (ix >= 0) peers[ix] = incoming else peers.add(incoming)
                 } else {
-                    peers.add(incoming)
+                    val existingIndex = peers.indexOfFirst { peerDedupKey(it) == key }
+                    if (existingIndex >= 0) {
+                        // Keep whichever record carries a friendly device
+                        // name. Stock Samsung alternates anonymous and
+                        // named instances on the wire; the picker should
+                        // settle on the named one once seen rather than
+                        // flicker back to "Quick Share Device".
+                        val existing = peers[existingIndex]
+                        val existingNamed = existing.endpointInfo?.deviceName != null
+                        val incomingNamed = incoming.endpointInfo?.deviceName != null
+                        if (incomingNamed || !existingNamed) {
+                            peers[existingIndex] = incoming
+                        }
+                    } else {
+                        peers.add(incoming)
+                    }
                 }
             }
             is DiscoveryEvent.Lost -> {
+                // Lost events fire per-instance-name. Because Resolved
+                // events may have replaced an older instance under the
+                // same addr+port row, the lost name may not match any
+                // current peer's `instanceName` — that's fine, we
+                // silently skip. The next mDNS query will re-resolve a
+                // still-valid record if Samsung is just rotating ids.
                 peers.removeAll { it.instanceName == event.instanceName }
             }
         }
         renderPeerList()
+    }
+
+    /**
+     * Returns the (primaryAddress, port) tuple used to dedup the picker's
+     * peer list, or `null` if [peer] has no usable connect target. Two
+     * mDNS records that resolve to the same TCP listener share this key
+     * regardless of mDNS instance name; that lets us collapse stock
+     * Quick Share's rotating-instance-id record stream into one stable
+     * row.
+     */
+    private fun peerDedupKey(peer: DiscoveredService): Pair<String, Int>? {
+        val addr = peer.primaryAddress()?.hostAddress ?: return null
+        return addr to peer.port
     }
 
     private fun renderPeerList() {
@@ -313,6 +377,53 @@ public class SendActivity : AppCompatActivity() {
         binding.sendNetworkHint.visibility = View.GONE
     }
 
+    /**
+     * Build a single-line diagnostic string capturing everything we know
+     * about [peer] at the moment the user picks it. Logged via
+     * [onPeerSelected] before any TCP work so a subsequent failure can
+     * be correlated against the exact target shape.
+     */
+    private fun formatPeerSnapshot(
+        peer: DiscoveredService,
+        chosenTarget: InetAddress,
+    ): String {
+        val instanceName = peer.instanceName
+        val endpointIdHex =
+            peer.endpointId
+                ?.joinToString("") { "%02x".format(it) }
+                ?: "<none>"
+        val addressList =
+            if (peer.addresses.isEmpty()) {
+                "<none>"
+            } else {
+                peer.addresses.joinToString(",") { it.hostAddress ?: "<unresolved>" }
+            }
+        val info = peer.endpointInfo
+        val infoSummary =
+            if (info == null) {
+                "<none>"
+            } else {
+                buildString {
+                    append("v=").append(info.version)
+                    append(" hidden=").append(info.hidden)
+                    append(" type=").append(info.deviceType.name)
+                    append(" name=")
+                    append(info.deviceName?.let { "\"$it\"" } ?: "<null>")
+                    if (info.tlvRecords.isNotEmpty()) {
+                        append(" tlv=").append(
+                            info.tlvRecords.joinToString(",") { tlv ->
+                                val valueHex = tlv.value.joinToString("") { "%02x".format(it) }
+                                "${tlv.type}:$valueHex"
+                            },
+                        )
+                    }
+                }
+            }
+        return "instance=$instanceName endpointId=$endpointIdHex " +
+            "addrs=[$addressList] picked=${chosenTarget.hostAddress} " +
+            "port=${peer.port} endpointInfo={$infoSummary}"
+    }
+
     @Suppress("ReturnCount")
     private fun peerLabel(peer: DiscoveredService): String {
         val name = peer.endpointInfo?.deviceName
@@ -345,6 +456,18 @@ public class SendActivity : AppCompatActivity() {
                 )
                 return
             }
+        // Verbose target snapshot at the moment of pick. Routed through
+        // Log.e (and the on-disk outbound log) because Funtouch filters
+        // Log.i for non-system apps — without this a Galaxy "peer
+        // closed" report leaves us guessing whether we even dialed the
+        // right address. Includes everything we know about the peer:
+        // mDNS instance name, the 4-byte endpoint id slice, the full
+        // address list (so we can spot IPv6 vs IPv4 selection bugs) plus
+        // the chosen primary, the TCP port, and the parsed EndpointInfo
+        // header byte (visBit / version / deviceType) and device name.
+        val targetSnapshot = formatPeerSnapshot(peer, target)
+        Log.e(OUTBOUND_TAG, "picked target: $targetSnapshot")
+        appendOutboundLog("picked target: $targetSnapshot")
         // Stop discovery — we've made our pick and don't want the JmDNS
         // browser holding the multicast lock during the actual transfer.
         discoveryJob?.cancel()

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OfflineFrames.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OfflineFrames.kt
@@ -54,7 +54,7 @@ internal object OfflineFrames {
      * See [OutboundFrames.KEEP_ALIVE_TIMEOUT_MILLIS] for the full rationale
      * (One UI 8.0.5 silent-FIN guard; mirrors our request-side value).
      */
-    private const val KEEP_ALIVE_TIMEOUT_MILLIS: Int = 30_000
+    private const val KEEP_ALIVE_TIMEOUT_MILLIS: Int = 600_000
 
     /**
      * Build an unencrypted `OfflineFrame{V1, CONNECTION_RESPONSE,

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnection.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnection.kt
@@ -109,8 +109,11 @@ import java.security.SecureRandom
  *   record into this concrete value.
  * @param port TCP port the receiver advertised in its endpoint record.
  * @param endpointId 4-char ASCII identifier the sender uses for itself
- *   in the opening `ConnectionRequest`. Default: `"NDLp"` (Quick
- *   Share's identifier shape — 4 ASCII characters).
+ *   in the opening `ConnectionRequest`. Default: a freshly generated
+ *   alphanumeric id via [generateEndpointId]. Quick Share peers (Samsung
+ *   One UI's GMS Nearby in particular) keep per-endpoint-id state for a
+ *   short window after a session tears down, and a fresh id per
+ *   connection avoids racing that teardown.
  * @param endpointInfo Serialized
  *   [io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo] bytes
  *   describing the sender. Default: empty (sender does not advertise a
@@ -131,7 +134,7 @@ import java.security.SecureRandom
 public class OutboundConnection(
     private val targetAddress: InetAddress,
     private val port: Int,
-    private val endpointId: String = DEFAULT_ENDPOINT_ID,
+    private val endpointId: String = generateEndpointId(),
     private val endpointInfo: ByteArray = ByteArray(0),
     private val qrCodeHandshakeData: ByteArray? = null,
     private val connectTimeoutMillis: Int = DEFAULT_CONNECT_TIMEOUT_MILLIS,
@@ -339,6 +342,15 @@ public class OutboundConnection(
         withContext(Dispatchers.IO) {
             val socket = Socket()
             socket.connect(InetSocketAddress(targetAddress, port), connectTimeoutMillis)
+            // TCP_NODELAY mirrors the receiver-side accept loop
+            // (`TcpReceiverServer` line ~414). Without it, Nagle batches
+            // our small UKEY2 frames (~50 B) and the unencrypted
+            // `ConnectionResponse{ACCEPT}` (~24 B) into a single segment,
+            // which the peer's framing parser handles fine but adds
+            // latency on the path that already needs to fit inside
+            // Samsung's UKEY2 server alarm. Best-effort: a misbehaving
+            // SocketImpl that rejects this option is non-fatal.
+            runCatching { socket.tcpNoDelay = true }
             socket
         }
 
@@ -410,12 +422,40 @@ public class OutboundConnection(
 
     public companion object {
         /**
-         * Default sender endpoint id ("NDLp" — Nearby Drop Lablup-port,
-         * but really just any 4-character ASCII string Quick Share
-         * peers tolerate). NearDrop uses "NCLp" / "FW**" with a similar
-         * intent.
+         * Generate a fresh 4-character sender endpoint id from the
+         * `[A-Za-z0-9]` alphabet stock Quick Share uses (see
+         * `google/nearby` `ClientProxy::GenerateEndpointId` and
+         * NearDrop's `OutboundNearbyConnection.swift`). A unique id per
+         * connection avoids colliding with stale per-endpoint state on
+         * the receiver: Samsung One UI's GMS Nearby keeps a
+         * `KeepAliveManager` loop keyed on endpoint id, and reusing the
+         * same id between attempts has been observed to race the
+         * teardown loop and produce intermittent silent FINs at the
+         * peer-ConnectionResponse step.
          */
-        public const val DEFAULT_ENDPOINT_ID: String = "NDLp"
+        @JvmStatic
+        public fun generateEndpointId(random: SecureRandom = SecureRandom()): String {
+            val out = CharArray(ENDPOINT_ID_LENGTH)
+            for (i in 0 until ENDPOINT_ID_LENGTH) {
+                out[i] = ENDPOINT_ID_ALPHABET[random.nextInt(ENDPOINT_ID_ALPHABET.length)]
+            }
+            return String(out)
+        }
+
+        /**
+         * Length of the sender endpoint id in bytes / characters. Stock
+         * Quick Share uses 4; NearDrop uses 4; we match.
+         */
+        private const val ENDPOINT_ID_LENGTH: Int = 4
+
+        /**
+         * Alphabet for [generateEndpointId]. Restricting to ASCII
+         * alphanumerics keeps the bytes deterministic across locales and
+         * lets every byte round-trip cleanly through any UTF-8/ASCII
+         * channel that downstream peers use to read this value.
+         */
+        private const val ENDPOINT_ID_ALPHABET: String =
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
 
         /**
          * Default TCP connect timeout, in milliseconds. 5 seconds is

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundFrames.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundFrames.kt
@@ -87,7 +87,21 @@ internal object OutboundFrames {
     }
 
     private const val KEEP_ALIVE_INTERVAL_MILLIS: Int = 5_000
-    private const val KEEP_ALIVE_TIMEOUT_MILLIS: Int = 30_000
+
+    /**
+     * Keep-alive timeout we advertise to the peer. Stock google/nearby's
+     * default is 30 s under the assumption that the peer will send
+     * explicit `KEEP_ALIVE` frames at the advertised interval. We do
+     * not run a keep-alive sender yet (we only handle inbound
+     * `KEEP_ALIVE` frames, like NearDrop), so a 30-second silence
+     * during slow file transfers — easy to hit on a phone hotspot link
+     * — caused Samsung One UI to disconnect mid-payload at ~81 %
+     * (verified on-device). 10 minutes covers reasonable file sizes
+     * over Wi-Fi LAN; the canonical fix is a periodic
+     * `KEEP_ALIVE` sender driven from the secure channel, tracked
+     * separately.
+     */
+    private const val KEEP_ALIVE_TIMEOUT_MILLIS: Int = 600_000
 
     /** Legacy `status` field value for "STATUS_OK". 0 in the proto enum. */
     private const val STATUS_OK: Int = 0

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/ukey2/Ukey2KeyEncoding.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/ukey2/Ukey2KeyEncoding.kt
@@ -66,8 +66,8 @@ internal object Ukey2KeyEncoding {
      */
     fun serialize(publicKey: ECPublicKey): ByteArray {
         val w = publicKey.w
-        val x = toFixedWidthCoordinate(w.affineX)
-        val y = toFixedWidthCoordinate(w.affineY)
+        val x = encodeP256Coordinate(w.affineX)
+        val y = encodeP256Coordinate(w.affineY)
         val ecKey =
             EcP256PublicKey
                 .newBuilder()
@@ -272,14 +272,27 @@ internal object Ukey2KeyEncoding {
      *
      *  - For values whose magnitude fits in `< 256` bits and whose top
      *    bit is `0`, the result is already 1..32 bytes — left-pad with
-     *    zeros.
-     *  - For values whose magnitude has the top bit set in 256 bits
-     *    (i.e., `>= 2^255`), the result is 33 bytes with a leading
-     *    `0x00` sign byte — drop it.
+     *    zeros to 32 bytes.
+     *  - For values whose magnitude has the top bit of the 256-bit
+     *    representation set (i.e., `>= 2^255`), `toByteArray()` returns
+     *    33 bytes with a leading `0x00` sign byte. **Keep the sign
+     *    byte** — Samsung One UI 8.0.5's GMS Nearby parses these bytes
+     *    via `new BigInteger(byte[])` (signed two's complement) and
+     *    rejects MSB-set 32-byte input as a negative integer with
+     *    `Point encoding must use only non-negative integers`. The
+     *    leading `0x00` makes the encoding unambiguously non-negative
+     *    under either parsing convention (signed two's complement or
+     *    `BigInteger(1, bytes)` unsigned magnitude). Verified on-device
+     *    against a Galaxy S24 Ultra: ~50% of P-256 keypairs trigger the
+     *    bug (top-bit-set is uniformly random), exactly matching the
+     *    "intermittent UKEY2 silent FIN" symptom we'd been chasing.
      *
-     * The output is always exactly [P256_COORDINATE_SIZE] bytes.
+     * Output is therefore variable length: typically 32 bytes,
+     * occasionally 33 bytes (when MSB=1). The proto field is `bytes`,
+     * so receivers that parse via `BigInteger(1, bytes)` see the
+     * correct magnitude either way.
      */
-    private fun toFixedWidthCoordinate(coordinate: BigInteger): ByteArray {
+    private fun encodeP256Coordinate(coordinate: BigInteger): ByteArray {
         require(coordinate.signum() >= 0) {
             // Public-key coordinates from a real P-256 keypair are always
             // in [0, p), so this is a sanity check, not an interop guard.
@@ -287,16 +300,22 @@ internal object Ukey2KeyEncoding {
         }
         val raw = coordinate.toByteArray()
         return when {
+            // 32 bytes: top bit is 0, so the encoding is already
+            // unambiguously non-negative under any parser.
             raw.size == P256_COORDINATE_SIZE -> raw
+            // 33 bytes: leading 0x00 sign byte + 32-byte magnitude. The
+            // top bit of the magnitude is 1; KEEPING the sign byte is
+            // what unblocks Samsung's strict-signed parser.
             raw.size == P256_COORDINATE_SIZE + 1 -> {
-                // 33 bytes: drop the leading sign byte (always 0x00 for
-                // non-negative BigInteger).
                 check(raw[0] == 0.toByte()) {
                     "Unexpected sign byte 0x${raw[0].toInt().and(BYTE_MASK).toString(HEX_RADIX)} " +
                         "in non-negative coordinate"
                 }
-                raw.copyOfRange(1, raw.size)
+                raw
             }
+            // Smaller than 32 bytes (small magnitude): left-pad with
+            // zeros to a fixed 32-byte form. The top bit will be 0 by
+            // construction, so no sign byte is needed.
             raw.size < P256_COORDINATE_SIZE -> {
                 val padded = ByteArray(P256_COORDINATE_SIZE)
                 raw.copyInto(padded, destinationOffset = P256_COORDINATE_SIZE - raw.size)

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/ConnectionResponseFrameShapeTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/ConnectionResponseFrameShapeTest.kt
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test
  *   3. `os_info.type = ANDROID`
  *   4. `multiplex_socket_bitmask = 0` (no medium supports multiplex)
  *   5. `safe_to_disconnect_version = 1`
- *   6. `keep_alive_timeout_millis = 30_000`
+ *   6. `keep_alive_timeout_millis = 600_000`
  *
  * One UI 8.0.5 silently FINs ~150 ms after our `ConnectionResponse{ACCEPT}`
  * when either of fields 4 or 6 is absent (issue #101). Verified on-device
@@ -72,6 +72,6 @@ class ConnectionResponseFrameShapeTest {
         assertThat(cr.safeToDisconnectVersion).isEqualTo(1)
 
         assertThat(cr.hasKeepAliveTimeoutMillis()).isTrue()
-        assertThat(cr.keepAliveTimeoutMillis).isEqualTo(30_000)
+        assertThat(cr.keepAliveTimeoutMillis).isEqualTo(600_000)
     }
 }

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/ukey2/Ukey2KeyEncodingTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/ukey2/Ukey2KeyEncodingTest.kt
@@ -60,14 +60,59 @@ class Ukey2KeyEncodingTest {
     }
 
     @Test
-    fun `serialize emits exactly 32 bytes for both X and Y coordinates`() {
+    fun `serialize emits 32 or 33 bytes for each P-256 coordinate`() {
+        // Output is 32 bytes when the field-element top bit is 0 (the
+        // common case) and 33 bytes (leading 0x00 sign byte + 32-byte
+        // magnitude) when the top bit is 1. The 33-byte form is what
+        // `BigInteger.toByteArray()` returns natively for a positive
+        // value with the top bit set; we keep the sign byte rather than
+        // stripping it, because Samsung One UI 8.0.5's GMS Nearby
+        // parses these bytes via `new BigInteger(byte[])` (signed
+        // two's complement) and rejects MSB=1 32-byte input as a
+        // negative integer. The variable encoding is unambiguous to any
+        // proto-aware receiver since the field is `bytes`.
         val pub = generateKeyPair().public as ECPublicKey
         val bytes = Ukey2KeyEncoding.serialize(pub)
 
         val parsed = GenericPublicKey.parseFrom(bytes)
         assertThat(parsed.type).isEqualTo(PublicKeyType.EC_P256)
-        assertThat(parsed.ecP256PublicKey.x.size()).isEqualTo(Ukey2.P256_COORDINATE_SIZE)
-        assertThat(parsed.ecP256PublicKey.y.size()).isEqualTo(Ukey2.P256_COORDINATE_SIZE)
+        val xSize = parsed.ecP256PublicKey.x.size()
+        val ySize = parsed.ecP256PublicKey.y.size()
+        assertThat(xSize).isAnyOf(Ukey2.P256_COORDINATE_SIZE, Ukey2.P256_COORDINATE_SIZE + 1)
+        assertThat(ySize).isAnyOf(Ukey2.P256_COORDINATE_SIZE, Ukey2.P256_COORDINATE_SIZE + 1)
+        // When the encoding is 33 bytes the leading byte must be the
+        // canonical 0x00 sign byte — not arbitrary leading data — so
+        // signed parsers see a non-negative value.
+        if (xSize == Ukey2.P256_COORDINATE_SIZE + 1) {
+            assertThat(parsed.ecP256PublicKey.x.byteAt(0)).isEqualTo(0.toByte())
+        }
+        if (ySize == Ukey2.P256_COORDINATE_SIZE + 1) {
+            assertThat(parsed.ecP256PublicKey.y.byteAt(0)).isEqualTo(0.toByte())
+        }
+    }
+
+    @Test
+    fun `serialize never produces an MSB-1 32-byte coordinate (Samsung BC parser regression guard)`() {
+        // Burn through enough random keypairs that we hit the ~50%
+        // probability of a top-bit-set coordinate. For every keypair,
+        // assert: a 32-byte output has top bit = 0; a 33-byte output
+        // has leading byte = 0x00. There is no other valid combination.
+        repeat(64) {
+            val pub = generateKeyPair().public as ECPublicKey
+            val bytes = Ukey2KeyEncoding.serialize(pub)
+            val parsed = GenericPublicKey.parseFrom(bytes)
+
+            for (coord in listOf(parsed.ecP256PublicKey.x, parsed.ecP256PublicKey.y)) {
+                val raw = coord.toByteArray()
+                if (raw.size == Ukey2.P256_COORDINATE_SIZE) {
+                    val topBit = (raw[0].toInt() and 0x80) != 0
+                    assertThat(topBit).isFalse()
+                } else {
+                    assertThat(raw.size).isEqualTo(Ukey2.P256_COORDINATE_SIZE + 1)
+                    assertThat(raw[0]).isEqualTo(0.toByte())
+                }
+            }
+        }
     }
 
     @Test
@@ -77,9 +122,12 @@ class Ukey2KeyEncodingTest {
         // `BigInteger.toByteArray()` form for values whose top bit is
         // set). The parser must drop the sign byte and recover the real
         // 32-byte coordinate.
-        val pub = generateKeyPair().public as ECPublicKey
-        val canonical = Ukey2KeyEncoding.serialize(pub)
-        val canonicalProto = GenericPublicKey.parseFrom(canonical)
+        //
+        // Since the canonical serializer now itself emits 33-byte
+        // coordinates whenever the top bit is set, find a keypair whose
+        // canonical X happens to be 32 bytes (top bit 0) so the
+        // synthetic 33-byte form we manufacture below is unambiguous.
+        val (pub, canonicalProto) = keyWithCanonicalXSize(Ukey2.P256_COORDINATE_SIZE)
 
         val originalX = canonicalProto.ecP256PublicKey.x.toByteArray()
         val padded = ByteArray(originalX.size + 1)
@@ -112,9 +160,11 @@ class Ukey2KeyEncodingTest {
         // assert that the parser at least DOES the padding (we observe
         // the rejection path that a length-32 vs. length-31 input takes
         // the same code path through normalizeCoordinate).
-        val pub = generateKeyPair().public as ECPublicKey
-        val canonical = Ukey2KeyEncoding.serialize(pub)
-        val canonicalProto = GenericPublicKey.parseFrom(canonical)
+        //
+        // Pin the canonical X to 32 bytes so the truncation arithmetic
+        // below produces a deterministic 31-byte input regardless of
+        // whether the random keypair's top bit is 0 or 1.
+        val (_, canonicalProto) = keyWithCanonicalXSize(Ukey2.P256_COORDINATE_SIZE)
 
         // Synthesize a coordinate whose top byte is 0x00 by zeroing the
         // most significant byte of X. The resulting point is overwhelmingly
@@ -246,6 +296,32 @@ class Ukey2KeyEncodingTest {
         val gen = KeyPairGenerator.getInstance("EC")
         gen.initialize(ECGenParameterSpec("secp256r1"))
         return gen.generateKeyPair()
+    }
+
+    /**
+     * Returns a freshly generated keypair whose canonical X coordinate
+     * encodes to exactly [targetSize] bytes after passing through
+     * [Ukey2KeyEncoding.serialize]. Used by tests that need a
+     * deterministic encoding length to manipulate.
+     *
+     * Probability per draw is ~50% (top bit of the X field element is
+     * uniformly random), so this loop terminates quickly. Caps at
+     * [maxAttempts] to avoid an infinite spin in the (astronomically
+     * unlikely) event of a stuck KeyPairGenerator.
+     */
+    private fun keyWithCanonicalXSize(
+        targetSize: Int,
+        maxAttempts: Int = 64,
+    ): Pair<ECPublicKey, GenericPublicKey> {
+        repeat(maxAttempts) {
+            val pub = generateKeyPairFresh().public as ECPublicKey
+            val canonical = Ukey2KeyEncoding.serialize(pub)
+            val canonicalProto = GenericPublicKey.parseFrom(canonical)
+            if (canonicalProto.ecP256PublicKey.x.size() == targetSize) {
+                return pub to canonicalProto
+            }
+        }
+        error("Could not produce a keypair whose canonical X is $targetSize bytes after $maxAttempts attempts")
     }
 
     companion object {

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/Discovery.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/Discovery.kt
@@ -57,6 +57,14 @@ public class Discovery internal constructor(
     private val registrar: NsdRegistrar,
     private val browser: NsdBrowser,
     private val networkWatcherFactory: NetworkWatcherFactory = NetworkWatcherFactory.NoOp,
+    /**
+     * When `true`, the browse path drops any record whose mDNS instance
+     * name matches one currently advertised by this process — that is,
+     * the multicast-loopback echo of our own publish. Disabled in
+     * tests that exercise the full publish→browse round-trip in a
+     * single fake-NSD harness, since the harness IS the loopback.
+     */
+    private val filterSelfPublishedInstances: Boolean = true,
 ) {
     private val diagnostics: DiagnosticsState = DiagnosticsState()
 
@@ -184,7 +192,7 @@ public class Discovery internal constructor(
                     browser.discover(QuickShareMdns.SERVICE_TYPE_NSD).collect { event ->
                         when (event) {
                             is NsdBrowserEvent.Found -> {
-                                Log.d(TAG, "browse: serviceFound name=${event.instanceName}")
+                                Log.i(TAG, "browse: serviceFound name=${event.instanceName}")
                                 diagnostics.recordEvent(
                                     DiagnosticEvent(
                                         kind = DiagnosticEvent.Kind.ADDED,
@@ -195,11 +203,12 @@ public class Discovery internal constructor(
                             }
 
                             is NsdBrowserEvent.Resolved -> {
-                                Log.d(
+                                Log.i(
                                     TAG,
                                     "browse: serviceResolved name=${event.instanceName} " +
                                         "addrs=${event.addresses.joinToString { it.hostAddress }} " +
-                                        "port=${event.port}",
+                                        "port=${event.port} " +
+                                        "txt=${formatTxtRecord(event.attributes)}",
                                 )
                                 diagnostics.recordEvent(
                                     DiagnosticEvent(
@@ -214,7 +223,7 @@ public class Discovery internal constructor(
                             }
 
                             is NsdBrowserEvent.Lost -> {
-                                Log.d(TAG, "browse: serviceLost name=${event.instanceName}")
+                                Log.i(TAG, "browse: serviceLost name=${event.instanceName}")
                                 diagnostics.recordEvent(
                                     DiagnosticEvent(
                                         kind = DiagnosticEvent.Kind.REMOVED,
@@ -276,6 +285,20 @@ public class Discovery internal constructor(
         if (addresses.isNotEmpty() && addresses.all { it.isLoopbackAddress }) {
             return null
         }
+        // The system mDNS responder reflects our own published
+        // advertisement back to our own browser through multicast
+        // loopback (the LAN IP the responder bound to is reachable on
+        // the same interface the browser listens on). Without this
+        // check, the sender-side picker would surface our own receiver
+        // TCP listener as a peer — picking it runs a WVMG-to-WVMG
+        // self-loopback transfer that completes successfully but never
+        // reaches a remote device. Cross-checking by instanceName is
+        // sufficient because mDNS-name uniqueness is guaranteed by the
+        // system NSD's auto-suffix-on-collision behaviour.
+        if (filterSelfPublishedInstances && LocalAdvertisedInstances.contains(event.instanceName)) {
+            Log.i(TAG, "browse: dropping self-loopback record ${event.instanceName}")
+            return null
+        }
 
         val rawTxt = event.attributes[QuickShareMdns.TXT_KEY_ENDPOINT_INFO]
         val decodedTxt = decodeTxtEndpointInfo(rawTxt)
@@ -295,6 +318,36 @@ public class Discovery internal constructor(
             port = event.port,
             endpointInfo = endpointInfo,
         )
+    }
+
+    /**
+     * Render a TXT record as a single-line `k1=v1, k2=v2, ...` string
+     * for diagnostic logging. Values are tried as ASCII first (so Quick
+     * Share's typical `n=<base64>` / `IPv4=<dotted>` / `b=<MAC>` keys
+     * stay human-readable); any value that isn't valid printable ASCII
+     * is rendered as `0x<hex>`. The output is bounded — values longer
+     * than 256 bytes are truncated with `…(<n> more)` so a misbehaving
+     * peer can't blow up logcat.
+     */
+    private fun formatTxtRecord(attributes: Map<String, ByteArray>): String {
+        if (attributes.isEmpty()) return "<empty>"
+        return attributes.entries
+            .sortedBy { it.key }
+            .joinToString(", ") { (key, value) -> "$key=${formatTxtValue(value)}" }
+    }
+
+    private fun formatTxtValue(value: ByteArray): String {
+        val cap = 256
+        val truncated = value.size > cap
+        val view = if (truncated) value.copyOfRange(0, cap) else value
+        val printable = view.all { b -> b.toInt() in 0x20..0x7E }
+        val rendered =
+            if (printable) {
+                "\"${String(view, Charsets.US_ASCII)}\""
+            } else {
+                "0x${view.joinToString("") { "%02x".format(it) }}"
+            }
+        return if (truncated) "$rendered…(${value.size - cap} more)" else rendered
     }
 
     /**
@@ -372,7 +425,14 @@ public class Discovery internal constructor(
             registrar: NsdRegistrar,
             browser: NsdBrowser,
             networkWatcherFactory: NetworkWatcherFactory = NetworkWatcherFactory.NoOp,
-        ): Discovery = Discovery(registrar, browser, networkWatcherFactory)
+            filterSelfPublishedInstances: Boolean = false,
+        ): Discovery =
+            Discovery(
+                registrar = registrar,
+                browser = browser,
+                networkWatcherFactory = networkWatcherFactory,
+                filterSelfPublishedInstances = filterSelfPublishedInstances,
+            )
 
         private fun systemNsdManager(context: Context): NsdManager =
             context.applicationContext.getSystemService(Context.NSD_SERVICE) as NsdManager
@@ -448,6 +508,7 @@ internal class NsdAdvertiseHandle(
             current?.close()
             current = null
         }
+        LocalAdvertisedInstances.unregister(registeredName)
         onClose()
     }
 
@@ -482,6 +543,9 @@ internal class NsdAdvertiseHandle(
             // contract of [Discovery.advertise] is "publish synchronously
             // before returning"; the call is bounded by NsdManager's
             // own timeout.
+            // Drop any prior name from the self-publish set if the
+            // platform auto-suffixed our name on a previous re-register.
+            LocalAdvertisedInstances.unregister(registeredName)
             val handle =
                 runBlocking {
                     registrar.register(
@@ -493,6 +557,14 @@ internal class NsdAdvertiseHandle(
                 }
             current = handle
             registeredName = handle.instanceName
+            // Add to the process-wide self-publish set so the browse
+            // path can drop our own record when the system NSD reflects
+            // it back through multicast loopback. Without this, the
+            // sender-side picker shows "Quick Share Device" entries
+            // that point at our own receiver TCP listener — picking
+            // one runs a self-loopback transfer that "succeeds" but
+            // does not actually reach a remote peer.
+            LocalAdvertisedInstances.register(registeredName)
             diagnostics.setAdvertiseBound(handle.hostAddress)
             Log.i(
                 Discovery.TAG,
@@ -501,6 +573,37 @@ internal class NsdAdvertiseHandle(
             )
         }
     }
+}
+
+/**
+ * Process-wide registry of mDNS instance names this app is currently
+ * advertising. Populated by [NsdAdvertiseHandle.register] and drained
+ * by [NsdAdvertiseHandle.close]; consulted by
+ * [Discovery.toDiscoveredService] to drop multicast-loopback echoes of
+ * our own advertisements.
+ *
+ * **Why a process-wide singleton?** The receiver-side
+ * [Discovery.advertise] and the sender-side [Discovery.browse] live on
+ * separate [Discovery] instances (the receiver foreground service and
+ * `SendActivity` each construct their own), but they share the same
+ * JVM. The cross-instance state is small (a single `Set<String>`),
+ * write-on-publish/close, and contention-free in practice.
+ */
+internal object LocalAdvertisedInstances {
+    private val names: java.util.concurrent.ConcurrentHashMap<String, Unit> =
+        java.util.concurrent.ConcurrentHashMap()
+
+    fun register(instanceName: String) {
+        if (instanceName.isBlank()) return
+        names[instanceName] = Unit
+    }
+
+    fun unregister(instanceName: String) {
+        if (instanceName.isBlank()) return
+        names.remove(instanceName)
+    }
+
+    fun contains(instanceName: String): Boolean = names.containsKey(instanceName)
 }
 
 /**

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/MdnsAdvertisementGate.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/MdnsAdvertisementGate.kt
@@ -10,6 +10,7 @@ import io.github.kyujincho.wvmg.discovery.ble.ScanActivity
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -74,6 +75,14 @@ import kotlinx.coroutines.launch
  *   `BleQuickShareScanner.activity` via [ActiveBleScannerHolder].
  * @param alwaysVisibleOverride sticky user-controlled override.
  * @param qrSessionActive QR-code-flow bypass flag.
+ * @param outboundSessionActive when `true`, vetoes any publish decision
+ *   and tears the mDNS record down. Used by `SendActivity` to prevent
+ *   the receiver-side mDNS publish from racing with our outbound
+ *   connection — Samsung One UI 8.0.5's GMS Nearby caches state for
+ *   our endpoint from the discovered WIFI_LAN service and then fails
+ *   `securegcm::UKey2Handshake::ParseHandshakeMessage` on the incoming
+ *   `client_finished` from the same IP. See
+ *   [OutboundSessionActiveHolder] for the full rationale.
  * @param debounceIdleMillis time after the last "should publish" signal
  *   before the gate unpublishes the advertisement. 30 s by default per
  *   issue #34.
@@ -83,6 +92,7 @@ public class MdnsAdvertisementGate(
     private val bleActivity: StateFlow<ScanActivity>,
     private val alwaysVisibleOverride: StateFlow<Boolean>,
     private val qrSessionActive: StateFlow<Boolean>,
+    private val outboundSessionActive: StateFlow<Boolean> = MutableStateFlow(false),
     private val debounceIdleMillis: Long = DEFAULT_DEBOUNCE_IDLE_MILLIS,
 ) {
     @Volatile
@@ -139,6 +149,9 @@ public class MdnsAdvertisementGate(
                 launch {
                     qrSessionActive.collect { apply(currentDecision(), scope) }
                 }
+                launch {
+                    outboundSessionActive.collect { apply(currentDecision(), scope) }
+                }
             }
     }
 
@@ -147,6 +160,7 @@ public class MdnsAdvertisementGate(
             bleActive = bleActivity.value is ScanActivity.Active,
             overrideOn = alwaysVisibleOverride.value,
             qrActive = qrSessionActive.value,
+            outboundActive = outboundSessionActive.value,
         )
 
     /**
@@ -172,7 +186,30 @@ public class MdnsAdvertisementGate(
         decision: Decision,
         scope: CoroutineScope,
     ) = synchronized(applyLock) {
-        val shouldPublish = decision.bleActive || decision.overrideOn || decision.qrActive
+        // An active outbound send unconditionally vetoes publishing,
+        // regardless of any other "should publish" signal — and tears
+        // down immediately, bypassing the 30-second debounce window.
+        // The race window with Samsung's UKEY2 server is on the order of
+        // milliseconds; honouring the BLE-pulse debounce here would
+        // leave the receiver-side mDNS advertised throughout the entire
+        // outbound session and re-trigger Samsung's
+        // `securegcm::UKey2Handshake::ParseHandshakeMessage` failure on
+        // every connect.
+        if (decision.outboundActive) {
+            debounceJob?.cancel()
+            debounceJob = null
+            if (session.isAdvertising) {
+                try {
+                    session.unpublishAdvertisement()
+                    Log.w(TAG, "unpublish: outbound send active; mDNS taken down immediately")
+                } catch (t: Throwable) {
+                    Log.w(TAG, "unpublish: threw during outbound veto", t)
+                }
+            }
+            return
+        }
+        val shouldPublish =
+            decision.bleActive || decision.overrideOn || decision.qrActive
         if (shouldPublish) {
             // Cancel any pending unpublish — we're back inside the
             // "should publish" half of the gate.
@@ -228,6 +265,7 @@ public class MdnsAdvertisementGate(
         val bleActive: Boolean,
         val overrideOn: Boolean,
         val qrActive: Boolean,
+        val outboundActive: Boolean,
     )
 
     public companion object {

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
@@ -342,6 +342,7 @@ public class ReceiverForegroundService : Service() {
                         ),
                 alwaysVisibleOverride = MdnsVisibilityOverrideHolder.activeFlow,
                 qrSessionActive = QrSessionActiveHolder.activeFlow,
+                outboundSessionActive = OutboundSessionActiveHolder.activeFlow,
             )
         gate.start(serviceScope)
         mdnsGate = gate
@@ -792,6 +793,53 @@ public object QrSessionActiveHolder {
      * or is cancelled.
      */
     public fun setQrSessionActive(active: Boolean) {
+        state.value = active
+    }
+}
+
+/**
+ * Process-wide flag for "an outbound send is currently in progress".
+ *
+ * Flipped on by `SendActivity.onCreate` and off by `onDestroy`. When set,
+ * [MdnsAdvertisementGate] vetoes its publish decision and tears the
+ * receiver-side mDNS record down for the duration of the send.
+ *
+ * **Why veto?** Empirical observation against Samsung Galaxy S24 Ultra
+ * (One UI 8.0.5 / Android 16): when WVMG concurrently publishes its
+ * receiver-side mDNS record AND opens an outbound `OutboundConnection`
+ * to the same Galaxy peer, Samsung's GMS Nearby (`NearbyConnections`)
+ * caches state for our endpoint from the WIFI_LAN service it
+ * discovered, then on the incoming TCP connect — same source IP,
+ * different endpoint id, sender role — Samsung's
+ * `securegcm::UKey2Handshake::ParseHandshakeMessage` fails on
+ * `client_finished` (verified ~73-267 ms after Samsung writes
+ * `server_init`, far below the 15-second `CancelableAlarm` timeout).
+ * Force-stopping the receiver service before a send unblocks UKEY2
+ * cleanly (verified end-to-end on the same hotspot setup); pausing the
+ * gate is the same effect, scoped automatically to the send.
+ *
+ * The gate's existing 30-second idle debounce remains in effect on the
+ * resume side: when `SendActivity` finishes and the flag flips off, the
+ * gate re-evaluates and re-publishes mDNS if any of the existing
+ * `bleActive` / `overrideOn` / `qrActive` signals call for it.
+ */
+public object OutboundSessionActiveHolder {
+    private val state: kotlinx.coroutines.flow.MutableStateFlow<Boolean> =
+        kotlinx.coroutines.flow.MutableStateFlow(false)
+
+    /** Hot flow signalling whether an outbound send is in progress. */
+    public val activeFlow: kotlinx.coroutines.flow.StateFlow<Boolean> = state
+
+    /** Current snapshot of [activeFlow]. */
+    public val isActive: Boolean
+        get() = state.value
+
+    /**
+     * Set the outbound-session flag. The host activity flips this on
+     * when [io.github.kyujincho.wvmg.send.SendActivity] enters the
+     * foreground and off when it leaves.
+     */
+    public fun setOutboundSessionActive(active: Boolean) {
         state.value = active
     }
 }


### PR DESCRIPTION
## Headline

`fix(ukey2): keep leading 0x00 sign byte on MSB-set P-256 coordinates` — the actual root cause of the random ~50%-rate UKEY2 silent FINs we'd been chasing on a Galaxy S24 Ultra (One UI 8.0.5 / Android 16). Backed by the Galaxy's GMS Nearby log captured during the failure:

\`\`\`
E NearbyConnections: iwmx: iwnj: Cannot parse public key:
    Point encoding must use only non-negative integers
    at iwnm.p (...)        <-- ECPoint coordinate parse
    at iwnm.b (...)        <-- ParseHandshakeMessage
\`\`\`

Samsung's UKEY2 server constructs each P-256 coordinate via \`new BigInteger(byte[])\` (signed two's complement). When our serializer stripped the leading 0x00 sign byte that \`BigInteger.toByteArray()\` emits for values whose 256-bit representation has bit 255 = 1 (random ~50% of keypairs), Samsung saw a 32-byte input with the top bit set and parsed it as a *negative* integer. BouncyCastle's ECPoint constructor then rejected it. Random keypair → random failure rate. Verified end-to-end: every connect attempt after the fix advances past UKEY2 cleanly.

## What's in the bundle

1. \`fix(ukey2)\`: P-256 negative-coordinate fix + regression test (the headline).
2. \`fix(outbound)\`: fresh endpoint id per connect (matches stock & NearDrop) + \`tcpNoDelay = true\` on the sender socket (mirrors the receiver path).
3. \`feat(discovery)\`: verbose TXT logging on every \`serviceResolved\` (was indispensable in finding the P-256 bug) + multicast-loopback self-filter so the picker doesn't surface our own receiver TCP listener as a peer.
4. \`feat(receiver)\`: pause receiver-side mDNS publish while \`SendActivity\` is in foreground, via a process-wide \`OutboundSessionActiveHolder\` veto on \`MdnsAdvertisementGate\`. Bypasses the BLE-pulse 30-second debounce on the veto path.
5. \`feat(send)\`: picker dedup by \`(primaryAddress, port)\` (collapses Samsung's rotating-instance-id rows into one), tie-breaker prefers named records, and a verbose target snapshot logged on pick.

## Known follow-up (not a regression)

On vivo Funtouch's \`NsdManager\`, registering a service of the same type as one we're discovering can put the system NSD's listener into a degraded state that doesn't fully recover after the unregister. With \`always-visible\` toggled on, the picker may then fail to find the Galaxy peer it had previously seen. Tracked separately; the gate veto landed here is still net-positive (stops the cross-role state pollution on stock Galaxy) and is a prerequisite for the deeper Funtouch-NSD workaround.