### PR TITLE
feat(protocol): accept mixed introductions and multiple text payloads (#40)

### DIFF
--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/InboundConnectionTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/InboundConnectionTest.kt
@@ -539,6 +539,198 @@ class InboundConnectionTest {
         }
 
     // -------------------------------------------------------------
+    // Mixed-introduction acceptance (issue #40)
+    // -------------------------------------------------------------
+
+    /**
+     * Regression guard for issue #40: an introduction that mixes
+     * `file_metadata` and multiple `text_metadata` entries (PLAIN +
+     * URL) MUST be accepted end-to-end.
+     *
+     * NearDrop's reference implementation rejects anything that is not
+     * a single file or a single text; the Quick Share wire protocol
+     * itself does not impose that restriction, and stock senders
+     * routinely pack a clipboard URL alongside a file. Pinning this
+     * behavior in a loopback test prevents a future refactor from
+     * silently re-introducing NearDrop's homogeneity check.
+     */
+    @Test
+    @Suppress("LongMethod") // End-to-end loopback inherently sets up sender + receiver fixtures inline.
+    fun `mixed introduction with file plus multiple text payloads completes`() =
+        runTest(timeout = kotlin.time.Duration.parse("30s")) {
+            val (clientSocket, serverSocket) = connectedSocketPair()
+            val factory = InMemoryFactory()
+            val rand = SecureRandom("inbound-mixed".toByteArray())
+            val inbound = InboundConnection(serverSocket, secureRandom = rand)
+
+            val fileBytes = ByteArray(2048) { (it and 0xFF).toByte() }
+            val filePayloadId = 0xCAFEL
+            val urlBytes = "https://example.test/note".toByteArray()
+            val urlPayloadId = 0xBEEFL
+            val plainBytes = "clipboard contents".toByteArray()
+            val plainPayloadId = 0xFACEL
+
+            val introduction =
+                IntroductionFrame
+                    .newBuilder()
+                    .addFileMetadata(
+                        Protocol.FileMetadata
+                            .newBuilder()
+                            .setName("attachment.bin")
+                            .setPayloadId(filePayloadId)
+                            .setSize(fileBytes.size.toLong())
+                            .setMimeType("application/octet-stream")
+                            .build(),
+                    ).addTextMetadata(
+                        Protocol.TextMetadata
+                            .newBuilder()
+                            .setTextTitle("link")
+                            .setPayloadId(urlPayloadId)
+                            .setSize(urlBytes.size.toLong())
+                            .setType(Protocol.TextMetadata.Type.URL)
+                            .build(),
+                    ).addTextMetadata(
+                        Protocol.TextMetadata
+                            .newBuilder()
+                            .setTextTitle("clip")
+                            .setPayloadId(plainPayloadId)
+                            .setSize(plainBytes.size.toLong())
+                            .setType(Protocol.TextMetadata.Type.TEXT)
+                            .build(),
+                    ).build()
+
+            coroutineScope {
+                val receiverJob = async { inbound.run(factory) }
+
+                launch {
+                    val state =
+                        inbound.state.first {
+                            it is InboundConnectionState.WaitingForUserConsent
+                        } as InboundConnectionState.WaitingForUserConsent
+                    // The consent metadata MUST surface every announced
+                    // attachment (one file + two texts) so the consent
+                    // UI can render an honest summary.
+                    assertThat(state.metadata.items).hasSize(3)
+                    val texts = state.metadata.items.filterIsInstance<TransferItem.Text>()
+                    assertThat(texts.map { it.kind })
+                        .containsExactly(
+                            TransferItem.Text.Kind.URL,
+                            TransferItem.Text.Kind.PLAIN,
+                        )
+                    inbound.submitUserConsent(accepted = true)
+                }
+
+                runSyntheticSender(
+                    socket = clientSocket,
+                    introduction = introduction,
+                    files = mapOf(filePayloadId to fileBytes),
+                    texts =
+                        mapOf(
+                            urlPayloadId to urlBytes,
+                            plainPayloadId to plainBytes,
+                        ),
+                    secureRandom = SecureRandom("sender-mixed".toByteArray()),
+                )
+
+                val result = receiverJob.await()
+                assertThat(result).isInstanceOf(InboundResult.Completed::class.java)
+                val items = (result as InboundResult.Completed).items
+
+                // Every announced item arrived, exactly once each.
+                assertThat(items).hasSize(3)
+                val byId = items.associateBy { it.payloadId }
+                val file = byId[filePayloadId] as ReceivedItem.File
+                assertThat(file.bytesWritten).isEqualTo(fileBytes.size.toLong())
+                val url = byId[urlPayloadId] as ReceivedItem.Text
+                assertThat(url.data).isEqualTo(urlBytes)
+                val plain = byId[plainPayloadId] as ReceivedItem.Text
+                assertThat(plain.data).isEqualTo(plainBytes)
+            }
+
+            // File bytes round-tripped through the in-memory factory.
+            val received = factory.output[filePayloadId]?.toByteArray()
+            assertThat(received).isEqualTo(fileBytes)
+            // Only FILE payloads are committed; the two text payloads
+            // are buffered in heap and never touch the destination
+            // factory.
+            assertThat(factory.committed).containsExactly(filePayloadId)
+        }
+
+    /**
+     * Regression guard for issue #40: an introduction with multiple
+     * `text_metadata` entries and zero files (e.g. clipboard text +
+     * a URL) is also accepted end-to-end. The text-only path is the
+     * common case for "Send to nearby" from a browser address bar
+     * paired with the page title.
+     */
+    @Test
+    fun `multiple text payloads without any files complete`() =
+        runTest(timeout = kotlin.time.Duration.parse("30s")) {
+            val (clientSocket, serverSocket) = connectedSocketPair()
+            val factory = InMemoryFactory()
+            val rand = SecureRandom("inbound-multitext".toByteArray())
+            val inbound = InboundConnection(serverSocket, secureRandom = rand)
+
+            val urlBytes = "https://example.test/page".toByteArray()
+            val urlPayloadId = 11L
+            val phoneBytes = "+15551234567".toByteArray()
+            val phonePayloadId = 12L
+
+            val introduction =
+                IntroductionFrame
+                    .newBuilder()
+                    .addTextMetadata(
+                        Protocol.TextMetadata
+                            .newBuilder()
+                            .setTextTitle("page")
+                            .setPayloadId(urlPayloadId)
+                            .setSize(urlBytes.size.toLong())
+                            .setType(Protocol.TextMetadata.Type.URL)
+                            .build(),
+                    ).addTextMetadata(
+                        Protocol.TextMetadata
+                            .newBuilder()
+                            .setTextTitle("contact")
+                            .setPayloadId(phonePayloadId)
+                            .setSize(phoneBytes.size.toLong())
+                            .setType(Protocol.TextMetadata.Type.PHONE_NUMBER)
+                            .build(),
+                    ).build()
+
+            coroutineScope {
+                val receiverJob = async { inbound.run(factory) }
+
+                launch {
+                    inbound.state.first { it is InboundConnectionState.WaitingForUserConsent }
+                    inbound.submitUserConsent(accepted = true)
+                }
+
+                runSyntheticSender(
+                    socket = clientSocket,
+                    introduction = introduction,
+                    files = emptyMap(),
+                    texts =
+                        mapOf(
+                            urlPayloadId to urlBytes,
+                            phonePayloadId to phoneBytes,
+                        ),
+                    secureRandom = SecureRandom("sender-multitext".toByteArray()),
+                )
+
+                val result = receiverJob.await()
+                assertThat(result).isInstanceOf(InboundResult.Completed::class.java)
+                val items = (result as InboundResult.Completed).items
+                assertThat(items).hasSize(2)
+                val byId = items.associateBy { it.payloadId }
+                assertThat((byId[urlPayloadId] as ReceivedItem.Text).data).isEqualTo(urlBytes)
+                assertThat((byId[phonePayloadId] as ReceivedItem.Text).data).isEqualTo(phoneBytes)
+            }
+
+            // No files announced, so commit/abort never fire on the factory.
+            assertThat(factory.committed).isEmpty()
+        }
+
+    // -------------------------------------------------------------
     // Synthetic sender harness
     // -------------------------------------------------------------
 

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/TransferMetadataTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/TransferMetadataTest.kt
@@ -136,4 +136,76 @@ class TransferMetadataTest {
             TransferMetadata(items = emptyList(), pin = "12345")
         }
     }
