### PR TITLE
feat(protocol): outbound KEEP_ALIVE ticker at 10-second cadence (#37)

### DIFF
--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/KeepAliveTicker.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/KeepAliveTicker.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.connection
+
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
+
+/**
+ * Outbound `KEEP_ALIVE` ticker shared infrastructure.
+ *
+ * PROTOCOL.md ("Connection management"):
+ * > Android sends offline frames of type `KEEP_ALIVE` every 10 seconds
+ * > and expects the server to do the same. If you don't, it will
+ * > terminate the connection after a while thinking your app crashed
+ * > or something. This especially comes into play when sending large
+ * > files.
+ *
+ * Without this ticker the upper bound on idle time is the advertised
+ * `keep_alive_timeout_millis` (we set 10 minutes); a chunk-to-chunk
+ * stall on a slow link, plus the receiver writing to slow storage,
+ * can blow past it. The ticker fires `KEEP_ALIVE{ack=false}` at the
+ * configured cadence and lets `SecureChannel`'s send mutex serialize
+ * its writes against payload chunks and FSM frames.
+ *
+ * Factored out from [OutboundConnectionDriver] purely for testability:
+ * the driver hot path passes the production cadence ([DEFAULT_INTERVAL_MILLIS])
+ * and a `SecureChannel::sendOfflineFrame` reference; tests pass a tiny
+ * cadence and a recording sink to exercise the loop in finite time.
+ */
+internal object KeepAliveTicker {
+    /**
+     * Production cadence. Matches PROTOCOL.md's documented stock-Android
+     * behaviour and the value advertised in our
+     * `ConnectionRequestFrame.keep_alive_interval_millis`.
+     */
+    const val DEFAULT_INTERVAL_MILLIS: Long = 10_000L
+
+    /**
+     * Run the ticker loop until cancelled.
+     *
+     * The first tick fires after [intervalMillis] of "quiet time"
+     * (i.e. there is no immediate-tick on entry). Cancellation is
+     * cooperative: any `CancellationException` is propagated; any
+     * other throwable from [send] (typically a socket I/O failure
+     * because the connection is being torn down) is forwarded to
+     * [onError] and the loop exits. The driver's receive loop is
+     * authoritative for the connection's terminal outcome; the
+     * ticker simply stops.
+     *
+     * @param intervalMillis Time between ticks. Production:
+     *   [DEFAULT_INTERVAL_MILLIS]. Tests inject smaller values.
+     * @param send Sink for one outbound `KEEP_ALIVE` frame. In
+     *   production this is `SecureChannel::sendOfflineFrame`; the
+     *   send mutex inside [io.github.kyujincho.wvmg.protocol.crypto.securemessage.SecureChannel]
+     *   provides per-connection serialization, satisfying the
+     *   acceptance criterion that the ticker not interleave with
+     *   payload writes.
+     * @param onError Invoked once when [send] fails. Default is a
+     *   silent no-op so production loops fail quietly during teardown.
+     */
+    suspend fun run(
+        intervalMillis: Long = DEFAULT_INTERVAL_MILLIS,
+        send: suspend (OfflineFrame) -> Unit,
+        onError: (Throwable) -> Unit = {},
+    ) {
+        require(intervalMillis > 0L) {
+            "KeepAliveTicker.run: intervalMillis must be positive, got $intervalMillis"
+        }
+        try {
+            while (true) {
+                delay(intervalMillis)
+                send(OfflineFrames.keepAlive(ack = false))
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (
+            @Suppress("TooGenericExceptionCaught") e: Throwable,
+        ) {
+            onError(e)
+        }
+    }
+}

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OfflineFrames.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OfflineFrames.kt
@@ -7,6 +7,7 @@ package io.github.kyujincho.wvmg.protocol.connection
 
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.ConnectionResponseFrame
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.DisconnectionFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.KeepAliveFrame
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OsInfo
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.V1Frame
@@ -141,6 +142,50 @@ internal object OfflineFrames {
                     .newBuilder()
                     .setType(V1Frame.FrameType.DISCONNECTION)
                     .setDisconnection(disconnection)
+                    .build(),
+            ).build()
+    }
+
+    /**
+     * Build an `OfflineFrame{V1, KEEP_ALIVE}` carrying a `KeepAliveFrame`
+     * with [ack] set as requested.
+     *
+     * Quick Share's contract (see PROTOCOL.md, "Connection management"):
+     * each side fires `KEEP_ALIVE{ack=false}` every 10 seconds and the
+     * peer is expected to do the same. When a side observes the peer's
+     * `ack=false` frame it MAY answer with `ack=true`; both sides
+     * cancel any "peer crashed" watchdog that fires after the
+     * advertised `keep_alive_timeout_millis`. Without an outbound
+     * ticker, long-idle transfers (>`keep_alive_timeout_millis`) get
+     * torn down by the peer's watchdog; with a 10 s outbound ticker
+     * the connection survives indefinitely on a healthy link.
+     *
+     * The `seq_num` field defined in the proto is currently ignored by
+     * stock Quick Share peers (no inbound implementation we have access
+     * to inspects it). Leaving it at the proto default keeps the
+     * outbound shape minimal and matches what NearDrop emits.
+     *
+     * @param ack `false` for a self-initiated tick (the common case
+     *   driven by [OutboundConnectionDriver]'s ticker); `true` for an
+     *   acknowledgement of an inbound `KEEP_ALIVE` (currently no driver
+     *   in this project sends acks — receivers ignore the missing reply
+     *   in steady state — but the helper keeps both shapes available
+     *   for tests and a future ack-reply path).
+     */
+    fun keepAlive(ack: Boolean = false): OfflineFrame {
+        val keepAlive =
+            KeepAliveFrame
+                .newBuilder()
+                .setAck(ack)
+                .build()
+        return OfflineFrame
+            .newBuilder()
+            .setVersion(OfflineFrame.Version.V1)
+            .setV1(
+                V1Frame
+                    .newBuilder()
+                    .setType(V1Frame.FrameType.KEEP_ALIVE)
+                    .setKeepAlive(keepAlive)
                     .build(),
             ).build()
     }

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionDriver.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionDriver.kt
@@ -270,6 +270,20 @@ internal class OutboundConnectionDriver(
             // InboundConnectionDriver.
             val wireChannel: Channel<OutboundWireMessage> = Channel(Channel.RENDEZVOUS)
             val pumpJob: Job = launch { runInboundPump(channel, wireChannel) }
+            // Outbound KEEP_ALIVE ticker (issue #37). PROTOCOL.md:
+            // "Android sends offline frames of type KEEP_ALIVE every
+            // 10 seconds and expects the server to do the same. If you
+            // don't, it will terminate the connection after a while
+            // thinking your app crashed or something." Without this
+            // ticker, our advertised keep_alive_timeout_millis (10 min)
+            // is the upper bound on how long an idle large-file send
+            // can take before the receiver tears the connection down.
+            //
+            // SecureChannel's send half is mutex-serialized internally,
+            // so the ticker can race with payload writes / FSM frame
+            // emissions safely — the next chunk simply waits behind a
+            // queued KEEP_ALIVE rather than interleaving inside it.
+            val keepAliveJob: Job = launch { runKeepAliveTicker(channel) }
             try {
                 val result = dispatchLoop(channel, fsm, wireChannel)
                 // Safe-disconnect drain: we advertised
@@ -299,20 +313,60 @@ internal class OutboundConnectionDriver(
                 }
                 result
             } finally {
-                // Close the socket BEFORE cancelAndJoin: the pump is parked
-                // in SecureChannel.receiveOfflineFrame()'s blocking Socket
-                // read under withContext(Dispatchers.IO), which does NOT
-                // honour coroutine cancellation while parked in a syscall.
-                // Closing the socket throws SocketException out of the read
-                // (the pump catches it as a Throwable and exits), so
-                // cancelAndJoin can complete. TCP guarantees any bytes
-                // already in the send buffer (CANCEL / Disconnection) are
-                // transmitted before the FIN, so the peer still reads our
-                // final frames before observing EOF.
+                // Cancel the KEEP_ALIVE ticker FIRST, before any socket
+                // close: the ticker spends almost all its life parked
+                // in delay() (which is cancellable, unlike a blocking
+                // socket read), so cancelAndJoin returns near-instantly
+                // and we avoid racing a tick against the in-flight
+                // terminal Disconnection. If the ticker happens to be
+                // mid-send when we cancel, it observes
+                // CancellationException out of the SecureChannel write
+                // and exits cleanly.
+                keepAliveJob.cancelAndJoin()
+                // Close the socket BEFORE cancelAndJoin'ing the pump:
+                // the pump is parked in SecureChannel.receiveOfflineFrame()'s
+                // blocking Socket read under withContext(Dispatchers.IO),
+                // which does NOT honour coroutine cancellation while
+                // parked in a syscall. Closing the socket throws
+                // SocketException out of the read (the pump catches it
+                // as a Throwable and exits), so cancelAndJoin can
+                // complete. TCP guarantees any bytes already in the
+                // send buffer (CANCEL / Disconnection) are transmitted
+                // before the FIN, so the peer still reads our final
+                // frames before observing EOF.
                 runCatching { socket.close() }
                 pumpJob.cancelAndJoin()
             }
         }
+
+    /**
+     * Outbound KEEP_ALIVE ticker. Once the SecureChannel is up,
+     * emits `KEEP_ALIVE{ack=false}` every
+     * [KeepAliveTicker.DEFAULT_INTERVAL_MILLIS] (10 s) to keep the
+     * peer's "peer crashed" watchdog from firing during long idle
+     * stretches (in particular: large-file payloads on slow Wi-Fi
+     * where chunk-to-chunk gaps can rival the advertised
+     * `keep_alive_timeout_millis`).
+     *
+     * Cancellation: structured-concurrency child of [runReceiveLoop]'s
+     * `coroutineScope`. The first `delay` is cancellable, so on
+     * teardown the ticker exits near-instantly without firing one last
+     * tick. If a `delay` elapses concurrently with teardown the next
+     * `sendOfflineFrame` either succeeds (race, harmless — the bytes
+     * sit in the TCP send buffer alongside the terminal frames) or
+     * throws a socket I/O exception out of the write, which the
+     * shared [KeepAliveTicker] forwards to the supplied error handler
+     * so cancellation isn't noisy. CancellationException is the
+     * explicit termination path and is rethrown.
+     */
+    private suspend fun runKeepAliveTicker(channel: SecureChannel) {
+        KeepAliveTicker.run(
+            send = channel::sendOfflineFrame,
+            onError = { e ->
+                logger("keep-alive: ticker stopped (${e::class.simpleName}: ${e.message ?: "null"})")
+            },
+        )
+    }
 
     /**
      * True when [result] is a terminal we ourselves drove a

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundFrames.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundFrames.kt
@@ -58,8 +58,10 @@ internal object OutboundFrames {
         //     connection is using; absence of any medium hits a validation
         //     in Nearby Connections that rejects the request.
         //   * keep_alive_interval / timeout are read by the receiver to
-        //     decide its own KEEP_ALIVE cadence; defaults of 5s / 30s are
-        //     what the Chromium reference and NearDrop both ship.
+        //     decide its own KEEP_ALIVE cadence. We advertise 10 s / 10 min
+        //     — PROTOCOL.md documents stock Android emitting KEEP_ALIVE
+        //     every 10 seconds; see KEEP_ALIVE_INTERVAL_MILLIS for the
+        //     timeout rationale.
         //   * endpoint_name is a legacy string field; some forks (older
         //     Samsung Quick Share) still inspect it. Setting it to the
         //     empty string keeps modern peers happy and gives legacy peers
@@ -86,20 +88,29 @@ internal object OutboundFrames {
             ).build()
     }
 
-    private const val KEEP_ALIVE_INTERVAL_MILLIS: Int = 5_000
+    /**
+     * Cadence at which our outbound `KEEP_ALIVE` ticker fires once the
+     * SecureChannel is up. Matches the value PROTOCOL.md documents stock
+     * Android Quick Share emitting ("Android sends offline frames of
+     * type KEEP_ALIVE every 10 seconds and expects the server to do
+     * the same"). The ticker itself lives in [KeepAliveTicker]; we
+     * only advertise the cadence here so the receiver knows what to
+     * expect on its watchdog.
+     */
+    private const val KEEP_ALIVE_INTERVAL_MILLIS: Int = 10_000
 
     /**
      * Keep-alive timeout we advertise to the peer. Stock google/nearby's
-     * default is 30 s under the assumption that the peer will send
-     * explicit `KEEP_ALIVE` frames at the advertised interval. We do
-     * not run a keep-alive sender yet (we only handle inbound
-     * `KEEP_ALIVE` frames, like NearDrop), so a 30-second silence
-     * during slow file transfers — easy to hit on a phone hotspot link
-     * — caused Samsung One UI to disconnect mid-payload at ~81 %
-     * (verified on-device). 10 minutes covers reasonable file sizes
-     * over Wi-Fi LAN; the canonical fix is a periodic
-     * `KEEP_ALIVE` sender driven from the secure channel, tracked
-     * separately.
+     * default is 30 s, predicated on the peer sending explicit
+     * `KEEP_ALIVE` frames at the advertised interval. We now run a
+     * 10 s outbound ticker (issue #37) so the spec-default 30 s would
+     * suffice in steady state, but 10 minutes preserves headroom for
+     * slow-network corner cases (phone-hotspot uplinks, momentary
+     * stalls during large-file SD-card writes) where a single missed
+     * KEEP_ALIVE under load shouldn't tear the connection down. Verified
+     * on-device that bumping from 30 s to 10 min cleared the
+     * Samsung One UI mid-payload disconnect at ~81 % on phone-hotspot
+     * links.
      */
     private const val KEEP_ALIVE_TIMEOUT_MILLIS: Int = 600_000
 

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/KeepAliveTickerTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/KeepAliveTickerTest.kt
@@ -1,0 +1,284 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.connection
+
+import com.google.common.truth.Truth.assertThat
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.KeepAliveFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.V1Frame
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.assertThrows
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Unit tests for the outbound `KEEP_ALIVE` ticker introduced in
+ * issue #37 ("Outbound keep-alive timer — 10-second cadence").
+ *
+ * Two layers are tested here:
+ *   1. [OfflineFrames.keepAlive] — frame shape (type, body, ack flag).
+ *   2. [KeepAliveTicker.run] — cadence, cooperative cancellation, and
+ *      error-path containment. Virtual time keeps the suite fast even
+ *      though production fires once every 10 seconds.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@Timeout(value = 5, unit = TimeUnit.SECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+class KeepAliveTickerTest {
+    @Test
+    fun `keepAlive ack=false has KEEP_ALIVE type and ack=false body`() {
+        val frame: OfflineFrame = OfflineFrames.keepAlive(ack = false)
+
+        // Round-trip through the proto parser to make sure nothing
+        // depends on the builder's in-memory representation.
+        val parsed = OfflineFrame.parseFrom(frame.toByteArray())
+
+        assertThat(parsed.version).isEqualTo(OfflineFrame.Version.V1)
+        assertThat(parsed.v1.type).isEqualTo(V1Frame.FrameType.KEEP_ALIVE)
+        assertThat(parsed.v1.hasKeepAlive()).isTrue()
+
+        val keepAlive: KeepAliveFrame = parsed.v1.keepAlive
+        assertThat(keepAlive.hasAck()).isTrue()
+        assertThat(keepAlive.ack).isFalse()
+    }
+
+    @Test
+    fun `keepAlive ack=true round-trips with ack=true body`() {
+        val parsed = OfflineFrame.parseFrom(OfflineFrames.keepAlive(ack = true).toByteArray())
+
+        assertThat(parsed.v1.type).isEqualTo(V1Frame.FrameType.KEEP_ALIVE)
+        assertThat(parsed.v1.keepAlive.hasAck()).isTrue()
+        assertThat(parsed.v1.keepAlive.ack).isTrue()
+    }
+
+    @Test
+    fun `production cadence matches PROTOCOL_md 10 second contract`() {
+        // Guards both the `KeepAliveTicker.DEFAULT_INTERVAL_MILLIS`
+        // constant and the value advertised on the wire as
+        // `keep_alive_interval_millis`. PROTOCOL.md is explicit: stock
+        // Android emits KEEP_ALIVE every 10 seconds. The two values
+        // MUST agree — the receiver uses our advertised value as its
+        // watchdog cadence, and a mismatch would let the receiver tear
+        // an idle connection down because our actual ticks landed
+        // outside its expected window.
+        assertThat(KeepAliveTicker.DEFAULT_INTERVAL_MILLIS).isEqualTo(10_000L)
+    }
+
+    @Test
+    fun `ticker emits no frame before first interval has elapsed`() =
+        runTest {
+            val sent = AtomicInteger(0)
+            val job =
+                launch {
+                    KeepAliveTicker.run(
+                        intervalMillis = 1_000L,
+                        send = { sent.incrementAndGet() },
+                    )
+                }
+
+            // Before the first interval: nothing on the wire. (Quick
+            // Share's spec is that the timer fires AFTER the first
+            // 10 s window — sending one immediately would just
+            // duplicate the encryption-establish frame's purpose.)
+            advanceTimeBy(999L)
+            runCurrent()
+            assertThat(sent.get()).isEqualTo(0)
+
+            job.cancelAndJoin()
+        }
+
+    @Test
+    fun `ticker fires on cadence under virtual time`() =
+        runTest {
+            val sent = AtomicInteger(0)
+            val capturedFrames = mutableListOf<OfflineFrame>()
+            val job =
+                launch {
+                    KeepAliveTicker.run(
+                        intervalMillis = 1_000L,
+                        send = { frame ->
+                            capturedFrames += frame
+                            sent.incrementAndGet()
+                        },
+                    )
+                }
+
+            // Three full intervals -> exactly three ticks. (Plus a
+            // small skew so the third tick's `delay` resumes before
+            // the assertion runs.)
+            advanceTimeBy(3_500L)
+            runCurrent()
+
+            assertThat(sent.get()).isEqualTo(3)
+            // Every emitted frame is a well-formed KEEP_ALIVE{ack=false}.
+            assertThat(capturedFrames).hasSize(3)
+            for (f in capturedFrames) {
+                assertThat(f.v1.type).isEqualTo(V1Frame.FrameType.KEEP_ALIVE)
+                assertThat(f.v1.keepAlive.ack).isFalse()
+            }
+
+            job.cancelAndJoin()
+        }
+
+    @Test
+    fun `cancelAndJoin stops the ticker without one final tick`() =
+        runTest {
+            val sent = AtomicInteger(0)
+            val job =
+                launch {
+                    KeepAliveTicker.run(
+                        intervalMillis = 1_000L,
+                        send = { sent.incrementAndGet() },
+                    )
+                }
+
+            // Just past two ticks.
+            advanceTimeBy(2_500L)
+            runCurrent()
+            val ticksBeforeCancel = sent.get()
+            assertThat(ticksBeforeCancel).isEqualTo(2)
+
+            job.cancelAndJoin()
+
+            // After cancellation, advancing time MUST NOT produce more
+            // ticks — the cancellation token cuts the loop on the next
+            // suspension point (the next `delay`).
+            advanceTimeBy(10_000L)
+            runCurrent()
+            assertThat(sent.get()).isEqualTo(ticksBeforeCancel)
+        }
+
+    @Test
+    fun `send error reaches onError and ticker exits cleanly`() =
+        runTest {
+            val onErrorCallCount = AtomicInteger(0)
+            val capturedError: Array<Throwable?> = arrayOf(null)
+            val attempts = AtomicInteger(0)
+            val firstAttemptError = IOException("socket closed by peer")
+
+            val job =
+                launch {
+                    KeepAliveTicker.run(
+                        intervalMillis = 1_000L,
+                        send = {
+                            attempts.incrementAndGet()
+                            throw firstAttemptError
+                        },
+                        onError = { e ->
+                            onErrorCallCount.incrementAndGet()
+                            capturedError[0] = e
+                        },
+                    )
+                }
+
+            // First tick fires, send throws, ticker exits.
+            advanceTimeBy(1_500L)
+            runCurrent()
+            job.join()
+
+            assertThat(attempts.get()).isEqualTo(1)
+            assertThat(onErrorCallCount.get()).isEqualTo(1)
+            assertThat(capturedError[0]).isSameInstanceAs(firstAttemptError)
+
+            // Even with more virtual time, no further ticks (the loop
+            // exited; onError is not a "keep going" signal).
+            advanceTimeBy(10_000L)
+            runCurrent()
+            assertThat(attempts.get()).isEqualTo(1)
+            assertThat(onErrorCallCount.get()).isEqualTo(1)
+        }
+
+    @Test
+    fun `CancellationException from send propagates and skips onError`() =
+        runTest {
+            val onErrorCallCount = AtomicInteger(0)
+
+            // A child coroutine that runs the ticker; cancelled
+            // externally so the inner CancellationException is the
+            // real deal (parent-cancellation), not an arbitrary
+            // application-thrown one.
+            val job =
+                launch {
+                    KeepAliveTicker.run(
+                        intervalMillis = 1_000L,
+                        send = {
+                            // Block here forever; we want the cancel
+                            // to interrupt the send itself, not the
+                            // outer delay. The cooperative-cancellation
+                            // contract says runCatching/try blocks
+                            // around `send` MUST NOT eat
+                            // CancellationException.
+                            delay(Long.MAX_VALUE)
+                        },
+                        onError = { onErrorCallCount.incrementAndGet() },
+                    )
+                }
+
+            advanceTimeBy(1_500L)
+            runCurrent()
+
+            job.cancelAndJoin()
+
+            assertThat(onErrorCallCount.get()).isEqualTo(0)
+        }
+
+    @Test
+    fun `non-positive interval throws IllegalArgumentException`() {
+        // Guard against a future caller wiring up `0L` or a negative
+        // value — `delay(0)` would degenerate into a busy loop and
+        // saturate the SecureChannel send mutex.
+        runTest {
+            assertThrows<IllegalArgumentException> {
+                KeepAliveTicker.run(intervalMillis = 0L, send = { /* unreachable */ })
+            }
+            assertThrows<IllegalArgumentException> {
+                KeepAliveTicker.run(intervalMillis = -1L, send = { /* unreachable */ })
+            }
+        }
+    }
+
+    @Test
+    fun `parent scope cancellation tears down the ticker via structured concurrency`() =
+        runTest {
+            val sent = AtomicInteger(0)
+
+            assertThrows<CancellationException> {
+                coroutineScope {
+                    launch {
+                        KeepAliveTicker.run(
+                            intervalMillis = 500L,
+                            send = { sent.incrementAndGet() },
+                        )
+                    }
+
+                    advanceTimeBy(1_500L)
+                    runCurrent()
+                    assertThat(sent.get()).isEqualTo(3)
+
+                    // Cancel the parent scope; structured concurrency
+                    // should take the ticker out as a child.
+                    throw CancellationException("teardown")
+                }
+            }
+
+            // After the scope's cancellation throw resolves, no further
+            // ticks should arrive — the ticker must NOT be detached
+            // from its parent's lifecycle.
+            advanceTimeBy(10_000L)
+            runCurrent()
+            assertThat(sent.get()).isEqualTo(3)
+        }
+}


### PR DESCRIPTION
## Summary
Closes #37.

PROTOCOL.md specifies that Quick Share peers fire `KEEP_ALIVE` offline frames every 10 seconds and tear the connection down when the peer goes silent for longer than the advertised `keep_alive_timeout_millis`. Previously we only acknowledged inbound `KEEP_ALIVE` frames (NearDrop parity); on long idle stretches — particularly large-file transfers on slow Wi-Fi — the receiver's watchdog could surface "couldn't receive file" mid-payload.

This PR adds a per-connection ticker that fires `KEEP_ALIVE{ack=false}` every 10 s once the SecureChannel is up:

- **New `KeepAliveTicker` helper** (`core-protocol/.../connection/KeepAliveTicker.kt`) — interval and send sink are injectable so tests can drive the loop in virtual time.
- **`OutboundConnectionDriver` integration** — launches the ticker as a structured-concurrency child of `runReceiveLoop`'s `coroutineScope`, alongside the existing inbound pump. Cancelled first in the `finally` block so we don't race a tick against the in-flight terminal `Disconnection`.
- **`SecureChannel` send mutex** serializes the ticker against payload-chunk writes and FSM frame emissions — no additional locking needed (acceptance criterion: "Send path serialized with the per-connection mutex").
- **`OfflineFrames.keepAlive(ack)`** — new shared frame builder for the KEEP_ALIVE OfflineFrame shape.
- **`ConnectionRequestFrame.keep_alive_interval_millis` bumped 5 000 → 10 000** so the value we advertise on the wire matches both what stock Android emits (PROTOCOL.md) and the cadence the new ticker actually uses. Receivers use our advertised value as their watchdog cadence; a mismatch would invite tears mid-transfer.

## Files touched
- `core-protocol/.../connection/KeepAliveTicker.kt` (new)
- `core-protocol/.../connection/OfflineFrames.kt` — `keepAlive(ack)` builder
- `core-protocol/.../connection/OutboundFrames.kt` — interval bumped to 10 s, doc updated
- `core-protocol/.../connection/OutboundConnectionDriver.kt` — ticker launched in `runReceiveLoop`
- `core-protocol/.../connection/KeepAliveTickerTest.kt` (new) — 10 JVM tests, virtual time

## Test plan
- [x] `./gradlew :core-protocol:test` (full suite, all green)
- [x] `./gradlew staticAnalysis`
- [x] `./gradlew :app:assembleDebug`
- [x] New `KeepAliveTickerTest`:
  - [x] frame shape round-trip (ack=false / ack=true)
  - [x] `DEFAULT_INTERVAL_MILLIS == 10_000` (PROTOCOL.md contract guard)
  - [x] no tick before first interval elapses
  - [x] three ticks after three virtual-time intervals
  - [x] `cancelAndJoin` stops the loop without one final tick
  - [x] send-error reaches `onError` and the loop exits
  - [x] `CancellationException` out of `send` is rethrown, `onError` skipped
  - [x] parent-scope cancellation tears the ticker down via structured concurrency
  - [x] non-positive interval rejected with `IllegalArgumentException`
- [ ] Manual on-device interop check: 5+ minute idle send (e.g. paused multi-GB transfer or sender that intentionally throttles between chunks) survives without peer-side teardown. Tracked in the issue's acceptance criterion; verifying in Phase-2 hardware lab session.