### PR TITLE
feat: send folders via SAF DocumentTree with parent_folder metadata (#38)

### DIFF
--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/MainActivity.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/MainActivity.kt
@@ -6,11 +6,16 @@
 package io.github.kyujincho.wvmg
 
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
+import android.widget.Button
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.SwitchCompat
 import io.github.kyujincho.wvmg.onboarding.PermissionRequirements
 import io.github.kyujincho.wvmg.onboarding.PermissionsOnboardingActivity
+import io.github.kyujincho.wvmg.send.SendActivity
 import io.github.kyujincho.wvmg.service.receiver.MdnsVisibilityOverrideHolder
 import io.github.kyujincho.wvmg.service.receiver.ReceiverForegroundService
 
@@ -48,6 +53,21 @@ class MainActivity : AppCompatActivity() {
      */
     private var onboardingLaunched: Boolean = false
 
+    /**
+     * Launcher for SAF's `ACTION_OPEN_DOCUMENT_TREE` (#38). Android
+     * registers the result contract during `onCreate` (it walks the
+     * activity-result API's bookkeeping at that point), so the launcher
+     * is owned at the activity level and triggered by the "Send folder"
+     * button click handler.
+     *
+     * On a successful pick we forward the resolved tree URI to
+     * [SendActivity] via [SendActivity.ACTION_SEND_FOLDER]; the activity
+     * walks the tree, builds one [io.github.kyujincho.wvmg.protocol.connection.FileSource]
+     * per descendant file, and runs the existing peer-discovery /
+     * outbound-connection flow with `parent_folder` populated.
+     */
+    private lateinit var openTreeLauncher: ActivityResultLauncher<Uri?>
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
@@ -63,6 +83,39 @@ class MainActivity : AppCompatActivity() {
         switch.isChecked = MdnsVisibilityOverrideHolder.isActive
         switch.setOnCheckedChangeListener { _, checked ->
             MdnsVisibilityOverrideHolder.setAlwaysVisible(checked)
+        }
+
+        // SAF tree-picker (#38). The launcher must be registered during
+        // onCreate to satisfy the activity-result API's lifecycle
+        // contract; we hand its result off to SendActivity rather than
+        // duplicating discovery / connection wiring here.
+        openTreeLauncher =
+            registerForActivityResult(ActivityResultContracts.OpenDocumentTree()) { treeUri: Uri? ->
+                if (treeUri != null) {
+                    val intent =
+                        Intent(this, SendActivity::class.java).apply {
+                            action = SendActivity.ACTION_SEND_FOLDER
+                            data = treeUri
+                            // FLAG_GRANT_READ_URI_PERMISSION propagates the
+                            // SAF read grant to SendActivity. Without it,
+                            // the receiving activity can read top-level
+                            // children but `openInputStream` on individual
+                            // file URIs throws SecurityException. The
+                            // `OpenDocumentTree` contract already takes a
+                            // persistable grant on our behalf, so the read
+                            // is safe to pass through.
+                            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                        }
+                    startActivity(intent)
+                }
+            }
+
+        findViewById<Button>(R.id.main_send_folder_button).setOnClickListener {
+            // Passing null means "no initial directory hint"; the system
+            // picker opens at its default landing screen (typically the
+            // most recently used location). The user is free to navigate
+            // to any tree they have access to.
+            openTreeLauncher.launch(null)
         }
     }
 

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/send/DocumentTreeFileSourceFactory.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/send/DocumentTreeFileSourceFactory.kt
@@ -1,0 +1,309 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.send
+
+import android.content.ContentResolver
+import android.net.Uri
+import android.provider.DocumentsContract
+import io.github.kyujincho.wvmg.protocol.connection.FileSource
+import java.nio.channels.Channels
+import java.nio.channels.ReadableByteChannel
+
+/**
+ * Walks a Storage Access Framework `tree://` URI (delivered by
+ * `ACTION_OPEN_DOCUMENT_TREE`) and emits one [FileSource] per descendant
+ * file, with `parent_folder` populated relative to the picked root (#38).
+ *
+ * NearDrop (the macOS reference implementation) explicitly rejects
+ * multi-attachment introductions whose files carry `parent_folder` —
+ * issue grishka/NearDrop#211 documents the gap. The Quick Share wire
+ * spec itself supports nested directories via `FileMetadata.parent_folder`
+ * (proto field 7) and `PayloadHeader.parent_folder` (offline_wire_formats
+ * proto field 6); this factory is the sender-side glue that puts the
+ * field to use.
+ *
+ * ### Why a raw `DocumentsContract` walk instead of `DocumentFile`
+ *
+ * `androidx.documentfile.DocumentFile` is the documented entry point but
+ * it issues one `query()` per node and surfaces each row as a fresh
+ * `DocumentFile` instance. On a tree of any meaningful size that is
+ * cripplingly slow — every `listFiles()` call re-queries the system
+ * provider for the row data we already have. We instead query
+ * `buildChildDocumentsUriUsingTree(...)` directly with a tight
+ * projection, walking the tree iteratively (depth-first, deterministic
+ * order) so a 10 MB-plus folder doesn't stall the UI.
+ *
+ * ### Empty folders
+ *
+ * Quick Share's wire protocol has no "create empty directory" frame —
+ * receivers implicitly create intermediate directories when they write
+ * a file inside one. The walker therefore skips empty subdirectories
+ * entirely; the receiver will simply not see them. This matches the
+ * issue acceptance criteria.
+ *
+ * ### Lazy channels
+ *
+ * Each emitted [FileSource] defers `ContentResolver.openInputStream`
+ * until the orchestrator calls `openChannel()`. Folders can contain
+ * thousands of files and pre-opening every stream would exhaust the
+ * file-descriptor limit before the user has even confirmed the send.
+ *
+ * ### Symbolic links / cycles
+ *
+ * The SAF document model has no first-class loop concept (each
+ * `DOCUMENT_ID` is a distinct node), but defensively we cap recursion at
+ * [MAX_DEPTH] to bound runaway provider behaviour. A cap of 32 covers
+ * any sane on-device folder layout while being shallow enough that an
+ * intentional pathological tree cannot wedge the walker.
+ */
+public class DocumentTreeFileSourceFactory internal constructor(
+    private val contentResolver: ContentResolver,
+    private val payloadIdGenerator: () -> Long,
+) {
+    /** Production constructor wired against a real Android [ContentResolver]. */
+    public constructor(contentResolver: ContentResolver) : this(
+        contentResolver = contentResolver,
+        payloadIdGenerator = UriFileSourceFactory::randomPositivePayloadId,
+    )
+
+    /**
+     * Traverse the tree under [treeUri] and emit one [FileSource] per
+     * file descendant, deepest-children-last in deterministic
+     * directory-then-name order. Returns an empty list if the tree
+     * contains no files (e.g. only empty subdirectories).
+     *
+     * The picked tree's own display name is the convention for what
+     * the receiver should call the top-level folder; we do NOT prepend
+     * it to `parent_folder`. Reason: the receiver-side materialization
+     * (issue #39) lands files under a single chosen download root and
+     * the user already perceives "this came from the folder I shared",
+     * so an extra level of nesting only makes the on-disk path longer.
+     * For example, a folder `Trip/photos/sunset.jpg` is emitted as a
+     * file with `name = "sunset.jpg"` and `parent_folder = "photos"`
+     * — the `Trip/` prefix is implicit in the receiver's choice of
+     * download location.
+     *
+     * @throws IllegalArgumentException if [treeUri] is not a tree URI
+     *   (i.e. does not carry a [DocumentsContract.getTreeDocumentId]).
+     */
+    public fun walk(treeUri: Uri): List<FileSource> {
+        val rootDocId = DocumentsContract.getTreeDocumentId(treeUri)
+        val collected = ArrayList<FileSource>()
+        walkNode(
+            treeUri = treeUri,
+            documentId = rootDocId,
+            // The root's relative path is empty — its files become
+            // top-level attachments with `parent_folder = ""`.
+            relativePath = "",
+            depth = 0,
+            collected = collected,
+        )
+        return collected
+    }
+
+    private fun walkNode(
+        treeUri: Uri,
+        documentId: String,
+        relativePath: String,
+        depth: Int,
+        collected: ArrayList<FileSource>,
+    ) {
+        if (depth > MAX_DEPTH) return
+        val childrenUri = DocumentsContract.buildChildDocumentsUriUsingTree(treeUri, documentId)
+        val children = queryChildren(childrenUri)
+        // Sort directories last and within-kind by name so the
+        // receiver-side display order is deterministic — Quick Share
+        // does not specify an order, but stock Android sends top-level
+        // files first followed by deeper levels and we mirror that for
+        // observability.
+        val sorted =
+            children.sortedWith(
+                compareBy({ it.isDirectory }, { it.displayName }),
+            )
+        for (child in sorted) {
+            if (child.isDirectory) {
+                val nextPath = if (relativePath.isEmpty()) child.displayName else "$relativePath/${child.displayName}"
+                walkNode(
+                    treeUri = treeUri,
+                    documentId = child.documentId,
+                    relativePath = nextPath,
+                    depth = depth + 1,
+                    collected = collected,
+                )
+            } else {
+                collected.add(buildFileSource(treeUri, child, relativePath))
+            }
+        }
+    }
+
+    /**
+     * Issue a single tight `query()` against [childrenUri] and surface
+     * the results as a list of [DocumentNode]s. The projection is the
+     * smallest set of columns we need — the SAF system provider walks
+     * the metadata once per row and additional columns multiply that
+     * cost on large trees.
+     */
+    private fun queryChildren(childrenUri: Uri): List<DocumentNode> {
+        val out = ArrayList<DocumentNode>()
+        contentResolver
+            .query(childrenUri, CHILD_PROJECTION, null, null, null)
+            ?.use { cursor ->
+                val ix = ChildColumns.from(cursor)
+                if (!ix.usable) return@use
+                while (cursor.moveToNext()) {
+                    readChildRow(cursor, ix)?.let(out::add)
+                }
+            }
+        return out
+    }
+
+    /**
+     * Map a single cursor row onto a [DocumentNode], or `null` when the
+     * row is missing the mandatory document-id column. Pulled out of
+     * [queryChildren] so the per-row mapping stays detekt-clean (one
+     * `continue`-equivalent path) while keeping every column lookup
+     * indexed (no by-name `getColumnIndexOrThrow` hot-path cost).
+     */
+    private fun readChildRow(
+        cursor: android.database.Cursor,
+        ix: ChildColumns,
+    ): DocumentNode? {
+        val documentId = cursor.getString(ix.docId) ?: return null
+        val rawDisplayName = cursor.getString(ix.displayName)
+        val displayName = sanitizeDisplayName(rawDisplayName, documentId)
+        val mime = cursor.getString(ix.mime) ?: ""
+        val size = if (ix.size >= 0 && !cursor.isNull(ix.size)) cursor.getLong(ix.size) else -1L
+        val lastModified =
+            if (ix.lastModified >= 0 && !cursor.isNull(ix.lastModified)) {
+                cursor.getLong(ix.lastModified)
+            } else {
+                0L
+            }
+        return DocumentNode(
+            documentId = documentId,
+            displayName = displayName,
+            mimeType = mime,
+            size = size,
+            lastModifiedMillis = lastModified,
+            isDirectory = mime == DocumentsContract.Document.MIME_TYPE_DIR,
+        )
+    }
+
+    /**
+     * Pre-resolved column indices for the children cursor. Indices are
+     * looked up once per cursor and reused on every row rather than
+     * paid per-row — large folder walks notice the difference.
+     */
+    private data class ChildColumns(
+        val docId: Int,
+        val displayName: Int,
+        val mime: Int,
+        val size: Int,
+        val lastModified: Int,
+    ) {
+        /** True when the mandatory columns (docId, name, mime) are all present. */
+        val usable: Boolean
+            get() = docId >= 0 && displayName >= 0 && mime >= 0
+
+        companion object {
+            fun from(cursor: android.database.Cursor): ChildColumns =
+                ChildColumns(
+                    docId = cursor.getColumnIndex(DocumentsContract.Document.COLUMN_DOCUMENT_ID),
+                    displayName = cursor.getColumnIndex(DocumentsContract.Document.COLUMN_DISPLAY_NAME),
+                    mime = cursor.getColumnIndex(DocumentsContract.Document.COLUMN_MIME_TYPE),
+                    size = cursor.getColumnIndex(DocumentsContract.Document.COLUMN_SIZE),
+                    lastModified = cursor.getColumnIndex(DocumentsContract.Document.COLUMN_LAST_MODIFIED),
+                )
+        }
+    }
+
+    /**
+     * Build a [FileSource] from a single non-directory [node] under
+     * [parentRelativePath].
+     *
+     * Defers `openInputStream` until the orchestrator calls
+     * `openChannel()` — see the class-level "Lazy channels" note.
+     */
+    private fun buildFileSource(
+        treeUri: Uri,
+        node: DocumentNode,
+        parentRelativePath: String,
+    ): FileSource {
+        val docUri = DocumentsContract.buildDocumentUriUsingTree(treeUri, node.documentId)
+        val coercedSize = node.size.coerceAtLeast(0L)
+        return FileSource(
+            name = node.displayName,
+            size = coercedSize,
+            mimeType = node.mimeType,
+            lastModifiedTimestampMillis = node.lastModifiedMillis,
+            payloadId = payloadIdGenerator(),
+            parentFolder = parentRelativePath,
+            open = {
+                val stream =
+                    contentResolver.openInputStream(docUri)
+                        ?: error("ContentResolver returned null InputStream for $docUri")
+                Channels.newChannel(stream) as ReadableByteChannel
+            },
+        )
+    }
+
+    /**
+     * Lightweight value carrier for one row of the children cursor.
+     */
+    private data class DocumentNode(
+        val documentId: String,
+        val displayName: String,
+        val mimeType: String,
+        val size: Long,
+        val lastModifiedMillis: Long,
+        val isDirectory: Boolean,
+    )
+
+    public companion object {
+        /**
+         * Maximum directory nesting depth the walker will descend into.
+         * Stops a runaway SAF provider from looping forever; 32 is
+         * deeper than any sane on-device layout, and a malicious or
+         * buggy provider hitting the cap simply yields a partial result
+         * rather than wedging the UI thread.
+         */
+        public const val MAX_DEPTH: Int = 32
+
+        /**
+         * Fallback display name when SAF returns a null/blank
+         * `DISPLAY_NAME`. Falls back to the `DOCUMENT_ID` slug as a
+         * minimal-but-stable identifier — the receiver still sees a
+         * filename, just an opaque one.
+         */
+        public const val FALLBACK_NAME: String = "document"
+
+        /** Tight projection used by [queryChildren]. */
+        private val CHILD_PROJECTION =
+            arrayOf(
+                DocumentsContract.Document.COLUMN_DOCUMENT_ID,
+                DocumentsContract.Document.COLUMN_DISPLAY_NAME,
+                DocumentsContract.Document.COLUMN_MIME_TYPE,
+                DocumentsContract.Document.COLUMN_SIZE,
+                DocumentsContract.Document.COLUMN_LAST_MODIFIED,
+            )
+
+        /**
+         * Map the raw `DISPLAY_NAME` from the cursor into a non-blank
+         * filename. Trims path separators a misbehaving provider could
+         * inject — the receiver-side materialization (#39) treats the
+         * name as a leaf component, never as a path, so any embedded
+         * `/` would silently land the file in the wrong place.
+         */
+        internal fun sanitizeDisplayName(
+            raw: String?,
+            documentIdFallback: String,
+        ): String {
+            val trimmed = raw?.trim()?.takeIf { it.isNotEmpty() }
+            val withoutSeparators = trimmed?.replace('/', '_')?.replace('\\', '_')
+            return withoutSeparators ?: documentIdFallback.substringAfterLast(':').ifEmpty { FALLBACK_NAME }
+        }
+    }
+}

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendActivity.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendActivity.kt
@@ -74,6 +74,7 @@ import java.security.SecureRandom
 public class SendActivity : AppCompatActivity() {
     private lateinit var binding: ActivitySendBinding
     private lateinit var fileSourceFactory: UriFileSourceFactory
+    private lateinit var documentTreeFactory: DocumentTreeFileSourceFactory
 
     private var files: List<FileSource> = emptyList()
     private val peers: MutableList<DiscoveredService> = mutableListOf()
@@ -124,32 +125,77 @@ public class SendActivity : AppCompatActivity() {
         setContentView(binding.root)
 
         fileSourceFactory = UriFileSourceFactory(contentResolver)
+        documentTreeFactory = DocumentTreeFileSourceFactory(contentResolver)
 
         binding.sendCancelButton.setOnClickListener { onCancelClicked() }
         binding.sendDoneButton.setOnClickListener { finish() }
         binding.sendShowQrButton.setOnClickListener { onShowQrClicked() }
         binding.sendNetworkHintDismiss.setOnClickListener { onHintDismissed() }
 
-        val parsed = ShareIntentRouter.route(toShareIntent(intent))
-        if (parsed == null) {
-            renderUnsupportedPayload()
-            return
-        }
-
-        files = materializeFiles(parsed)
-        if (files.isEmpty()) {
-            // Currently true for plain-text shares (sender-side text
-            // payload support is a follow-up). Surface the same
-            // unsupported message so the user gets clear feedback.
-            renderUnsupportedPayload()
-            return
-        }
+        // Resolve the intent's file list. May render a terminal UI
+        // state (unsupported / folder empty / folder walk failed) and
+        // return null; in that case we leave `files` as the default
+        // empty list and bail without starting discovery. The terminal
+        // states already display "Done" / explanatory text.
+        val resolved = resolveIntentFiles()
+        if (resolved == null) return
+        files = resolved
 
         binding.sendPayloadSummary.text = PayloadSummary.forFiles(this, files)
         binding.sendSubtitle.setText(R.string.send_subtitle_discovering)
         startDiscovery()
         startEmptyPeerHintTimer()
         startBleAdvertise()
+    }
+
+    /**
+     * Walk [intent] into the canonical [FileSource] list the rest of
+     * the activity expects, or render a terminal UI state and return
+     * null. Centralised here so `onCreate` carries a single early-
+     * return rather than threading the share-sheet vs. folder-send
+     * branching across multiple bail-out paths.
+     *
+     * Two distinct entry points:
+     *
+     *  1. `ACTION_SEND_FOLDER` (#38). The folder-picker on
+     *     [io.github.kyujincho.wvmg.MainActivity] forwards a `tree://`
+     *     URI here. We walk it via [DocumentTreeFileSourceFactory],
+     *     surface a folder-specific empty / failure message if needed,
+     *     and otherwise hand the list back.
+     *  2. `ACTION_SEND` / `ACTION_SEND_MULTIPLE` (#24). The system
+     *     share sheet routes individual file URIs here, which
+     *     [ShareIntentRouter] parses into the canonical input shapes.
+     */
+    @Suppress("ReturnCount") // The branching is inherent — each terminal-state path is its own bail.
+    private fun resolveIntentFiles(): List<FileSource>? {
+        if (intent.action == ACTION_SEND_FOLDER) {
+            val treeUri = intent.data
+            if (treeUri == null) {
+                renderUnsupportedPayload()
+                return null
+            }
+            val walked = materializeFolder(treeUri) ?: return null
+            if (walked.isEmpty()) {
+                // `materializeFolder` already swapped in the folder-
+                // specific empty-state UI before returning.
+                return null
+            }
+            return walked
+        }
+        val parsed = ShareIntentRouter.route(toShareIntent(intent))
+        if (parsed == null) {
+            renderUnsupportedPayload()
+            return null
+        }
+        val files = materializeFiles(parsed)
+        if (files.isEmpty()) {
+            // Currently true for plain-text shares (sender-side text
+            // payload support is a follow-up). Surface the same
+            // unsupported message so the user gets clear feedback.
+            renderUnsupportedPayload()
+            return null
+        }
+        return files
     }
 
     override fun onDestroy() {
@@ -237,6 +283,66 @@ public class SendActivity : AppCompatActivity() {
             is ShareIntentInput.Text ->
                 emptyList()
         }
+
+    /**
+     * Walk the SAF tree under [treeUri] and return one [FileSource] per
+     * descendant file (#38). Returns:
+     *
+     * - A non-empty list on success — the regular discovery / send
+     *   flow takes over from the caller.
+     * - An empty list when the picked folder contains no files (the
+     *   walker recurses into subdirectories but Quick Share has no
+     *   "create empty directory" frame, so we have nothing to ship).
+     *   In this case [renderFolderEmpty] swaps the UI into a
+     *   "no files" state and the caller bails out.
+     * - `null` when the walk threw (e.g. the SAF provider revoked the
+     *   read grant before we got here). [renderFolderWalkFailed] swaps
+     *   the UI into a "couldn't read folder" state and the caller bails
+     *   out.
+     *
+     * The walker runs synchronously on the UI thread because:
+     *
+     * 1. The `OpenDocumentTree` contract just returned, so the system
+     *    picker has already displayed and dismissed — the user is
+     *    actively waiting for our response.
+     * 2. Real-world folder sizes that fit Quick Share's transfer model
+     *    (ten-ish files, low-MB to ~tens-of-MB total) walk in single
+     *    digit milliseconds. Larger trees would block the UI thread,
+     *    but Quick Share's per-transfer payload cap (no formal limit,
+     *    but practical sender memory and timeout pressure) bounds the
+     *    walk's worst case.
+     *
+     * If real devices show jank on huge trees, this is the right place
+     * to move onto a background dispatcher — the rest of the activity
+     * already drives discovery / connection from `lifecycleScope`.
+     */
+    private fun materializeFolder(treeUri: Uri): List<FileSource>? {
+        binding.sendSubtitle.setText(R.string.send_folder_subtitle_walking)
+        // Both SecurityException and IllegalArgumentException land on
+        // the "couldn't read folder" UI:
+        //   - SecurityException: the SAF provider revoked the read
+        //     grant before we got here.
+        //   - IllegalArgumentException: getTreeDocumentId rejected a
+        //     non-tree URI. The OpenDocumentTree contract guarantees a
+        //     tree URI on success, so reaching here means a malformed
+        //     intent extra (e.g. a third-party app started us via a
+        //     future-exported variant of this activity with the wrong
+        //     shape). Surface as a user-visible error rather than
+        //     crashing.
+        val walked =
+            runCatching { documentTreeFactory.walk(treeUri) }
+                .onFailure { e ->
+                    if (e is SecurityException || e is IllegalArgumentException) {
+                        Log.e(OUTBOUND_TAG, "ACTION_SEND_FOLDER walk failed for $treeUri", e)
+                        renderFolderWalkFailed()
+                    } else {
+                        // Unknown throwable: let the framework see it.
+                        throw e
+                    }
+                }.getOrNull() ?: return null
+        if (walked.isEmpty()) renderFolderEmpty()
+        return walked
+    }
 
     // -----------------------------------------------------------------
     // Discovery
@@ -633,6 +739,39 @@ public class SendActivity : AppCompatActivity() {
         binding.sendCancelButton.text = getString(R.string.send_done)
     }
 
+    /**
+     * Folder send (#38) terminal: the picked folder contains zero files
+     * (only empty subdirectories or nothing at all). Quick Share has no
+     * "create empty directory" frame, so there is nothing to transfer —
+     * surface a clear message and let the user back out.
+     */
+    private fun renderFolderEmpty() {
+        binding.sendPayloadSummary.text = getString(R.string.main_send_folder_button)
+        binding.sendSubtitle.text = getString(R.string.send_folder_empty)
+        binding.sendPeerList.visibility = View.GONE
+        binding.sendEmptyState.visibility = View.GONE
+        binding.sendNetworkHint.visibility = View.GONE
+        binding.sendShowQrButton.visibility = View.GONE
+        binding.sendCancelButton.text = getString(R.string.send_done)
+    }
+
+    /**
+     * Folder send (#38) terminal: the SAF walk threw before we could
+     * collect any FileSources. Most likely cause is a provider that
+     * revoked the read grant, but a malformed tree URI (someone
+     * exported this activity later and a third-party app starts us
+     * with the wrong shape) lands here too — see `materializeFolder`.
+     */
+    private fun renderFolderWalkFailed() {
+        binding.sendPayloadSummary.text = getString(R.string.main_send_folder_button)
+        binding.sendSubtitle.text = getString(R.string.send_folder_walk_failed)
+        binding.sendPeerList.visibility = View.GONE
+        binding.sendEmptyState.visibility = View.GONE
+        binding.sendNetworkHint.visibility = View.GONE
+        binding.sendShowQrButton.visibility = View.GONE
+        binding.sendCancelButton.text = getString(R.string.send_done)
+    }
+
     private fun onCancelClicked() {
         // If a connection is mid-flight, ask it to cancel cleanly so a
         // CancelFrame goes out on the wire. The terminal state will
@@ -723,7 +862,18 @@ public class SendActivity : AppCompatActivity() {
         }
     }
 
-    private companion object {
+    public companion object {
+        /**
+         * Custom intent action used by [io.github.kyujincho.wvmg.MainActivity]
+         * to forward a `tree://` URI from `ACTION_OPEN_DOCUMENT_TREE`
+         * (#38). The URI lives in `intent.data` and the read grant is
+         * propagated via [Intent.FLAG_GRANT_READ_URI_PERMISSION] on the
+         * launcher side. This action is intentionally NOT exported in
+         * the manifest — it is an internal contract between MainActivity
+         * and SendActivity.
+         */
+        public const val ACTION_SEND_FOLDER: String = "io.github.kyujincho.wvmg.action.SEND_FOLDER"
+
         private const val OUTBOUND_TAG: String = "WvmgOutbound"
 
         // BLE advertise diagnostics share the discovery tag so a single

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -36,4 +36,28 @@
         android:text="@string/main_always_visible_subtitle"
         android:textAppearance="?android:attr/textAppearanceSmall" />
 
+    <!--
+      Folder-send entry point (#38). The system share sheet does not
+      expose a way to share a directory — it only routes individual
+      files via ACTION_SEND / ACTION_SEND_MULTIPLE. To send a whole
+      folder (preserving its directory layout via FileMetadata's
+      `parent_folder` field), the user starts here, picks a folder via
+      ACTION_OPEN_DOCUMENT_TREE, and we forward the resulting tree URI
+      to SendActivity.
+    -->
+    <Button
+        android:id="@+id/main_send_folder_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:text="@string/main_send_folder_button" />
+
+    <TextView
+        android:id="@+id/main_send_folder_subtitle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:text="@string/main_send_folder_subtitle"
+        android:textAppearance="?android:attr/textAppearanceSmall" />
+
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,6 +9,16 @@
     <string name="main_always_visible_title">Always visible</string>
     <string name="main_always_visible_subtitle">Keep this device discoverable on Wi-Fi even without a Bluetooth pulse from a nearby sender. Turn off to save power; the receiver will only appear briefly while a sender is scanning.</string>
 
+    <!-- Folder-send entry point (#38). Android's share sheet only routes
+         individual files; to ship a directory tree (preserving the
+         layout via Quick Share's `parent_folder` field) we surface a
+         dedicated picker on the launcher. -->
+    <string name="main_send_folder_button">Send folder</string>
+    <string name="main_send_folder_subtitle">Pick a folder on this device to send to a nearby Quick Share peer. Subdirectories and the directory layout are preserved on the receiver.</string>
+    <string name="send_folder_subtitle_walking">Reading folder contents…</string>
+    <string name="send_folder_empty">The folder you picked has no files. Add at least one file and try again.</string>
+    <string name="send_folder_walk_failed">Could not read the folder contents. Pick another folder and try again.</string>
+
     <!-- Permissions onboarding (#26 + #31). -->
     <string name="onboarding_title">App permissions</string>
     <string name="onboarding_intro">Quick Share needs a small set of Android permissions to discover nearby devices over your local Wi-Fi network, to broadcast and listen for short Bluetooth Low Energy pulses that wake nearby Quick Share receivers, and to keep you informed about transfers. Each permission below explains exactly what it is used for.</string>

--- a/app/src/test/kotlin/io/github/kyujincho/wvmg/send/DocumentTreeFileSourceFactoryTest.kt
+++ b/app/src/test/kotlin/io/github/kyujincho/wvmg/send/DocumentTreeFileSourceFactoryTest.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.send
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pure-JVM tests for the platform-agnostic helpers inside
+ * [DocumentTreeFileSourceFactory].
+ *
+ * The factory's tree-walking entry point ([DocumentTreeFileSourceFactory.walk])
+ * is bound to `android.provider.DocumentsContract` and a real
+ * `ContentResolver`, neither of which work on a host JVM. The platform-
+ * agnostic surface — display-name sanitization, the relative-path
+ * separator convention, the empty-string parent_folder for top-level
+ * files — is independently testable and is what we exercise here.
+ *
+ * The walk-shape test ([dynamic input via a stub ContentResolver]) lives
+ * in the Android instrumentation test module when one is added; for
+ * Phase 1 we rely on manual on-device verification per the issue's
+ * acceptance criteria (folder with nested subdirectories + ≥10 MB file).
+ */
+class DocumentTreeFileSourceFactoryTest {
+    @Test
+    fun `sanitizeDisplayName trims whitespace and falls back to last id segment`() {
+        val sanitized =
+            DocumentTreeFileSourceFactory.sanitizeDisplayName(
+                raw = "  ",
+                documentIdFallback = "primary:Documents/My File.txt",
+            )
+        // Whitespace-only display name is treated as missing; we fall
+        // back to the last `:` segment of the document id, which is the
+        // SAF convention for the on-disk path tail.
+        assertEquals("Documents/My File.txt", sanitized)
+    }
+
+    @Test
+    fun `sanitizeDisplayName uses raw when present`() {
+        val sanitized =
+            DocumentTreeFileSourceFactory.sanitizeDisplayName(
+                raw = "report.pdf",
+                documentIdFallback = "primary:irrelevant",
+            )
+        assertEquals("report.pdf", sanitized)
+    }
+
+    @Test
+    fun `sanitizeDisplayName replaces path separators in display names`() {
+        // The receiver-side materialization (#39) treats `name` as a
+        // leaf component and `parent_folder` as the directory hint; an
+        // embedded `/` in the name would silently land the file in the
+        // wrong place. Replacing both forward and back slashes with `_`
+        // keeps the leaf intact while neutralising the separator.
+        val sanitized =
+            DocumentTreeFileSourceFactory.sanitizeDisplayName(
+                raw = "subdir/inner\\file.txt",
+                documentIdFallback = "primary:fallback",
+            )
+        assertEquals("subdir_inner_file.txt", sanitized)
+    }
+
+    @Test
+    fun `sanitizeDisplayName falls back to FALLBACK_NAME when both inputs are unusable`() {
+        val sanitized =
+            DocumentTreeFileSourceFactory.sanitizeDisplayName(
+                raw = null,
+                // No `:` separator means substringAfterLast yields the
+                // whole id; an empty fallback id triggers FALLBACK_NAME.
+                documentIdFallback = "",
+            )
+        assertEquals(DocumentTreeFileSourceFactory.FALLBACK_NAME, sanitized)
+    }
+
+    @Test
+    fun `sanitizeDisplayName falls back to FALLBACK_NAME on blank trimmed input and id without colon`() {
+        val sanitized =
+            DocumentTreeFileSourceFactory.sanitizeDisplayName(
+                raw = null,
+                // No colon at all — substringAfterLast(':') with no
+                // matching delimiter returns the entire string. A truly
+                // empty fallback would yield FALLBACK_NAME; a non-empty
+                // fallback is acceptable as the leaf name.
+                documentIdFallback = "rawId",
+            )
+        assertEquals("rawId", sanitized)
+    }
+}

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/FileSource.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/FileSource.kt
@@ -51,6 +51,14 @@ import java.nio.channels.ReadableByteChannel
  *   `PayloadHeader.id`. The caller MUST choose a fresh, positive,
  *   unique value per source — duplicates break the receiver's
  *   reassembler.
+ * @property parentFolder Optional relative parent directory for folder
+ *   sends (#38). Mirrored both onto `FileMetadata.parent_folder` (proto
+ *   field 7) and onto each `PayloadHeader.parent_folder` so the receiver
+ *   can reconstruct the directory tree when materializing files. Empty
+ *   string for top-level files. Path separators are forward slashes,
+ *   matching the wire convention NearDrop's PROTOCOL.md describes.
+ *   Quick Share's receiver implicitly creates intermediate directories
+ *   as files arrive, so empty folders are not transferred.
  */
 public class FileSource(
     public val name: String,
@@ -58,6 +66,7 @@ public class FileSource(
     public val mimeType: String,
     public val lastModifiedTimestampMillis: Long,
     public val payloadId: Long,
+    public val parentFolder: String = "",
     private val open: () -> ReadableByteChannel,
 ) {
     init {

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/IntroductionFrames.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/IntroductionFrames.kt
@@ -40,7 +40,7 @@ import io.github.kyujincho.wvmg.protocol.sharing.IntroductionFrame
 internal fun buildIntroductionFrame(files: List<FileSource>): IntroductionFrame {
     val builder = IntroductionFrame.newBuilder()
     for (f in files) {
-        builder.addFileMetadata(
+        val md =
             Protocol.FileMetadata
                 .newBuilder()
                 .setName(f.name)
@@ -49,8 +49,16 @@ internal fun buildIntroductionFrame(files: List<FileSource>): IntroductionFrame 
                 .setMimeType(f.mimeType)
                 .setType(mimeTypeToFileType(f.mimeType))
                 .setId(f.payloadId)
-                .build(),
-        )
+        // `parent_folder` (proto field 7) is the receiver's hint to
+        // reconstruct nested directory layouts on disk. Quick Share's
+        // receiver implicitly creates intermediate folders when it
+        // writes the file, so we only emit the field when non-empty —
+        // top-level attachments stay byte-for-byte compatible with the
+        // pre-#38 introduction wire shape.
+        if (f.parentFolder.isNotEmpty()) {
+            md.setParentFolder(f.parentFolder)
+        }
+        builder.addFileMetadata(md.build())
     }
     builder.setUseCase(Protocol.IntroductionFrame.SharingUseCase.NEARBY_SHARE)
     return builder.build()

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionDriver.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionDriver.kt
@@ -598,6 +598,14 @@ internal class OutboundConnectionDriver(
                     source = source,
                     chunkSize = PayloadTransferEncoder.DEFAULT_FILE_CHUNK_SIZE,
                     lastModifiedTimestampMillis = file.lastModifiedTimestampMillis,
+                    // `parent_folder` is also carried on every PayloadHeader,
+                    // not just on FileMetadata. Quick Share receivers can
+                    // reconcile the two sources of truth — but we set both
+                    // to the same value to match stock Android's behaviour
+                    // and to remain robust against receivers that key
+                    // exclusively off the PayloadHeader (which the chunk
+                    // assembler sees first, before negotiation finalizes).
+                    parentFolder = file.parentFolder,
                 )
             for (frame in frames) {
                 // Poll for cancellation between chunks. trySend semantics

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/IntroductionFramesTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/IntroductionFramesTest.kt
@@ -25,6 +25,7 @@ class IntroductionFramesTest {
         size: Long,
         mimeType: String,
         payloadId: Long,
+        parentFolder: String = "",
     ): FileSource =
         FileSource(
             name = name,
@@ -32,6 +33,7 @@ class IntroductionFramesTest {
             mimeType = mimeType,
             lastModifiedTimestampMillis = 0L,
             payloadId = payloadId,
+            parentFolder = parentFolder,
             open = { Channels.newChannel(ByteArrayInputStream(ByteArray(0))) as ReadableByteChannel },
         )
 
@@ -64,6 +66,42 @@ class IntroductionFramesTest {
             assertThat(md.payloadId).isEqualTo(expected.payloadId)
             assertThat(md.id).isNotEqualTo(0L)
         }
+    }
+
+    @Test
+    fun `top-level files leave parent_folder unset`() {
+        // Plain file shares (#24's pre-existing flow) must remain
+        // byte-for-byte compatible with the pre-#38 introduction shape.
+        // Receivers that branch on `hasParentFolder()` must observe
+        // false for a top-level file.
+        val intro =
+            buildIntroductionFrame(
+                listOf(fileSource("photo.jpg", 1, "image/jpeg", payloadId = 1L)),
+            )
+        val md = intro.getFileMetadata(0)
+        assertThat(md.hasParentFolder()).isFalse()
+        assertThat(md.parentFolder).isEqualTo("")
+    }
+
+    @Test
+    fun `folder send carries parent_folder for nested files`() {
+        // #38: SAF DocumentTree walks emit one FileMetadata per file
+        // with `parent_folder` set to the relative directory path.
+        // Receivers materialize directories implicitly as files arrive
+        // (Quick Share has no dedicated "create empty directory" frame).
+        val files =
+            listOf(
+                fileSource("README.md", 256, "text/markdown", payloadId = 11L),
+                fileSource("logo.png", 4_096, "image/png", payloadId = 12L, parentFolder = "assets"),
+                fileSource("hero.png", 8_192, "image/png", payloadId = 13L, parentFolder = "assets/img"),
+                fileSource("notes.txt", 1_024, "text/plain", payloadId = 14L, parentFolder = "docs/2024"),
+            )
+        val intro = buildIntroductionFrame(files)
+        assertThat(intro.fileMetadataCount).isEqualTo(4)
+        assertThat(intro.getFileMetadata(0).hasParentFolder()).isFalse()
+        assertThat(intro.getFileMetadata(1).parentFolder).isEqualTo("assets")
+        assertThat(intro.getFileMetadata(2).parentFolder).isEqualTo("assets/img")
+        assertThat(intro.getFileMetadata(3).parentFolder).isEqualTo("docs/2024")
     }
 
     @Test


### PR DESCRIPTION
## Summary

Implements **#38** — folder-send via SAF `ACTION_OPEN_DOCUMENT_TREE`, populating `FileMetadata.parent_folder` and the matching `PayloadHeader.parent_folder` so the receiver can reconstruct nested directory layouts. NearDrop rejects multi-attachment introductions whose files carry `parent_folder`, but the Quick Share wire spec supports it natively — this PR wires up the sender side; the matching receiver-side materialisation lands in #39.

### What changed

- **`:core-protocol`**
  - `FileSource` gains an optional `parentFolder` property defaulted to `""` so existing callers (top-level shares from #24) stay byte-for-byte compatible.
  - `buildIntroductionFrame` writes `FileMetadata.parent_folder` only when non-empty (preserves the pre-#38 wire shape for plain file sends).
  - `OutboundConnectionDriver.streamOneFile` mirrors `parentFolder` onto every `PayloadHeader`.
  - New `IntroductionFramesTest` cases verify the top-level-unset and nested-set behaviours.
- **`:app`**
  - New `DocumentTreeFileSourceFactory` walks a SAF tree URI depth-first via `DocumentsContract` (cheaper than `DocumentFile.listFiles()` on real-world trees), emits one `FileSource` per descendant file, and lazily defers `openInputStream` so large folders do not pre-open thousands of FDs. Skips empty subdirectories. Caps recursion at depth 32 as a defensive guard against pathological provider behaviour.
  - New "Send folder" button on `MainActivity` launches `ACTION_OPEN_DOCUMENT_TREE` via `ActivityResultContracts.OpenDocumentTree` and forwards the resulting tree URI to `SendActivity` via the internal action `io.github.kyujincho.wvmg.action.SEND_FOLDER` plus `FLAG_GRANT_READ_URI_PERMISSION`.
  - `SendActivity` accepts the new action, walks the tree, and otherwise reuses the existing discovery / outbound-connection flow. New terminal UI states cover "folder is empty" and "could not read folder contents".
  - New JVM tests for `DocumentTreeFileSourceFactory.sanitizeDisplayName` (path-separator handling, fallback chain).

### Notes

- The internal `ACTION_SEND_FOLDER` is intentionally NOT exported in the manifest — only `MainActivity` invokes it. The activity gracefully renders a "couldn't read folder" state if a third-party caller ever invokes it with the wrong shape (defensive `IllegalArgumentException` catch).
- The walk runs synchronously on the UI thread; real-world Quick Share-sized folders walk in single-digit milliseconds. If this becomes a UI-jank source on huge trees we can move it to a background dispatcher — the rest of the activity already uses `lifecycleScope`.
- Pre-existing test failure on `main` (`AndroidManifestPermissionsTest.multicast lock permission is no longer declared after nsd migration`) is unrelated to this change — it has been failing since #101 re-added `CHANGE_WIFI_MULTICAST_STATE` for the FGS gate. Out of scope for this PR.

## Test plan

- [x] `./gradlew :core-protocol:test` — all 250+ tests pass, including the new `IntroductionFramesTest` cases.
- [x] `./gradlew :app:testDebugUnitTest` — 51/52 pass; the one failure is the pre-existing manifest test on `main`.
- [x] `./gradlew staticAnalysis` — ktlint + detekt clean.
- [x] `./gradlew :app:assembleDebug` — APK builds.
- [ ] Manual on-device interop: pick a folder containing nested subdirectories with at least one file ≥10 MB; confirm the receiver sees the correct directory layout (gated on #39's receiver-side support).