### PR TITLE
feat(payload): preserve last_modified_timestamp_millis on receive

### DIFF
--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/send/UriFileSourceFactory.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/send/UriFileSourceFactory.kt
@@ -8,6 +8,7 @@ package io.github.kyujincho.wvmg.send
 import android.content.ContentResolver
 import android.database.Cursor
 import android.net.Uri
+import android.provider.MediaStore
 import android.provider.OpenableColumns
 import io.github.kyujincho.wvmg.protocol.connection.FileSource
 import java.nio.channels.Channels
@@ -130,7 +131,18 @@ public class UriFileSourceFactory internal constructor(
             name = name,
             size = size,
             mimeType = mimeType,
-            lastModifiedTimestampMillis = 0L,
+            // MediaStore.MediaColumns.DATE_MODIFIED is "seconds since
+            // epoch"; the proto field is millis. Convert here so the
+            // wire carries the same precision the receiver expects.
+            // 0 / negative is the documented "unknown" value — pass
+            // through unchanged so the receiver leaves the platform
+            // default rather than rewriting to the Unix epoch.
+            lastModifiedTimestampMillis =
+                if (metadata.lastModifiedSeconds > 0L) {
+                    metadata.lastModifiedSeconds * SECOND_IN_MILLIS
+                } else {
+                    0L
+                },
             payloadId = payloadId,
             open = open,
         )