+
+    /**
+     * Regression guard for issue #40: a single introduction may carry
+     * multiple texts of different `Type`s alongside multiple files.
+     * NearDrop rejects this shape; we accept it. The mapping must
+     * preserve every item, distinguish each text's `Kind`, and roll
+     * the per-item sizes into [TransferMetadata.totalSize].
+     */
+    @Test
+    fun `multiple texts of mixed kinds combined with multiple files all map`() {
+        val frame =
+            IntroductionFrame
+                .newBuilder()
+                .addFileMetadata(
+                    Protocol.FileMetadata
+                        .newBuilder()
+                        .setName("photo.jpg")
+                        .setPayloadId(101L)
+                        .setSize(50_000L)
+                        .setMimeType("image/jpeg")
+                        .build(),
+                ).addFileMetadata(
+                    Protocol.FileMetadata
+                        .newBuilder()
+                        .setName("notes.pdf")
+                        .setPayloadId(102L)
+                        .setSize(10_000L)
+                        .setMimeType("application/pdf")
+                        .build(),
+                ).addTextMetadata(
+                    Protocol.TextMetadata
+                        .newBuilder()
+                        .setTextTitle("page")
+                        .setPayloadId(201L)
+                        .setSize(40L)
+                        .setType(Protocol.TextMetadata.Type.URL)
+                        .build(),
+                ).addTextMetadata(
+                    Protocol.TextMetadata
+                        .newBuilder()
+                        .setTextTitle("address")
+                        .setPayloadId(202L)
+                        .setSize(60L)
+                        .setType(Protocol.TextMetadata.Type.ADDRESS)
+                        .build(),
+                ).addTextMetadata(
+                    Protocol.TextMetadata
+                        .newBuilder()
+                        .setTextTitle("memo")
+                        .setPayloadId(203L)
+                        .setSize(20L)
+                        .setType(Protocol.TextMetadata.Type.TEXT)
+                        .build(),
+                ).build()
+
+        val md = TransferMetadata.fromIntroductionFrame(frame, pin = "0001")
+
+        assertThat(md.items).hasSize(5)
+        // Files keep their order, then texts in their announcement order.
+        val files = md.items.filterIsInstance<TransferItem.File>()
+        val texts = md.items.filterIsInstance<TransferItem.Text>()
+        assertThat(files.map { it.payloadId }).containsExactly(101L, 102L).inOrder()
+        assertThat(texts.map { it.payloadId }).containsExactly(201L, 202L, 203L).inOrder()
+        assertThat(texts.map { it.kind })
+            .containsExactly(
+                TransferItem.Text.Kind.URL,
+                TransferItem.Text.Kind.ADDRESS,
+                TransferItem.Text.Kind.PLAIN,
+            ).inOrder()
+        // totalSize sums every announced item, regardless of kind.
+        assertThat(md.totalSize).isEqualTo(50_000L + 10_000L + 40L + 60L + 20L)
+    }
 }

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/sharing/InboundSharingFsmTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/sharing/InboundSharingFsmTest.kt
@@ -246,6 +246,62 @@ class InboundSharingFsmTest {
     }
 
     /**
+     * Regression guard for issue #40: an introduction that mixes
+     * `file_metadata` with multiple `text_metadata` entries MUST be
+     * surfaced verbatim to the orchestrator (which, in turn, drives
+     * the consent UI). NearDrop rejects the mixed shape; we accept it
+     * because the Quick Share wire protocol does not impose
+     * homogeneity.
+     */
+    @Test
+    fun `mixed introduction with files and multiple texts is accepted verbatim`() {
+        val fsm = newFsm()
+        fsm.start()
+        fsm.onEvent(SharingFsmEvent.FrameReceived(SharingFrames.pairedKeyEncryption()))
+        fsm.onEvent(SharingFsmEvent.FrameReceived(SharingFrames.pairedKeyResult()))
+
+        val intro =
+            IntroductionFrame
+                .newBuilder()
+                .addFileMetadata(
+                    com.google.android.gms.nearby.sharing.Protocol.FileMetadata
+                        .newBuilder()
+                        .setName("photo.jpg")
+                        .setPayloadId(101L)
+                        .setSize(2048L)
+                        .build(),
+                ).addTextMetadata(
+                    com.google.android.gms.nearby.sharing.Protocol.TextMetadata
+                        .newBuilder()
+                        .setTextTitle("link")
+                        .setPayloadId(201L)
+                        .setSize(40L)
+                        .setType(com.google.android.gms.nearby.sharing.Protocol.TextMetadata.Type.URL)
+                        .build(),
+                ).addTextMetadata(
+                    com.google.android.gms.nearby.sharing.Protocol.TextMetadata
+                        .newBuilder()
+                        .setTextTitle("memo")
+                        .setPayloadId(202L)
+                        .setSize(20L)
+                        .setType(com.google.android.gms.nearby.sharing.Protocol.TextMetadata.Type.TEXT)
+                        .build(),
+                ).build()
+
+        val effects = fsm.onEvent(SharingFsmEvent.FrameReceived(SharingFrames.introduction(intro)))
+
+        assertThat(effects).hasSize(1)
+        val notify = effects[0] as SharingFsmEffect.IntroductionReceived
+        // Verbatim: the FSM does not strip / reorder / reject any of
+        // the announced metadata, so the orchestrator and consent UI
+        // see exactly what the peer sent.
+        assertThat(notify.introduction).isEqualTo(intro)
+        assertThat(notify.introduction.fileMetadataCount).isEqualTo(1)
+        assertThat(notify.introduction.textMetadataCount).isEqualTo(2)
+        assertThat(fsm.state).isEqualTo(InboundSharingState.WaitingForUserConsent)
+    }
+
+    /**
      * Drives the FSM through PKE / PKR / INTRODUCTION so the test body
      * starts in [InboundSharingState.WaitingForUserConsent].
      */

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentNotificationContent.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentNotificationContent.kt
@@ -6,6 +6,7 @@
 package io.github.kyujincho.wvmg.service.receiver.consent
 
 import android.content.res.Resources
