### PR TITLE
feat: out-of-order FILE chunk writes via SeekableByteChannel (#44)

### DIFF
--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/payload/ByteRangeSet.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/payload/ByteRangeSet.kt
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.payload
+
+/**
+ * Mutable, ordered set of half-open byte ranges `[start, end)` over a
+ * single payload.
+ *
+ * Used by [PayloadAssembler] to track which byte ranges of an inbound
+ * FILE payload have already been written. Quick Share's wire spec
+ * permits chunks to arrive in any order — sequential delivery is a
+ * property of TCP, not of the application protocol — and #44 relaxes
+ * the assembler's strict in-order check so the receiver can survive
+ * mediums (Wi-Fi Direct, BLE L2CAP) that do not preserve order at the
+ * application layer.
+ *
+ * ### Invariants
+ *
+ *  - All ranges are stored in a sorted, **non-overlapping**, **non-
+ *    adjacent** form. After any successful [add], the set's internal
+ *    list contains ranges with the property that `ranges[i].end <
+ *    ranges[i+1].start` (strictly less, never equal — adjacent ranges
+ *    are merged on insert).
+ *  - Range bounds are non-negative; the empty range `[start, start)` is
+ *    a no-op (silently ignored).
+ *
+ * ### Performance
+ *
+ *  - [add] is `O(log n + k)` where `n` is the number of stored ranges
+ *    and `k` is the number of existing ranges that the new range
+ *    overlaps or touches. In the common case (sequential arrival) `k`
+ *    is constant — the new range merges with the tail and `n` stays
+ *    at 1.
+ *  - [contains] is `O(log n)` via binary search.
+ *  - [coveredBytes] is `O(n)` and is invoked only at completion-check
+ *    time, not on every chunk.
+ *
+ * ### Why a custom container instead of `RangeSet` / `IntervalTree`
+ *
+ * Pulling Guava just for `RangeSet` would balloon `:core-protocol`'s
+ * dependency surface (Guava + its transitive `error_prone_annotations`
+ * etc.) for the sake of one container that handles fewer cases than
+ * we need anyway (Guava's `RangeSet` distinguishes open / closed
+ * endpoints; we only ever use half-open `[start, end)`). A few dozen
+ * lines of straight Kotlin keep the JVM-only build self-contained.
+ *
+ * Internal-ish API: not part of the documented `:core-protocol` public
+ * surface, but `public` so the JVM tests can verify it. Marked
+ * explicitly to keep `explicitApi()` happy.
+ */
+public class ByteRangeSet {
+    /**
+     * Storage for the canonical, sorted, non-overlapping range list.
+     * Backed by `ArrayList` so the merge path can splice in place.
+     *
+     * Visibility kept `internal` so tests in the same module can assert
+     * on the exact merge layout, while production callers use only the
+     * methods below.
+     */
+    internal val ranges: ArrayList<Range> = ArrayList()
+
+    /**
+     * Half-open interval `[start, end)`. Equality / hash code are
+     * structural so a [ByteRangeSet] can be compared by content in
+     * tests.
+     *
+     * @property start inclusive lower bound, must be `>= 0`.
+     * @property end exclusive upper bound, must be `>= start`.
+     */
+    public data class Range(
+        val start: Long,
+        val end: Long,
+    ) {
+        init {
+            require(start >= 0) { "start must be non-negative, got $start" }
+            require(end >= start) { "end ($end) must be >= start ($start)" }
+        }
+    }
+
+    /**
+     * Total number of bytes covered across all stored ranges.
+     *
+     * `O(n)` over the range count — typically very small (1 in the
+     * happy ordered-arrival case, a few dozen in the worst pathological
+     * shuffled case).
+     */
+    public val coveredBytes: Long
+        get() {
+            var total = 0L
+            for (r in ranges) total += r.end - r.start
+            return total
+        }
+
+    /**
+     * Number of distinct ranges currently stored. Visible mainly for
+     * diagnostics / tests; production code paths only care about
+     * [coveredBytes] and [contains].
+     */
+    public val size: Int get() = ranges.size
+
+    /**
+     * Insert the half-open range `[start, end)` into the set.
+     *
+     * Overlapping or adjacent ranges are merged so the set stays
+     * canonical. Returns information about whether the insert added
+     * any genuinely-new bytes — callers (the FILE assembler) use this
+     * to detect duplicate / overlapping chunk delivery.
+     *
+     * @return [AddResult] describing the outcome.
+     * @throws IllegalArgumentException if `end < start` or `start < 0`.
+     */
+    public fun add(
+        start: Long,
+        end: Long,
+    ): AddResult {
+        require(start >= 0) { "start must be non-negative, got $start" }
+        require(end >= start) { "end ($end) must be >= start ($start)" }
+        if (start == end) {
+            // Empty range is a no-op. Treated as "fully covered" since
+            // there are no bytes to add.
+            return AddResult.AlreadyCovered
+        }
+
+        // Find the first existing range whose end is strictly greater
+        // than `start` — that's the leftmost range we might overlap or
+        // be adjacent-on-the-left to. Anything before it ends before
+        // `start` and is untouched.
+        var i = 0
+        while (i < ranges.size && ranges[i].end < start) {
+            i += 1
+        }
+
+        // Now extend the merge window forward as long as the next
+        // existing range either overlaps or is adjacent to the running
+        // [newStart, newEnd) window.
+        var newStart = start
+        var newEnd = end
+        var overlappingBytes = 0L
+        // Sentinel "no consumption yet" markers. `consumedFirst < 0`
+        // means the merge loop did not consume any existing range; in
+        // that case we splice the new range in at position `i` instead
+        // of replacing a span. The two sentinels are slightly different
+        // so a stray `consumedLast - consumedFirst + 1` length cannot
+        // accidentally be 0 — we always check `consumedFirst >= 0`.
+        var consumedFirst = NO_CONSUMPTION
+        var consumedLast = NO_CONSUMPTION_LAST
+        while (i < ranges.size && ranges[i].start <= newEnd) {
+            val r = ranges[i]
+            // Track how many bytes of this insert overlap an existing
+            // range. The `add` is a duplicate-only insert if every byte
+            // of [start, end) lands inside a pre-existing range.
+            val overlapStart = maxOf(start, r.start)
+            val overlapEnd = minOf(end, r.end)
+            if (overlapEnd > overlapStart) {
+                overlappingBytes += overlapEnd - overlapStart
+            }
+            if (consumedFirst == NO_CONSUMPTION) consumedFirst = i
+            consumedLast = i
+            newStart = minOf(newStart, r.start)
+            newEnd = maxOf(newEnd, r.end)
+            i += 1
+        }
+
+        if (consumedFirst != NO_CONSUMPTION) {
+            // Replace the [consumedFirst..consumedLast] contiguous span
+            // with the merged range in one subList clear + insert.
+            ranges.subList(consumedFirst, consumedLast + 1).clear()
+            ranges.add(consumedFirst, Range(newStart, newEnd))
+        } else {
+            // No overlap or adjacency — insert at position `i`, which
+            // by the loop invariant is the first range whose start is
+            // strictly greater than newEnd (or end of list).
+            ranges.add(i, Range(newStart, newEnd))
+        }
+
+        val insertedSize = end - start
+        return when {
+            overlappingBytes == 0L -> AddResult.Added(addedBytes = insertedSize)
+            overlappingBytes == insertedSize -> AddResult.AlreadyCovered
+            else -> AddResult.PartialOverlap(addedBytes = insertedSize - overlappingBytes)
+        }
+    }
+
+    /**
+     * Whether `[start, end)` is fully contained in some stored range.
+     */
+    public fun contains(
+        start: Long,
+        end: Long,
+    ): Boolean {
+        // Linear scan is fine for our small `n`; binary search would
+        // optimize the worst case but the constant factor on n<=20 is
+        // unimprovable. Single exit point keeps detekt happy and lets
+        // the loop short-circuit via the `found` sentinel and an early
+        // structural break-out via `done` once we have walked past the
+        // candidate range.
+        if (start == end) return true
+        var found = false
+        var done = false
+        for (r in ranges) {
+            if (r.start > start) {
+                done = true
+            } else if (r.start <= start && end <= r.end) {
+                found = true
+                done = true
+            }
+            if (done) break
+        }
+        return found
+    }
+
+    /**
+     * Remove every stored range. Used during connection teardown so a
+     * pooled assembler does not carry over state from a prior payload.
+     */
+    public fun clear() {
+        ranges.clear()
+    }
+
+    /**
+     * Whether the set is exactly the single range `[0, totalSize)`,
+     * i.e. the payload is fully covered with no gaps. `true` for the
+     * degenerate `totalSize = 0` empty payload.
+     */
+    public fun isComplete(totalSize: Long): Boolean {
+        require(totalSize >= 0) { "totalSize must be non-negative, got $totalSize" }
+        if (totalSize == 0L) return true
+        return ranges.size == 1 && ranges[0].start == 0L && ranges[0].end == totalSize
+    }
+
+    /**
+     * Outcome of an [add] call.
+     *
+     * The distinction is exposed so callers can discriminate
+     * "duplicate chunk re-delivered" from "chunk landed in a fresh
+     * region". The assembler uses [AlreadyCovered] to deduplicate
+     * gracefully (write nothing, advance no state) and
+     * [PartialOverlap] to flag a malformed chunk that overlaps an
+     * existing range while extending it — that shape is **not**
+     * permitted on the wire and is treated as a protocol error.
+     */
+    private companion object {
+        /**
+         * Sentinel "no range consumed yet" marker for the first index
+         * tracked during the merge loop in [add]. Any non-negative value
+         * is a valid index; we use `-1` as the not-set marker.
+         */
+        const val NO_CONSUMPTION: Int = -1
+
+        /**
+         * Companion sentinel for the last-consumed index. Distinct
+         * from [NO_CONSUMPTION] so a casual reader can tell the two
+         * apart, and so a length computation `last - first + 1` cannot
+         * accidentally evaluate to 0 if both sentinels are still set.
+         */
+        const val NO_CONSUMPTION_LAST: Int = -2
+    }
+
+    public sealed interface AddResult {
+        /** The inserted range was strictly new; [addedBytes] equals the body size. */
+        public data class Added(
+            val addedBytes: Long,
+        ) : AddResult
+
+        /** Every byte of the inserted range was already covered. */
+        public object AlreadyCovered : AddResult
+
+        /**
+         * The inserted range overlaps an existing range but ALSO
+         * extends beyond it. The wire protocol does not permit this:
+         * a peer that re-sends a chunk MUST send the original byte
+         * range exactly. Callers MUST treat this as a malformed-frame
+         * protocol error.
+         *
+         * @property addedBytes Number of bytes that were genuinely
+         *   new (i.e. not already covered).
+         */
+        public data class PartialOverlap(
+            val addedBytes: Long,
+        ) : AddResult
+    }
+}

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/payload/FileDestinationFactory.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/payload/FileDestinationFactory.kt
@@ -6,7 +6,7 @@
 package io.github.kyujincho.wvmg.protocol.payload
 
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.PayloadTransferFrame.PayloadHeader
-import java.nio.channels.WritableByteChannel
+import java.nio.channels.SeekableByteChannel
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardOpenOption
@@ -18,15 +18,19 @@ import java.nio.file.StandardOpenOption
  * "save into this exact path"; every received file gets a destination
  * decided by the host platform:
  *
- *  - On Android we route the bytes through `MediaStore` / `ContentResolver`
- *    and end up with a content URI under `Downloads/`. There is no
- *    `java.io.File` involved at all — the right primitive is a
- *    [WritableByteChannel] that wraps the `OutputStream` returned by
- *    `ContentResolver.openOutputStream(uri)`.
+ *  - On Android we spool bytes through a private-storage `RandomAccessFile`
+ *    until the transfer completes, then publish the spool file's bytes
+ *    into `MediaStore` / `ContentResolver` on commit. The `WritableByteChannel`
+ *    surface alone is not enough — issue #44 added support for chunks
+ *    arriving out of order (necessary once we add Wi-Fi Direct or BLE
+ *    L2CAP mediums in #4.x) and that requires `SeekableByteChannel.position`.
  *  - On the JVM (host-side test harness, or a hypothetical desktop port)
- *    we want a real file on disk under a configurable directory.
+ *    we want a real file on disk under a configurable directory; a
+ *    `FileChannel` from `Files.newByteChannel` already implements
+ *    [SeekableByteChannel].
  *  - For unit tests we want an in-memory channel so we can assert on the
- *    exact bytes that were written without touching the filesystem.
+ *    exact bytes that were written without touching the filesystem; a
+ *    small `ByteBuffer`-backed [SeekableByteChannel] adapter is enough.
  *
  * `:core-protocol` lives below the platform line (no `android.*` imports
  * are allowed), so the assembler cannot itself open a `MediaStore`
@@ -36,9 +40,14 @@ import java.nio.file.StandardOpenOption
  * the payload's first chunk.
  *
  * The factory contract:
- *  - It MUST return a [WritableByteChannel] in a state ready to accept
- *    `header.total_size` bytes worth of `write()` calls. The channel is
- *    opened in *write-from-byte-zero* mode; the assembler does not seek.
+ *  - It MUST return a [SeekableByteChannel] in a state ready to accept
+ *    `header.total_size` bytes worth of `write()` calls at arbitrary
+ *    offsets. The channel is opened with the cursor at byte 0; the
+ *    assembler calls [SeekableByteChannel.position] before each write
+ *    so a chunk that arrives out of order lands at its declared offset.
+ *  - Implementations MAY pre-allocate the destination to `total_size`
+ *    bytes (e.g. by truncating to the final size up front) but the
+ *    assembler does not require it.
  *  - The assembler closes the channel exactly once: either on the
  *    `LAST_CHUNK` of a successful payload, or as part of cleanup when a
  *    later chunk of that payload causes a [PayloadProtocolException]. The
@@ -85,10 +94,12 @@ public interface FileDestinationFactory {
      *   `last_modified_timestamp_millis`. Implementations should use
      *   `file_name` and `parent_folder` for naming, and may use
      *   `total_size` to pre-allocate the destination.
-     * @return A [WritableByteChannel] that the assembler will [write][WritableByteChannel.write]
-     *   `total_size` bytes to before closing.
+     * @return A [SeekableByteChannel] that the assembler will
+     *   [write][SeekableByteChannel.write] `total_size` bytes to (across
+     *   one or more chunks, possibly delivered out of order) before
+     *   closing.
      */
-    public fun open(header: PayloadHeader): WritableByteChannel
+    public fun open(header: PayloadHeader): SeekableByteChannel
 
     /**
      * Publish the destination for [payloadId] now that the assembler has
@@ -166,18 +177,21 @@ public class TempFileDestinationFactory(
      */
     private val baseDirectory: Path? = null,
 ) : FileDestinationFactory {
-    override fun open(header: PayloadHeader): WritableByteChannel {
+    override fun open(header: PayloadHeader): SeekableByteChannel {
         val dir = baseDirectory ?: defaultDir()
         Files.createDirectories(dir)
         val safeName = sanitize(header.fileName.ifEmpty { "unnamed" })
         val target = dir.resolve("payload-${header.id}-$safeName")
         // CREATE_NEW would be ideal for safety, but tests can re-run with
         // colliding payload ids; TRUNCATE_EXISTING gives us idempotent
-        // open behavior. The assembler writes start at byte zero so this
-        // is correct.
+        // open behavior. We also enable READ so the channel is fully
+        // seekable (FileChannel implements SeekableByteChannel either
+        // way, but TRUNCATE_EXISTING + write-only on some JVMs reports
+        // a non-seekable position cursor; READ keeps the contract clean).
         return Files.newByteChannel(
             target,
             StandardOpenOption.CREATE,
+            StandardOpenOption.READ,
             StandardOpenOption.WRITE,
             StandardOpenOption.TRUNCATE_EXISTING,
         )

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/payload/PayloadAssembler.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/payload/PayloadAssembler.kt
@@ -10,7 +10,7 @@ import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.Payl
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.PayloadTransferFrame.PayloadHeader
 import io.github.kyujincho.wvmg.protocol.transport.FramedConnection
 import java.io.ByteArrayOutputStream
-import java.nio.channels.WritableByteChannel
+import java.nio.channels.SeekableByteChannel
 
 /**
  * Reassembles `PayloadTransferFrame` chunks into complete BYTES and FILE
@@ -28,13 +28,20 @@ import java.nio.channels.WritableByteChannel
  * chunks of a peer-chosen size. Three properties make a naive
  * implementation wrong:
  *
- *  1. **Strict in-order requirement.** Each chunk's `offset` MUST equal
- *     the cumulative byte count we have already received for that
- *     `payload_id`. The wire is reliable (TCP) but a misbehaving or
- *     malicious peer can still send an offset that does not line up;
- *     accepting that would let the peer corrupt the buffer. NearDrop
- *     rejects this with a protocol error and so do we
- *     ([PayloadProtocolException]).
+ *  1. **Strict in-order BYTES, out-of-order-tolerant FILE.** Each
+ *     BYTES chunk's `offset` MUST equal the cumulative byte count we
+ *     have already received for that `payload_id`. BYTES payloads are
+ *     small negotiation messages and reordering is meaningless for
+ *     them. FILE payloads, however, may arrive in any order: this
+ *     was relaxed in #44 so the receiver can survive future mediums
+ *     (Wi-Fi Direct, BLE L2CAP) where the application layer cannot
+ *     assume FIFO. The FILE path persists each chunk via
+ *     [SeekableByteChannel.position] + write at the chunk's declared
+ *     offset, and tracks coverage with a [ByteRangeSet]. Duplicate
+ *     chunks (offset + body matches a fully-covered range) are
+ *     deduplicated; partial overlaps that ALSO extend an existing
+ *     range remain a protocol error because the wire spec does not
+ *     permit them.
  *  2. **Per-payload state, not per-frame.** Multiple payloads can be
  *     "in flight" simultaneously (Android's transfer-setup phase
  *     interleaves a small BYTES negotiation payload with one or more
@@ -97,13 +104,29 @@ public class PayloadAssembler(
     )
 
     /**
-     * In-flight FILE payload. Tracks the destination channel, the byte
-     * count we have written so far, and the original header.
+     * In-flight FILE payload.
+     *
+     * Tracks:
+     *  - The destination [SeekableByteChannel] returned by the factory.
+     *  - The original [PayloadHeader] (used to keep [PayloadEvent.FileComplete]
+     *    faithful to the original metadata even after several chunks).
+     *  - A [ByteRangeSet] recording exactly which byte ranges the
+     *    assembler has already written to the channel. The set drives
+     *    both the duplicate-chunk shortcut (skip writes that land inside
+     *    an already-covered region) and the LAST_CHUNK completion check
+     *    (require `[0, total_size)` is fully covered before accepting).
+     *  - A `position` cursor we manage explicitly: `SeekableByteChannel.position(off)`
+     *    + write is the canonical out-of-order pattern, but seeking is
+     *    only worth its syscall if we are about to write somewhere other
+     *    than the current cursor. We track the cursor here so the common
+     *    sequential case (write, write, write at successive offsets)
+     *    elides the seek.
      */
     private class FileState(
         val header: PayloadHeader,
-        val channel: WritableByteChannel,
-        var bytesWritten: Long,
+        val channel: SeekableByteChannel,
+        var coverage: ByteRangeSet,
+        var cursor: Long,
     )
 
     private val bytesInFlight: MutableMap<Long, BytesState> = HashMap()
@@ -302,14 +325,36 @@ public class PayloadAssembler(
      *
      * FILE payloads can be GB-scale. We never buffer in memory — every
      * chunk's body is written straight through to the
-     * [WritableByteChannel] that the [fileDestinationFactory] returned
+     * [SeekableByteChannel] that the [fileDestinationFactory] returned
      * for this payload. The factory is invoked exactly once, on the
-     * first chunk; we bail out if the per-chunk offset disagrees with
-     * the running write count, the same way NearDrop does.
+     * first chunk.
+     *
+     * #### Out-of-order tolerance (#44)
+     *
+     * Each chunk carries an `offset` field naming where its body bytes
+     * belong in the file. The assembler:
+     *  1. Validates `offset >= 0` and `offset + body.size <= total_size`.
+     *  2. Consults [ByteRangeSet] to classify the chunk as new,
+     *     duplicate, or partial-overlap.
+     *  3. For genuinely new bytes, seeks the channel to `offset` (only
+     *     if the cursor is not already there — in the sequential happy
+     *     path the seek is elided) and writes the body.
+     *  4. For duplicate chunks (every byte already covered) the body is
+     *     dropped and the cursor is unchanged — the peer simply re-sent
+     *     a chunk after a transient stall, which is allowed.
+     *  5. For partial-overlap chunks (some bytes new, some duplicate-
+     *     in-different-range) the wire is malformed and we surface a
+     *     [PayloadProtocolException].
+     *
+     * `LAST_CHUNK` no longer implies "I have written `total_size` bytes";
+     * it now means "no more chunks are coming". Completion requires the
+     * coverage set to span exactly `[0, total_size)`.
      */
     @Suppress(
         "ThrowsCount", // Each throw documents a distinct FILE-reassembly invariant.
         "NestedBlockDepth", // Streaming-write loop + close cleanup is inherently nested.
+        "LongMethod", // Out-of-order branches + completion check are inherently long; splitting hides flow.
+        "CyclomaticComplexMethod", // The branch count tracks the wire spec's invariant set; flattening obscures it.
     )
     private fun handleFile(
         payloadId: Long,
@@ -327,70 +372,122 @@ public class PayloadAssembler(
                 // registered any state yet, so there is nothing to
                 // clean up.
                 val channel = fileDestinationFactory.open(header)
-                FileState(header, channel, bytesWritten = 0L).also {
+                FileState(
+                    header = header,
+                    channel = channel,
+                    coverage = ByteRangeSet(),
+                    cursor = 0L,
+                ).also {
                     filesInFlight[payloadId] = it
                 }
             }
 
-        val written = state.bytesWritten
-        if (chunk.offset != written) {
-            // Match NearDrop's cleanup behavior: drop the in-flight
-            // record but also close the destination channel so the
-            // partial file is at least flushed.
+        val body = chunk.body
+        val bodySize = body.size()
+        val chunkOffset = chunk.offset
+        val totalSize = state.header.totalSize
+
+        // Validate the offset and the chunk's footprint against the
+        // declared total_size BEFORE consulting coverage. A peer that
+        // claims `offset = -1` or `offset + body > total` is malformed
+        // regardless of what bytes we may have already received.
+        if (chunkOffset < 0) {
             filesInFlight.remove(payloadId)
             runCatching { state.channel.close() }
             throw PayloadProtocolException(
-                "FILE payload_id=$payloadId chunk offset=${chunk.offset} " +
-                    "does not match bytes written=$written",
+                "FILE payload_id=$payloadId chunk offset=$chunkOffset is negative",
             )
         }
-
-        val body = chunk.body
-        val bodySize = body.size()
-        val newWritten = written + bodySize.toLong()
-        if (newWritten > state.header.totalSize) {
+        val chunkEnd = chunkOffset + bodySize.toLong()
+        if (chunkEnd > totalSize) {
             filesInFlight.remove(payloadId)
             runCatching { state.channel.close() }
             throw PayloadProtocolException(
                 "FILE payload_id=$payloadId chunk would write past total_size=" +
-                    "${state.header.totalSize} (current=$written, body=$bodySize)",
+                    "$totalSize (offset=$chunkOffset, body=$bodySize)",
             )
         }
 
         if (bodySize > 0) {
-            // Copy through ByteBuffer: ByteString does not expose a
-            // zero-copy `WritableByteChannel.write` directly, but its
-            // `asReadOnlyByteBufferList()` lets us hand the channel an
-            // already-prepared buffer. For most chunks the list has a
-            // single segment; we still loop in case a peer sends a
-            // segmented body.
-            try {
-                for (segment in body.asReadOnlyByteBufferList()) {
-                    while (segment.hasRemaining()) {
-                        state.channel.write(segment)
+            // Classify the chunk against current coverage so we know
+            // whether to write, dedupe, or fail. The coverage set is
+            // mutated inside `add` only after we have committed to
+            // writing — a partial-overlap result must not leave the set
+            // in a half-merged state, so we check first and only mutate
+            // on the Added path.
+            val classification = classifyFileChunk(state.coverage, chunkOffset, chunkEnd)
+            when (classification) {
+                FileChunkClassification.AlreadyCovered -> {
+                    // Duplicate chunk: drop the body, leave cursor and
+                    // coverage alone. The wire is well-formed.
+                }
+                FileChunkClassification.PartialOverlap -> {
+                    filesInFlight.remove(payloadId)
+                    runCatching { state.channel.close() }
+                    throw PayloadProtocolException(
+                        "FILE payload_id=$payloadId chunk [$chunkOffset, $chunkEnd) partially " +
+                            "overlaps a previously-received range; protocol does not permit " +
+                            "split-and-extend re-delivery",
+                    )
+                }
+                FileChunkClassification.NewBytes -> {
+                    try {
+                        // Only seek if the cursor is not already where
+                        // we need to write. The sequential happy path
+                        // never seeks; the out-of-order path seeks once
+                        // per non-contiguous arrival.
+                        if (state.cursor != chunkOffset) {
+                            state.channel.position(chunkOffset)
+                        }
+                        for (segment in body.asReadOnlyByteBufferList()) {
+                            while (segment.hasRemaining()) {
+                                state.channel.write(segment)
+                            }
+                        }
+                        state.cursor = chunkEnd
+                        // Mutate coverage only after the write succeeded
+                        // so an I/O failure does not leave the set
+                        // claiming bytes the channel never received.
+                        state.coverage.add(chunkOffset, chunkEnd)
+                    } catch (e: java.io.IOException) {
+                        filesInFlight.remove(payloadId)
+                        runCatching { state.channel.close() }
+                        throw PayloadProtocolException(
+                            "FILE payload_id=$payloadId write to destination channel failed",
+                            e,
+                        )
                     }
                 }
-            } catch (e: java.io.IOException) {
-                filesInFlight.remove(payloadId)
-                runCatching { state.channel.close() }
-                throw PayloadProtocolException(
-                    "FILE payload_id=$payloadId write to destination channel failed",
-                    e,
-                )
             }
-            state.bytesWritten = newWritten
+        } else if (chunkOffset != totalSize && !state.coverage.contains(chunkOffset, chunkEnd)) {
+            // Empty body at an offset that is neither the LAST_CHUNK
+            // terminator (offset == total_size) nor inside a covered
+            // range. The wire spec uses empty-body chunks only for the
+            // LAST_CHUNK terminator; an empty body in the middle of the
+            // file with a fresh offset is ambiguous and not something
+            // any conformant peer sends. Allowing it would let a
+            // misbehaving peer steer the cursor without leaving any
+            // observable trace in coverage.
+            filesInFlight.remove(payloadId)
+            runCatching { state.channel.close() }
+            throw PayloadProtocolException(
+                "FILE payload_id=$payloadId empty-body chunk at offset=$chunkOffset is not " +
+                    "the LAST_CHUNK terminator and does not lie inside a covered range",
+            )
         }
 
         return if ((chunk.flags and LAST_CHUNK_FLAG) != 0) {
-            // LAST_CHUNK: the file is complete. Validate the running
-            // count matches the declared total_size and close the
-            // channel. The factory does not own close; we do.
-            if (state.bytesWritten != state.header.totalSize) {
+            // LAST_CHUNK: the peer is telling us no more chunks are
+            // coming. Completion now requires the coverage set to span
+            // [0, total_size) exactly.
+            if (!state.coverage.isComplete(totalSize)) {
                 filesInFlight.remove(payloadId)
                 runCatching { state.channel.close() }
+                val covered = state.coverage.coveredBytes
                 throw PayloadProtocolException(
-                    "FILE payload_id=$payloadId LAST_CHUNK at ${state.bytesWritten} bytes " +
-                        "differs from declared total_size=${state.header.totalSize}",
+                    "FILE payload_id=$payloadId LAST_CHUNK with $covered bytes covered, " +
+                        "differs from declared total_size=$totalSize " +
+                        "(${state.coverage.size} range(s) seen)",
                 )
             }
             filesInFlight.remove(payloadId)
@@ -402,15 +499,46 @@ public class PayloadAssembler(
                     e,
                 )
             }
-            PayloadEvent.FileComplete(payloadId, state.header, state.bytesWritten)
+            PayloadEvent.FileComplete(payloadId, state.header, totalSize)
         } else {
             PayloadEvent.Progress(
                 payloadId = payloadId,
-                bytesReceived = state.bytesWritten,
-                totalSize = state.header.totalSize,
+                bytesReceived = state.coverage.coveredBytes,
+                totalSize = totalSize,
                 type = PayloadHeader.PayloadType.FILE,
             )
         }
+    }
+
+    /**
+     * Classify a FILE chunk's `[start, end)` against the current
+     * coverage set without mutating either. The mutation happens later
+     * in [handleFile], on the success path of the actual write.
+     *
+     * The trio of outcomes mirrors [ByteRangeSet.AddResult] but does not
+     * actually call `add`: probing whether `[start, end)` is fully
+     * contained, fully fresh, or a mixed partial-overlap is enough.
+     */
+    private enum class FileChunkClassification { AlreadyCovered, PartialOverlap, NewBytes }
+
+    private fun classifyFileChunk(
+        coverage: ByteRangeSet,
+        start: Long,
+        end: Long,
+    ): FileChunkClassification {
+        if (start == end || coverage.contains(start, end)) {
+            return FileChunkClassification.AlreadyCovered
+        }
+        // Walk only the prefix of stored ranges whose start lies before
+        // `end`; anything past that point cannot overlap. The chained
+        // `takeWhile` + `any` structure replaces a hand-written loop
+        // with two break statements, which detekt rejects.
+        val partial =
+            coverage.ranges
+                .asSequence()
+                .takeWhile { it.start < end }
+                .any { it.end > start }
+        return if (partial) FileChunkClassification.PartialOverlap else FileChunkClassification.NewBytes
     }
 
     public companion object {

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/InboundConnectionTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/InboundConnectionTest.kt
@@ -32,12 +32,11 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
-import java.io.ByteArrayOutputStream
 import java.net.InetAddress
 import java.net.ServerSocket
 import java.net.Socket
 import java.nio.ByteBuffer
-import java.nio.channels.WritableByteChannel
+import java.nio.channels.SeekableByteChannel
 import java.security.SecureRandom
 
 /**
@@ -93,9 +92,13 @@ class InboundConnectionTest {
         return client to server
     }
 
-    /** In-memory file destination factory. Captures bytes per payload. */
+    /**
+     * In-memory file destination factory. Captures bytes per payload
+     * via a [SeekableByteChannel] so the assembler's #44 out-of-order
+     * write path is exercised end-to-end.
+     */
     private class InMemoryFactory : FileDestinationFactory {
-        val output: MutableMap<Long, ByteArrayOutputStream> = HashMap()
+        val output: MutableMap<Long, InMemorySeekable> = HashMap()
 
         /** Payload ids the orchestrator called [commit] on. */
         val committed: MutableList<Long> = mutableListOf()
@@ -112,27 +115,11 @@ class InboundConnectionTest {
         override fun open(
             header: com.google.location.nearby.connections.proto.OfflineWireFormatsProto
                 .PayloadTransferFrame.PayloadHeader,
-        ): WritableByteChannel {
-            val buf = ByteArrayOutputStream()
-            output[header.id] = buf
+        ): SeekableByteChannel {
+            val ch = InMemorySeekable()
+            output[header.id] = ch
             inFlight += header.id
-            return object : WritableByteChannel {
-                private var open = true
-
-                override fun write(src: ByteBuffer): Int {
-                    val n = src.remaining()
-                    val arr = ByteArray(n)
-                    src.get(arr)
-                    buf.write(arr)
-                    return n
-                }
-
-                override fun close() {
-                    open = false
-                }
-
-                override fun isOpen(): Boolean = open
-            }
+            return ch
         }
 
         override fun commit(payloadId: Long): Boolean {
@@ -153,6 +140,61 @@ class InboundConnectionTest {
             }
             inFlight.clear()
             return count
+        }
+    }
+
+    /**
+     * Lightweight in-memory [SeekableByteChannel] used by the test
+     * factory. Backs a `ByteArray` sized to the largest write seen so
+     * far; supports `position()` + write so chunks can land at any
+     * offset.
+     */
+    private class InMemorySeekable : SeekableByteChannel {
+        private var buffer: ByteArray = ByteArray(0)
+        private var size: Long = 0
+        private var pos: Long = 0
+        private var open: Boolean = true
+
+        fun toByteArray(): ByteArray = buffer.copyOf(size.toInt())
+
+        override fun isOpen(): Boolean = open
+
+        override fun close() {
+            open = false
+        }
+
+        override fun read(dst: ByteBuffer): Int = throw UnsupportedOperationException()
+
+        override fun write(src: ByteBuffer): Int {
+            val n = src.remaining()
+            if (n == 0) return 0
+            ensureCapacity(pos + n)
+            src.get(buffer, pos.toInt(), n)
+            pos += n
+            if (pos > size) size = pos
+            return n
+        }
+
+        override fun position(): Long = pos
+
+        override fun position(newPosition: Long): SeekableByteChannel {
+            pos = newPosition
+            return this
+        }
+
+        override fun size(): Long = size
+
+        override fun truncate(newSize: Long): SeekableByteChannel {
+            if (newSize < size) size = newSize
+            if (pos > size) pos = size
+            return this
+        }
+
+        private fun ensureCapacity(min: Long) {
+            if (min <= buffer.size) return
+            var newCap = buffer.size.coerceAtLeast(16)
+            while (newCap < min) newCap = (newCap + (newCap shr 1)).coerceAtLeast(min.toInt())
+            buffer = buffer.copyOf(newCap)
         }
     }
 

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionTest.kt
@@ -20,14 +20,13 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import java.io.ByteArrayInputStream
-import java.io.ByteArrayOutputStream
 import java.net.InetAddress
 import java.net.ServerSocket
 import java.net.Socket
 import java.nio.ByteBuffer
 import java.nio.channels.Channels
 import java.nio.channels.ReadableByteChannel
-import java.nio.channels.WritableByteChannel
+import java.nio.channels.SeekableByteChannel
 import java.security.SecureRandom
 import java.util.concurrent.TimeUnit
 
@@ -66,30 +65,72 @@ class OutboundConnectionTest {
         }
     }
 
-    /** In-memory file destination factory for the inbound side. */
+    /**
+     * In-memory file destination factory for the inbound side. Backs
+     * each payload with a [SeekableByteChannel] so the assembler's
+     * #44 out-of-order write path is exercised end-to-end.
+     */
     private class InMemoryFactory : FileDestinationFactory {
-        val output: MutableMap<Long, ByteArrayOutputStream> = HashMap()
+        val output: MutableMap<Long, InMemorySeekable> = HashMap()
 
-        override fun open(header: PayloadHeader): WritableByteChannel {
-            val buf = ByteArrayOutputStream()
-            output[header.id] = buf
-            return object : WritableByteChannel {
-                private var open = true
+        override fun open(header: PayloadHeader): SeekableByteChannel {
+            val ch = InMemorySeekable()
+            output[header.id] = ch
+            return ch
+        }
+    }
 
-                override fun write(src: ByteBuffer): Int {
-                    val n = src.remaining()
-                    val arr = ByteArray(n)
-                    src.get(arr)
-                    buf.write(arr)
-                    return n
-                }
+    /**
+     * Lightweight in-memory [SeekableByteChannel] used by the test
+     * factory. See [InboundConnectionTest.InMemorySeekable] for the
+     * full contract; duplicated here to keep tests independent.
+     */
+    private class InMemorySeekable : SeekableByteChannel {
+        private var buffer: ByteArray = ByteArray(0)
+        private var size: Long = 0
+        private var pos: Long = 0
+        private var open: Boolean = true
 
-                override fun close() {
-                    open = false
-                }
+        fun toByteArray(): ByteArray = buffer.copyOf(size.toInt())
 
-                override fun isOpen(): Boolean = open
-            }
+        override fun isOpen(): Boolean = open
+
+        override fun close() {
+            open = false
+        }
+
+        override fun read(dst: ByteBuffer): Int = throw UnsupportedOperationException()
+
+        override fun write(src: ByteBuffer): Int {
+            val n = src.remaining()
+            if (n == 0) return 0
+            ensureCapacity(pos + n)
+            src.get(buffer, pos.toInt(), n)
+            pos += n
+            if (pos > size) size = pos
+            return n
+        }
+
+        override fun position(): Long = pos
+
+        override fun position(newPosition: Long): SeekableByteChannel {
+            pos = newPosition
+            return this
+        }
+
+        override fun size(): Long = size
+
+        override fun truncate(newSize: Long): SeekableByteChannel {
+            if (newSize < size) size = newSize
+            if (pos > size) pos = size
+            return this
+        }
+
+        private fun ensureCapacity(min: Long) {
+            if (min <= buffer.size) return
+            var newCap = buffer.size.coerceAtLeast(16)
+            while (newCap < min) newCap = (newCap + (newCap shr 1)).coerceAtLeast(min.toInt())
+            buffer = buffer.copyOf(newCap)
         }
     }
 

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/payload/ByteRangeSetTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/payload/ByteRangeSetTest.kt
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.payload
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * Tests for [ByteRangeSet] — the small interval-set helper that backs
+ * [PayloadAssembler]'s out-of-order FILE chunk tracking (#44).
+ *
+ * Coverage is structured around the three kinds of insert outcome
+ * ([ByteRangeSet.AddResult.Added], [ByteRangeSet.AddResult.AlreadyCovered],
+ * [ByteRangeSet.AddResult.PartialOverlap]) plus the canonicalization
+ * invariant (sorted, non-overlapping, non-adjacent).
+ */
+class ByteRangeSetTest {
+    @Test
+    fun `empty set is incomplete for non-zero total and complete for zero`() {
+        val s = ByteRangeSet()
+        assertThat(s.size).isEqualTo(0)
+        assertThat(s.coveredBytes).isEqualTo(0L)
+        assertThat(s.isComplete(0)).isTrue()
+        assertThat(s.isComplete(10)).isFalse()
+    }
+
+    @Test
+    fun `adding a fresh range reports Added with the full size`() {
+        val s = ByteRangeSet()
+        val r = s.add(10, 20)
+        assertThat(r).isEqualTo(ByteRangeSet.AddResult.Added(addedBytes = 10))
+        assertThat(s.coveredBytes).isEqualTo(10L)
+        assertThat(s.size).isEqualTo(1)
+    }
+
+    @Test
+    fun `adding the same range a second time reports AlreadyCovered`() {
+        val s = ByteRangeSet()
+        s.add(0, 100)
+        val r = s.add(0, 100)
+        assertThat(r).isEqualTo(ByteRangeSet.AddResult.AlreadyCovered)
+        assertThat(s.coveredBytes).isEqualTo(100L)
+        assertThat(s.size).isEqualTo(1)
+    }
+
+    @Test
+    fun `adding a range fully contained in an existing one reports AlreadyCovered`() {
+        val s = ByteRangeSet()
+        s.add(0, 100)
+        val r = s.add(20, 50)
+        assertThat(r).isEqualTo(ByteRangeSet.AddResult.AlreadyCovered)
+        assertThat(s.coveredBytes).isEqualTo(100L)
+    }
+
+    @Test
+    fun `adding a range that partially overlaps reports PartialOverlap with delta`() {
+        val s = ByteRangeSet()
+        s.add(0, 100)
+        // [50, 150) overlaps [0, 100) on [50, 100) (50 bytes) and
+        // extends [100, 150) (50 fresh bytes).
+        val r = s.add(50, 150)
+        assertThat(r).isEqualTo(ByteRangeSet.AddResult.PartialOverlap(addedBytes = 50))
+        assertThat(s.coveredBytes).isEqualTo(150L)
+        assertThat(s.size).isEqualTo(1)
+    }
+
+    @Test
+    fun `adjacent ranges merge into one canonical range`() {
+        val s = ByteRangeSet()
+        s.add(0, 50)
+        s.add(50, 100) // exactly adjacent at 50 -> merges
+        assertThat(s.size).isEqualTo(1)
+        assertThat(s.coveredBytes).isEqualTo(100L)
+        assertThat(s.isComplete(100)).isTrue()
+    }
+
+    @Test
+    fun `non-adjacent ranges stay separate`() {
+        val s = ByteRangeSet()
+        s.add(0, 10)
+        s.add(20, 30)
+        s.add(40, 50)
+        assertThat(s.size).isEqualTo(3)
+        assertThat(s.coveredBytes).isEqualTo(30L)
+        assertThat(s.isComplete(50)).isFalse()
+    }
+
+    @Test
+    fun `inserting a range that bridges two existing ranges merges all three`() {
+        val s = ByteRangeSet()
+        s.add(0, 10)
+        s.add(20, 30)
+        // [10, 20) is the gap; bridging it merges everything into one.
+        val r = s.add(10, 20)
+        assertThat(r).isEqualTo(ByteRangeSet.AddResult.Added(addedBytes = 10))
+        assertThat(s.size).isEqualTo(1)
+        assertThat(s.coveredBytes).isEqualTo(30L)
+    }
+
+    @Test
+    fun `inserting a range that subsumes multiple existing ranges merges them all`() {
+        val s = ByteRangeSet()
+        s.add(10, 20)
+        s.add(30, 40)
+        s.add(50, 60)
+        // [0, 100) covers all three plus extra fresh bytes.
+        val r = s.add(0, 100)
+        // Existing covered bytes: 30. Inserted size: 100. Genuinely new: 70.
+        assertThat(r).isInstanceOf(ByteRangeSet.AddResult.PartialOverlap::class.java)
+        assertThat((r as ByteRangeSet.AddResult.PartialOverlap).addedBytes).isEqualTo(70L)
+        assertThat(s.size).isEqualTo(1)
+        assertThat(s.coveredBytes).isEqualTo(100L)
+    }
+
+    @Test
+    fun `insertion order does not change canonical layout for shuffled chunks`() {
+        // Two assemblers, same chunk set, different insertion order:
+        // both should reach the identical canonical form.
+        val s1 = ByteRangeSet()
+        val s2 = ByteRangeSet()
+        listOf(0L to 10L, 10L to 20L, 20L to 30L, 30L to 40L)
+            .forEach { (a, b) -> s1.add(a, b) }
+        listOf(20L to 30L, 0L to 10L, 30L to 40L, 10L to 20L)
+            .forEach { (a, b) -> s2.add(a, b) }
+        assertThat(s1.ranges).isEqualTo(s2.ranges)
+        assertThat(s1.isComplete(40)).isTrue()
+    }
+
+    @Test
+    fun `contains returns true for any sub-range of a stored range`() {
+        val s = ByteRangeSet()
+        s.add(100, 200)
+        assertThat(s.contains(100, 200)).isTrue()
+        assertThat(s.contains(110, 190)).isTrue()
+        assertThat(s.contains(100, 100)).isTrue()
+        assertThat(s.contains(150, 150)).isTrue()
+        assertThat(s.contains(99, 200)).isFalse()
+        assertThat(s.contains(100, 201)).isFalse()
+        assertThat(s.contains(0, 50)).isFalse()
+    }
+
+    @Test
+    fun `clear empties the set`() {
+        val s = ByteRangeSet()
+        s.add(0, 10)
+        s.add(20, 30)
+        s.clear()
+        assertThat(s.size).isEqualTo(0)
+        assertThat(s.coveredBytes).isEqualTo(0L)
+    }
+
+    @Test
+    fun `negative or inverted ranges are rejected`() {
+        val s = ByteRangeSet()
+        assertThrows<IllegalArgumentException> { s.add(-1, 0) }
+        assertThrows<IllegalArgumentException> { s.add(10, 5) }
+    }
+
+    @Test
+    fun `Range itself rejects negative and inverted bounds`() {
+        assertThrows<IllegalArgumentException> { ByteRangeSet.Range(-1, 0) }
+        assertThrows<IllegalArgumentException> { ByteRangeSet.Range(10, 5) }
+    }
+
+    @Test
+    fun `empty range insert is a no-op and reports AlreadyCovered`() {
+        val s = ByteRangeSet()
+        val r = s.add(5, 5)
+        assertThat(r).isEqualTo(ByteRangeSet.AddResult.AlreadyCovered)
+        assertThat(s.size).isEqualTo(0)
+    }
+
+    @Test
+    fun `isComplete strictly checks for single-range full coverage`() {
+        val s = ByteRangeSet()
+        s.add(0, 50)
+        s.add(60, 100)
+        assertThat(s.isComplete(100)).isFalse()
+        s.add(50, 60)
+        assertThat(s.isComplete(100)).isTrue()
+    }
+}

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/payload/PayloadAssemblerTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/payload/PayloadAssemblerTest.kt
@@ -12,10 +12,9 @@ import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.Payl
 import com.google.protobuf.ByteString
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import java.io.ByteArrayOutputStream
 import java.nio.ByteBuffer
 import java.nio.channels.Channels
-import java.nio.channels.WritableByteChannel
+import java.nio.channels.SeekableByteChannel
 import kotlin.random.Random
 
 /**
@@ -86,47 +85,95 @@ class PayloadAssemblerTest {
 
     /**
      * Capturing [FileDestinationFactory] that hands every payload an
-     * in-memory [java.io.ByteArrayOutputStream] wrapped as a
-     * [WritableByteChannel]. Tests can read back what was written via
-     * [outputs] and inspect [opened] / [closed] counters to confirm the
-     * channel lifecycle.
+     * in-memory [SeekableByteChannel]. Tests can read back what was
+     * written via [outputs] and inspect [opened] / [closed] counters to
+     * confirm the channel lifecycle.
+     *
+     * The channel is seekable so the assembler's #44 out-of-order code
+     * path is exercised directly: chunks delivered with non-sequential
+     * offsets call `position()` and write into the right slot of the
+     * backing buffer, just as a `RandomAccessFile`-backed channel
+     * would on Android.
      */
     private class CapturingFactory : FileDestinationFactory {
-        val outputs: MutableMap<Long, ByteArrayOutputStream> = HashMap()
+        val outputs: MutableMap<Long, InMemorySeekableChannel> = HashMap()
         var opened: Int = 0
             private set
         var closed: Int = 0
             private set
 
-        override fun open(header: PayloadHeader): WritableByteChannel {
+        override fun open(header: PayloadHeader): SeekableByteChannel {
             opened += 1
-            val sink = ByteArrayOutputStream()
-            outputs[header.id] = sink
-            val raw: WritableByteChannel = Channels.newChannel(sink)
-            return CountingChannel(raw, onClose = { closed += 1 })
+            val ch = InMemorySeekableChannel(onClose = { closed += 1 })
+            outputs[header.id] = ch
+            return ch
         }
     }
 
     /**
-     * Wraps a [WritableByteChannel] and increments a counter on close so
-     * the test can assert that the assembler closed the destination
-     * exactly once.
+     * Minimal in-memory [SeekableByteChannel] for tests. Backs a single
+     * `ByteArray` that grows on writes past the current size; supports
+     * out-of-order writes via [position] + [write] (writing past the end
+     * fills any uncovered bytes with zero). The file content is the
+     * concatenation of every byte written; tests read it back via
+     * [toByteArray].
      */
-    private class CountingChannel(
-        private val delegate: WritableByteChannel,
+    private class InMemorySeekableChannel(
         private val onClose: () -> Unit,
-    ) : WritableByteChannel by delegate {
-        private var closed: Boolean = false
+    ) : SeekableByteChannel {
+        private var buffer: ByteArray = ByteArray(0)
+        private var size: Long = 0
+        private var pos: Long = 0
+        private var open: Boolean = true
+
+        fun toByteArray(): ByteArray = buffer.copyOf(size.toInt())
+
+        override fun isOpen(): Boolean = open
 
         override fun close() {
-            if (!closed) {
-                closed = true
-                onClose()
-            }
-            delegate.close()
+            if (!open) return
+            open = false
+            onClose()
         }
 
-        override fun isOpen(): Boolean = !closed && delegate.isOpen
+        override fun read(dst: ByteBuffer): Int = throw UnsupportedOperationException("not used by assembler")
+
+        override fun write(src: ByteBuffer): Int {
+            check(open) { "channel closed" }
+            val n = src.remaining()
+            if (n == 0) return 0
+            ensureCapacity(pos + n)
+            src.get(buffer, pos.toInt(), n)
+            pos += n
+            if (pos > size) size = pos
+            return n
+        }
+
+        override fun position(): Long = pos
+
+        override fun position(newPosition: Long): SeekableByteChannel {
+            require(newPosition >= 0) { "negative position $newPosition" }
+            pos = newPosition
+            return this
+        }
+
+        override fun size(): Long = size
+
+        override fun truncate(newSize: Long): SeekableByteChannel {
+            require(newSize >= 0)
+            if (newSize < size) size = newSize
+            if (pos > size) pos = size
+            return this
+        }
+
+        private fun ensureCapacity(min: Long) {
+            if (min <= buffer.size) return
+            // Match ArrayList's growth heuristic — size + size/2 — so
+            // many small writes do not pay an O(n^2) bill.
+            var newCap = buffer.size.coerceAtLeast(16)
+            while (newCap < min) newCap = (newCap + (newCap shr 1)).coerceAtLeast(min.toInt())
+            buffer = buffer.copyOf(newCap)
+        }
     }
 
     // ------------------------------------------------------------------
@@ -468,10 +515,16 @@ class PayloadAssemblerTest {
     // ------------------------------------------------------------------
 
     @Test
-    fun `FILE rejects chunk with offset mismatch and closes the channel`() {
+    fun `FILE rejects chunk that partially overlaps a covered range and extends it`() {
+        // #44 allows chunks to arrive out of order or be re-sent
+        // verbatim. What it does NOT allow is a chunk that overlaps a
+        // covered range AND extends past it: such a chunk would mean the
+        // peer has changed the chunk boundary mid-stream, which the wire
+        // spec does not permit and which would corrupt the receiver's
+        // coverage tracking.
         val factory = CapturingFactory()
         val assembler = PayloadAssembler(fileDestinationFactory = factory)
-        // First chunk 100 bytes, ok.
+        // First chunk covers [0, 100).
         assembler.onPayloadTransfer(
             chunkFrame(
                 payloadId = 300,
@@ -483,7 +536,8 @@ class PayloadAssemblerTest {
                 fileName = "x.bin",
             ),
         )
-        // Second chunk lies about offset (claims 50, real is 100).
+        // Second chunk would cover [50, 150). Overlaps [0, 100) on the
+        // [50, 100) sub-interval AND extends beyond it.
         val ex =
             assertThrows<PayloadProtocolException> {
                 assembler.onPayloadTransfer(
@@ -492,14 +546,13 @@ class PayloadAssemblerTest {
                         type = PayloadHeader.PayloadType.FILE,
                         totalSize = 1000,
                         offset = 50,
-                        body = ByteArray(50) { 0x33 },
+                        body = ByteArray(100) { 0x33 },
                         lastChunk = false,
                         fileName = "x.bin",
                     ),
                 )
             }
-        assertThat(ex.message).contains("offset=50")
-        assertThat(ex.message).contains("bytes written=100")
+        assertThat(ex.message).contains("partially overlaps")
         assertThat(factory.closed).isEqualTo(1)
         assertThat(assembler.inFlightPayloadCount).isEqualTo(0)
     }
@@ -544,7 +597,7 @@ class PayloadAssemblerTest {
                     ),
                 )
             }
-        assertThat(ex.message).contains("LAST_CHUNK at 100 bytes")
+        assertThat(ex.message).contains("100 bytes covered")
         assertThat(ex.message).contains("total_size=1000")
         assertThat(factory.closed).isEqualTo(1)
     }
@@ -735,7 +788,7 @@ class PayloadAssemblerTest {
     fun `factory exception on first FILE chunk leaks no state`() {
         val throwingFactory =
             object : FileDestinationFactory {
-                override fun open(header: PayloadHeader): WritableByteChannel =
+                override fun open(header: PayloadHeader): SeekableByteChannel =
                     throw java.io.IOException("simulated open failure")
             }
         val assembler = PayloadAssembler(fileDestinationFactory = throwingFactory)
@@ -882,5 +935,216 @@ class PayloadAssemblerTest {
         assertThat(lastEvent).isInstanceOf(PayloadEvent.FileComplete::class.java)
         assertThat(factory.outputs[9000]!!.toByteArray()).isEqualTo(data)
         assertThat(factory.closed).isEqualTo(1)
+    }
+
+    // ------------------------------------------------------------------
+    // FILE — out-of-order delivery (#44)
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `FILE chunks delivered in shuffled order reassemble into the correct bytes`() {
+        // The acceptance test for #44: feed chunks of a FILE payload in a
+        // randomized order to the assembler and verify the reconstructed
+        // bytes match the original. The terminator (zero-body
+        // LAST_CHUNK) is the very last frame; everything before it can
+        // arrive in any order.
+        val factory = CapturingFactory()
+        val assembler = PayloadAssembler(fileDestinationFactory = factory)
+        val total = 64 * 1024
+        val chunkSize = 4 * 1024
+        val data = Random(0xBADCAFE).nextBytes(total)
+
+        // Build the (offset, body) pairs in declared order...
+        val chunks =
+            buildList {
+                var off = 0
+                while (off < total) {
+                    val end = (off + chunkSize).coerceAtMost(total)
+                    add(off.toLong() to data.copyOfRange(off, end))
+                    off = end
+                }
+            }
+        // ...then shuffle them with a seeded PRNG so the test is
+        // deterministic across runs but exercises a non-trivial order.
+        val shuffled = chunks.shuffled(java.util.Random(0xFA1AFE1L))
+
+        for ((offset, body) in shuffled) {
+            val ev =
+                assembler.onPayloadTransfer(
+                    chunkFrame(
+                        payloadId = 4242,
+                        type = PayloadHeader.PayloadType.FILE,
+                        totalSize = total.toLong(),
+                        offset = offset,
+                        body = body,
+                        lastChunk = false,
+                        fileName = "shuffled.bin",
+                    ),
+                )
+            assertThat(ev).isInstanceOf(PayloadEvent.Progress::class.java)
+        }
+        // Now the LAST_CHUNK terminator at offset == total_size with
+        // empty body. Coverage is already complete so this finalizes.
+        val terminator =
+            assembler.onPayloadTransfer(
+                chunkFrame(
+                    payloadId = 4242,
+                    type = PayloadHeader.PayloadType.FILE,
+                    totalSize = total.toLong(),
+                    offset = total.toLong(),
+                    body = ByteArray(0),
+                    lastChunk = true,
+                    fileName = "shuffled.bin",
+                ),
+            )
+        assertThat(terminator).isInstanceOf(PayloadEvent.FileComplete::class.java)
+        assertThat(factory.outputs[4242]!!.toByteArray()).isEqualTo(data)
+        assertThat(factory.closed).isEqualTo(1)
+    }
+
+    @Test
+    fun `FILE LAST_CHUNK arriving before all data chunks errors with gap report`() {
+        // Variant: the peer sends LAST_CHUNK while the coverage set still
+        // has gaps. This should be rejected — LAST_CHUNK is a final
+        // signal that no more chunks are coming, so a missing range is
+        // an unrecoverable protocol error.
+        val factory = CapturingFactory()
+        val assembler = PayloadAssembler(fileDestinationFactory = factory)
+        val total = 256
+        val data = Random(0xC0FFEE).nextBytes(total)
+        // Send only [0, 128) and then a LAST_CHUNK at offset=total.
+        assembler.onPayloadTransfer(
+            chunkFrame(
+                payloadId = 5,
+                type = PayloadHeader.PayloadType.FILE,
+                totalSize = total.toLong(),
+                offset = 0,
+                body = data.copyOfRange(0, 128),
+                lastChunk = false,
+                fileName = "gap.bin",
+            ),
+        )
+        val ex =
+            assertThrows<PayloadProtocolException> {
+                assembler.onPayloadTransfer(
+                    chunkFrame(
+                        payloadId = 5,
+                        type = PayloadHeader.PayloadType.FILE,
+                        totalSize = total.toLong(),
+                        offset = total.toLong(),
+                        body = ByteArray(0),
+                        lastChunk = true,
+                        fileName = "gap.bin",
+                    ),
+                )
+            }
+        assertThat(ex.message).contains("LAST_CHUNK")
+        assertThat(ex.message).contains("128 bytes covered")
+        assertThat(ex.message).contains("total_size=256")
+        assertThat(factory.closed).isEqualTo(1)
+    }
+
+    @Test
+    fun `FILE duplicate chunk delivered verbatim is silently deduped`() {
+        // A peer that re-sends an exact previously-delivered chunk is
+        // permitted (think: BLE retransmit, or a NIC handing the same
+        // datagram up twice). The assembler must not double-write nor
+        // raise a protocol error. Coverage stays unchanged.
+        val factory = CapturingFactory()
+        val assembler = PayloadAssembler(fileDestinationFactory = factory)
+        val total = 32
+        val data = Random(0xDADADA).nextBytes(total)
+        val first =
+            chunkFrame(
+                payloadId = 9,
+                type = PayloadHeader.PayloadType.FILE,
+                totalSize = total.toLong(),
+                offset = 0,
+                body = data,
+                lastChunk = false,
+                fileName = "dup.bin",
+            )
+        // Send the exact same chunk three times.
+        assembler.onPayloadTransfer(first)
+        assembler.onPayloadTransfer(first)
+        val ev3 = assembler.onPayloadTransfer(first)
+        assertThat(ev3).isInstanceOf(PayloadEvent.Progress::class.java)
+        // Coverage should be exactly [0, 32) — still one range — no
+        // matter how many duplicates we forwarded.
+        // Now finalize.
+        val done =
+            assembler.onPayloadTransfer(
+                chunkFrame(
+                    payloadId = 9,
+                    type = PayloadHeader.PayloadType.FILE,
+                    totalSize = total.toLong(),
+                    offset = total.toLong(),
+                    body = ByteArray(0),
+                    lastChunk = true,
+                    fileName = "dup.bin",
+                ),
+            )
+        assertThat(done).isInstanceOf(PayloadEvent.FileComplete::class.java)
+        assertThat(factory.outputs[9]!!.toByteArray()).isEqualTo(data)
+    }
+
+    @Test
+    fun `FILE rejects a chunk with a negative offset`() {
+        val factory = CapturingFactory()
+        val assembler = PayloadAssembler(fileDestinationFactory = factory)
+        val ex =
+            assertThrows<PayloadProtocolException> {
+                assembler.onPayloadTransfer(
+                    chunkFrame(
+                        payloadId = 1,
+                        type = PayloadHeader.PayloadType.FILE,
+                        totalSize = 100,
+                        offset = -1,
+                        body = ByteArray(10),
+                        lastChunk = false,
+                        fileName = "neg.bin",
+                    ),
+                )
+            }
+        assertThat(ex.message).contains("negative")
+    }
+
+    @Test
+    fun `FILE LAST_CHUNK with body data that completes the file is accepted`() {
+        // The encoder sends LAST_CHUNK as a separate empty frame, but
+        // the assembler must also tolerate a peer that fuses the final
+        // body bytes with the LAST_CHUNK flag (the legacy iOS / macOS
+        // shape). As long as coverage ends exactly at total_size, the
+        // payload completes.
+        val factory = CapturingFactory()
+        val assembler = PayloadAssembler(fileDestinationFactory = factory)
+        val data = Random(0xFEEDFACE).nextBytes(64)
+        // First half, no LAST_CHUNK.
+        assembler.onPayloadTransfer(
+            chunkFrame(
+                payloadId = 11,
+                type = PayloadHeader.PayloadType.FILE,
+                totalSize = data.size.toLong(),
+                offset = 0,
+                body = data.copyOfRange(0, 32),
+                lastChunk = false,
+                fileName = "fused.bin",
+            ),
+        )
+        // Second half WITH LAST_CHUNK on the same data frame.
+        val ev =
+            assembler.onPayloadTransfer(
+                chunkFrame(
+                    payloadId = 11,
+                    type = PayloadHeader.PayloadType.FILE,
+                    totalSize = data.size.toLong(),
+                    offset = 32,
+                    body = data.copyOfRange(32, 64),
+                    lastChunk = true,
+                    fileName = "fused.bin",
+                ),
+            )
+        assertThat(ev).isInstanceOf(PayloadEvent.FileComplete::class.java)
+        assertThat(factory.outputs[11]!!.toByteArray()).isEqualTo(data)
     }
 }

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/downloads/DownloadsWriterFactory.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/downloads/DownloadsWriterFactory.kt
@@ -9,6 +9,7 @@ import android.content.Context
 import android.os.Build
 import android.os.Environment
 import androidx.annotation.VisibleForTesting
+import java.io.File
 
 /**
  * Public entry point for constructing a [MediaStoreDownloadsFactory]
@@ -57,7 +58,13 @@ public object DownloadsWriterFactory {
                     Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS),
                 )
             }
-        return MediaStoreDownloadsFactory(DownloadsWriter(environment))
+        // Spool inbound FILE payloads under a private cache subdirectory
+        // so we can keep them off the public Downloads scan even on
+        // legacy storage. cacheDir is automatically reclaimed by the
+        // platform under storage pressure, which is the right behavior
+        // for transient transfer state.
+        val spoolDirectory = File(context.cacheDir, SPOOL_SUBDIRECTORY)
+        return MediaStoreDownloadsFactory(DownloadsWriter(environment), spoolDirectory)
     }
 
     /**
@@ -66,6 +73,16 @@ public object DownloadsWriterFactory {
      * production code paths only see [create].
      */
     @VisibleForTesting
-    internal fun fromEnvironment(environment: DownloadsEnvironment): MediaStoreDownloadsFactory =
-        MediaStoreDownloadsFactory(DownloadsWriter(environment))
+    internal fun fromEnvironment(
+        environment: DownloadsEnvironment,
+        spoolDirectory: File,
+    ): MediaStoreDownloadsFactory = MediaStoreDownloadsFactory(DownloadsWriter(environment), spoolDirectory)
+
+    /**
+     * Subdirectory inside the app's `cacheDir` where in-flight FILE
+     * payloads are spooled. The directory is created lazily on the
+     * first transfer and cleared on factory teardown
+     * ([MediaStoreDownloadsFactory.abortAll]).
+     */
+    internal const val SPOOL_SUBDIRECTORY: String = "wvmg-payload-spool"
 }

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/downloads/MediaStoreDownloadsFactory.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/downloads/MediaStoreDownloadsFactory.kt
@@ -7,8 +7,9 @@ package io.github.kyujincho.wvmg.service.downloads
 
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.PayloadTransferFrame.PayloadHeader
 import io.github.kyujincho.wvmg.protocol.payload.FileDestinationFactory
-import java.nio.channels.Channels
-import java.nio.channels.WritableByteChannel
+import java.io.File
+import java.io.RandomAccessFile
+import java.nio.channels.SeekableByteChannel
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -21,10 +22,30 @@ import java.util.concurrent.ConcurrentHashMap
  * The split is hidden behind a [DownloadsEnvironment]; the public API
  * here works the same on both.
  *
+ * ### Why a spool file
+ *
+ * `:core-protocol`'s [PayloadAssembler] expects a [SeekableByteChannel]
+ * destination (#44 — out-of-order FILE chunk delivery requires
+ * `position(offset)` + write semantics). Neither `MediaStore`'s
+ * `ContentResolver.openOutputStream` nor a plain `FileOutputStream`
+ * gives us seekable writes through their `OutputStream` surface, so we
+ * spool every in-flight payload to a private-storage `RandomAccessFile`
+ * first. The spool's `FileChannel` is fully seekable, satisfying the
+ * assembler's contract.
+ *
+ * On a successful [commit] we copy the spool bytes into the
+ * `DownloadsEnvironment` destination's output stream and publish the
+ * row. On [abort] we delete the spool and discard the destination.
+ *
+ * The spool also makes the future resume work in #43 considerably
+ * simpler: the partial bytes are already on disk in their final byte
+ * positions, so a reconnect can resume by re-opening the spool file
+ * and seeking to the next un-covered offset.
+ *
  * ### Why a stateful factory
  *
  * The [PayloadAssembler] in `:core-protocol` calls `close()` on the
- * returned [WritableByteChannel] on BOTH the success path (LAST_CHUNK
+ * returned [SeekableByteChannel] on BOTH the success path (LAST_CHUNK
  * arrived, byte count matches) and the failure path (a malformed
  * mid-stream chunk). `close()` alone cannot tell which case it is —
  * but committing a partial file to the Downloads UI is harmful (the
@@ -32,7 +53,7 @@ import java.util.concurrent.ConcurrentHashMap
  *
  * To resolve this without changing the `:core-protocol` interface,
  * `MediaStoreDownloadsFactory` keeps a per-payload-id table of
- * [DownloadsWriter.Handle]s. The wrapping orchestrator (#21):
+ * [InFlight] entries. The wrapping orchestrator (#21):
  *
  *  1. Calls [open] when the assembler asks for a destination.
  *  2. On `PayloadEvent.FileComplete` from the assembler, calls
@@ -40,11 +61,11 @@ import java.util.concurrent.ConcurrentHashMap
  *  3. On any error / cancel / unexpected channel close before
  *     LAST_CHUNK, calls [abort] with that payload id.
  *
- * Either [commit] or [abort] also closes the underlying
- * [WritableByteChannel] if the assembler hadn't already, and removes
- * the handle from the in-flight map. Both are idempotent so a
- * double-call (e.g. abort during teardown after a commit during
- * normal completion) is a no-op.
+ * Either [commit] or [abort] also closes the underlying channel and
+ * the spool file if the assembler hadn't already, and removes the
+ * entry from the in-flight map. Both are idempotent so a double-call
+ * (e.g. abort during teardown after a commit during normal completion)
+ * is a no-op.
  *
  * ### Thread safety
  *
@@ -60,44 +81,67 @@ import java.util.concurrent.ConcurrentHashMap
  *   constructed via [DownloadsWriterFactory.create]. Tests pass a
  *   writer wrapping a fake [DownloadsEnvironment] so the routing logic
  *   is exercised on a plain JVM.
+ * @param spoolDirectory Directory to use for per-payload spool files.
+ *   In production this is the app's `cacheDir`. Tests inject a
+ *   `@TempDir`. The directory is created lazily on the first [open]
+ *   call.
  */
 public class MediaStoreDownloadsFactory internal constructor(
     private val writer: DownloadsWriter,
+    private val spoolDirectory: File,
 ) : FileDestinationFactory {
     /**
-     * Per-payload tracking entry. Bundles the [DownloadsWriter.Handle]
-     * with the sender-supplied `last_modified_timestamp_millis` captured
-     * at [open] time so that [commit] can apply it to the destination
-     * (issue #41). A separate field — rather than re-reading from a
-     * cached `PayloadHeader` — avoids retaining the protobuf object
-     * any longer than the assembler does.
-     */
-    private class InFlightEntry(
-        val handle: DownloadsWriter.Handle,
-        val lastModifiedTimestampMillis: Long,
-    )
-
-    /**
-     * Map of payload id -> tracking entry. A payload that is
+     * Map of payload id -> in-flight bookkeeping. A payload that is
      * mid-transfer has an entry; on commit/abort the entry is removed.
      */
-    private val inFlight: MutableMap<Long, InFlightEntry> = ConcurrentHashMap()
+    private val inFlight: MutableMap<Long, InFlight> = ConcurrentHashMap()
+
+    /**
+     * Per-payload bookkeeping kept while a FILE transfer is in flight.
+     *
+     * Bundling the destination handle with the local spool file, its
+     * channel, and the sender's `last_modified_timestamp_millis` lets
+     * [commit] / [abort] tear down everything in one call without the
+     * orchestrator having to know about the spool or to re-thread the
+     * `PayloadHeader`.
+     *
+     * @property handle The destination reservation against
+     *   [DownloadsEnvironment]. Receives the spool bytes on [commit];
+     *   gets discarded on [abort].
+     * @property spoolFile Private-storage temp file backing [channel].
+     *   Deleted on either commit or abort.
+     * @property channel The seekable view into [spoolFile] handed up to
+     *   the assembler. Closed before bytes are copied out on commit, or
+     *   before the spool is deleted on abort.
+     * @property lastModifiedTimestampMillis Sender-supplied
+     *   `PayloadHeader.last_modified_timestamp_millis` captured at
+     *   [open] time; routed through to the environment on [commit] so
+     *   the destination's mtime matches the original (issue #41).
+     */
+    private class InFlight(
+        val handle: DownloadsWriter.Handle,
+        val spoolFile: File,
+        val channel: SeekableByteChannel,
+        val lastModifiedTimestampMillis: Long,
+    )
 
     /**
      * Open a destination channel for an inbound FILE payload. Called
      * by the [PayloadAssembler] on the first chunk of each payload.
      *
      * The destination is sanitized, collision-suffixed, and reserved
-     * (as `IS_PENDING=1` on API 29+) before this returns. The returned
-     * channel writes bytes into the reserved storage; the assembler
-     * closes the channel after the last chunk OR after a malformed
-     * frame causes a [PayloadProtocolException].
+     * (as `IS_PENDING=1` on API 29+) before this returns. A private
+     * spool file is created in [spoolDirectory] and its
+     * [SeekableByteChannel] view is returned to the assembler. The
+     * assembler closes the channel after the last chunk OR after a
+     * malformed frame causes a `PayloadProtocolException`.
      *
      * @throws java.io.IOException if [DownloadsWriter.beginWrite]
-     *   cannot allocate a slot. The assembler propagates this; the
-     *   orchestrator turns it into an `InboundResult.Failed`.
+     *   cannot allocate a slot, or if the spool file cannot be
+     *   created. The assembler propagates this; the orchestrator turns
+     *   it into an `InboundResult.Failed`.
      */
-    override fun open(header: PayloadHeader): WritableByteChannel {
+    override fun open(header: PayloadHeader): SeekableByteChannel {
         // The peer can advertise a `parent_folder` but Quick Share
         // doesn't actually mean "create a subdirectory" by it -- it
         // means "this file belongs to a logical folder share". We
@@ -105,30 +149,54 @@ public class MediaStoreDownloadsFactory internal constructor(
         // user can move it into a folder afterwards. NearDrop does
         // the same.
         val handle = writer.beginWrite(rawFileName = header.fileName, mimeType = null)
-        // Track by payload id so the orchestrator can later commit
-        // or abort using only the id (it doesn't keep a reference to
-        // the channel itself). We also stash the sender's last-modified
-        // timestamp here (issue #41) so commit() can route it through
-        // to the environment without the orchestrator having to
-        // re-thread the header.
+        // Allocate the spool file under the configured directory.
+        // Using the payload id keeps the filename deterministic for
+        // diagnostics and rules out collision with other in-flight
+        // payloads even within a single connection.
+        if (!spoolDirectory.exists()) spoolDirectory.mkdirs()
+        val spoolFile = File(spoolDirectory, "wvmg-spool-${header.id}.part")
+        // Pre-existing spool file from a previous crashed transfer
+        // would corrupt the current payload's content; truncate by
+        // opening with "rw" and explicitly setting length=0. (#43 will
+        // re-purpose this exact file for resume; for now we treat any
+        // leftover as stale.)
+        val raf = RandomAccessFile(spoolFile, "rw")
+        try {
+            raf.setLength(0L)
+        } catch (e: java.io.IOException) {
+            runCatching { raf.close() }
+            runCatching { spoolFile.delete() }
+            handle.discard()
+            throw e
+        }
+        val channel = raf.channel
+        // Stash the sender's last-modified timestamp here (issue #41)
+        // so commit() can route it through to the environment without
+        // the orchestrator having to re-thread the PayloadHeader.
         inFlight[header.id] =
-            InFlightEntry(
+            InFlight(
                 handle = handle,
+                spoolFile = spoolFile,
+                channel = channel,
                 lastModifiedTimestampMillis = header.lastModifiedTimestampMillis,
             )
-        // OutputStream -> WritableByteChannel adapter from java.nio.
-        // Buffers internally; safe for the assembler's per-chunk
-        // ByteBuffer writes.
-        return Channels.newChannel(handle.outputStream)
+        return channel
     }
 
     /**
      * Mark the destination for [payloadId] as visible to the user.
      *
-     * On API 29+ this clears the `IS_PENDING` flag on the
-     * `MediaStore.Downloads` row; on API 24-28 it renames the
+     * Closes the spool channel, copies its bytes into the
+     * [DownloadsEnvironment] destination's output stream, and commits
+     * the destination. On API 29+ this clears the `IS_PENDING` flag on
+     * the `MediaStore.Downloads` row; on API 24-28 it renames the
      * `.part` placeholder to its final name (legacy environment
-     * implementation detail).
+     * implementation detail). The captured
+     * `last_modified_timestamp_millis` (issue #41) is forwarded so the
+     * destination's mtime matches the original.
+     *
+     * Best-effort cleanup of the spool file: failure to delete the
+     * temp file does not fail the commit.
      *
      * @return `true` if a destination was tracked for [payloadId] and
      *   has now been committed; `false` if no such destination exists
@@ -136,25 +204,43 @@ public class MediaStoreDownloadsFactory internal constructor(
      */
     override fun commit(payloadId: Long): Boolean {
         val entry = inFlight.remove(payloadId) ?: return false
-        entry.handle.commit(lastModifiedTimestampMillis = entry.lastModifiedTimestampMillis)
+        // Close the spool channel before reading the file back out.
+        // The assembler usually has already closed it, but if a
+        // commit-from-orchestrator races a pending close we make this
+        // idempotent.
+        runCatching { entry.channel.close() }
+        try {
+            entry.spoolFile.inputStream().use { input ->
+                entry.handle.outputStream.use { output -> input.copyTo(output) }
+            }
+            entry.handle.commit(lastModifiedTimestampMillis = entry.lastModifiedTimestampMillis)
+        } finally {
+            // Always delete the spool, even if the copy failed (the
+            // bytes are already in MediaStore at that point and we
+            // do not want to leave temp files behind).
+            runCatching { entry.spoolFile.delete() }
+        }
         return true
     }
 
     /**
      * Discard the destination for [payloadId]. Closes the underlying
-     * stream and deletes the reserved storage so the user never sees
-     * a partial file.
+     * channel, deletes the spool file, and asks the
+     * [DownloadsEnvironment] to delete the reserved row/file so the
+     * user never sees a partial download.
      *
      * Safe to call concurrently with the receive loop's writes -- the
-     * close cascades through `Channels.newChannel`, ending the next
+     * close cascades through the spool channel, ending the next
      * `write()` call with a `ClosedChannelException` which the
-     * assembler maps to a [PayloadProtocolException].
+     * assembler maps to a `PayloadProtocolException`.
      *
      * @return `true` if a destination was tracked for [payloadId] and
      *   has now been discarded; `false` if no such destination exists.
      */
     override fun abort(payloadId: Long): Boolean {
         val entry = inFlight.remove(payloadId) ?: return false
+        runCatching { entry.channel.close() }
+        runCatching { entry.spoolFile.delete() }
         entry.handle.discard()
         return true
     }

--- a/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/downloads/MediaStoreDownloadsFactoryTest.kt
+++ b/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/downloads/MediaStoreDownloadsFactoryTest.kt
@@ -8,7 +8,9 @@ package io.github.kyujincho.wvmg.service.downloads
 import com.google.common.truth.Truth.assertThat
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.PayloadTransferFrame.PayloadHeader
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 import java.nio.ByteBuffer
+import java.nio.file.Path
 
 /**
  * Exercises [MediaStoreDownloadsFactory] against a [FakeDownloadsEnvironment].
@@ -27,9 +29,11 @@ class MediaStoreDownloadsFactoryTest {
     // ------------------------------------------------------------------
 
     @Test
-    fun `open returns a channel that writes bytes into the environment`() {
+    fun `open returns a channel that writes bytes into the environment`(
+        @TempDir spool: Path,
+    ) {
         val env = FakeDownloadsEnvironment()
-        val factory = DownloadsWriterFactory.fromEnvironment(env)
+        val factory = DownloadsWriterFactory.fromEnvironment(env, spool.toFile())
         val header = fileHeader(id = 100, name = "doc.pdf", totalSize = 4)
 
         val channel = factory.open(header)
@@ -47,9 +51,11 @@ class MediaStoreDownloadsFactoryTest {
     }
 
     @Test
-    fun `open sanitizes the peer-supplied filename`() {
+    fun `open sanitizes the peer-supplied filename`(
+        @TempDir spool: Path,
+    ) {
         val env = FakeDownloadsEnvironment()
-        val factory = DownloadsWriterFactory.fromEnvironment(env)
+        val factory = DownloadsWriterFactory.fromEnvironment(env, spool.toFile())
         val header = fileHeader(id = 1, name = "../../etc/passwd", totalSize = 0)
 
         factory.open(header).close()
@@ -63,9 +69,11 @@ class MediaStoreDownloadsFactoryTest {
     }
 
     @Test
-    fun `open with empty filename uses the fallback name`() {
+    fun `open with empty filename uses the fallback name`(
+        @TempDir spool: Path,
+    ) {
         val env = FakeDownloadsEnvironment()
-        val factory = DownloadsWriterFactory.fromEnvironment(env)
+        val factory = DownloadsWriterFactory.fromEnvironment(env, spool.toFile())
         val header = fileHeader(id = 99, name = "", totalSize = 0)
 
         factory.open(header).close()
@@ -80,13 +88,15 @@ class MediaStoreDownloadsFactoryTest {
     // ------------------------------------------------------------------
 
     @Test
-    fun `commit forwards the senders last_modified timestamp to the environment`() {
+    fun `commit forwards the senders last_modified timestamp to the environment`(
+        @TempDir spool: Path,
+    ) {
         // Issue #41: PayloadHeader.last_modified_timestamp_millis must
         // round-trip from the assembler's open() through the factory's
         // commit() down to the underlying environment so the
         // MediaStore row (or legacy file) carries the original mtime.
         val env = FakeDownloadsEnvironment()
-        val factory = DownloadsWriterFactory.fromEnvironment(env)
+        val factory = DownloadsWriterFactory.fromEnvironment(env, spool.toFile())
         val ts = 1_700_000_000_000L
         val header =
             PayloadHeader
@@ -107,12 +117,14 @@ class MediaStoreDownloadsFactoryTest {
     }
 
     @Test
-    fun `commit forwards zero when the sender omitted the timestamp`() {
+    fun `commit forwards zero when the sender omitted the timestamp`(
+        @TempDir spool: Path,
+    ) {
         // A peer that left last_modified_timestamp_millis at the proto
         // default (0) must NOT cause us to overwrite the platform's
         // default mtime — the environment receives 0L and ignores it.
         val env = FakeDownloadsEnvironment()
-        val factory = DownloadsWriterFactory.fromEnvironment(env)
+        val factory = DownloadsWriterFactory.fromEnvironment(env, spool.toFile())
         val header = fileHeader(id = 200L, name = "no-ts.bin", totalSize = 0)
 
         factory.open(header).close()
@@ -123,9 +135,11 @@ class MediaStoreDownloadsFactoryTest {
     }
 
     @Test
-    fun `commit returns true once and false on second call`() {
+    fun `commit returns true once and false on second call`(
+        @TempDir spool: Path,
+    ) {
         val env = FakeDownloadsEnvironment()
-        val factory = DownloadsWriterFactory.fromEnvironment(env)
+        val factory = DownloadsWriterFactory.fromEnvironment(env, spool.toFile())
         val header = fileHeader(id = 7, name = "first.bin", totalSize = 0)
 
         factory.open(header).close()
@@ -134,9 +148,11 @@ class MediaStoreDownloadsFactoryTest {
     }
 
     @Test
-    fun `abort deletes the destination and removes it from in-flight`() {
+    fun `abort deletes the destination and removes it from in-flight`(
+        @TempDir spool: Path,
+    ) {
         val env = FakeDownloadsEnvironment()
-        val factory = DownloadsWriterFactory.fromEnvironment(env)
+        val factory = DownloadsWriterFactory.fromEnvironment(env, spool.toFile())
         val header = fileHeader(id = 8, name = "to-cancel.bin", totalSize = 0)
 
         factory.open(header)
@@ -150,18 +166,22 @@ class MediaStoreDownloadsFactoryTest {
     }
 
     @Test
-    fun `abort on unknown payloadId is a no-op`() {
+    fun `abort on unknown payloadId is a no-op`(
+        @TempDir spool: Path,
+    ) {
         val env = FakeDownloadsEnvironment()
-        val factory = DownloadsWriterFactory.fromEnvironment(env)
+        val factory = DownloadsWriterFactory.fromEnvironment(env, spool.toFile())
 
         assertThat(factory.abort(payloadId = 999_999L)).isFalse()
         assertThat(env.slots).isEmpty()
     }
 
     @Test
-    fun `abortAll discards every in-flight destination`() {
+    fun `abortAll discards every in-flight destination`(
+        @TempDir spool: Path,
+    ) {
         val env = FakeDownloadsEnvironment()
-        val factory = DownloadsWriterFactory.fromEnvironment(env)
+        val factory = DownloadsWriterFactory.fromEnvironment(env, spool.toFile())
 
         factory.open(fileHeader(id = 1, name = "a.bin", totalSize = 0))
         factory.open(fileHeader(id = 2, name = "b.bin", totalSize = 0))
@@ -175,9 +195,11 @@ class MediaStoreDownloadsFactoryTest {
     }
 
     @Test
-    fun `commit after abort returns false because handle was already disposed`() {
+    fun `commit after abort returns false because handle was already disposed`(
+        @TempDir spool: Path,
+    ) {
         val env = FakeDownloadsEnvironment()
-        val factory = DownloadsWriterFactory.fromEnvironment(env)
+        val factory = DownloadsWriterFactory.fromEnvironment(env, spool.toFile())
         val header = fileHeader(id = 42, name = "aborted-then-committed.bin", totalSize = 0)
 
         factory.open(header)


### PR DESCRIPTION
Closes #44.

## Summary

Quick Share splits each FILE payload into chunks, and historically the receiver assumed strictly sequential delivery: every chunk's `offset` had to equal the running write count or the connection was torn down. That invariant comes from TCP's ordered-delivery guarantee, but it does not hold once we add Wi-Fi Direct or BLE L2CAP mediums (#4.x) where the application layer is free to reorder.

This PR relaxes the FILE-side check while keeping BYTES strictly in order, satisfying issue #44's acceptance criteria:

- File payload writes go through a `RandomAccessFile`-backed `FileChannel` (a `SeekableByteChannel`).
- Received byte ranges are tracked per payload in a small `ByteRangeSet` (sorted, non-overlapping, non-adjacent canonical form). Duplicate chunks are silently deduplicated; partial-overlap chunks remain a protocol error.
- Chunks that would extend past `total_size` are still rejected.
- BYTES payloads keep their strict in-order check (BYTES are small full-message-at-once negotiation messages).
- Acceptance unit test feeds chunks in shuffled order and verifies the reconstructed file content.

## Implementation notes

- `FileDestinationFactory.open()` now returns `SeekableByteChannel` (a sub-interface of `WritableByteChannel`). `TempFileDestinationFactory` already produces one via `Files.newByteChannel`.
- `MediaStoreDownloadsFactory` was reworked to spool each in-flight FILE payload through a private-storage `RandomAccessFile` (its `FileChannel` is fully seekable), then copy the bytes into `MediaStore.Downloads` on commit. The spool also makes #43's resume work simpler — partial bytes are already on disk in their final positions.
- `LAST_CHUNK` no longer implies "I have written `total_size` bytes"; completion now requires the coverage set to span `[0, total_size)` exactly. A `LAST_CHUNK` that arrives with gaps surfaces a clear protocol error.
- The two test files (`InboundConnectionTest`, `OutboundConnectionTest`) had their `InMemoryFactory` switched from a `WritableByteChannel`-backed `ByteArrayOutputStream` to a small in-memory `SeekableByteChannel` so the existing integration tests now also exercise the seekable contract end-to-end.

## Test plan

- [x] `./gradlew :core-protocol:test` — all 219 JVM tests pass, including 18 new tests across `ByteRangeSetTest` and the FILE-out-of-order section of `PayloadAssemblerTest`.
- [x] `./gradlew :service-android:testDebugUnitTest` — `MediaStoreDownloadsFactoryTest` updated for the new spool-directory injection point.
- [x] `./gradlew staticAnalysis` — clean.
- [x] `./gradlew :app:assembleDebug` — APK builds.