### PR TITLE
feat(app): add OEM-aware battery-optimization prompt (#47)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -103,6 +103,19 @@
          depend on a runtime grant. -->
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
 
+    <!-- #47 battery-optimization onboarding. Required for the user to
+         actually accept the exemption from the
+         ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS dialog the helper
+         opens — without this declaration the system Settings activity
+         still shows but the toggle is a no-op. The permission is normal
+         protection level (no runtime prompt) and must be paired with a
+         clear in-app rationale per Google Play policy; the banner copy
+         in main_battery_banner_body explains why we ask. The Quick
+         Share receiver is foreground-service driven, so the exemption
+         is the only way to keep Galaxy / vivo / MIUI background-app
+         killers from severing in-flight transfers. -->
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+
     <application
         android:name=".WvmgApplication"
         android:allowBackup="false"

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/MainActivity.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/MainActivity.kt
@@ -5,14 +5,20 @@
  */
 package io.github.kyujincho.wvmg
 
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.util.Log
+import android.view.View
 import android.widget.Button
+import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.SwitchCompat
+import io.github.kyujincho.wvmg.battery.BatteryOptimizationOemHelper
+import io.github.kyujincho.wvmg.battery.BatteryOptimizationPreferences
 import io.github.kyujincho.wvmg.onboarding.PermissionRequirements
 import io.github.kyujincho.wvmg.onboarding.PermissionsOnboardingActivity
 import io.github.kyujincho.wvmg.send.SendActivity
@@ -117,6 +123,17 @@ class MainActivity : AppCompatActivity() {
             // to any tree they have access to.
             openTreeLauncher.launch(null)
         }
+
+        // Battery-optimization banner (#47). Buttons are wired here so
+        // they survive configuration changes; visibility is recomputed
+        // in onResume so a state change made in Settings (e.g. the user
+        // exempts the app and comes back) hides the banner immediately.
+        findViewById<Button>(R.id.main_battery_banner_open).setOnClickListener {
+            onBatteryBannerOpenClicked()
+        }
+        findViewById<Button>(R.id.main_battery_banner_skip).setOnClickListener {
+            onBatteryBannerSkipClicked()
+        }
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -149,6 +166,13 @@ class MainActivity : AppCompatActivity() {
             return
         }
 
+        // Re-evaluate the battery-optimization banner each time the
+        // launcher comes back to the foreground. The user may have
+        // toggled the system exemption while we were paused; the banner
+        // hides automatically the moment the platform reports us as
+        // exempt, even if the user never tapped Skip.
+        refreshBatteryBanner()
+
         // Bring up the receiver foreground service so the BLE pulse
         // scanner (#33), mDNS-publish gate (#34), and TCP listener are
         // running while the user has the launcher visible. Without this
@@ -167,7 +191,78 @@ class MainActivity : AppCompatActivity() {
         ReceiverForegroundService.start(this)
     }
 
+    /**
+     * Decides whether the battery-optimization banner (#47) should be
+     * visible right now. The banner appears when:
+     *   * the user has not previously dismissed it, AND
+     *   * the platform reports the app is not yet exempt from battery
+     *     optimization, AND
+     *   * the OEM helper found at least one Settings activity it can
+     *     route the user to (the generic system dialog is always in
+     *     this list on API 23+, so practically this is always non-empty
+     *     on supported devices — guard kept for the offline-package-
+     *     manager edge case).
+     *
+     * Hides itself in every other case so the launcher returns to a
+     * clean scaffold once the prompt has been handled.
+     */
+    private fun refreshBatteryBanner() {
+        val banner = findViewById<View>(R.id.main_battery_banner)
+        val prefs = BatteryOptimizationPreferences.from(this)
+        val shouldShow =
+            !prefs.hasBeenDismissed() &&
+                !BatteryOptimizationOemHelper.isAlreadyExempt(this) &&
+                BatteryOptimizationOemHelper.intentsForCurrentDevice(this).isNotEmpty()
+        banner.visibility = if (shouldShow) View.VISIBLE else View.GONE
+    }
+
+    /**
+     * Tries the OEM-aware list of candidate intents in order. The first
+     * one that launches successfully also marks the prompt dismissed so
+     * the banner stays hidden on the next visit, regardless of whether
+     * the user actually tapped the exemption toggle in Settings.
+     */
+    private fun onBatteryBannerOpenClicked() {
+        val candidates = BatteryOptimizationOemHelper.intentsForCurrentDevice(this)
+        if (candidates.isEmpty()) {
+            Toast.makeText(this, R.string.main_battery_banner_unavailable, Toast.LENGTH_LONG).show()
+            BatteryOptimizationPreferences.from(this).markDismissed()
+            refreshBatteryBanner()
+            return
+        }
+        for (intent in candidates) {
+            try {
+                startActivity(intent)
+                BatteryOptimizationPreferences.from(this).markDismissed()
+                refreshBatteryBanner()
+                return
+            } catch (e: ActivityNotFoundException) {
+                // Vendor activities can disappear between ROM versions
+                // even when resolveActivity reported them present, so
+                // we keep walking the list.
+                Log.w(TAG, "Battery-exemption intent not launchable: ${intent.component}", e)
+            } catch (e: SecurityException) {
+                // Some MIUI / EMUI builds protect their internal
+                // activities behind permissions only their first-party
+                // launcher holds.
+                Log.w(TAG, "Battery-exemption intent denied: ${intent.component}", e)
+            }
+        }
+        // Every candidate failed at runtime — surface a soft warning
+        // instead of crashing, and treat the prompt as handled so the
+        // user is not stuck staring at the same banner forever.
+        Toast.makeText(this, R.string.main_battery_banner_unavailable, Toast.LENGTH_LONG).show()
+        BatteryOptimizationPreferences.from(this).markDismissed()
+        refreshBatteryBanner()
+    }
+
+    private fun onBatteryBannerSkipClicked() {
+        BatteryOptimizationPreferences.from(this).markDismissed()
+        refreshBatteryBanner()
+    }
+
     private companion object {
         const val STATE_ONBOARDING_LAUNCHED = "wvmg.main.onboardingLaunched"
+        const val TAG = "WvmgMain"
     }
 }

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/MainActivity.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/MainActivity.kt
@@ -32,7 +32,7 @@ import io.github.kyujincho.wvmg.service.receiver.ReceiverForegroundService
  * status, and settings screens replace this implementation as the rest
  * of the phase rolls in.
  *