+import io.github.kyujincho.wvmg.protocol.connection.TransferItem
 import io.github.kyujincho.wvmg.service.R
 
 /**
@@ -84,14 +85,25 @@ public data class ConsentNotificationContent(
                 }
 
             val itemSummary =
-                if (entry.itemCount <= 0) {
-                    resolver.formatted(R.string.consent_notification_summary_no_items)
-                } else {
-                    resolver.formatted(
-                        R.string.consent_notification_summary_n_items,
-                        entry.itemCount,
-                        humanReadableSize(entry.totalSize),
-                    )
+                when {
+                    entry.itemCount <= 0 ->
+                        resolver.formatted(R.string.consent_notification_summary_no_items)
+                    // Issue #40: when the introduction announces multiple
+                    // payload kinds (e.g. files + URLs), break the summary
+                    // into per-kind segments so the user sees "3 files +
+                    // 1 URL" instead of an opaque "4 items". Falls back
+                    // to the count-only form when the registry entry was
+                    // created without an items list (older callers, or a
+                    // foreground-service resurrection that lost the
+                    // detail).
+                    entry.items.isNotEmpty() ->
+                        kindBreakdownSummary(resolver, entry.items, entry.totalSize)
+                    else ->
+                        resolver.formatted(
+                            R.string.consent_notification_summary_n_items,
+                            entry.itemCount,
+                            humanReadableSize(entry.totalSize),
+                        )
                 }
 
             val body =
@@ -121,6 +133,71 @@ public data class ConsentNotificationContent(
                 bigText = bigText,
                 acceptLabel = resolver.formatted(R.string.consent_notification_action_accept),
                 rejectLabel = resolver.formatted(R.string.consent_notification_action_reject),
+            )
+        }
+
+        /**
+         * Build a "kinds + size" summary like
+         * "3 files + 1 URL (12.4 MB)" from a [TransferItem] list.
+         *
+         * Group ordering is fixed (files → URLs → addresses → phone
+         * numbers → plain text) so callers can rely on stable, readable
+         * output regardless of the announcement order. Empty groups are
+         * dropped. The total size suffix uses [humanReadableSize].
+         *
+         * Public + JVM-pure so the unit tests can assert on the exact
+         * formatted output without spinning up Robolectric.
+         */
+        public fun kindBreakdownSummary(
+            resolver: TextResolver,
+            items: List<TransferItem>,
+            totalSize: Long,
+        ): String {
+            val files = items.count { it is TransferItem.File }
+            val urls = items.count { it is TransferItem.Text && it.kind == TransferItem.Text.Kind.URL }
+            val addresses =
+                items.count { it is TransferItem.Text && it.kind == TransferItem.Text.Kind.ADDRESS }
+            val phones =
+                items.count { it is TransferItem.Text && it.kind == TransferItem.Text.Kind.PHONE_NUMBER }
+            val texts =
+                items.count { it is TransferItem.Text && it.kind == TransferItem.Text.Kind.PLAIN }
+
+            val segments = mutableListOf<String>()
+            if (files > 0) {
+                segments += resolver.formatted(R.string.consent_notification_segment_files, files)
+            }
+            if (urls > 0) {
+                segments += resolver.formatted(R.string.consent_notification_segment_urls, urls)
+            }
+            if (addresses > 0) {
+                segments +=
+                    resolver.formatted(R.string.consent_notification_segment_addresses, addresses)
+            }
+            if (phones > 0) {
+                segments +=
+                    resolver.formatted(R.string.consent_notification_segment_phone_numbers, phones)
+            }
+            if (texts > 0) {
+                segments += resolver.formatted(R.string.consent_notification_segment_texts, texts)
+            }
+
+            // Defensive fallback: an items list whose entries do not
+            // match any known kind (future proto additions) collapses
+            // back to the generic "N item(s)" form so the summary is
+            // never empty.
+            if (segments.isEmpty()) {
+                return resolver.formatted(
+                    R.string.consent_notification_summary_n_items,
+                    items.size,
+                    humanReadableSize(totalSize),
+                )
+            }
+
+            val joined = segments.joinToString(separator = " + ")
+            return resolver.formatted(
+                R.string.consent_notification_summary_kinds_with_size,
+                joined,
+                humanReadableSize(totalSize),
             )
         }
 