@@ -139,6 +151,9 @@ public class UriFileSourceFactory internal constructor(
     public companion object {
         /** Fallback display name when neither MediaStore nor the URI carries one. */
         public const val DEFAULT_NAME: String = "shared-file"
+
+        /** Conversion factor between `DATE_MODIFIED` (seconds) and the wire's millis. */
+        internal const val SECOND_IN_MILLIS: Long = 1000L
 
         /**
          * Generates a positive 63-bit payload id. The Quick Share
@@ -174,6 +189,15 @@ public data class UriMetadata(
     val size: Long,
     /** `ContentResolver.getType(uri)`. `null` when no mapping is known. */
     val mimeType: String?,
+    /**
+     * `MediaStore.MediaColumns.DATE_MODIFIED`. Documented as **seconds**
+     * since epoch (the proto wire format is millis — the conversion
+     * happens in [UriFileSourceFactory.buildFileSource]). `0L` when the
+     * column is missing or null; many providers (e.g. NFC share, in-app
+     * stream URIs) do not expose a modification time and that's a
+     * documented "unknown" value, not an error. See issue #41.
+     */
+    val lastModifiedSeconds: Long = 0L,
 )
 
 /**
@@ -208,33 +232,48 @@ internal class ContentResolverMetadataReader(
     private val contentResolver: ContentResolver,
 ) : UriMetadataReader {
     override fun read(uri: Uri): UriMetadata {
-        val (displayName, size) = readOpenableColumns(uri)
+        val cursorMetadata = readCursorColumns(uri)
         val mime = contentResolver.getType(uri)
-        return UriMetadata(displayName = displayName, size = size, mimeType = mime)
+        return UriMetadata(
+            displayName = cursorMetadata.displayName,
+            size = cursorMetadata.size,
+            mimeType = mime,
+            lastModifiedSeconds = cursorMetadata.lastModifiedSeconds,
+        )
     }
 
     /**
-     * Issues a `query()` against the `OpenableColumns` projection and
-     * extracts the display name + size with documented fallbacks
-     * (`null` / `-1`) for missing or null cells. Lifted out of [read]
-     * so the cursor-walk depth stays well under detekt's [NestedBlockDepth]
-     * threshold.
+     * Issues a `query()` against [PROJECTION] and extracts the display
+     * name, size, and last-modified timestamp with documented fallbacks
+     * (`null` / `-1` / `0`) for missing or null cells. Lifted out of
+     * [read] so the cursor-walk depth stays well under detekt's
+     * `NestedBlockDepth` threshold.
+     *
+     * `MediaStore.MediaColumns.DATE_MODIFIED` is queried alongside the
+     * `OpenableColumns` so a single cursor walk captures everything
+     * needed to populate [UriMetadata]. Providers that do not expose
+     * `DATE_MODIFIED` simply return a missing column, which we map to
+     * `0L` (the documented "unknown" sentinel — `FileSource` then
+     * forwards `0L` onto the wire and the receiver leaves the
+     * platform's default modification time).
      */
-    private fun readOpenableColumns(uri: Uri): Pair<String?, Long> {
+    private fun readCursorColumns(uri: Uri): CursorMetadata {
         var displayName: String? = null
         var size: Long = -1L
+        var lastModifiedSeconds: Long = 0L
         // ContentResolver.query: (uri, projection, selection, selectionArgs, sortOrder).
-        // Selection / args / order are unused — we only need both
-        // OpenableColumns rows for the single referenced URI.
+        // Selection / args / order are unused — we only need the
+        // projection columns for the single referenced URI.
         contentResolver
             .query(uri, PROJECTION, null, null, null)
             ?.use { cursor: Cursor ->
                 if (cursor.moveToFirst()) {
                     displayName = readDisplayName(cursor)
                     size = readSize(cursor)
+                    lastModifiedSeconds = readLastModifiedSeconds(cursor)
                 }
             }
-        return displayName to size
+        return CursorMetadata(displayName, size, lastModifiedSeconds)
     }
 
     private fun readDisplayName(cursor: Cursor): String? {
@@ -250,8 +289,33 @@ internal class ContentResolverMetadataReader(
         return cursor.getLong(index)
     }
 
+    private fun readLastModifiedSeconds(cursor: Cursor): Long {
+        val index = cursor.getColumnIndex(MediaStore.MediaColumns.DATE_MODIFIED)
+        if (index < 0 || cursor.isNull(index)) return 0L
+        // MediaStore documents DATE_MODIFIED as Unix-time seconds. We
+        // surface negative or zero values as 0L so the upstream caller
+        // can route them through the "unknown timestamp" path.
+        return cursor.getLong(index).coerceAtLeast(0L)
+    }
+
+    /**
+     * Internal value carrier for the three cursor-derived columns. A
+     * `Triple` would compile but reading `.third` for a long-since-epoch
+     * timestamp is unfriendly to call sites.
+     */
+    private data class CursorMetadata(
+        val displayName: String?,
+        val size: Long,
+        val lastModifiedSeconds: Long,
+    )
+
     private companion object {
-        val PROJECTION = arrayOf(OpenableColumns.DISPLAY_NAME, OpenableColumns.SIZE)
+        val PROJECTION =
+            arrayOf(
+                OpenableColumns.DISPLAY_NAME,
+                OpenableColumns.SIZE,
+                MediaStore.MediaColumns.DATE_MODIFIED,
+            )
     }
 }
 

--- a/app/src/test/kotlin/io/github/kyujincho/wvmg/send/UriFileSourceFactoryTest.kt
+++ b/app/src/test/kotlin/io/github/kyujincho/wvmg/send/UriFileSourceFactoryTest.kt
@@ -55,6 +55,56 @@ class UriFileSourceFactoryTest {
     }
 
     @Test
+    fun `carries last modified seconds converted to millis on the wire`() {
+        // Issue #41: MediaColumns.DATE_MODIFIED is documented as Unix
+        // seconds. The proto wire format for
+        // PayloadHeader.last_modified_timestamp_millis is millis. The
+        // factory must convert at the boundary so the receiver sees the
+        // sender's actual mtime (not 1000x off, not zero).
+        val factory = factoryWithFixedId(2024)
+
+        val source =
+            factory.buildFileSource(
+                metadata =
+                    UriMetadata(
+                        displayName = "dated.bin",
+                        size = 4,
+                        mimeType = "application/octet-stream",
+                        lastModifiedSeconds = 1_700_000_000L,
+                    ),
+                fallbackPathSegment = null,
+                payloadId = 2024,
+                open = { newChannel(sampleBytes) },
+            )
+
+        assertEquals(1_700_000_000_000L, source.lastModifiedTimestampMillis)
+    }
+
+    @Test
+    fun `zero last modified seconds produces zero millis on the wire`() {
+        // Provider returned no DATE_MODIFIED column, surfaced as 0L.
+        // The factory must keep that as 0L on the wire so the receiver
+        // does not rewrite the file's mtime to the Unix epoch.
+        val factory = factoryWithFixedId(2025)
+
+        val source =
+            factory.buildFileSource(
+                metadata =
+                    UriMetadata(
+                        displayName = "undated.bin",
+                        size = 0,
+                        mimeType = null,
+                        lastModifiedSeconds = 0L,
+                    ),
+                fallbackPathSegment = null,
+                payloadId = 2025,
+                open = { newChannel(sampleBytes) },
+            )
+
+        assertEquals(0L, source.lastModifiedTimestampMillis)
+    }
+
+    @Test
     fun `falls back to last path segment when display name missing`() {
         val factory = factoryWithFixedId(7)
 

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/downloads/DownloadsEnvironment.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/downloads/DownloadsEnvironment.kt
@@ -85,8 +85,20 @@ internal interface DownloadsEnvironment {
     /**
      * Make the destination visible to the user. Idempotent — a
      * second call is a no-op.
+     *
+     * @param lastModifiedTimestampMillis When non-zero, request that the
+     *   environment record this value as the destination's modification
+     *   time (seconds-precision on `MediaStore`, millis on the legacy
+     *   filesystem). `0L` means "leave the platform default", which is
+     *   the right behavior when the sender never carried a timestamp
+     *   (e.g. NearDrop pre-grishka/NearDrop#195, or any peer that left
+     *   `PayloadHeader.last_modified_timestamp_millis = 0`). See
+     *   issue #41 for the wire-side analysis.
      */
-    fun commit(destination: Destination)
+    fun commit(
+        destination: Destination,
+        lastModifiedTimestampMillis: Long = 0L,
+    )
 
     /**
      * Delete the destination's underlying storage. Used on cancel or

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/downloads/DownloadsWriter.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/downloads/DownloadsWriter.kt
@@ -189,12 +189,18 @@ internal class DownloadsWriter(
          * (especially `MediaStore` on API 29+) cannot mark a row
          * non-pending while a `ContentResolver` output stream is
          * still open against it.
+         *
+         * @param lastModifiedTimestampMillis Sender-provided modification
+         *   time from `PayloadHeader.last_modified_timestamp_millis`. Pass
+         *   `0L` (the default) when no timestamp was carried; the
+         *   environment leaves the platform default in that case. See
+         *   issue #41.
          */
-        fun commit() {
+        fun commit(lastModifiedTimestampMillis: Long = 0L) {
             if (disposed) return
             disposed = true
             runCatching { outputStream.close() }
-            environment.commit(destination)
+            environment.commit(destination, lastModifiedTimestampMillis)
         }
 
         /**

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/downloads/LegacyDownloadsEnvironment.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/downloads/LegacyDownloadsEnvironment.kt
@@ -87,7 +87,10 @@ internal class LegacyDownloadsEnvironment(
         return FileOutputStream(partFile, false)
     }
 
-    override fun commit(destination: DownloadsEnvironment.Destination) {
+    override fun commit(
+        destination: DownloadsEnvironment.Destination,
+        lastModifiedTimestampMillis: Long,
+    ) {
         val (partFile, displayName) = destination.requireLegacyPair()
         val finalFile = File(downloadsDir, displayName)
         // renameTo is best-effort on legacy filesystems. If it fails
@@ -96,6 +99,15 @@ internal class LegacyDownloadsEnvironment(
         if (!partFile.renameTo(finalFile)) {
             partFile.copyTo(finalFile, overwrite = false)
             partFile.delete()
+        }
+        // Apply the sender's mtime AFTER the rename — `File.setLastModified`
+        // on the placeholder would be lost during `renameTo` on some
+        // filesystems. Best-effort: a failure (e.g. read-only mount,
+        // exotic FS that does not support setMTime) is silently ignored
+        // because the bytes are already safely on disk; users can
+        // observe the modify time via the OS regardless.
+        if (lastModifiedTimestampMillis > 0L) {
+            runCatching { finalFile.setLastModified(lastModifiedTimestampMillis) }
         }
     }
 

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/downloads/MediaStoreDownloadsEnvironment.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/downloads/MediaStoreDownloadsEnvironment.kt
@@ -79,11 +79,24 @@ internal class MediaStoreDownloadsEnvironment(
             ?: throw IOException("ContentResolver.openOutputStream returned null for $uri")
     }
 
-    override fun commit(destination: DownloadsEnvironment.Destination) {
+    override fun commit(
+        destination: DownloadsEnvironment.Destination,
+        lastModifiedTimestampMillis: Long,
+    ) {
         val uri = destination.requireMediaStoreUri()
         val values =
             ContentValues().apply {
                 put(MediaStore.Downloads.IS_PENDING, 0)
+                // MediaStore.MediaColumns.DATE_MODIFIED is documented as
+                // "seconds since epoch" — divide the wire-format millis
+                // before writing. We only set the column when the
+                // sender actually carried a timestamp; passing `0` (the
+                // proto default) here would silently rewrite valid
+                // rows to the Unix epoch, which is worse than leaving
+                // the platform's "now" default.
+                if (lastModifiedTimestampMillis > 0L) {
+                    put(MediaStore.MediaColumns.DATE_MODIFIED, lastModifiedTimestampMillis / SECOND_IN_MILLIS)
+                }
             }
         // Best-effort: a failure here means the file is on disk but
         // remains marked pending. The orchestrator surfaces the error
@@ -118,5 +131,10 @@ internal class MediaStoreDownloadsEnvironment(
             "MediaStoreDownloadsEnvironment received a destination it didn't issue: $this"
         }
         return uri
+    }
+
+    private companion object {
+        /** Conversion factor between the wire's millis precision and `DATE_MODIFIED`'s seconds precision. */
+        const val SECOND_IN_MILLIS: Long = 1000L
     }
 }

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/downloads/MediaStoreDownloadsFactory.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/downloads/MediaStoreDownloadsFactory.kt
@@ -65,10 +65,23 @@ public class MediaStoreDownloadsFactory internal constructor(
     private val writer: DownloadsWriter,
 ) : FileDestinationFactory {
     /**
-     * Map of payload id -> open destination handle. A payload that is
+     * Per-payload tracking entry. Bundles the [DownloadsWriter.Handle]
+     * with the sender-supplied `last_modified_timestamp_millis` captured
+     * at [open] time so that [commit] can apply it to the destination
+     * (issue #41). A separate field — rather than re-reading from a
+     * cached `PayloadHeader` — avoids retaining the protobuf object
+     * any longer than the assembler does.
+     */
+    private class InFlightEntry(
+        val handle: DownloadsWriter.Handle,
+        val lastModifiedTimestampMillis: Long,
+    )
+
+    /**
+     * Map of payload id -> tracking entry. A payload that is
      * mid-transfer has an entry; on commit/abort the entry is removed.
      */
-    private val inFlight: MutableMap<Long, DownloadsWriter.Handle> = ConcurrentHashMap()
+    private val inFlight: MutableMap<Long, InFlightEntry> = ConcurrentHashMap()
 
     /**
      * Open a destination channel for an inbound FILE payload. Called
@@ -94,8 +107,15 @@ public class MediaStoreDownloadsFactory internal constructor(
         val handle = writer.beginWrite(rawFileName = header.fileName, mimeType = null)
         // Track by payload id so the orchestrator can later commit
         // or abort using only the id (it doesn't keep a reference to
-        // the channel itself).
-        inFlight[header.id] = handle
+        // the channel itself). We also stash the sender's last-modified
+        // timestamp here (issue #41) so commit() can route it through
+        // to the environment without the orchestrator having to
+        // re-thread the header.
+        inFlight[header.id] =
+            InFlightEntry(
+                handle = handle,
+                lastModifiedTimestampMillis = header.lastModifiedTimestampMillis,
+            )
         // OutputStream -> WritableByteChannel adapter from java.nio.
         // Buffers internally; safe for the assembler's per-chunk
         // ByteBuffer writes.
@@ -115,8 +135,8 @@ public class MediaStoreDownloadsFactory internal constructor(
      *   (already committed, already aborted, or never opened).
      */
     override fun commit(payloadId: Long): Boolean {
-        val handle = inFlight.remove(payloadId) ?: return false
-        handle.commit()
+        val entry = inFlight.remove(payloadId) ?: return false
+        entry.handle.commit(lastModifiedTimestampMillis = entry.lastModifiedTimestampMillis)
         return true
     }
 
@@ -134,8 +154,8 @@ public class MediaStoreDownloadsFactory internal constructor(
      *   has now been discarded; `false` if no such destination exists.
      */
     override fun abort(payloadId: Long): Boolean {
-        val handle = inFlight.remove(payloadId) ?: return false
-        handle.discard()
+        val entry = inFlight.remove(payloadId) ?: return false
+        entry.handle.discard()
         return true
     }
 

--- a/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/downloads/DownloadsWriterTest.kt
+++ b/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/downloads/DownloadsWriterTest.kt
@@ -189,7 +189,10 @@ class DownloadsWriterTest {
 
                 override fun openOutputStream(destination: DownloadsEnvironment.Destination) = error("not reached")
 
-                override fun commit(destination: DownloadsEnvironment.Destination) = error("not reached")
+                override fun commit(
+                    destination: DownloadsEnvironment.Destination,
+                    lastModifiedTimestampMillis: Long,
+                ) = error("not reached")
 
                 override fun discard(destination: DownloadsEnvironment.Destination) = error("not reached")
             }

--- a/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/downloads/FakeDownloadsEnvironment.kt
+++ b/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/downloads/FakeDownloadsEnvironment.kt
@@ -66,11 +66,18 @@ internal class FakeDownloadsEnvironment(
         return slot.buffer
     }
 
-    override fun commit(destination: DownloadsEnvironment.Destination) {
+    override fun commit(
+        destination: DownloadsEnvironment.Destination,
+        lastModifiedTimestampMillis: Long,
+    ) {
         val slot = slots[destination.displayName] ?: return
         if (slot.discarded) return
         slot.pending = false
         slot.committed = true
+        // Record the timestamp the writer asked for so #41's tests can
+        // assert that the per-payload value was preserved end-to-end
+        // through the factory layer.
+        slot.committedLastModifiedTimestampMillis = lastModifiedTimestampMillis
     }
 
     override fun discard(destination: DownloadsEnvironment.Destination) {
@@ -91,6 +98,13 @@ internal class FakeDownloadsEnvironment(
         var pending: Boolean,
         var committed: Boolean,
         var discarded: Boolean,
+        /**
+         * Whatever value [commit] was last invoked with for this slot.
+         * `0L` until commit fires; tests for #41 assert that the
+         * factory routes the sender's
+         * `PayloadHeader.last_modified_timestamp_millis` through here.
+         */
+        var committedLastModifiedTimestampMillis: Long = 0L,
     ) : DownloadsEnvironment.Destination {
         override val internalKey: Any get() = displayName
     }

--- a/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/downloads/LegacyDownloadsEnvironmentTest.kt
+++ b/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/downloads/LegacyDownloadsEnvironmentTest.kt
@@ -60,6 +60,50 @@ class LegacyDownloadsEnvironmentTest {
     }
 
     @Test
+    fun `commit applies the senders last_modified timestamp to the visible file`(
+        @TempDir downloadsDir: Path,
+    ) {
+        // Issue #41: when the sender carries
+        // PayloadHeader.last_modified_timestamp_millis, commit must
+        // route it to the on-disk file so the user sees the original
+        // mtime (matching stock Quick Share behavior — and fixing
+        // grishka/NearDrop#195's complaint at the receiver level).
+        val env = LegacyDownloadsEnvironment(downloadsDir.toFile())
+        val ts = 1_700_000_000_000L
+
+        val destination = env.insertPending("dated.txt", mimeType = "text/plain")
+        env.openOutputStream(destination).use { it.write(byteArrayOf(0x01)) }
+        env.commit(destination, lastModifiedTimestampMillis = ts)
+
+        val finalFile = File(downloadsDir.toFile(), "dated.txt")
+        assertThat(finalFile.exists()).isTrue()
+        // POSIX filesystems and most JDK implementations support
+        // millisecond precision on setLastModified; accept exact match.
+        assertThat(finalFile.lastModified()).isEqualTo(ts)
+    }
+
+    @Test
+    fun `commit with zero timestamp leaves the platform default mtime`(
+        @TempDir downloadsDir: Path,
+    ) {
+        // A 0L timestamp means the sender did not advertise an mtime;
+        // the receiver must NOT overwrite the file's own creation time
+        // with the Unix epoch. Equivalent invariant to the MediaStore
+        // env's `if (lastModifiedTimestampMillis > 0L)` guard.
+        val env = LegacyDownloadsEnvironment(downloadsDir.toFile())
+        val before = System.currentTimeMillis()
+
+        val destination = env.insertPending("no-ts.txt", mimeType = "text/plain")
+        env.openOutputStream(destination).use { it.write(byteArrayOf(0x02)) }
+        env.commit(destination, lastModifiedTimestampMillis = 0L)
+
+        val finalFile = File(downloadsDir.toFile(), "no-ts.txt")
+        // mtime must remain in the recent past, not be rewritten to
+        // the Unix epoch (which would be ~55 years ago).
+        assertThat(finalFile.lastModified()).isAtLeast(before - 5_000L)
+    }
+
+    @Test
     fun `discard deletes the placeholder and never produces a visible file`(
         @TempDir downloadsDir: Path,
     ) {

--- a/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/downloads/MediaStoreDownloadsFactoryTest.kt
+++ b/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/downloads/MediaStoreDownloadsFactoryTest.kt
@@ -80,6 +80,49 @@ class MediaStoreDownloadsFactoryTest {
     // ------------------------------------------------------------------
 
     @Test
+    fun `commit forwards the senders last_modified timestamp to the environment`() {
+        // Issue #41: PayloadHeader.last_modified_timestamp_millis must
+        // round-trip from the assembler's open() through the factory's
+        // commit() down to the underlying environment so the
+        // MediaStore row (or legacy file) carries the original mtime.
+        val env = FakeDownloadsEnvironment()
+        val factory = DownloadsWriterFactory.fromEnvironment(env)
+        val ts = 1_700_000_000_000L
+        val header =
+            PayloadHeader
+                .newBuilder()
+                .setId(123L)
+                .setType(PayloadHeader.PayloadType.FILE)
+                .setFileName("dated.bin")
+                .setTotalSize(0)
+                .setLastModifiedTimestampMillis(ts)
+                .build()
+
+        factory.open(header).close()
+        assertThat(factory.commit(header.id)).isTrue()
+
+        val slot = env.slots["dated.bin"]!!
+        assertThat(slot.committed).isTrue()
+        assertThat(slot.committedLastModifiedTimestampMillis).isEqualTo(ts)
+    }
+
+    @Test
+    fun `commit forwards zero when the sender omitted the timestamp`() {
+        // A peer that left last_modified_timestamp_millis at the proto
+        // default (0) must NOT cause us to overwrite the platform's
+        // default mtime — the environment receives 0L and ignores it.
+        val env = FakeDownloadsEnvironment()
+        val factory = DownloadsWriterFactory.fromEnvironment(env)
+        val header = fileHeader(id = 200L, name = "no-ts.bin", totalSize = 0)
+
+        factory.open(header).close()
+        assertThat(factory.commit(header.id)).isTrue()
+
+        val slot = env.slots["no-ts.bin"]!!
+        assertThat(slot.committedLastModifiedTimestampMillis).isEqualTo(0L)
+    }
+
+    @Test
     fun `commit returns true once and false on second call`() {
         val env = FakeDownloadsEnvironment()
         val factory = DownloadsWriterFactory.fromEnvironment(env)


### PR DESCRIPTION
## Summary

Closes #41.

`PayloadHeader.last_modified_timestamp_millis` carries the original mtime from the sender. Stock Quick Share sets it; NearDrop ignored it (grishka/NearDrop#195). This change makes the receiver apply the timestamp on disk and ensures our sender advertises it from `MediaStore.MediaColumns.DATE_MODIFIED`.

### Receiver (mtime applied on commit)
- `DownloadsEnvironment.commit` gains a `lastModifiedTimestampMillis` parameter.
- `MediaStoreDownloadsEnvironment` writes `MediaStore.MediaColumns.DATE_MODIFIED` (seconds; converts from the wire's millis).
- `LegacyDownloadsEnvironment` calls `File.setLastModified` *after* the rename (some FS lose the placeholder's mtime on rename).
- `MediaStoreDownloadsFactory` captures the timestamp at `open()` so `commit()` can route it without making the orchestrator track headers.
- `0L` (proto default) is preserved as "leave the platform default", so a pre-NearDrop-#195 peer that never advertised the field does not cause us to rewrite mtime to the Unix epoch.

### Sender (timestamp populated from MediaStore)
- `UriFileSourceFactory` queries `MediaStore.MediaColumns.DATE_MODIFIED` alongside `OpenableColumns` and converts seconds -> millis on the wire.
- Providers that do not expose `DATE_MODIFIED` surface `0L`, which falls through cleanly to the receiver's "leave default" path.

### Test coverage
- `MediaStoreDownloadsFactoryTest`: timestamp round-trips through `open` + `commit`; zero is preserved.
- `LegacyDownloadsEnvironmentTest`: `File.lastModified()` matches the requested timestamp; `0L` does not rewrite mtime.
- `UriFileSourceFactoryTest`: seconds -> millis conversion in `buildFileSource`; zero stays zero.
- `FakeDownloadsEnvironment` records `committedLastModifiedTimestampMillis` so the factory tests can assert end-to-end.

## Test plan
- [x] `./gradlew :core-protocol:test` passes
- [x] `./gradlew :service-android:testDebugUnitTest` passes (new + existing)
- [x] `./gradlew :app:testDebugUnitTest --tests UriFileSourceFactoryTest` passes
- [x] `./gradlew :app:assembleDebug` succeeds
- [x] `./gradlew staticAnalysis` (ktlint + detekt) clean
- [ ] Manual interop: send a dated file from this app to NearDrop / stock Quick Share and back; verify the saved file's mtime matches the source within 1 s