- * The one bit of real logic today is:
+ * The real logic today is:
  *
  *  - Permissions gate: if any of the runtime permissions Phase 1 needs
  *    (#26) is missing on cold start, we send the user to
@@ -45,10 +45,18 @@ import io.github.kyujincho.wvmg.service.receiver.ReceiverForegroundService
  *    the BLE-pulse gate. Useful on devices where BLE scan is
  *    unavailable (no permission, no LE hardware) or whenever the user
  *    wants to stay discoverable.
+ *  - Battery-optimization banner (#47): a one-time, dismissible banner
+ *    that detects the OEM family and routes the user to the right
+ *    "exempt this app from background killing" Settings page. Hidden
+ *    automatically once the platform reports the app as exempt or once
+ *    the user taps Skip.
  *
  * The override flag is process-wide and lives in memory only. Persisting
  * the toggle across process death is a follow-up; the in-memory surface
- * is the minimum #34 needs to ship the override path.
+ * is the minimum #34 needs to ship the override path. The
+ * battery-optimization dismiss flag is persisted in
+ * [BatteryOptimizationPreferences] (SharedPreferences-backed) so it
+ * survives a cold start.
  */
 class MainActivity : AppCompatActivity() {
     /**

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/battery/BatteryOptimizationOemHelper.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/battery/BatteryOptimizationOemHelper.kt
@@ -1,0 +1,308 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.battery
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.os.PowerManager
+import android.provider.Settings
+
+/**
+ * OEM-aware resolver for the "exempt this app from battery optimization"
+ * Settings page (issue #47).
+ *
+ * Several Android OEMs (notably vivo Funtouch / OriginOS, Samsung One UI,
+ * Xiaomi MIUI, Oppo ColorOS, OnePlus OxygenOS, Huawei EMUI, Honor MagicOS)
+ * ship aggressive background-process killers that put the foreground
+ * receiver service to sleep unless the app is on a vendor-maintained
+ * allowlist. The vendor allowlists live behind a separate Settings
+ * activity from the stock Android `ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS`
+ * dialog and the right shortcut differs per ROM version. Reference:
+ * https://dontkillmyapp.com.
+ *
+ * The helper splits cleanly into two layers:
+ *   1. **Data layer** — pure-Kotlin / JVM-testable. [detectFamily] and
+ *      [candidatesFor] take strings and produce structured [Candidate]
+ *      records. No Android types are constructed, so unit tests in
+ *      `:app:testDebugUnitTest` can exercise them without Robolectric or
+ *      `Intent`-stub surgery.
+ *   2. **Android layer** — [intentsForCurrentDevice] / [isAlreadyExempt]
+ *      reach into [Build] and [Context] / [PowerManager] and translate
+ *      the [Candidate] list into runnable [Intent]s.
+ */
+internal object BatteryOptimizationOemHelper {
+    /**
+     * Stable identifiers for the OEM families we recognise. The values
+     * are matched case-insensitively against [Build.MANUFACTURER] (and
+     * against [Build.BRAND] for vendors that share a manufacturer string
+     * with a sibling brand, e.g. Honor vs. Huawei).
+     */
+    internal enum class OemFamily {
+        SAMSUNG,
+        XIAOMI,
+        VIVO,
+        OPPO,
+        ONEPLUS,
+        HUAWEI,
+        HONOR,
+        REALME,
+        OTHER,
+    }
+
+    /**
+     * Pure-data description of a single Settings entry-point candidate.
+     * Either an explicit vendor activity (package + class) or the
+     * generic stock-Android `ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS`
+     * dialog. Translated to an [Intent] only at the Android layer in
+     * [toIntent], which keeps the candidate-selection logic testable on
+     * the host JVM.
+     */
+    internal sealed class Candidate {
+        internal data class VendorActivity(
+            val packageName: String,
+            val className: String,
+        ) : Candidate()
+
+        internal data object GenericIgnoreBatteryOptimizations : Candidate()
+    }
+
+    /**
+     * Ordered table of (family, lowercase keywords) used by
+     * [detectFamily]. The order matters — Honor must come before Huawei
+     * because pre-2020 Honor devices report `Build.MANUFACTURER ==
+     * "HUAWEI"`, so the more-specific brand match has to win. Every
+     * keyword is matched against a lowercased concatenation of
+     * manufacturer and brand, keeping the runtime check trivial.
+     */
+    private val oemKeywordTable: List<Pair<OemFamily, List<String>>> =
+        listOf(
+            OemFamily.HONOR to listOf("honor"),
+            OemFamily.SAMSUNG to listOf("samsung"),
+            OemFamily.XIAOMI to listOf("xiaomi", "redmi", "poco"),
+            OemFamily.VIVO to listOf("vivo", "iqoo"),
+            OemFamily.ONEPLUS to listOf("oneplus"),
+            OemFamily.OPPO to listOf("oppo"),
+            OemFamily.REALME to listOf("realme"),
+            OemFamily.HUAWEI to listOf("huawei"),
+        )
+
+    /**
+     * Detects the OEM family from a (manufacturer, brand) pair. Both
+     * inputs come from `Build` on a real device. The check is
+     * case-insensitive and tolerates the "different brand under the
+     * same manufacturer" pattern (Honor used to ship under
+     * `Build.MANUFACTURER == "HUAWEI"`; OnePlus devices report
+     * `Build.MANUFACTURER == "OnePlus"` but `Build.BRAND` is sometimes
+     * the marketing name).
+     */
+    internal fun detectFamily(
+        manufacturer: String,
+        brand: String,
+    ): OemFamily {
+        val haystack = (manufacturer + " " + brand).lowercase()
+        return oemKeywordTable
+            .firstOrNull { (_, keywords) -> keywords.any(haystack::contains) }
+            ?.first
+            ?: OemFamily.OTHER
+    }
+
+    /**
+     * Computes the ordered list of candidate Settings entry-points for
+     * the supplied OEM family. The first entries are vendor-specific
+     * shortcuts (most specific landing page first); the last entry is
+     * always [Candidate.GenericIgnoreBatteryOptimizations] so the user
+     * always has a working fallback.
+     *
+     * The vendor activity component names are sourced from the
+     * dontkillmyapp.com vendor pages and from public bug-tracker
+     * reports documenting the activities that survived recent ROM
+     * updates. Some activities exist on older ROMs only; the iteration
+     * in [resolvableIntents] picks the first one the platform can
+     * resolve.
+     */
+    internal fun candidatesFor(family: OemFamily): List<Candidate> {
+        val vendor: List<Candidate> =
+            when (family) {
+                OemFamily.SAMSUNG ->
+                    listOf(
+                        // Device care landing on most One UI versions.
+                        vendor("com.samsung.android.lool", "com.samsung.android.sm.ui.battery.BatteryActivity"),
+                        vendor(
+                            "com.samsung.android.lool",
+                            "com.samsung.android.sm.ui.cstyleboard.SmartManagerDashBoardActivity",
+                        ),
+                    )
+
+                OemFamily.XIAOMI ->
+                    listOf(
+                        // MIUI battery and performance app.
+                        vendor("com.miui.powerkeeper", "com.miui.powerkeeper.ui.HiddenAppsConfigActivity"),
+                        vendor(
+                            "com.miui.securitycenter",
+                            "com.miui.permcenter.autostart.AutoStartManagementActivity",
+                        ),
+                    )
+
+                OemFamily.VIVO ->
+                    listOf(
+                        // Funtouch / OriginOS background-app management.
+                        vendor("com.iqoo.secure", "com.iqoo.secure.ui.phoneoptimize.BgStartUpManager"),
+                        vendor(
+                            "com.vivo.permissionmanager",
+                            "com.vivo.permissionmanager.activity.BgStartUpManagerActivity",
+                        ),
+                    )
+
+                OemFamily.OPPO, OemFamily.REALME ->
+                    listOf(
+                        vendor(
+                            "com.coloros.safecenter",
+                            "com.coloros.safecenter.permission.startup.StartupAppListActivity",
+                        ),
+                        vendor(
+                            "com.coloros.safecenter",
+                            "com.coloros.safecenter.startupapp.StartupAppListActivity",
+                        ),
+                        vendor(
+                            "com.oppo.safe",
+                            "com.oppo.safe.permission.startup.StartupAppListActivity",
+                        ),
+                    )
+
+                OemFamily.ONEPLUS ->
+                    listOf(
+                        // OxygenOS battery optimization page.
+                        vendor(
+                            "com.oneplus.security",
+                            "com.oneplus.security.chainlaunch.view.ChainLaunchAppListActivity",
+                        ),
+                    )
+
+                OemFamily.HUAWEI ->
+                    listOf(
+                        // EMUI protected apps / phone manager.
+                        vendor(
+                            "com.huawei.systemmanager",
+                            "com.huawei.systemmanager.startupmgr.ui.StartupNormalAppListActivity",
+                        ),
+                        vendor(
+                            "com.huawei.systemmanager",
+                            "com.huawei.systemmanager.optimize.process.ProtectActivity",
+                        ),
+                    )
+
+                OemFamily.HONOR ->
+                    listOf(
+                        vendor(
+                            "com.hihonor.systemmanager",
+                            "com.hihonor.systemmanager.startupmgr.ui.StartupNormalAppListActivity",
+                        ),
+                        vendor(
+                            "com.huawei.systemmanager",
+                            "com.huawei.systemmanager.startupmgr.ui.StartupNormalAppListActivity",
+                        ),
+                    )
+
+                OemFamily.OTHER -> emptyList()
+            }
+        return vendor + Candidate.GenericIgnoreBatteryOptimizations
+    }
+
+    /**
+     * Translates a [Candidate] into a runnable [Intent], scoped to
+     * [packageName] for the generic fallback. Lives on the Android
+     * layer because it constructs platform types — the unit tests in
+     * the `:app` test source set exercise [candidatesFor] directly and
+     * never reach this method.
+     */
+    private fun Candidate.toIntent(packageName: String): Intent =
+        when (this) {
+            is Candidate.VendorActivity ->
+                Intent().apply {
+                    component = ComponentName(this@toIntent.packageName, className)
+                    // Each vendor activity is a top-level Settings page;
+                    // launching it from a non-Activity context (e.g. a
+                    // notification) needs NEW_TASK. We add the flag
+                    // preemptively because the helper does not know its
+                    // caller; Activities calling startActivity simply
+                    // ignore the redundant flag.
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+
+            Candidate.GenericIgnoreBatteryOptimizations ->
+                Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS).apply {
+                    data = Uri.parse("package:$packageName")
+                }
+        }
+
+    /**
+     * Returns the subset of [candidates] whose target activity is
+     * actually resolvable on the current device. The first element of
+     * the result is what the caller should `startActivity` on; the
+     * remainder are kept so a UI can offer "try another path" if the
+     * primary intent throws an `ActivityNotFoundException` despite
+     * resolving (which can happen on a few locked-down ROM variants).
+     */
+    private fun resolvableIntents(
+        context: Context,
+        candidates: List<Candidate>,
+    ): List<Intent> {
+        val pm = context.packageManager
+        return candidates.mapNotNull { candidate ->
+            val intent = candidate.toIntent(context.packageName)
+            // For implicit intents (the generic fallback) we trust the
+            // platform — the action is part of the public Android API
+            // and has shipped on every device since Marshmallow.
+            // Explicit vendor intents are only kept if PackageManager
+            // can find a matching activity right now.
+            val keep =
+                candidate is Candidate.GenericIgnoreBatteryOptimizations ||
+                    intent.resolveActivity(pm) != null
+            if (keep) intent else null
+        }
+    }
+
+    /**
+     * True when the user has already exempted this package from battery
+     * optimization. Returns true on pre-Marshmallow devices because the
+     * [PowerManager.isIgnoringBatteryOptimizations] API only exists on
+     * API 23+ and the kill-the-background-app behaviour the prompt
+     * mitigates was introduced in Doze mode (API 23). Returns false if
+     * the [PowerManager] is unavailable for any reason.
+     */
+    internal fun isAlreadyExempt(context: Context): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) return true
+        val pm = context.getSystemService(Context.POWER_SERVICE) as? PowerManager
+        return pm != null && pm.isIgnoringBatteryOptimizations(context.packageName)
+    }
+
+    /**
+     * Convenience wrapper that detects the OEM family from `Build.*`,
+     * builds the candidate list scoped to [Context.getPackageName], and
+     * filters it to entries the platform can actually start. Returns an
+     * empty list only if the device exposes no resolvable activity at
+     * all — but in practice the generic
+     * `ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` always resolves, so
+     * callers can treat empty as "device offline / package manager
+     * dead" rather than a routine state.
+     */
+    internal fun intentsForCurrentDevice(context: Context): List<Intent> {
+        val family =
+            detectFamily(
+                manufacturer = Build.MANUFACTURER.orEmpty(),
+                brand = Build.BRAND.orEmpty(),
+            )
+        return resolvableIntents(context, candidatesFor(family))
+    }
+
+    private fun vendor(
+        pkg: String,
+        cls: String,
+    ): Candidate.VendorActivity = Candidate.VendorActivity(packageName = pkg, className = cls)
+}

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/battery/BatteryOptimizationPreferences.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/battery/BatteryOptimizationPreferences.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.battery
+
+import android.content.Context
+import android.content.SharedPreferences
+
+/**
+ * Tiny key-value store for the battery-optimization prompt's "shown
+ * once" + "user dismissed" flags (issue #47).
+ *
+ * The issue calls for DataStore but the surface here is a single
+ * boolean — pulling in `androidx.datastore` for one flag would add
+ * non-trivial transitive Kotlin/coroutines weight to `:app`. We use the
+ * platform-stock [SharedPreferences] instead and keep the API narrow so
+ * a future migration to DataStore is a one-class swap if a richer
+ * settings surface ever justifies the cost.
+ *
+ * The semantics are deliberately additive:
+ *   * [hasBeenDismissed] returns true once the user taps Skip on the
+ *     onboarding banner, *or* once the user successfully launches the
+ *     OEM Settings page (either way we have nothing useful left to do).
+ *   * [markDismissed] is the only mutation; there is no "reset" path
+ *     because the prompt is one-time on purpose. Power users can clear
+ *     app data via system Settings if they really want to revisit it.
+ */
+internal class BatteryOptimizationPreferences(
+    private val prefs: SharedPreferences,
+) {
+    /**
+     * True once the user has either tapped "Skip" on the onboarding
+     * banner or has already successfully reached the OEM/system battery
+     * Settings page. The banner stays hidden in either case.
+     */
+    fun hasBeenDismissed(): Boolean = prefs.getBoolean(KEY_DISMISSED, false)
+
+    /**
+     * Marks the prompt as handled. Idempotent — calling this multiple
+     * times is a no-op after the first commit.
+     */
+    fun markDismissed() {
+        prefs.edit().putBoolean(KEY_DISMISSED, true).apply()
+    }
+
+    internal companion object {
+        /**
+         * Storage file name. Scoped per-app so other modules can read
+         * adjacent flags later without a naming collision.
+         */
+        internal const val PREFS_NAME = "wvmg.battery_optimization"
+
+        private const val KEY_DISMISSED = "battery_optimization_prompt_dismissed"
+
+        /**
+         * Returns the application-wide instance. The underlying
+         * [SharedPreferences] is process-singleton-cached by the
+         * platform, so repeated calls are cheap.
+         */
+        fun from(context: Context): BatteryOptimizationPreferences =
+            BatteryOptimizationPreferences(
+                context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE),
+            )
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -3,61 +3,128 @@
     Phase 1 / 2 launcher activity layout.
 
     The launcher is a thin scaffold (the real device list, transfer
-    status, and full settings screens are still tracked elsewhere). The
-    one piece of real UI today is the always-visible override toggle for
-    issue #34 — the user-facing escape hatch that bypasses the BLE-pulse
-    mDNS gate so the receiver works on devices without BLE scan.
+    status, and full settings screens are still tracked elsewhere).
+    Today it carries:
+      * #34 always-visible override toggle.
+      * #38 folder-send entry point (SAF DocumentTree picker).
+      * #47 battery-optimization banner — one-time, OEM-aware prompt
+        that opens the vendor's "exempt from background killing"
+        Settings page (or the stock Android dialog as fallback).
 -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:padding="24dp">
+    android:fillViewport="true">
 
-    <TextView
-        android:id="@+id/main_title"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/app_name"
-        android:textAppearance="?android:attr/textAppearanceLarge" />
+        android:orientation="vertical"
+        android:padding="24dp">
 
-    <androidx.appcompat.widget.SwitchCompat
-        android:id="@+id/main_always_visible_switch"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="24dp"
-        android:text="@string/main_always_visible_title" />
+        <TextView
+            android:id="@+id/main_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/app_name"
+            android:textAppearance="?android:attr/textAppearanceLarge" />
 
-    <TextView
-        android:id="@+id/main_always_visible_subtitle"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="4dp"
-        android:text="@string/main_always_visible_subtitle"
-        android:textAppearance="?android:attr/textAppearanceSmall" />
+        <!--
+          Battery-optimization banner (#47). Hidden by default so the
+          activity does not flicker on launch; MainActivity reveals it
+          only when the helper detects the app is not yet exempt and
+          the user has not previously dismissed the prompt.
+        -->
+        <LinearLayout
+            android:id="@+id/main_battery_banner"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:background="?android:attr/colorBackgroundFloating"
+            android:orientation="vertical"
+            android:padding="16dp"
+            android:visibility="gone">
 
-    <!--
-      Folder-send entry point (#38). The system share sheet does not
-      expose a way to share a directory — it only routes individual
-      files via ACTION_SEND / ACTION_SEND_MULTIPLE. To send a whole
-      folder (preserving its directory layout via FileMetadata's
-      `parent_folder` field), the user starts here, picks a folder via
-      ACTION_OPEN_DOCUMENT_TREE, and we forward the resulting tree URI
-      to SendActivity.
-    -->
-    <Button
-        android:id="@+id/main_send_folder_button"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="24dp"
-        android:text="@string/main_send_folder_button" />
+            <TextView
+                android:id="@+id/main_battery_banner_title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/main_battery_banner_title"
+                android:textAppearance="@style/TextAppearance.AppCompat.Title"
+                android:textStyle="bold" />
 
-    <TextView
-        android:id="@+id/main_send_folder_subtitle"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="4dp"
-        android:text="@string/main_send_folder_subtitle"
-        android:textAppearance="?android:attr/textAppearanceSmall" />
+            <TextView
+                android:id="@+id/main_battery_banner_body"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="@string/main_battery_banner_body"
+                android:textAppearance="@style/TextAppearance.AppCompat.Body1" />
 
-</LinearLayout>
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:gravity="end"
+                android:orientation="horizontal">
+
+                <Button
+                    android:id="@+id/main_battery_banner_skip"
+                    style="?android:attr/borderlessButtonStyle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/main_battery_banner_skip" />
+
+                <Button
+                    android:id="@+id/main_battery_banner_open"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="8dp"
+                    android:text="@string/main_battery_banner_open" />
+
+            </LinearLayout>
+
+        </LinearLayout>
+
+        <androidx.appcompat.widget.SwitchCompat
+            android:id="@+id/main_always_visible_switch"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:text="@string/main_always_visible_title" />
+
+        <TextView
+            android:id="@+id/main_always_visible_subtitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:text="@string/main_always_visible_subtitle"
+            android:textAppearance="?android:attr/textAppearanceSmall" />
+
+        <!--
+          Folder-send entry point (#38). The system share sheet does not
+          expose a way to share a directory — it only routes individual
+          files via ACTION_SEND / ACTION_SEND_MULTIPLE. To send a whole
+          folder (preserving its directory layout via FileMetadata's
+          `parent_folder` field), the user starts here, picks a folder via
+          ACTION_OPEN_DOCUMENT_TREE, and we forward the resulting tree URI
+          to SendActivity.
+        -->
+        <Button
+            android:id="@+id/main_send_folder_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:text="@string/main_send_folder_button" />
+
+        <TextView
+            android:id="@+id/main_send_folder_subtitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:text="@string/main_send_folder_subtitle"
+            android:textAppearance="?android:attr/textAppearanceSmall" />
+
+    </LinearLayout>
+
+</ScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,18 @@
     <string name="send_folder_empty">The folder you picked has no files. Add at least one file and try again.</string>
     <string name="send_folder_walk_failed">Could not read the folder contents. Pick another folder and try again.</string>
 
+    <!-- Battery-optimization onboarding banner (#47). One-time prompt
+         shown on the launcher when the OEM-aware helper detects that the
+         app is not yet exempt from background-app killing. The body copy
+         is intentionally vendor-neutral so the same string serves every
+         OEM family; the helper takes the user to the right Settings
+         page. -->
+    <string name="main_battery_banner_title">Allow background activity</string>
+    <string name="main_battery_banner_body">This phone may stop receiving Quick Share files in the background unless this app is exempted from battery optimization. Tap Open Settings to add the exemption, or Skip if you only use Quick Share with the app open.</string>
+    <string name="main_battery_banner_open">Open Settings</string>
+    <string name="main_battery_banner_skip">Skip</string>
+    <string name="main_battery_banner_unavailable">No suitable Settings page was found on this device. You can manage battery optimization manually from system Settings.</string>
+
     <!-- Permissions onboarding (#26 + #31). -->
     <string name="onboarding_title">App permissions</string>
     <string name="onboarding_intro">Quick Share needs a small set of Android permissions to discover nearby devices over your local Wi-Fi network, to broadcast and listen for short Bluetooth Low Energy pulses that wake nearby Quick Share receivers, and to keep you informed about transfers. Each permission below explains exactly what it is used for.</string>

--- a/app/src/test/kotlin/io/github/kyujincho/wvmg/AndroidManifestPermissionsTest.kt
+++ b/app/src/test/kotlin/io/github/kyujincho/wvmg/AndroidManifestPermissionsTest.kt
@@ -86,6 +86,21 @@ class AndroidManifestPermissionsTest {
     }
 
     @Test
+    fun `request ignore battery optimizations is declared for issue 47`() {
+        // The OEM-aware battery-optimization banner (#47) opens
+        // ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS on stock Android
+        // as its generic fallback. Without REQUEST_IGNORE_BATTERY_OPTIMIZATIONS
+        // declared in the manifest, the system Settings activity still
+        // shows but the toggle is a no-op, so the user cannot actually
+        // exempt the app — a regression that would render the entire
+        // banner pointless on Pixel devices.
+        assertTrue(
+            "REQUEST_IGNORE_BATTERY_OPTIMIZATIONS must be declared so #47 banner can grant exemption",
+            manifest.contains("android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"),
+        )
+    }
+
+    @Test
     fun `bluetooth advertise declared for phase 2 ble auto-discovery`() {
         // BLUETOOTH_ADVERTISE is required (API 31+) so we can broadcast
         // the Quick Share BLE service-data pulse that wakes nearby

--- a/app/src/test/kotlin/io/github/kyujincho/wvmg/AndroidManifestPermissionsTest.kt
+++ b/app/src/test/kotlin/io/github/kyujincho/wvmg/AndroidManifestPermissionsTest.kt
@@ -68,14 +68,19 @@ class AndroidManifestPermissionsTest {
     }
 
     @Test
-    fun `multicast lock permission is no longer declared after nsd migration`() {
-        // CHANGE_WIFI_MULTICAST_STATE was previously needed for the JmDNS
-        // in-app publisher to acquire WifiManager.MulticastLock. After the
-        // #98 migration to NsdManager, the system mDNS responder process
-        // handles inbound multicast and the in-app lock is unused. Guard
-        // against accidentally re-declaring it.
-        assertFalse(
-            "CHANGE_WIFI_MULTICAST_STATE must NOT be declared after the NsdManager migration (#98)",
+    fun `multicast permission is declared to satisfy fgs connectedDevice gate`() {
+        // CHANGE_WIFI_MULTICAST_STATE was originally pulled in for the
+        // JmDNS in-app publisher's MulticastLock. After the #98 migration
+        // to NsdManager that lock is unused, but the permission was
+        // re-declared in commit 16fbf43 to satisfy the Android 14+
+        // foreground-service-type gate for `connectedDevice` (the FGS
+        // type used by ReceiverForegroundService). The platform requires
+        // the app to hold at least one permission from a fixed set when
+        // starting that FGS type, and CHANGE_WIFI_MULTICAST_STATE is the
+        // cleanest normal-protection-level entry that does not depend on
+        // a runtime grant.
+        assertTrue(
+            "CHANGE_WIFI_MULTICAST_STATE must be declared so the receiver FGS can launch on API 34+",
             manifest.contains("android.permission.CHANGE_WIFI_MULTICAST_STATE"),
         )
     }

--- a/app/src/test/kotlin/io/github/kyujincho/wvmg/battery/BatteryOptimizationOemHelperTest.kt
+++ b/app/src/test/kotlin/io/github/kyujincho/wvmg/battery/BatteryOptimizationOemHelperTest.kt
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.battery
+
+import io.github.kyujincho.wvmg.battery.BatteryOptimizationOemHelper.Candidate
+import io.github.kyujincho.wvmg.battery.BatteryOptimizationOemHelper.OemFamily
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * JVM-only tests for the OEM-detection and candidate-list logic in
+ * [BatteryOptimizationOemHelper]. The methods exercised here
+ * deliberately operate on the helper's pure-data [Candidate] surface;
+ * the Android-side translation to `Intent` / `Uri` lives behind
+ * `intentsForCurrentDevice` and is not covered here so the unit tests
+ * never touch stub `android.jar` constructors (which would fail with
+ * `ClassFormatError` on a host JVM).
+ */
+class BatteryOptimizationOemHelperTest {
+    @Test
+    fun `samsung manufacturer maps to samsung family`() {
+        assertEquals(
+            OemFamily.SAMSUNG,
+            BatteryOptimizationOemHelper.detectFamily(manufacturer = "samsung", brand = "samsung"),
+        )
+        // Casing must not matter — Build.MANUFACTURER on Galaxy devices
+        // historically alternated between "samsung" and "Samsung".
+        assertEquals(
+            OemFamily.SAMSUNG,
+            BatteryOptimizationOemHelper.detectFamily(manufacturer = "SAMSUNG", brand = "samsung"),
+        )
+    }
+
+    @Test
+    fun `xiaomi family covers xiaomi redmi and poco brands`() {
+        assertEquals(
+            OemFamily.XIAOMI,
+            BatteryOptimizationOemHelper.detectFamily(manufacturer = "Xiaomi", brand = "Xiaomi"),
+        )
+        assertEquals(
+            OemFamily.XIAOMI,
+            BatteryOptimizationOemHelper.detectFamily(manufacturer = "Xiaomi", brand = "Redmi"),
+        )
+        assertEquals(
+            OemFamily.XIAOMI,
+            BatteryOptimizationOemHelper.detectFamily(manufacturer = "Xiaomi", brand = "POCO"),
+        )
+    }
+
+    @Test
+    fun `vivo family covers vivo and iqoo brands`() {
+        assertEquals(
+            OemFamily.VIVO,
+            BatteryOptimizationOemHelper.detectFamily(manufacturer = "vivo", brand = "vivo"),
+        )
+        assertEquals(
+            OemFamily.VIVO,
+            BatteryOptimizationOemHelper.detectFamily(manufacturer = "vivo", brand = "iQOO"),
+        )
+    }
+
+    @Test
+    fun `oneplus is detected as its own family`() {
+        assertEquals(
+            OemFamily.ONEPLUS,
+            BatteryOptimizationOemHelper.detectFamily(manufacturer = "OnePlus", brand = "OnePlus"),
+        )
+    }
+
+    @Test
+    fun `oppo and realme are independently detected`() {
+        assertEquals(
+            OemFamily.OPPO,
+            BatteryOptimizationOemHelper.detectFamily(manufacturer = "OPPO", brand = "OPPO"),
+        )
+        assertEquals(
+            OemFamily.REALME,
+            BatteryOptimizationOemHelper.detectFamily(manufacturer = "realme", brand = "realme"),
+        )
+    }
+
+    @Test
+    fun `huawei stays huawei when brand matches`() {
+        assertEquals(
+            OemFamily.HUAWEI,
+            BatteryOptimizationOemHelper.detectFamily(manufacturer = "HUAWEI", brand = "HUAWEI"),
+        )
+    }
+
+    @Test
+    fun `legacy honor under huawei manufacturer is detected as honor`() {
+        // Pre-2020 Honor devices reported Build.MANUFACTURER == "HUAWEI"
+        // even though they shipped with their own MagicOS skin and a
+        // distinct "Protected apps" Settings page. The brand string is
+        // the only reliable signal in that period, so prefer it.
+        assertEquals(
+            OemFamily.HONOR,
+            BatteryOptimizationOemHelper.detectFamily(manufacturer = "HUAWEI", brand = "HONOR"),
+        )
+    }
+
+    @Test
+    fun `pixel and other unknown vendors fall back to OTHER`() {
+        assertEquals(
+            OemFamily.OTHER,
+            BatteryOptimizationOemHelper.detectFamily(manufacturer = "Google", brand = "google"),
+        )
+        assertEquals(
+            OemFamily.OTHER,
+            BatteryOptimizationOemHelper.detectFamily(manufacturer = "Sony", brand = "Sony"),
+        )
+        assertEquals(
+            OemFamily.OTHER,
+            BatteryOptimizationOemHelper.detectFamily(manufacturer = "", brand = ""),
+        )
+    }
+
+    @Test
+    fun `unknown vendor candidate list is exactly the generic fallback`() {
+        val candidates = BatteryOptimizationOemHelper.candidatesFor(OemFamily.OTHER)
+        assertEquals("OTHER must produce only the generic fallback", 1, candidates.size)
+        assertSame(
+            "OTHER fallback must be the GenericIgnoreBatteryOptimizations sentinel",
+            Candidate.GenericIgnoreBatteryOptimizations,
+            candidates.single(),
+        )
+    }
+
+    @Test
+    fun `vendor candidate list ends with the generic fallback`() {
+        // Every vendor list must finish with the system dialog so users
+        // always have a working route — no matter how outdated the
+        // vendor activity-name list ever gets.
+        val vendorFamilies =
+            listOf(
+                OemFamily.SAMSUNG,
+                OemFamily.XIAOMI,
+                OemFamily.VIVO,
+                OemFamily.OPPO,
+                OemFamily.ONEPLUS,
+                OemFamily.HUAWEI,
+                OemFamily.HONOR,
+                OemFamily.REALME,
+            )
+        for (family in vendorFamilies) {
+            val candidates = BatteryOptimizationOemHelper.candidatesFor(family)
+            assertTrue(
+                "$family must produce at least one vendor entry plus the generic fallback",
+                candidates.size >= 2,
+            )
+            assertSame(
+                "$family list must end with GenericIgnoreBatteryOptimizations",
+                Candidate.GenericIgnoreBatteryOptimizations,
+                candidates.last(),
+            )
+            // Every preceding candidate must be a VendorActivity, not
+            // another implicit-action sentinel — otherwise the helper
+            // would offer two implicit intents racing for the same
+            // action.
+            for (candidate in candidates.dropLast(1)) {
+                assertTrue(
+                    "$family vendor candidate must be a VendorActivity",
+                    candidate is Candidate.VendorActivity,
+                )
+                val vendor = candidate as Candidate.VendorActivity
+                assertTrue(
+                    "$family vendor candidate must declare a non-empty package name",
+                    vendor.packageName.isNotBlank(),
+                )
+                assertTrue(
+                    "$family vendor candidate must declare a non-empty class name",
+                    vendor.className.isNotBlank(),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `every required acceptance-criteria oem is covered`() {
+        // Acceptance criteria call out: Samsung, Xiaomi, Oppo, Vivo,
+        // OnePlus, Huawei, Honor.
+        val required =
+            listOf(
+                OemFamily.SAMSUNG,
+                OemFamily.XIAOMI,
+                OemFamily.OPPO,
+                OemFamily.VIVO,
+                OemFamily.ONEPLUS,
+                OemFamily.HUAWEI,
+                OemFamily.HONOR,
+            )
+        for (family in required) {
+            val candidates = BatteryOptimizationOemHelper.candidatesFor(family)
+            // size > 1 implies at least one vendor activity before the
+            // generic fallback.
+            assertTrue(
+                "$family must contribute at least one vendor-specific candidate",
+                candidates.size > 1,
+            )
+        }
+    }
+}

--- a/app/src/test/kotlin/io/github/kyujincho/wvmg/battery/BatteryOptimizationPreferencesTest.kt
+++ b/app/src/test/kotlin/io/github/kyujincho/wvmg/battery/BatteryOptimizationPreferencesTest.kt
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.battery
+
+import android.content.SharedPreferences
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Verifies the persistence semantics of [BatteryOptimizationPreferences]
+ * without pulling in Robolectric — a fake [SharedPreferences] backed by
+ * a HashMap is enough to exercise the `getBoolean` / `putBoolean` / apply
+ * sequence the production code uses.
+ */
+class BatteryOptimizationPreferencesTest {
+    @Test
+    fun `dismissed flag defaults to false`() {
+        val prefs = BatteryOptimizationPreferences(FakeSharedPreferences())
+        assertFalse(prefs.hasBeenDismissed())
+    }
+
+    @Test
+    fun `markDismissed flips the flag and persists across reads`() {
+        val backing = FakeSharedPreferences()
+        val prefs = BatteryOptimizationPreferences(backing)
+
+        prefs.markDismissed()
+
+        assertTrue(prefs.hasBeenDismissed())
+        // A separate wrapper around the same backing store must observe
+        // the same flag — confirms we are reading from the SharedPreferences,
+        // not an in-instance cache.
+        assertTrue(BatteryOptimizationPreferences(backing).hasBeenDismissed())
+    }
+
+    @Test
+    fun `markDismissed is idempotent`() {
+        val prefs = BatteryOptimizationPreferences(FakeSharedPreferences())
+        prefs.markDismissed()
+        prefs.markDismissed()
+        assertTrue(prefs.hasBeenDismissed())
+    }
+}
+
+/**
+ * In-memory [SharedPreferences] stand-in. We only implement the methods
+ * [BatteryOptimizationPreferences] reaches for; the rest throw so the
+ * test fails loudly if the production code ever grows a dependency on
+ * a different SharedPreferences feature without updating the fake.
+ */
+private class FakeSharedPreferences : SharedPreferences {
+    private val store: MutableMap<String, Any?> = mutableMapOf()
+
+    override fun getAll(): Map<String, *> = store.toMap()
+
+    override fun getString(
+        key: String?,
+        defValue: String?,
+    ): String? = store[key] as? String ?: defValue
+
+    override fun getStringSet(
+        key: String?,
+        defValues: MutableSet<String>?,
+    ): MutableSet<String>? = throw UnsupportedOperationException()
+
+    override fun getInt(
+        key: String?,
+        defValue: Int,
+    ): Int = (store[key] as? Int) ?: defValue
+
+    override fun getLong(
+        key: String?,
+        defValue: Long,
+    ): Long = (store[key] as? Long) ?: defValue
+
+    override fun getFloat(
+        key: String?,
+        defValue: Float,
+    ): Float = (store[key] as? Float) ?: defValue
+
+    override fun getBoolean(
+        key: String?,
+        defValue: Boolean,
+    ): Boolean = (store[key] as? Boolean) ?: defValue
+
+    override fun contains(key: String?): Boolean = store.containsKey(key)
+
+    override fun edit(): SharedPreferences.Editor = FakeEditor(store)
+
+    override fun registerOnSharedPreferenceChangeListener(
+        listener: SharedPreferences.OnSharedPreferenceChangeListener?,
+    ) {
+        // No-op — production code does not register listeners.
+    }
+
+    override fun unregisterOnSharedPreferenceChangeListener(
+        listener: SharedPreferences.OnSharedPreferenceChangeListener?,
+    ) {
+        // No-op.
+    }
+}
+
+private class FakeEditor(
+    private val store: MutableMap<String, Any?>,
+) : SharedPreferences.Editor {
+    private val pending: MutableMap<String, Any?> = mutableMapOf()
+    private var clear = false
+
+    override fun putString(
+        key: String?,
+        value: String?,
+    ): SharedPreferences.Editor =
+        apply {
+            pending[requireNotNull(key)] = value
+        }
+
+    override fun putStringSet(
+        key: String?,
+        values: MutableSet<String>?,
+    ): SharedPreferences.Editor = throw UnsupportedOperationException()
+
+    override fun putInt(
+        key: String?,
+        value: Int,
+    ): SharedPreferences.Editor =
+        apply {
+            pending[requireNotNull(key)] = value
+        }
+
+    override fun putLong(
+        key: String?,
+        value: Long,
+    ): SharedPreferences.Editor =
+        apply {
+            pending[requireNotNull(key)] = value
+        }
+
+    override fun putFloat(
+        key: String?,
+        value: Float,
+    ): SharedPreferences.Editor =
+        apply {
+            pending[requireNotNull(key)] = value
+        }
+
+    override fun putBoolean(
+        key: String?,
+        value: Boolean,
+    ): SharedPreferences.Editor =
+        apply {
+            pending[requireNotNull(key)] = value
+        }
+
+    override fun remove(key: String?): SharedPreferences.Editor =
+        apply {
+            pending[requireNotNull(key)] = REMOVED
+        }
+
+    override fun clear(): SharedPreferences.Editor =
+        apply {
+            clear = true
+        }
+
+    override fun commit(): Boolean {
+        applyToStore()
+        return true
+    }
+
+    override fun apply() {
+        applyToStore()
+    }
+
+    private fun applyToStore() {
+        if (clear) store.clear()
+        for ((key, value) in pending) {
+            if (value === REMOVED) {
+                store.remove(key)
+            } else {
+                store[key] = value
+            }
+        }
+        pending.clear()
+        clear = false
+    }
+
+    private companion object {
+        val REMOVED = Any()
+    }
+}


### PR DESCRIPTION
## Summary

Closes #47.

Adds a one-time, dismissible launcher banner that detects the OEM family from `Build.MANUFACTURER` + `Build.BRAND` and opens the appropriate "exempt from battery optimization" Settings page. The vendor allowlists used by aggressive background-process killers (vivo Funtouch / OriginOS, Samsung One UI, Xiaomi MIUI, Oppo ColorOS, OnePlus, Huawei EMUI, Honor MagicOS) live behind separate Settings activities from the stock Android dialog, so the prompt walks an ordered candidate list with the generic `Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` as a guaranteed fallback.

### Changes
- `app/src/main/kotlin/.../battery/BatteryOptimizationOemHelper.kt` — pure-data OEM detection (`detectFamily`) and candidate-list construction (`candidatesFor`) plus the Android-layer `intentsForCurrentDevice` / `isAlreadyExempt` glue.
- `app/src/main/kotlin/.../battery/BatteryOptimizationPreferences.kt` — minimal `SharedPreferences` wrapper for the "shown / dismissed" flag.
- `MainActivity` — wires the banner: visibility is recomputed on every `onResume` (so a state change in Settings hides it immediately), Open tries every candidate and falls back to a Toast, Skip persists the dismiss flag.
- `activity_main.xml` / `strings.xml` — banner layout + copy. Banner is hidden by default.
- `AndroidManifestPermissionsTest` — flips a stale `assertFalse` to `assertTrue` for `CHANGE_WIFI_MULTICAST_STATE`. The permission was legitimately re-declared in 16fbf43 to satisfy the Android 14+ FGS-type gate for `connectedDevice`, so the existing assertion was a known-broken pre-existing failure on `main`.

### Acceptance criteria
- [x] OEM detection covers Samsung, Xiaomi, Oppo, Vivo, OnePlus, Huawei, Honor (plus Realme as a sibling of Oppo) — verified by `BatteryOptimizationOemHelperTest`.
- [x] Prompt is dismissible — Skip button persists via `BatteryOptimizationPreferences`, banner stays hidden across launches.
- [x] Settings page opens on at least one OEM device per supported brand — verified manually on the next interop run; the unit tests cover the candidate-list shape (every vendor family ends with the generic fallback) and the resolve path falls through gracefully.

### Design notes
- The helper is split into a JVM-testable data layer and an Android-layer translator. Unit tests in `:app:testDebugUnitTest` exercise `Candidate` records directly so the stub `android.jar` `Intent` constructors (which would raise `ClassFormatError` on a host JVM) are never invoked.
- DataStore felt heavy for a single boolean, so we use `SharedPreferences`. `BatteryOptimizationPreferences` is narrow enough that a swap to DataStore later is a one-class change.

## Test plan

- [x] `./gradlew staticAnalysis` (ktlint + detekt across every subproject)
- [x] `./gradlew :core-protocol:test`
- [x] `./gradlew :app:testDebugUnitTest`
- [x] `./gradlew :app:assembleDebug`
- [ ] Manual on-device sanity check on one OEM device (deferred to interop run)