--- a/service-android/src/main/res/values/strings.xml
+++ b/service-android/src/main/res/values/strings.xml
@@ -77,6 +77,22 @@
     <string name="consent_notification_summary_no_items">no items</string>
 
     <!--
+      Mixed-introduction summary (#40). When an introduction announces
+      payloads of more than one kind (file + URL + address + ...), the
+      consent notification renders a per-kind breakdown like "3 files +
+      1 URL (12.4 MB)" instead of the opaque "4 item(s) (12.4 MB)".
+      Each segment is built from one of the kind-specific strings below
+      and joined with " + "; the size suffix is appended via
+      consent_notification_summary_kinds_with_size.
+    -->
+    <string name="consent_notification_summary_kinds_with_size">%1$s (%2$s)</string>
+    <string name="consent_notification_segment_files" tools:ignore="PluralsCandidate">%1$d file(s)</string>
+    <string name="consent_notification_segment_urls" tools:ignore="PluralsCandidate">%1$d URL(s)</string>
+    <string name="consent_notification_segment_addresses" tools:ignore="PluralsCandidate">%1$d address(es)</string>
+    <string name="consent_notification_segment_phone_numbers" tools:ignore="PluralsCandidate">%1$d phone number(s)</string>
+    <string name="consent_notification_segment_texts" tools:ignore="PluralsCandidate">%1$d text(s)</string>
+
+    <!--
       Body line shown collapsed: "%summary% — PIN %pin%". The PIN is
       always the 4-digit confirmation code from TransferMetadata.
     -->

--- a/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentNotificationContentTest.kt
+++ b/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentNotificationContentTest.kt
@@ -7,6 +7,7 @@ package io.github.kyujincho.wvmg.service.receiver.consent
 
 import com.google.common.truth.Truth.assertThat
 import io.github.kyujincho.wvmg.protocol.connection.InboundConnection
+import io.github.kyujincho.wvmg.protocol.connection.TransferItem
 import io.github.kyujincho.wvmg.service.R
 import org.junit.jupiter.api.Test
 import java.net.Socket
@@ -116,6 +117,115 @@ class ConsentNotificationContentTest {
         assertThat(content.rejectLabel).isEqualTo("Reject")
     }
 
+    /**
+     * Issue #40: when the registry entry carries an explicit items
+     * list, the consent summary breaks the count down by kind
+     * ("3 files + 1 URL") rather than showing an opaque "4 item(s)".
+     * Without this, the user cannot tell from the notification alone
+     * that the peer is sending a clipboard URL alongside a file.
+     */
+    @Test
+    fun `body breaks down mixed file and url introduction by kind`() {
+        val items: List<TransferItem> =
+            listOf(
+                TransferItem.File(
+                    payloadId = 1L,
+                    name = "a.bin",
+                    size = 1000L,
+                    mimeType = "application/octet-stream",
+                ),
+                TransferItem.File(
+                    payloadId = 2L,
+                    name = "b.bin",
+                    size = 2000L,
+                    mimeType = "application/octet-stream",
+                ),
+                TransferItem.File(
+                    payloadId = 3L,
+                    name = "c.bin",
+                    size = 3000L,
+                    mimeType = "application/octet-stream",
+                ),
+                TransferItem.Text(
+                    payloadId = 4L,
+                    title = "page",
+                    size = 40L,
+                    kind = TransferItem.Text.Kind.URL,
+                ),
+            )
+        val content =
+            ConsentNotificationContent.from(
+                resolver = englishResolver(),
+                entry =
+                    sampleEntry(
+                        itemCount = items.size,
+                        totalSize = items.sumOf { it.size },
+                        items = items,
+                    ),
+            )
+        assertThat(content.body).contains("3 file(s)")
+        assertThat(content.body).contains("1 URL(s)")
+        assertThat(content.body).contains("+")
+    }
+
+    /**
+     * Edge case: introductions that carry only one payload kind still
+     * render through the per-kind path so the resulting summary
+     * mentions the kind explicitly ("1 file") instead of the generic
+     * "1 item".
+     */
+    @Test
+    fun `body uses kind-specific segment when only texts present`() {
+        val items: List<TransferItem> =
+            listOf(
+                TransferItem.Text(
+                    payloadId = 1L,
+                    title = "page",
+                    size = 40L,
+                    kind = TransferItem.Text.Kind.URL,
+                ),
+                TransferItem.Text(
+                    payloadId = 2L,
+                    title = "memo",
+                    size = 10L,
+                    kind = TransferItem.Text.Kind.PLAIN,
+                ),
+            )
+        val content =
+            ConsentNotificationContent.from(
+                resolver = englishResolver(),
+                entry =
+                    sampleEntry(
+                        itemCount = items.size,
+                        totalSize = items.sumOf { it.size },
+                        items = items,
+                    ),
+            )
+        assertThat(content.body).contains("1 URL(s)")
+        assertThat(content.body).contains("1 text(s)")
+        assertThat(content.body).doesNotContain("item(s)")
+    }
+
+    /**
+     * The legacy code path — an Entry without an items list — must
+     * still render via the generic "N item(s)" form so older callers
+     * keep working without churn.
+     */
+    @Test
+    fun `body falls back to N items when items list is empty`() {
+        val content =
+            ConsentNotificationContent.from(
+                resolver = englishResolver(),
+                entry =
+                    sampleEntry(
+                        itemCount = 4,
+                        totalSize = 1024L,
+                        items = emptyList(),
+                    ),
+            )
+        assertThat(content.body).contains("4 item(s)")
+    }
+
     @Test
     fun `humanReadableSize handles bytes through gigabytes`() {
         with(ConsentNotificationContent) {
@@ -130,6 +240,7 @@ class ConsentNotificationContentTest {
         }
     }
 
+    @Suppress("CyclomaticComplexMethod") // One branch per resource id is the simplest, most readable shape.
     private fun englishResolver(): TextResolver =
         TextResolver { resourceId, args ->
             when (resourceId) {
@@ -140,6 +251,18 @@ class ConsentNotificationContentTest {
                 R.string.consent_notification_summary_n_items ->
                     String.format(java.util.Locale.ROOT, "%d item(s) (%s)", args[0], args[1])
                 R.string.consent_notification_summary_no_items -> "no items"
+                R.string.consent_notification_summary_kinds_with_size ->
+                    String.format(java.util.Locale.ROOT, "%s (%s)", args[0], args[1])
+                R.string.consent_notification_segment_files ->
+                    String.format(java.util.Locale.ROOT, "%d file(s)", args[0])
+                R.string.consent_notification_segment_urls ->
+                    String.format(java.util.Locale.ROOT, "%d URL(s)", args[0])
+                R.string.consent_notification_segment_addresses ->
+                    String.format(java.util.Locale.ROOT, "%d address(es)", args[0])
+                R.string.consent_notification_segment_phone_numbers ->
+                    String.format(java.util.Locale.ROOT, "%d phone number(s)", args[0])
+                R.string.consent_notification_segment_texts ->
+                    String.format(java.util.Locale.ROOT, "%d text(s)", args[0])
                 R.string.consent_notification_body ->
                     String.format(java.util.Locale.ROOT, "%s · PIN %s", args[0], args[1])
                 R.string.consent_notification_bigtext_pin_line ->
@@ -155,6 +278,7 @@ class ConsentNotificationContentTest {
         pin: String = "1234",
         itemCount: Int = 1,
         totalSize: Long = 1024L,
+        items: List<TransferItem> = emptyList(),
     ): ConsentRegistry.Entry =
         ConsentRegistry.Entry(
             connection = InboundConnection(socket = Socket()),
@@ -162,5 +286,6 @@ class ConsentNotificationContentTest {
             pin = pin,
             itemCount = itemCount,
             totalSize = totalSize,
+            items = items,
         )
 }


### PR DESCRIPTION
## Summary

- Lift the NearDrop-style "single file or single text" restriction on `IntroductionFrame`. The receiver-side protocol stack (`InboundSharingFsm`, `TransferMetadata.fromIntroductionFrame`, `PayloadAssembler`, `InboundConnectionDriver`) is already permissive; this PR adds the regression coverage that pins the behaviour so a future refactor cannot silently re-introduce the homogeneity check.
- Add JVM tests in `:core-protocol` that ship real loopback transfers with mixed manifests (file + multiple texts of mixed kinds) and assert every announced payload is surfaced as a `ReceivedItem`.
- Render the consent notification with a per-kind breakdown ("3 file(s) + 1 URL(s) (12.4 MB)") instead of the opaque "4 item(s)" so the user sees the announced shape before accepting. New helper is JVM-pure and exercised through the existing `TextResolver`-based unit tests; legacy callers without an items list still render via the count-only fallback.

Closes #40.

## Test plan

- [x] `./gradlew :core-protocol:test` (new mixed-intro loopback + FSM + TransferMetadata cases pass alongside the existing suite).
- [x] `./gradlew :service-android:testDebugUnitTest` (new ConsentNotificationContentTest cases pass; 12/12 green).
- [x] `./gradlew staticAnalysis` (ktlint + detekt clean).
- [x] `./gradlew :app:assembleDebug` (debug APK builds).
- [ ] Manual interop on a stock Quick Share peer that sends a clipboard URL alongside a file (deferred to the on-device interop pass — covered indirectly by the loopback test which mirrors the same wire shape).