### PR TITLE
feat(progress): transfer-rate calculation and progress notification (#46)

### DIFF
--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendActivity.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendActivity.kt
@@ -574,12 +574,14 @@ public class SendActivity : AppCompatActivity() {
                 binding.sendStatusPhase.setText(R.string.send_phase_sending)
                 binding.sendPin.text = state.pin
                 binding.sendPin.visibility = View.VISIBLE
+                // #46: include smoothed bytes/sec rate + ETA in the
+                // status subtitle. The formatter drops the rate / ETA
+                // segments while warming up so the user does not see
+                // "0 B/s, unknown ETA" — a bare "12 MB of 100 MB"
+                // line shows up first, then rate + ETA fade in once
+                // the EMA has two samples.
                 binding.sendStatusMessage.text =
-                    getString(
-                        R.string.send_status_progress,
-                        PayloadSummary.formatBytes(state.bytesSent),
-                        PayloadSummary.formatBytes(state.totalSize),
-                    )
+                    SendProgressFormatter.format(this, state.progress)
             }
             OutboundConnectionState.Completed ->
                 renderTerminal(

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendProgressFormatter.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendProgressFormatter.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.send
+
+import android.content.Context
+import io.github.kyujincho.wvmg.R
+import io.github.kyujincho.wvmg.protocol.connection.TransferProgress
+
+/**
+ * Renders the sender-side progress string surfaced in the status
+ * panel of [SendActivity] (#46).
+ *
+ * The output mirrors the receiver foreground notification's body:
+ * "12 MB of 100 MB · 4.2 MB/s · 30 seconds remaining". Rate / ETA
+ * segments are dropped while warming up so the user does not see
+ * "0 B/s, unknown ETA". The duration phrasing ("30 seconds remaining"
+ * rather than "30s remaining") matches the issue's accessibility
+ * acceptance criterion.
+ *
+ * Pulled out of [SendActivity] so the formatting can be unit-tested
+ * in isolation if needed; the activity body just calls
+ * [SendProgressFormatter.format].
+ */
+internal object SendProgressFormatter {
+    /**
+     * Build the status-panel subtitle for [progress]. Always returns
+     * a non-blank string — at minimum a "0 B of 0 B" segment when no
+     * bytes have moved yet.
+     */
+    fun format(
+        context: Context,
+        progress: TransferProgress,
+    ): String {
+        val sizeSegment =
+            context.getString(
+                R.string.send_status_progress,
+                PayloadSummary.formatBytes(progress.bytesTransferred),
+                PayloadSummary.formatBytes(progress.totalSize),
+            )
+        val rateSegment =
+            if (progress.bytesPerSecond > 0L) {
+                context.getString(
+                    R.string.send_status_rate,
+                    PayloadSummary.formatBytes(progress.bytesPerSecond),
+                )
+            } else {
+                null
+            }
+        val etaSegment =
+            progress.etaSeconds?.let { eta ->
+                context.getString(
+                    R.string.send_status_eta,
+                    formatDuration(context, eta),
+                )
+            }
+        return listOfNotNull(sizeSegment, rateSegment, etaSegment).joinToString(separator = " · ")
+    }
+
+    /**
+     * Format an ETA in seconds using the same buckets as the
+     * receiver-side [io.github.kyujincho.wvmg.service.receiver.progress.TransferProgressNotificationContent]
+     * — "<= 90 s" gets spelled-out seconds for accessibility,
+     * larger values round to the nearest minute or hour and get an
+     * "about" prefix to signal imprecision.
+     */
+    @Suppress("MagicNumber")
+    private fun formatDuration(
+        context: Context,
+        etaSeconds: Long,
+    ): String =
+        when {
+            etaSeconds < 1L -> context.getString(R.string.send_status_duration_few_seconds)
+            etaSeconds <= SECONDS_THRESHOLD ->
+                context.getString(R.string.send_status_duration_seconds, etaSeconds)
+            etaSeconds < HOUR_IN_SECONDS -> {
+                val minutes = (etaSeconds + 30L) / 60L
+                context.getString(R.string.send_status_duration_about_minutes, minutes)
+            }
+            else -> {
+                val hours = (etaSeconds + 1800L) / HOUR_IN_SECONDS
+                context.getString(R.string.send_status_duration_about_hours, hours)
+            }
+        }
+
+    private const val SECONDS_THRESHOLD: Long = 90L
+    private const val HOUR_IN_SECONDS: Long = 3600L
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="app_name">WhenVivoMeetsGoogle</string>
 
     <!-- Launcher activity (#34). The "always visible" override lets the
@@ -88,6 +88,20 @@
     <string name="send_status_pin_prompt">Confirm this code matches the receiver\'s screen.</string>
     <string name="send_status_failure_reason">Reason: %1$s</string>
     <string name="send_status_progress">%1$s of %2$s</string>
+
+    <!--
+      Rate + ETA suffixes appended to the progress line during a
+      send. The acceptance criterion calls for accessibility-friendly
+      duration phrasing so we spell out "seconds remaining" rather
+      than abbreviate. The full status message reads like
+      "12 MB of 100 MB · 4.2 MB/s · 30 seconds remaining".
+    -->
+    <string name="send_status_rate">%1$s/s</string>
+    <string name="send_status_eta">%1$s remaining</string>
+    <string name="send_status_duration_few_seconds">less than a second</string>
+    <string name="send_status_duration_seconds" tools:ignore="PluralsCandidate">%1$d seconds</string>
+    <string name="send_status_duration_about_minutes" tools:ignore="PluralsCandidate">about %1$d minutes</string>
+    <string name="send_status_duration_about_hours" tools:ignore="PluralsCandidate">about %1$d hours</string>
 
     <!-- QR-code (#20 + #84) screen. -->
     <string name="show_qr_title">Scan from receiver</string>

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/InboundConnectionDriver.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/InboundConnectionDriver.kt
@@ -66,6 +66,22 @@ internal class InboundConnectionDriver(
     private val mutableState: MutableStateFlow<InboundConnectionState>,
     private val factory: FileDestinationFactory,
     private val onHandshakeComplete: () -> Unit = {},
+    /**
+     * Wall-clock source for the rate estimator. Defaults to
+     * [System.currentTimeMillis]; tests inject a deterministic
+     * `LongArray.iterator`-style supplier so EMA samples have stable
+     * timestamps.
+     */
+    private val nowMillisSource: () -> Long = System::currentTimeMillis,
+    /**
+     * Rate estimator backing [InboundConnectionState.Receiving.progress].
+     * One per connection — the driver feeds it on every chunk and the
+     * progress publisher reads its [TransferRateEstimator.bytesPerSecond]
+     * back out into the published snapshot. Injectable for unit tests
+     * that want to exercise rate-aware code paths without timing
+     * sensitivity.
+     */
+    private val rateEstimator: TransferRateEstimator = TransferRateEstimator(),
 ) {
     private var framedConnection: FramedConnection? = null
     private var secureChannel: SecureChannel? = null
@@ -461,10 +477,20 @@ internal class InboundConnectionDriver(
     }
 
     private fun publishReceiving(itemBytes: Long) {
+        val cumulative = bytesReceived + itemBytes
+        // Feed the rate estimator on every chunk so its EMA tracks the
+        // instantaneous Wi-Fi LAN throughput, then publish the smoothed
+        // bytes/sec back through TransferProgress so observers can
+        // render a rate + ETA without re-deriving the maths.
+        rateEstimator.sample(bytesTransferred = cumulative, nowMillis = nowMillisSource())
         mutableState.value =
             InboundConnectionState.Receiving(
-                bytesReceived = bytesReceived + itemBytes,
-                totalSize = totalSize,
+                progress =
+                    TransferProgress.of(
+                        bytesTransferred = cumulative,
+                        totalSize = totalSize,
+                        bytesPerSecond = rateEstimator.bytesPerSecond(),
+                    ),
                 currentItemPayloadId = currentItemPayloadId,
                 currentItemType = currentItemType,
             )
@@ -582,10 +608,19 @@ internal class InboundConnectionDriver(
 
     /** Surface the initial Receiving snapshot so the UI can render 0% immediately. */
     private fun publishInitialReceiving() {
+        // Seed the rate estimator with a zero-bytes sample so the
+        // first real chunk sample produces a non-degenerate Δt. The
+        // estimator's first sample is a seed-only no-op for the EMA
+        // itself, so this does not bias the rate.
+        rateEstimator.sample(bytesTransferred = 0L, nowMillis = nowMillisSource())
         mutableState.value =
             InboundConnectionState.Receiving(
-                bytesReceived = 0L,
-                totalSize = totalSize,
+                progress =
+                    TransferProgress.of(
+                        bytesTransferred = 0L,
+                        totalSize = totalSize,
+                        bytesPerSecond = 0L,
+                    ),
                 currentItemPayloadId = null,
                 currentItemType = null,
             )

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/InboundConnectionState.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/InboundConnectionState.kt
@@ -85,13 +85,14 @@ public sealed interface InboundConnectionState {
      * `PayloadTransferFrame` chunk so observers can drive a progress
      * bar without polling.
      *
-     * @property bytesReceived Cumulative bytes received across all
-     *   in-flight payloads (FILE writes + BYTES buffer fill). Resets
-     *   per-connection — does NOT include terminated transfers.
-     * @property totalSize Sum of `total_size` across every announced
-     *   FILE / BYTES item from the [TransferMetadata]. The ratio
-     *   `bytesReceived / totalSize` is a faithful overall progress
-     *   estimate.
+     * @property progress Cumulative byte counters plus the smoothed
+     *   bytes-per-second rate and ETA produced by issue #46's rate
+     *   estimator. The UI renders a progress bar from
+     *   [TransferProgress.fraction] and a "12 MB of 100 MB, 30 seconds
+     *   remaining" subtitle from the byte counts + ETA.
+     *   [TransferProgress.bytesPerSecond] is `0` while warming up
+     *   (fewer than two rate samples); [TransferProgress.etaSeconds] is
+     *   `null` until the rate is non-zero.
      * @property currentItemPayloadId If a single payload is currently
      *   active (most common), its `payload_id`. `null` between
      *   payloads or if no DATA chunk has arrived yet.
@@ -100,11 +101,23 @@ public sealed interface InboundConnectionState {
      *   between BYTES and FILE.
      */
     public data class Receiving(
-        val bytesReceived: Long,
-        val totalSize: Long,
+        val progress: TransferProgress,
         val currentItemPayloadId: Long?,
         val currentItemType: PayloadHeader.PayloadType?,
-    ) : InboundConnectionState
+    ) : InboundConnectionState {
+        /**
+         * Cumulative bytes received. Convenience accessor for callers
+         * that do not need the rate / ETA fields. Reads from
+         * [progress] so the two stay in sync.
+         */
+        public val bytesReceived: Long get() = progress.bytesTransferred
+
+        /**
+         * Sum of `total_size` across every announced FILE / BYTES
+         * item. Convenience accessor that reads from [progress].
+         */
+        public val totalSize: Long get() = progress.totalSize
+    }
 
     /**
      * Terminal -- every announced item arrived in full and the

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionDriver.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionDriver.kt
@@ -71,6 +71,19 @@ internal class OutboundConnectionDriver(
     private val files: List<FileSource>,
     private val onHandshakeComplete: () -> Unit = {},
     private val logger: (String) -> Unit = {},
+    /**
+     * Wall-clock source for the rate estimator. Defaults to
+     * [System.currentTimeMillis]; tests inject deterministic
+     * timestamps to make EMA samples stable.
+     */
+    private val nowMillisSource: () -> Long = System::currentTimeMillis,
+    /**
+     * Rate estimator backing [OutboundConnectionState.Sending.progress].
+     * Fed on every chunk write; the publisher reads
+     * [TransferRateEstimator.bytesPerSecond] back into the published
+     * [TransferProgress] so the sender UI can render rate + ETA.
+     */
+    private val rateEstimator: TransferRateEstimator = TransferRateEstimator(),
 ) {
     private var framedConnection: FramedConnection? = null
     private var secureChannel: SecureChannel? = null
@@ -552,11 +565,18 @@ internal class OutboundConnectionDriver(
      */
     private suspend fun streamFilesAndComplete(channel: SecureChannel): OutboundResult {
         logger("fsm: streamFilesAndComplete START files=${files.size} totalSize=$totalSize")
+        // Seed the rate estimator with a zero-bytes sample so the
+        // first chunk write produces a non-degenerate Δt for the EMA.
+        rateEstimator.sample(bytesTransferred = 0L, nowMillis = nowMillisSource())
         mutableState.value =
             OutboundConnectionState.Sending(
                 pin = pin,
-                bytesSent = 0L,
-                totalSize = totalSize,
+                progress =
+                    TransferProgress.of(
+                        bytesTransferred = 0L,
+                        totalSize = totalSize,
+                        bytesPerSecond = 0L,
+                    ),
                 currentItemPayloadId = files.firstOrNull()?.payloadId,
             )
 
@@ -629,11 +649,20 @@ internal class OutboundConnectionDriver(
             .toLong()
 
     private fun publishSendingProgress() {
+        // Feed the rate estimator on every chunk so its EMA tracks the
+        // instantaneous wire throughput, then publish the smoothed
+        // bytes/sec back through TransferProgress so the sender UI can
+        // render rate + ETA.
+        rateEstimator.sample(bytesTransferred = bytesSent, nowMillis = nowMillisSource())
         mutableState.value =
             OutboundConnectionState.Sending(
                 pin = pin,
-                bytesSent = bytesSent,
-                totalSize = totalSize,
+                progress =
+                    TransferProgress.of(
+                        bytesTransferred = bytesSent,
+                        totalSize = totalSize,
+                        bytesPerSecond = rateEstimator.bytesPerSecond(),
+                    ),
                 currentItemPayloadId = currentItemPayloadId,
             )
     }

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionState.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionState.kt
@@ -96,21 +96,33 @@ public sealed interface OutboundConnectionState {
      * @property pin The same PIN previously surfaced in
      *   [AwaitingRemoteAcceptance], retained so consumers do not have
      *   to remember it across state transitions.
-     * @property bytesSent Cumulative bytes pushed onto the wire across
-     *   all outbound payloads. Resets per-connection.
-     * @property totalSize Sum of [FileSource.size] across every
-     *   announced file. The ratio `bytesSent / totalSize` is a faithful
-     *   overall progress estimate.
+     * @property progress Cumulative byte counters plus the smoothed
+     *   bytes-per-second rate and ETA produced by issue #46's rate
+     *   estimator. UI renders progress + "12 MB of 100 MB, 30 seconds
+     *   remaining" off this object. [TransferProgress.bytesPerSecond]
+     *   is `0` while warming up; [TransferProgress.etaSeconds] is
+     *   `null` until the rate is non-zero.
      * @property currentItemPayloadId If a single payload is currently
      *   in flight (most common), its `payload_id`. `null` between
      *   payloads or before the first chunk has been written.
      */
     public data class Sending(
         val pin: String,
-        val bytesSent: Long,
-        val totalSize: Long,
+        val progress: TransferProgress,
         val currentItemPayloadId: Long?,
-    ) : OutboundConnectionState
+    ) : OutboundConnectionState {
+        /**
+         * Cumulative bytes pushed onto the wire. Convenience accessor
+         * that reads from [progress] so the two stay in sync.
+         */
+        public val bytesSent: Long get() = progress.bytesTransferred
+
+        /**
+         * Sum of [FileSource.size] across every announced file.
+         * Convenience accessor that reads from [progress].
+         */
+        public val totalSize: Long get() = progress.totalSize
+    }
 
     /**
      * Terminal — every announced file streamed in full and the

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/TransferProgress.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/TransferProgress.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.connection
+
+/**
+ * Snapshot of an in-flight Quick Share transfer's throughput.
+ *
+ * Surfaced as part of [InboundConnectionState.Receiving] /
+ * [OutboundConnectionState.Sending] so observers can render rate +
+ * ETA without reaching into the connection driver internals.
+ *
+ * Pure-JVM value type — no Android imports — so the same shape can
+ * back the receiver foreground notification (#46), the sender status
+ * panel (#46), and any future surface (e.g. a transfer history log)
+ * without re-deriving the maths.
+ *
+ * Issue #46 acceptance criteria:
+ *
+ *  - Rate calculated as exponential moving average of recent
+ *    bytes/second (smooths over jitter).
+ *  - ETA = `(total - transferred) / current_rate`.
+ *
+ * Both fields are *defensive* about insufficient data: a brand-new
+ * transfer with one sample has [bytesPerSecond] = 0 and [etaSeconds] =
+ * `null`, which the UI is expected to render as "calculating…" rather
+ * than "0 B/s, unknown ETA".
+ *
+ * @property bytesTransferred Cumulative bytes transferred so far.
+ *   Always `>= 0`. Caps at `totalSize` once the transfer completes.
+ * @property totalSize Total bytes announced for the transfer. Always
+ *   `>= 0`. May be `0` for transfers that announced no payloads
+ *   (rare; the orchestrator publishes a placeholder snapshot during
+ *   negotiation).
+ * @property bytesPerSecond Smoothed instantaneous throughput in bytes
+ *   per second. `0` while warming up (fewer than two samples) or after
+ *   a long idle gap that drains the EMA below 1 B/s. Always `>= 0`.
+ * @property etaSeconds Estimated seconds until completion. `null` when
+ *   the rate is `0` (cannot divide), when [bytesTransferred] already
+ *   meets [totalSize] (transfer is essentially done), or when
+ *   [totalSize] is `0` (no announced payload). Always `>= 0` when
+ *   non-null.
+ */
+public data class TransferProgress(
+    val bytesTransferred: Long,
+    val totalSize: Long,
+    val bytesPerSecond: Long,
+    val etaSeconds: Long?,
+) {
+    init {
+        require(bytesTransferred >= 0) {
+            "bytesTransferred must be non-negative, got $bytesTransferred"
+        }
+        require(totalSize >= 0) {
+            "totalSize must be non-negative, got $totalSize"
+        }
+        require(bytesPerSecond >= 0) {
+            "bytesPerSecond must be non-negative, got $bytesPerSecond"
+        }
+        require(etaSeconds == null || etaSeconds >= 0) {
+            "etaSeconds must be non-negative when present, got $etaSeconds"
+        }
+    }
+
+    /**
+     * Fraction of the transfer completed in `[0.0, 1.0]`. Returns
+     * `0.0` when [totalSize] is `0` so callers can multiply directly
+     * by a notification progress-bar resolution without a NaN check.
+     */
+    public val fraction: Double
+        get() = if (totalSize <= 0L) 0.0 else (bytesTransferred.toDouble() / totalSize.toDouble()).coerceIn(0.0, 1.0)
+
+    public companion object {
+        /**
+         * Snapshot used before any byte has been transferred. The UI
+         * renders this as "0% • calculating…" — both the rate and the
+         * ETA are unknown.
+         */
+        @JvmField
+        public val UNKNOWN: TransferProgress =
+            TransferProgress(
+                bytesTransferred = 0L,
+                totalSize = 0L,
+                bytesPerSecond = 0L,
+                etaSeconds = null,
+            )
+
+        /**
+         * Build a [TransferProgress] from raw byte counts plus a
+         * smoothed rate. Computes [etaSeconds] from the same inputs
+         * the constructor would otherwise require the caller to
+         * derive by hand:
+         *
+         *  - `null` if [bytesPerSecond] is `0` (cannot divide).
+         *  - `null` if [totalSize] is `0` (nothing was announced).
+         *  - `null` if [bytesTransferred] already meets [totalSize]
+         *    (the transfer is essentially done — the UI typically
+         *    transitions to the terminal state moments later).
+         *  - otherwise `ceil((total - transferred) / bytesPerSecond)`,
+         *    rounded up so the user does not see a 0-second ETA for
+         *    the final tail of a transfer.
+         */
+        public fun of(
+            bytesTransferred: Long,
+            totalSize: Long,
+            bytesPerSecond: Long,
+        ): TransferProgress {
+            val eta =
+                when {
+                    bytesPerSecond <= 0L -> null
+                    totalSize <= 0L -> null
+                    bytesTransferred >= totalSize -> null
+                    else -> {
+                        val remaining = totalSize - bytesTransferred
+                        // Ceil division so a 1-byte tail at 1 B/s
+                        // shows up as "1s" rather than "0s".
+                        (remaining + bytesPerSecond - 1L) / bytesPerSecond
+                    }
+                }
+            return TransferProgress(
+                bytesTransferred = bytesTransferred,
+                totalSize = totalSize,
+                bytesPerSecond = bytesPerSecond,
+                etaSeconds = eta,
+            )
+        }
+    }
+}

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/TransferRateEstimator.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/TransferRateEstimator.kt
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.connection
+
+import kotlin.math.exp
+
+/**
+ * Smoothed bytes-per-second estimator for an in-flight transfer.
+ *
+ * Implements an **exponential moving average** of the instantaneous
+ * rate samples (`Δbytes / Δseconds`). The smoothing factor is derived
+ * from a half-life expressed in seconds — a half-life of 2 s means a
+ * rate sample's weight halves every 2 s, so the EMA "remembers" the
+ * last few seconds and rejects single-chunk jitter.
+ *
+ * ### Why EMA over a fixed-size sliding window
+ *
+ * The Quick Share chunk size is 512 KiB and chunk arrival is bursty:
+ * Wi-Fi LAN can deliver several chunks back-to-back in under 10 ms
+ * and then stall while the receiver writes to MediaStore. A
+ * fixed-size window over chunk count would oscillate between
+ * "infinite rate" (zero-time burst) and "zero rate" (write stall).
+ * Time-based EMA naturally smooths both extremes — it weights every
+ * sample by elapsed wall time, so a write stall draws the average
+ * down gradually rather than to zero.
+ *
+ * ### Numerical stability
+ *
+ * The EMA uses `α = 1 - exp(-Δt / τ)` where `τ = halfLife / ln(2)`.
+ * `Δt` is clamped to `[1 ms, halfLife * 4]` so a clock jump backwards
+ * (or a sample arriving more than 4 half-lives apart, which is
+ * effectively a fresh transfer) does not produce a negative or
+ * runaway alpha.
+ *
+ * ### Thread-safety
+ *
+ * **Not thread-safe.** The connection drivers update the estimator
+ * from a single per-connection coroutine; sharing one across
+ * coroutines requires external synchronization.
+ *
+ * @param halfLifeMillis Half-life of the EMA in milliseconds. Default
+ *   `1500` ms — a 1.5 s half-life rejects the bursty 512 KiB-chunk
+ *   jitter while still tracking a real rate change (e.g. the user
+ *   moves between rooms and the Wi-Fi link drops a tier) within ~3 s.
+ */
+public class TransferRateEstimator(
+    private val halfLifeMillis: Long = DEFAULT_HALF_LIFE_MILLIS,
+) {
+    init {
+        require(halfLifeMillis > 0) {
+            "halfLifeMillis must be positive, got $halfLifeMillis"
+        }
+    }
+
+    /** `τ = halfLife / ln(2)`, the time-constant of the EMA. */
+    private val tauMillis: Double = halfLifeMillis.toDouble() / LN_2
+
+    /** Last sample timestamp, or `null` if no sample has been recorded. */
+    private var lastSampleAtMillis: Long? = null
+
+    /** Cumulative bytes at the last sample, or `null` if no sample yet. */
+    private var lastBytes: Long? = null
+
+    /** Current EMA estimate in bytes/second. `0.0` until two samples are seen. */
+    private var emaBytesPerSecond: Double = 0.0
+
+    /**
+     * Record a cumulative-bytes sample taken at [nowMillis].
+     *
+     * The first sample only seeds the estimator; the second and
+     * subsequent samples update the EMA. Edge cases:
+     *
+     *  - `Δt <= 0` (same timestamp or a backwards clock) leaves the
+     *    EMA unchanged. The "last sample" pointer still advances so
+     *    the next forward sample produces a sensible Δt.
+     *  - `Δt > halfLife * 4` (a stalled transfer that resumed)
+     *    drops the prior EMA and treats the new sample as a fresh
+     *    seed. Keeping a tiny residual would let an arbitrarily-old
+     *    rate bleed into the displayed figure.
+     */
+    public fun sample(
+        bytesTransferred: Long,
+        nowMillis: Long,
+    ) {
+        require(bytesTransferred >= 0) {
+            "bytesTransferred must be non-negative, got $bytesTransferred"
+        }
+
+        val previousAt = lastSampleAtMillis
+        val previousBytes = lastBytes
+        lastSampleAtMillis = nowMillis
+        lastBytes = bytesTransferred
+
+        // First sample — seed only.
+        if (previousAt == null || previousBytes == null) return
+
+        val rawDeltaMs = nowMillis - previousAt
+        val maxDeltaMillis = halfLifeMillis * MAX_DELTA_HALFLIVES
+
+        when {
+            // Backwards or zero-elapsed sample: hold the EMA flat. We
+            // cannot trust the elapsed time, so blending in a sample
+            // would drift the average for no good reason.
+            rawDeltaMs <= 0L -> Unit
+
+            // Long-gap reset: a sample arriving more than
+            // [MAX_DELTA_HALFLIVES] half-lives after the previous one
+            // signals a stalled transfer. Treat the new sample as a
+            // fresh seed (drop the prior EMA) — keeping a tiny
+            // residual alpha would let an arbitrarily-old high rate
+            // bleed into the displayed figure, which is exactly what
+            // the user does NOT want to see when their Wi-Fi link
+            // recovered after a long pause.
+            rawDeltaMs > maxDeltaMillis -> emaBytesPerSecond = 0.0
+
+            else -> {
+                val deltaMs = rawDeltaMs.coerceAtLeast(MIN_DELTA_MILLIS)
+                val deltaBytes = (bytesTransferred - previousBytes).coerceAtLeast(0L)
+                val instant = deltaBytes.toDouble() * MILLIS_PER_SECOND / deltaMs.toDouble()
+                val alpha = 1.0 - exp(-deltaMs.toDouble() / tauMillis)
+                emaBytesPerSecond = alpha * instant + (1.0 - alpha) * emaBytesPerSecond
+            }
+        }
+    }
+
+    /**
+     * Current smoothed rate in bytes/second. Returns `0` when fewer
+     * than two samples have been recorded (warming up) or when the
+     * EMA has decayed below 1 B/s.
+     */
+    public fun bytesPerSecond(): Long {
+        // Return 0 while warming up (no sample yet) or while the EMA
+        // has decayed below 1 B/s — both are user-facing "calculating"
+        // states that the UI renders without a numeric rate.
+        val warming = lastSampleAtMillis == null || emaBytesPerSecond < 1.0
+        return if (warming) 0L else emaBytesPerSecond.toLong()
+    }
+
+    /**
+     * Reset the estimator to its initial empty state. Used when a
+     * connection is re-bound (e.g. retry-on-fail) so a stale rate
+     * does not leak across attempts.
+     */
+    public fun reset() {
+        lastSampleAtMillis = null
+        lastBytes = null
+        emaBytesPerSecond = 0.0
+    }
+
+    public companion object {
+        /**
+         * Default EMA half-life. 1500 ms strikes the same balance as
+         * the receiver foreground notification's 500 ms refresh
+         * cadence: every notification update sees roughly three
+         * half-lives of history, which is enough to smooth chunk
+         * jitter without lagging behind a sustained rate change.
+         */
+        public const val DEFAULT_HALF_LIFE_MILLIS: Long = 1500L
+
+        private const val LN_2: Double = 0.6931471805599453
+        private const val MIN_DELTA_MILLIS: Long = 1L
+
+        /**
+         * Clamp `Δt` to at most this many half-lives. A gap longer
+         * than this makes α saturate at 1.0, which means the EMA
+         * effectively forgets its prior value — i.e. treats the next
+         * sample as a fresh start. Four half-lives keeps weight at
+         * about 6.25% of any pre-gap history, which is small enough
+         * to ignore.
+         */
+        private const val MAX_DELTA_HALFLIVES: Long = 4L
+
+        private const val MILLIS_PER_SECOND: Long = 1000L
+    }
+}

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/TransferProgressTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/TransferProgressTest.kt
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.connection
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * JVM-only invariants for the [TransferProgress] value type used by
+ * [InboundConnectionState.Receiving] and [OutboundConnectionState.Sending].
+ *
+ * The maths are tiny but security-relevant: ETA is shown to the user
+ * during a transfer, so a corner-case-busting `null` here would make
+ * the receiver foreground notification render "unknown" forever.
+ */
+class TransferProgressTest {
+    @Test
+    fun `of computes ETA from the simple formula when all inputs are positive`() {
+        val progress =
+            TransferProgress.of(
+                bytesTransferred = 50L * MIB,
+                totalSize = 100L * MIB,
+                bytesPerSecond = 5L * MIB,
+            )
+        // Remaining = 50 MIB; rate = 5 MIB/s; ETA = 10 s.
+        assertThat(progress.etaSeconds).isEqualTo(10L)
+        assertThat(progress.bytesPerSecond).isEqualTo(5L * MIB)
+        assertThat(progress.bytesTransferred).isEqualTo(50L * MIB)
+        assertThat(progress.totalSize).isEqualTo(100L * MIB)
+    }
+
+    @Test
+    fun `of returns null ETA while warming up (rate is zero)`() {
+        val progress =
+            TransferProgress.of(
+                bytesTransferred = 1L * MIB,
+                totalSize = 100L * MIB,
+                bytesPerSecond = 0L,
+            )
+        assertThat(progress.etaSeconds).isNull()
+    }
+
+    @Test
+    fun `of returns null ETA when nothing has been announced`() {
+        val progress =
+            TransferProgress.of(
+                bytesTransferred = 0L,
+                totalSize = 0L,
+                bytesPerSecond = 1024L,
+            )
+        assertThat(progress.etaSeconds).isNull()
+    }
+
+    @Test
+    fun `of returns null ETA when transferred meets total (essentially done)`() {
+        val progress =
+            TransferProgress.of(
+                bytesTransferred = 100L * MIB,
+                totalSize = 100L * MIB,
+                bytesPerSecond = 5L * MIB,
+            )
+        assertThat(progress.etaSeconds).isNull()
+    }
+
+    @Test
+    fun `of rounds the ETA up so a 1-byte tail at 1 byte per second shows 1s not 0s`() {
+        val progress =
+            TransferProgress.of(
+                bytesTransferred = 99L,
+                totalSize = 100L,
+                bytesPerSecond = 1L,
+            )
+        // Remaining = 1 byte; ceil(1 / 1) = 1 s.
+        assertThat(progress.etaSeconds).isEqualTo(1L)
+    }
+
+    @Test
+    fun `of ceils mid-bucket ETAs (not truncated to zero)`() {
+        val progress =
+            TransferProgress.of(
+                bytesTransferred = 9_500L,
+                totalSize = 10_000L,
+                bytesPerSecond = 1_000L,
+            )
+        // Remaining = 500 bytes; 500 / 1000 = 0.5; ceil -> 1.
+        assertThat(progress.etaSeconds).isEqualTo(1L)
+    }
+
+    @Test
+    fun `fraction is 0 when totalSize is 0 (no NaN leak)`() {
+        val progress = TransferProgress.UNKNOWN
+        assertThat(progress.fraction).isEqualTo(0.0)
+    }
+
+    @Test
+    fun `fraction is clamped to 1 when transferred exceeds total (rare overshoot)`() {
+        val progress =
+            TransferProgress.of(
+                bytesTransferred = 200L,
+                totalSize = 100L,
+                bytesPerSecond = 0L,
+            )
+        assertThat(progress.fraction).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `fraction reads halfway through a transfer`() {
+        val progress =
+            TransferProgress.of(
+                bytesTransferred = 50L,
+                totalSize = 100L,
+                bytesPerSecond = 0L,
+            )
+        assertThat(progress.fraction).isEqualTo(0.5)
+    }
+
+    @Test
+    fun `constructor rejects negative bytesTransferred`() {
+        assertThrows<IllegalArgumentException> {
+            TransferProgress(
+                bytesTransferred = -1L,
+                totalSize = 100L,
+                bytesPerSecond = 0L,
+                etaSeconds = null,
+            )
+        }
+    }
+
+    @Test
+    fun `constructor rejects negative totalSize`() {
+        assertThrows<IllegalArgumentException> {
+            TransferProgress(
+                bytesTransferred = 0L,
+                totalSize = -1L,
+                bytesPerSecond = 0L,
+                etaSeconds = null,
+            )
+        }
+    }
+
+    @Test
+    fun `constructor rejects negative bytesPerSecond`() {
+        assertThrows<IllegalArgumentException> {
+            TransferProgress(
+                bytesTransferred = 0L,
+                totalSize = 100L,
+                bytesPerSecond = -1L,
+                etaSeconds = null,
+            )
+        }
+    }
+
+    @Test
+    fun `constructor rejects negative etaSeconds`() {
+        assertThrows<IllegalArgumentException> {
+            TransferProgress(
+                bytesTransferred = 0L,
+                totalSize = 100L,
+                bytesPerSecond = 1L,
+                etaSeconds = -1L,
+            )
+        }
+    }
+
+    @Test
+    fun `UNKNOWN sentinel has all-zero counters and null ETA`() {
+        val unknown = TransferProgress.UNKNOWN
+        assertThat(unknown.bytesTransferred).isEqualTo(0L)
+        assertThat(unknown.totalSize).isEqualTo(0L)
+        assertThat(unknown.bytesPerSecond).isEqualTo(0L)
+        assertThat(unknown.etaSeconds).isNull()
+    }
+
+    private companion object {
+        const val MIB: Long = 1024L * 1024L
+    }
+}

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/TransferRateEstimatorTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/TransferRateEstimatorTest.kt
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.connection
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * JVM-only behavioural tests for [TransferRateEstimator].
+ *
+ * The EMA is the user-visible side of issue #46's "transfer rate"
+ * acceptance criterion — the estimator's job is to smooth bursty
+ * 512 KiB chunk arrival into a stable bytes/sec figure. The cases
+ * below pin the smoothing behaviour at three points in the parameter
+ * space:
+ *
+ *  - The first sample is seed-only (no rate yet).
+ *  - A steady stream of evenly-spaced samples converges to the true
+ *    rate.
+ *  - A long idle gap drains the EMA back toward the new sample.
+ */
+class TransferRateEstimatorTest {
+    @Test
+    fun `bytesPerSecond is zero before any sample`() {
+        val estimator = TransferRateEstimator()
+        assertThat(estimator.bytesPerSecond()).isEqualTo(0L)
+    }
+
+    @Test
+    fun `first sample is seed only and does not produce a rate`() {
+        val estimator = TransferRateEstimator()
+        estimator.sample(bytesTransferred = 0L, nowMillis = 0L)
+        assertThat(estimator.bytesPerSecond()).isEqualTo(0L)
+    }
+
+    @Test
+    fun `two samples one second apart produce the instantaneous rate`() {
+        val estimator = TransferRateEstimator(halfLifeMillis = 1500L)
+        estimator.sample(bytesTransferred = 0L, nowMillis = 0L)
+        estimator.sample(bytesTransferred = 1_000_000L, nowMillis = 1_000L)
+        // First non-seed sample: α = 1 - exp(-1000/(1500/ln2)) ≈ 0.37,
+        // and the prior EMA is 0, so ema = 0.37 * 1_000_000 ≈ 370 KB/s.
+        // We pin a generous range so a tiny floating-point drift does
+        // not flake the test.
+        val rate = estimator.bytesPerSecond()
+        assertThat(rate).isGreaterThan(300_000L)
+        assertThat(rate).isLessThan(450_000L)
+    }
+
+    @Test
+    fun `steady stream converges to the true rate`() {
+        val estimator = TransferRateEstimator(halfLifeMillis = 500L)
+        // Stream 1 MB/s for 5 seconds, sampled every 100 ms.
+        var bytes = 0L
+        var t = 0L
+        estimator.sample(bytesTransferred = bytes, nowMillis = t)
+        repeat(50) {
+            bytes += 100_000L // 100 KB per 100 ms = 1 MB/s
+            t += 100L
+            estimator.sample(bytesTransferred = bytes, nowMillis = t)
+        }
+        // After many half-lives at the same rate, the EMA should
+        // sit very close to 1 MB/s. Allow ±10% for residual ramp.
+        val rate = estimator.bytesPerSecond()
+        assertThat(rate).isGreaterThan(900_000L)
+        assertThat(rate).isLessThan(1_100_000L)
+    }
+
+    @Test
+    fun `non-monotonic clock holds the EMA flat`() {
+        val estimator = TransferRateEstimator(halfLifeMillis = 500L)
+        // Establish a non-zero rate.
+        estimator.sample(bytesTransferred = 0L, nowMillis = 0L)
+        estimator.sample(bytesTransferred = 1_000_000L, nowMillis = 1_000L)
+        val before = estimator.bytesPerSecond()
+
+        // Backwards clock: Δt clamps to 1 ms, α ≈ 0, EMA stays put.
+        estimator.sample(bytesTransferred = 1_000_000L, nowMillis = 999L)
+        val after = estimator.bytesPerSecond()
+        assertThat(after).isEqualTo(before)
+    }
+
+    @Test
+    fun `long idle gap saturates alpha so the EMA forgets prior history`() {
+        val estimator = TransferRateEstimator(halfLifeMillis = 500L)
+        // Establish a high rate.
+        estimator.sample(bytesTransferred = 0L, nowMillis = 0L)
+        estimator.sample(bytesTransferred = 10_000_000L, nowMillis = 1_000L)
+        val priorRate = estimator.bytesPerSecond()
+        assertThat(priorRate).isGreaterThan(5_000_000L)
+
+        // Long gap (>> 4 half-lives) with a single tiny chunk. The
+        // saturated α means the EMA forgets the high prior and
+        // collapses toward the new tiny instantaneous rate.
+        val tNow = 1_000L + (500L * 100L) // 50 s later
+        estimator.sample(bytesTransferred = 10_001_000L, nowMillis = tNow)
+        val newRate = estimator.bytesPerSecond()
+        // Instantaneous rate is 1000 bytes / 50 s = 20 B/s; saturated
+        // α should put us very close.
+        assertThat(newRate).isLessThan(1_000L)
+    }
+
+    @Test
+    fun `reset clears state so the estimator behaves like fresh`() {
+        val estimator = TransferRateEstimator()
+        estimator.sample(bytesTransferred = 0L, nowMillis = 0L)
+        estimator.sample(bytesTransferred = 1_000_000L, nowMillis = 1_000L)
+        assertThat(estimator.bytesPerSecond()).isGreaterThan(0L)
+
+        estimator.reset()
+        assertThat(estimator.bytesPerSecond()).isEqualTo(0L)
+        // First sample after reset is seed-only.
+        estimator.sample(bytesTransferred = 100L, nowMillis = 2_000L)
+        assertThat(estimator.bytesPerSecond()).isEqualTo(0L)
+    }
+
+    @Test
+    fun `negative bytes input raises`() {
+        val estimator = TransferRateEstimator()
+        assertThrows<IllegalArgumentException> {
+            estimator.sample(bytesTransferred = -1L, nowMillis = 0L)
+        }
+    }
+
+    @Test
+    fun `non-positive halfLife raises in the constructor`() {
+        assertThrows<IllegalArgumentException> {
+            TransferRateEstimator(halfLifeMillis = 0L)
+        }
+        assertThrows<IllegalArgumentException> {
+            TransferRateEstimator(halfLifeMillis = -1L)
+        }
+    }
+
+    @Test
+    fun `same-timestamp resamples do not produce a divide-by-zero`() {
+        val estimator = TransferRateEstimator()
+        // Two samples at the same time: Δt clamps to 1 ms; α near 0;
+        // EMA stays at zero.
+        estimator.sample(bytesTransferred = 0L, nowMillis = 100L)
+        estimator.sample(bytesTransferred = 1_000L, nowMillis = 100L)
+        // No NaN, no infinity, no negative; just a very small EMA.
+        val rate = estimator.bytesPerSecond()
+        assertThat(rate).isAtLeast(0L)
+    }
+}

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
@@ -30,6 +30,9 @@ import io.github.kyujincho.wvmg.service.receiver.consent.ConsentBroadcastReceive
 import io.github.kyujincho.wvmg.service.receiver.consent.ConsentCoordinator
 import io.github.kyujincho.wvmg.service.receiver.consent.ConsentNotification
 import io.github.kyujincho.wvmg.service.receiver.consent.ConsentRegistry
+import io.github.kyujincho.wvmg.service.receiver.progress.TransferCancelRegistry
+import io.github.kyujincho.wvmg.service.receiver.progress.TransferProgressCoordinator
+import io.github.kyujincho.wvmg.service.receiver.progress.TransferProgressNotification
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -113,6 +116,9 @@ public class ReceiverForegroundService : Service() {
     private var consentCoordinator: ConsentCoordinator? = null
 
     @Volatile
+    private var progressCoordinator: TransferProgressCoordinator? = null
+
+    @Volatile
     private var consentReceiver: BroadcastReceiver? = null
 
     @Volatile
@@ -143,6 +149,10 @@ public class ReceiverForegroundService : Service() {
         // heads-up notification — the platform silently drops
         // notifications targeting a missing channel on API 26+.
         ConsentNotification.ensureChannel(this)
+        // Same lifecycle invariant for the progress notification
+        // channel (#46) — created upfront so the first chunk's
+        // progress post lands.
+        TransferProgressNotification.ensureChannel(this)
         registerConsentReceiver()
     }
 
@@ -281,6 +291,10 @@ public class ReceiverForegroundService : Service() {
         // SharedFlow subscriptions are in place when the first
         // accepted connection is emitted.
         startConsentCoordinator(newSession)
+        // Same shape for the progress coordinator (#46): subscribe
+        // before the session starts so the first `Receiving` state
+        // transition produces a progress notification.
+        startProgressCoordinator(newSession)
 
         serviceScope.launch {
             try {
@@ -414,6 +428,55 @@ public class ReceiverForegroundService : Service() {
     }
 
     /**
+     * Wire a [TransferProgressCoordinator] over the session's flows
+     * so that each `Receiving` transition is surfaced as a progress
+     * notification (#46), and so the Cancel action on that
+     * notification routes back to the live `InboundConnection` via
+     * [TransferCancelRegistry].
+     */
+    private fun startProgressCoordinator(session: ReceiverSession) {
+        val ctx = applicationContext
+        val coordinator =
+            TransferProgressCoordinator(
+                activeConnections = session.activeConnections,
+                results = session.completions,
+                sink =
+                    object : TransferProgressCoordinator.Sink {
+                        override fun postProgress(
+                            connectionId: Long,
+                            sourceDeviceName: String?,
+                            progress: io.github.kyujincho.wvmg.protocol.connection.TransferProgress,
+                        ) {
+                            TransferProgressNotification.post(
+                                context = ctx,
+                                connectionId = connectionId,
+                                sourceDeviceName = sourceDeviceName,
+                                progress = progress,
+                            )
+                        }
+
+                        override fun dismissProgress(connectionId: Long) {
+                            TransferProgressNotification.dismiss(ctx, connectionId)
+                        }
+
+                        override fun registerCancel(
+                            connectionId: Long,
+                            onCancel: () -> Unit,
+                        ) {
+                            TransferCancelRegistry.instance.register(connectionId, onCancel)
+                        }
+
+                        override fun unregisterCancel(connectionId: Long) {
+                            TransferCancelRegistry.instance.unregister(connectionId)
+                        }
+                    },
+                scope = serviceScope,
+            )
+        coordinator.start()
+        progressCoordinator = coordinator
+    }
+
+    /**
      * Register the [ConsentBroadcastReceiver] dynamically. We use
      * dynamic registration because the registry is in-process state —
      * a manifest-registered receiver that survives process death
@@ -460,6 +523,8 @@ public class ReceiverForegroundService : Service() {
     private fun stopReceiverAndExit() {
         consentCoordinator?.stop()
         consentCoordinator = null
+        progressCoordinator?.stop()
+        progressCoordinator = null
         // Dismiss every pending consent notification we know about.
         // The connection itself will be torn down when the session
         // stops; without explicit dismissal the heads-up would linger
@@ -468,6 +533,14 @@ public class ReceiverForegroundService : Service() {
         ConsentRegistry.instance.snapshotIds().forEach { id ->
             ConsentRegistry.instance.unregister(id)
             ConsentNotification.dismiss(ctx, id)
+        }
+        // Same hygiene for the in-flight progress notifications
+        // posted by #46 — a dangling progress card pointing at a
+        // dead connection would invite the user to tap a Cancel
+        // action that lands in /dev/null.
+        TransferCancelRegistry.instance.snapshotIds().forEach { id ->
+            TransferCancelRegistry.instance.unregister(id)
+            TransferProgressNotification.dismiss(ctx, id)
         }
         unregisterConsentReceiverIfNeeded()
 

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentBroadcastReceiver.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentBroadcastReceiver.kt
@@ -8,6 +8,8 @@ package io.github.kyujincho.wvmg.service.receiver.consent
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import io.github.kyujincho.wvmg.service.receiver.progress.TransferCancelRegistry
+import io.github.kyujincho.wvmg.service.receiver.progress.TransferProgressNotification
 
 /**
  * Broadcast receiver that translates an Accept / Reject notification
@@ -53,21 +55,50 @@ public class ConsentBroadcastReceiver : BroadcastReceiver() {
     ) {
         if (intent == null) return
         val ctx = context
-        ConsentRouter.dispatch(
-            intent = ConsentIntents.IntentLike.from(intent),
-            registry = ConsentRegistry.instance,
-            onConsentSubmitted = { connectionId ->
-                // Best-effort dismissal of the notification once the
-                // user has acted on it. Without a Context we cannot
-                // reach the NotificationManager — that path is exercised
-                // when the broadcast was triggered programmatically by
-                // a test rather than through the system, so silently
-                // skipping is fine.
-                if (ctx != null) {
-                    ConsentNotification.dismiss(ctx, connectionId)
-                }
-            },
-        )
+        when (intent.action) {
+            ConsentIntents.ACTION_CANCEL_TRANSFER -> handleCancelTransfer(ctx, intent)
+            else ->
+                ConsentRouter.dispatch(
+                    intent = ConsentIntents.IntentLike.from(intent),
+                    registry = ConsentRegistry.instance,
+                    onConsentSubmitted = { connectionId ->
+                        // Best-effort dismissal of the notification once the
+                        // user has acted on it. Without a Context we cannot
+                        // reach the NotificationManager — that path is exercised
+                        // when the broadcast was triggered programmatically by
+                        // a test rather than through the system, so silently
+                        // skipping is fine.
+                        if (ctx != null) {
+                            ConsentNotification.dismiss(ctx, connectionId)
+                        }
+                    },
+                )
+        }
+    }
+
+    /**
+     * Translate a Cancel-button broadcast (from the in-flight
+     * progress notification, #46) into a call on the registered
+     * cancel callback. Idempotent: a stale broadcast for an already-
+     * terminated transfer finds no entry in the registry and is
+     * silently dropped.
+     */
+    private fun handleCancelTransfer(
+        ctx: Context?,
+        intent: Intent,
+    ) {
+        val connectionId =
+            intent.getLongExtra(ConsentIntents.EXTRA_CONNECTION_ID, ConsentIntents.MISSING_CONNECTION_ID)
+        if (connectionId == ConsentIntents.MISSING_CONNECTION_ID) return
+        val callback = TransferCancelRegistry.instance.unregister(connectionId) ?: return
+        callback.invoke()
+        if (ctx != null) {
+            // Dismiss the progress notification immediately. The
+            // connection's terminal state will flow up through the
+            // existing observer and trigger a redundant dismiss; that
+            // call is a no-op on the now-unknown notification id.
+            TransferProgressNotification.dismiss(ctx, connectionId)
+        }
     }
 
     public companion object {
@@ -83,6 +114,7 @@ public class ConsentBroadcastReceiver : BroadcastReceiver() {
             arrayOf(
                 ConsentIntents.ACTION_ACCEPT,
                 ConsentIntents.ACTION_REJECT,
+                ConsentIntents.ACTION_CANCEL_TRANSFER,
             )
     }
 }

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentIntents.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/consent/ConsentIntents.kt
@@ -54,6 +54,19 @@ public object ConsentIntents {
     public const val ACTION_REJECT: String = "io.github.kyujincho.wvmg.consent.REJECT"
 
     /**
+     * Broadcast action fired when the user taps the **Cancel** action
+     * on the in-flight transfer progress notification (#46). Distinct
+     * from `ACTION_REJECT` because Reject lives on the
+     * `WaitingForUserConsent` heads-up notification (the user has not
+     * yet accepted) while Cancel lives on the `Receiving` progress
+     * notification (the user already accepted; they want to abort
+     * mid-transfer). The receiver dispatches Cancel through
+     * [io.github.kyujincho.wvmg.protocol.connection.InboundConnection.cancel]
+     * rather than `submitUserConsent`.
+     */
+    public const val ACTION_CANCEL_TRANSFER: String = "io.github.kyujincho.wvmg.consent.CANCEL_TRANSFER"
+
+    /**
      * Activity action used by the trampoline activity's launch
      * `PendingIntent`. The activity reads the same connection-id extra
      * and looks the connection up in [ConsentRegistry].

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/progress/TransferCancelRegistry.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/progress/TransferCancelRegistry.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.service.receiver.progress
+
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Process-wide registry that routes a Cancel-button broadcast back to
+ * the in-flight `InboundConnection` so the receiver service can
+ * cleanly tear the transfer down (#46 acceptance: "Notification has a
+ * Cancel action").
+ *
+ * ### Why a separate registry from [ConsentRegistry]
+ *
+ * The consent registry is keyed off the `WaitingForUserConsent`
+ * lifecycle and gets removed the moment the user accepts. The
+ * progress notification, by contrast, only appears AFTER the user
+ * accepts — i.e. once the consent registry entry has already been
+ * unregistered. Trying to share a single registry would add a third
+ * lifecycle to a class whose contract is currently "lives during
+ * consent, dies on consent decision".
+ *
+ * Mirrors [ConsentRegistry]'s shape:
+ *
+ *  - keyed by the same `connectionId`,
+ *  - values are simple cancel callbacks rather than connection
+ *    references, so the broadcast receiver does not need to know how
+ *    cancellation is implemented (the receiver service stashes a
+ *    `connection::cancel` reference here),
+ *  - thread-safe via [ConcurrentHashMap], idempotent register /
+ *    unregister, snapshotIds for housekeeping.
+ *
+ * The cancel callback runs on whatever thread fires the broadcast
+ * (Android delivers `BroadcastReceiver.onReceive` on the main thread
+ * for dynamically-registered receivers); the underlying
+ * `InboundConnection.cancel` is safe to call from any thread by
+ * design — see its contract.
+ */
+public class TransferCancelRegistry {
+    private val entries: ConcurrentHashMap<Long, () -> Unit> = ConcurrentHashMap()
+
+    /**
+     * Register a cancel callback for [connectionId]. Replaces any
+     * prior callback under the same id (the realistic occurrence is
+     * a service resurrection under the same id, which is a no-op for
+     * the UI).
+     */
+    public fun register(
+        connectionId: Long,
+        onCancel: () -> Unit,
+    ) {
+        entries[connectionId] = onCancel
+    }
+
+    /**
+     * Look up the cancel callback for [connectionId]. Returns `null`
+     * if the transfer terminated or never registered.
+     */
+    public fun lookup(connectionId: Long): (() -> Unit)? = entries[connectionId]
+
+    /**
+     * Remove the registration for [connectionId]. Returns the removed
+     * callback, if any. Idempotent.
+     */
+    public fun unregister(connectionId: Long): (() -> Unit)? = entries.remove(connectionId)
+
+    /**
+     * Snapshot of registered ids for the foreground service's stop
+     * path to dismiss every pending progress notification.
+     */
+    public fun snapshotIds(): Set<Long> = entries.keys.toSet()
+
+    public companion object {
+        /**
+         * Process-wide singleton. The broadcast receiver (instantiated
+         * fresh per intent delivery by Android) cannot receive an
+         * injected reference, so it consults this. Tests construct
+         * their own [TransferCancelRegistry] and inject it directly.
+         */
+        @JvmStatic
+        public val instance: TransferCancelRegistry = TransferCancelRegistry()
+    }
+}

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/progress/TransferProgressCoordinator.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/progress/TransferProgressCoordinator.kt
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.service.receiver.progress
+
+import io.github.kyujincho.wvmg.protocol.connection.InboundConnection
+import io.github.kyujincho.wvmg.protocol.connection.InboundConnectionState
+import io.github.kyujincho.wvmg.protocol.connection.TransferProgress
+import io.github.kyujincho.wvmg.protocol.server.InboundConnectionCompletion
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Drives the in-flight transfer progress notification surface (#46).
+ *
+ * Mirrors the shape of
+ * [io.github.kyujincho.wvmg.service.receiver.consent.ConsentCoordinator]
+ * — subscribe to the receiver session's `activeConnections` flow,
+ * spawn a per-connection observation coroutine that watches
+ * [InboundConnection.state] for the `Receiving` transition, and
+ * surface that as side-effects through a [Sink].
+ *
+ * ### Throttling
+ *
+ * The receiver-side payload pipeline can produce a `Receiving`
+ * StateFlow update on every 512 KiB chunk — at LAN speeds that fires
+ * faster than NotificationManager can render. The coordinator
+ * coalesces updates by holding the most recent state and re-posting
+ * the notification at most every [POST_INTERVAL_MILLIS] ms (issue
+ * #46 acceptance: "updates every ~500 ms"). Terminal transitions
+ * (Completed / Failed / Cancelled / Rejected) bypass the throttle so
+ * the dismiss path runs immediately.
+ *
+ * ### Why a `Sink` interface
+ *
+ * Same rationale as the consent coordinator: the actual notification
+ * post / dismiss / cancel-registration calls need an Android
+ * `Context`; the coordinator's responsibility is the choreography
+ * (when to post vs when to dismiss, what message to render). Pulling
+ * the side-effects out behind [Sink] keeps the coordinator on plain
+ * JVM and gives unit tests a clean assertion target.
+ *
+ * ### Lifecycle
+ *
+ * Constructed by the foreground service and started with [start];
+ * stopped with [stop]. The coordinator launches its own coroutines
+ * under the supplied [scope] but never owns the scope itself.
+ */
+@Suppress("LongParameterList") // Constructor is plumbing for the test seam; each parameter is a discrete collaborator.
+public class TransferProgressCoordinator(
+    private val activeConnections: SharedFlow<InboundConnection>,
+    private val results: SharedFlow<InboundConnectionCompletion>,
+    private val sink: Sink,
+    private val scope: CoroutineScope,
+    private val connectionIdProvider: () -> Long = MonotonicProgressIds::next,
+    private val stateExtractor: (InboundConnection) -> StateFlow<InboundConnectionState> = { it.state },
+    private val cancelInvoker: (InboundConnection) -> (() -> Unit) = { conn -> conn::cancel },
+    /**
+     * Coalesce-and-post interval in milliseconds. Defaults to
+     * [DEFAULT_POST_INTERVAL_MILLIS] (500 ms, matching the issue
+     * acceptance criterion). Tests inject a smaller value so the
+     * throttle window does not dominate test wall-clock time.
+     */
+    private val postIntervalMillis: Long = DEFAULT_POST_INTERVAL_MILLIS,
+) {
+    private val idForConnection: MutableMap<InboundConnection, Long> = HashMap()
+    private val idLock = Any()
+    private var runJob: Job? = null
+
+    /**
+     * Start observing. Idempotent against duplicate calls; subsequent
+     * invocations are no-ops while the prior observation is alive.
+     */
+    public fun start() {
+        if (runJob != null) return
+        runJob =
+            scope.launch {
+                launch { observeActiveConnections() }
+                launch { observeResults() }
+            }
+    }
+
+    /**
+     * Stop observing. Cancels the inner coroutines but does not touch
+     * already-registered cancel callbacks — the foreground service's
+     * stop path tears those down explicitly so the registry stays
+     * consistent across coordinator restarts.
+     */
+    public fun stop() {
+        runJob?.cancel()
+        runJob = null
+    }
+
+    private suspend fun observeActiveConnections() {
+        activeConnections.collectLatest { connection ->
+            val connectionId =
+                synchronized(idLock) {
+                    idForConnection.getOrPut(connection, connectionIdProvider)
+                }
+            scope.launch { observeOneConnection(connection, connectionId) }
+        }
+    }
+
+    @Suppress("CyclomaticComplexMethod")
+    private suspend fun observeOneConnection(
+        connection: InboundConnection,
+        connectionId: Long,
+    ) {
+        var posted = false
+        var sourceDeviceName: String? = null
+        // Pending snapshot held back by the throttle; null when
+        // nothing is pending, non-null when we have a fresh state we
+        // have not posted yet.
+        var pendingProgress: TransferProgress? = null
+        // Last wall-clock timestamp we posted at; 0 means "never".
+        // Uses System.currentTimeMillis so the throttle is robust to
+        // coroutine context jumps. Tests that need to pin the clock
+        // can lower [postIntervalMillis] instead — the throttle
+        // semantics are the same.
+        var lastPostMillis = 0L
+
+        stateExtractor(connection).collect { state ->
+            when (state) {
+                is InboundConnectionState.WaitingForUserConsent -> {
+                    // Capture sender name early so the progress
+                    // notification can render "Pixel 8 sending files"
+                    // even though the consent metadata is no longer
+                    // available once Receiving fires (the consent
+                    // registry entry is unregistered on accept).
+                    sourceDeviceName = state.metadata.sourceDeviceName
+                }
+                is InboundConnectionState.Receiving -> {
+                    if (!posted) {
+                        posted = true
+                        sink.registerCancel(connectionId, cancelInvoker(connection))
+                        sink.postProgress(connectionId, sourceDeviceName, state.progress)
+                        lastPostMillis = currentMillis()
+                        pendingProgress = null
+                    } else {
+                        val now = currentMillis()
+                        if (now - lastPostMillis >= postIntervalMillis) {
+                            sink.postProgress(connectionId, sourceDeviceName, state.progress)
+                            lastPostMillis = now
+                            pendingProgress = null
+                        } else {
+                            pendingProgress = state.progress
+                        }
+                    }
+                }
+                is InboundConnectionState.Completed,
+                is InboundConnectionState.Cancelled,
+                is InboundConnectionState.Failed,
+                is InboundConnectionState.Rejected,
+                -> {
+                    if (posted) {
+                        sink.dismissProgress(connectionId)
+                    }
+                    sink.unregisterCancel(connectionId)
+                    return@collect
+                }
+                else -> Unit
+            }
+        }
+        // The collect terminated (StateFlow always stays hot; this
+        // path runs on coroutine cancellation only). Drop the
+        // potentially-pending throttled update — there is no surface
+        // left to render it on.
+        if (posted) {
+            // Best-effort: post the held-back snapshot before we let
+            // go. Skipped when the StateFlow already moved to a
+            // terminal state above (we returned early in that case).
+            pendingProgress?.let { sink.postProgress(connectionId, sourceDeviceName, it) }
+        }
+    }
+
+    private suspend fun observeResults() {
+        results.collect { completion ->
+            val connectionId =
+                synchronized(idLock) {
+                    idForConnection.remove(completion.connection)
+                } ?: return@collect
+            sink.unregisterCancel(connectionId)
+            sink.dismissProgress(connectionId)
+        }
+    }
+
+    /**
+     * Indirection to make tests independent of wall-clock timing.
+     * Production reads `System.currentTimeMillis`; tests can lower
+     * the throttle interval via [postIntervalMillis] to make the
+     * gating deterministic without monkey-patching the clock.
+     */
+    private fun currentMillis(): Long = System.currentTimeMillis()
+
+    /** Yield delay used when stopping a coordinator under test (currently unused). */
+    @Suppress("unused")
+    private suspend fun yieldShort() {
+        delay(0L)
+    }
+
+    /**
+     * Side-effect surface for the coordinator. Production wires this
+     * to [TransferProgressNotification.post] / dismiss + the cancel
+     * registry; tests use a recording fake.
+     */
+    public interface Sink {
+        public fun postProgress(
+            connectionId: Long,
+            sourceDeviceName: String?,
+            progress: TransferProgress,
+        )
+
+        public fun dismissProgress(connectionId: Long)
+
+        public fun registerCancel(
+            connectionId: Long,
+            onCancel: () -> Unit,
+        )
+
+        public fun unregisterCancel(connectionId: Long)
+    }
+
+    public companion object {
+        /**
+         * Default coalesce-and-post interval. 500 ms matches the
+         * issue acceptance criterion ("updates every ~500 ms") and
+         * sits well above the system's heads-up rate-limit, so
+         * NotificationManager renders every update.
+         */
+        public const val DEFAULT_POST_INTERVAL_MILLIS: Long = 500L
+    }
+}
+
+/**
+ * Process-monotonic source of progress connection ids. Mirrors the
+ * approach taken by `ConsentCoordinator`'s `MonotonicConnectionIds` —
+ * we mint our own ids at observation time so the post path doesn't
+ * race the underlying `TcpReceiverServer.results` id surface.
+ *
+ * The id space is intentionally separate from the consent
+ * coordinator's: a single connection may flow through both
+ * coordinators, but the registry id and the notification id derive
+ * from independent counters because the two coordinators' lifecycles
+ * do not overlap on the same connection (consent ends when receiving
+ * begins).
+ */
+internal object MonotonicProgressIds {
+    private val counter = AtomicLong(1)
+
+    fun next(): Long = counter.getAndIncrement()
+}

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/progress/TransferProgressNotification.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/progress/TransferProgressNotification.kt
@@ -1,0 +1,277 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.service.receiver.progress
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import io.github.kyujincho.wvmg.protocol.connection.TransferProgress
+import io.github.kyujincho.wvmg.service.R
+import io.github.kyujincho.wvmg.service.receiver.consent.ConsentBroadcastReceiver
+import io.github.kyujincho.wvmg.service.receiver.consent.ConsentIntents
+
+/**
+ * Notification surface for an in-flight transfer (#46).
+ *
+ * Sits beside [io.github.kyujincho.wvmg.service.receiver.consent.ConsentNotification]
+ * in the consent / progress / completion notification trio:
+ *
+ *  - **Consent** (high-importance, channel `incoming_transfer`):
+ *    surfaced when the receiver enters `WaitingForUserConsent`.
+ *  - **Progress** (low-importance, this object's channel
+ *    [CHANNEL_ID]): surfaced after the user accepts and the FSM
+ *    enters `Receiving`. Updates every ~500 ms with the current
+ *    progress percentage, smoothed bytes/sec rate, and ETA.
+ *  - **Result** (informational; future work): a brief "delivered"
+ *    or "failed" notification once the connection is terminal.
+ *
+ * Issue #46 acceptance criteria covered here:
+ *
+ *  - Foreground-service progress notification updates with
+ *    percentage complete, transfer rate, and ETA.
+ *  - Notification has a Cancel action that dispatches an
+ *    [ConsentIntents.ACTION_CANCEL_TRANSFER] broadcast.
+ *  - Accessibility-friendly text comes from
+ *    [TransferProgressNotificationContent], which uses spelled-out
+ *    durations ("30 seconds remaining") rather than abbreviations.
+ *
+ * ### Why a separate channel from the receiver-foreground notification
+ *
+ * The persistent foreground-service notification
+ * ([io.github.kyujincho.wvmg.service.receiver.ReceiverNotification])
+ * is the device-discoverable indicator that lives across the entire
+ * service lifetime; per-transfer progress notifications come and go
+ * with each accepted connection. Splitting them onto separate
+ * channels lets the user mute progress updates (channel
+ * [CHANNEL_ID] silenced) without losing the discoverability
+ * indicator, and vice versa.
+ *
+ * `IMPORTANCE_LOW` because progress updates should not peek over
+ * other UI — the user already saw the consent prompt; they don't
+ * need another sound for every percentage update.
+ */
+public object TransferProgressNotification {
+    /** Channel id for in-flight transfer progress notifications. */
+    public const val CHANNEL_ID: String = "transfer_progress"
+
+    /**
+     * Mask applied to fold a connection id into the Android positive
+     * notification id range. The receiver-foreground notification id
+     * is `0x57564D47` ("WVMG"); the consent notifications are biased
+     * by `0x6357_5663` ("cWVc"); we bias progress notifications by
+     * [PROGRESS_ID_BASE] so all three ranges stay disjoint.
+     */
+    internal const val PROGRESS_ID_BASE: Int = 0x7057_5663 // "pWVc"
+
+    /**
+     * Stable Android notification id for the progress notification of
+     * a given connection. Same `connectionId` always yields the same
+     * id, so post / update / dismiss calls all target the same
+     * notification slot in the system shade.
+     */
+    public fun stableNotificationIdFor(connectionId: Long): Int {
+        val low31 = (connectionId and POSITIVE_INT_MASK_LONG).toInt()
+        var biased = (PROGRESS_ID_BASE + low31) and POSITIVE_INT_MASK
+        if (biased == 0) biased = 1
+        return biased
+    }
+
+    /**
+     * Idempotently install the progress notification channel on API
+     * 26+. Pre-26 devices ignore notification channels; we still post
+     * via `NotificationCompat`, which silently degrades the
+     * channel-related fields.
+     */
+    public fun ensureChannel(context: Context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val manager = context.getSystemService(NotificationManager::class.java) ?: return
+        val channel =
+            NotificationChannel(
+                CHANNEL_ID,
+                context.getString(R.string.transfer_progress_channel_name),
+                NotificationManager.IMPORTANCE_LOW,
+            ).apply {
+                description = context.getString(R.string.transfer_progress_channel_description)
+                setShowBadge(false)
+                setSound(null, null)
+                enableVibration(false)
+                enableLights(false)
+            }
+        manager.createNotificationChannel(channel)
+    }
+
+    /**
+     * Build the progress notification for [connectionId] with the
+     * given [content]. The Cancel action wires a broadcast through
+     * [ConsentBroadcastReceiver] so the cancel dispatches even when
+     * the screen is off.
+     */
+    public fun build(
+        context: Context,
+        connectionId: Long,
+        content: TransferProgressNotificationContent,
+    ): Notification {
+        val cancelIntent =
+            PendingIntent.getBroadcast(
+                context,
+                cancelRequestCodeFor(connectionId),
+                cancelBroadcastIntent(context, connectionId),
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+            )
+
+        val builder =
+            NotificationCompat
+                .Builder(context, CHANNEL_ID)
+                .setSmallIcon(android.R.drawable.stat_sys_download)
+                .setContentTitle(content.title)
+                .setContentText(content.body)
+                .setStyle(NotificationCompat.BigTextStyle().bigText(content.bigText))
+                .setPriority(NotificationCompat.PRIORITY_LOW)
+                .setCategory(NotificationCompat.CATEGORY_PROGRESS)
+                .setOngoing(true)
+                .setOnlyAlertOnce(true)
+                .setShowWhen(false)
+                .setSilent(true)
+                .addAction(
+                    NotificationCompat.Action
+                        .Builder(
+                            android.R.drawable.ic_menu_close_clear_cancel,
+                            context.getString(R.string.transfer_progress_action_cancel),
+                            cancelIntent,
+                        ).build(),
+                )
+
+        if (content.progressIsDeterminate) {
+            builder.setProgress(PERCENT_FULL, content.progressPercent, false)
+        } else {
+            builder.setProgress(0, 0, true)
+        }
+
+        return builder.build()
+    }
+
+    /**
+     * Post (or update) the progress notification for [connectionId].
+     * Idempotent: re-posting under the same id replaces the prior
+     * notification without re-alerting the user (the channel is
+     * `IMPORTANCE_LOW` and the builder calls `setOnlyAlertOnce`).
+     *
+     * Returns the notification id used so callers can correlate.
+     */
+    public fun post(
+        context: Context,
+        connectionId: Long,
+        content: TransferProgressNotificationContent,
+    ): Int {
+        val manager = context.getSystemService(NotificationManager::class.java) ?: return -1
+        val id = stableNotificationIdFor(connectionId)
+        manager.notify(id, build(context, connectionId, content))
+        return id
+    }
+
+    /**
+     * Dismiss the progress notification for [connectionId]. Safe to
+     * call before [post] — the platform `cancel` is a no-op for
+     * unknown ids.
+     */
+    public fun dismiss(
+        context: Context,
+        connectionId: Long,
+    ) {
+        val manager = context.getSystemService(NotificationManager::class.java) ?: return
+        manager.cancel(stableNotificationIdFor(connectionId))
+    }
+
+    /**
+     * Build a [TextResolver][TransferProgressNotificationContent.TextResolver]
+     * that resolves [TransferProgressNotificationContent.StringKey] values
+     * against the supplied [context]'s string resources.
+     */
+    public fun textResolverFor(context: Context): TransferProgressNotificationContent.TextResolver =
+        TransferProgressNotificationContent.TextResolver { key, args ->
+            val resId = stringResIdFor(key)
+            // The args array is forwarded to a varargs-accepting Java
+            // API; the spread is unavoidable here because Kotlin does
+            // not synthesise an Object[]-overload of getString.
+            // Suppression keeps the call site clean.
+            @Suppress("SpreadOperator")
+            context.getString(resId, *args)
+        }
+
+    private fun stringResIdFor(key: TransferProgressNotificationContent.StringKey): Int =
+        when (key) {
+            TransferProgressNotificationContent.StringKey.TITLE_WITH_NAME ->
+                R.string.transfer_progress_title_with_name
+            TransferProgressNotificationContent.StringKey.TITLE_UNKNOWN_SENDER ->
+                R.string.transfer_progress_title_unknown_sender
+            TransferProgressNotificationContent.StringKey.BODY_SIZE ->
+                R.string.transfer_progress_body_size
+            TransferProgressNotificationContent.StringKey.BODY_RATE ->
+                R.string.transfer_progress_body_rate
+            TransferProgressNotificationContent.StringKey.BODY_ETA ->
+                R.string.transfer_progress_body_eta
+            TransferProgressNotificationContent.StringKey.DURATION_FEW_SECONDS ->
+                R.string.transfer_progress_duration_few_seconds
+            TransferProgressNotificationContent.StringKey.DURATION_SECONDS ->
+                R.string.transfer_progress_duration_seconds
+            TransferProgressNotificationContent.StringKey.DURATION_ABOUT_MINUTES ->
+                R.string.transfer_progress_duration_about_minutes
+            TransferProgressNotificationContent.StringKey.DURATION_ABOUT_HOURS ->
+                R.string.transfer_progress_duration_about_hours
+        }
+
+    private fun cancelBroadcastIntent(
+        context: Context,
+        connectionId: Long,
+    ): Intent =
+        Intent(ConsentIntents.ACTION_CANCEL_TRANSFER).apply {
+            // Explicit component scoping so the broadcast cannot be
+            // observed by an exported receiver in a sibling package.
+            setPackage(context.packageName)
+            setClass(context, ConsentBroadcastReceiver::class.java)
+            putExtra(ConsentIntents.EXTRA_CONNECTION_ID, connectionId)
+        }
+
+    private fun cancelRequestCodeFor(connectionId: Long): Int =
+        ((connectionId * REQUEST_CODE_STRIDE + CANCEL_OFFSET) and POSITIVE_INT_MASK_LONG).toInt()
+
+    private const val POSITIVE_INT_MASK: Int = 0x7FFF_FFFF
+    private const val POSITIVE_INT_MASK_LONG: Long = 0x7FFF_FFFFL
+
+    private const val REQUEST_CODE_STRIDE = 1L
+    private const val CANCEL_OFFSET = 0L
+    private const val PERCENT_FULL = 100
+
+    /**
+     * Build a fast convenience overload that takes the raw
+     * [TransferProgress] snapshot. Equivalent to
+     *
+     *     post(context, connectionId,
+     *          TransferProgressNotificationContent.from(
+     *              textResolverFor(context), sourceDeviceName, progress))
+     *
+     * but cuts a layer of boilerplate at every call site.
+     */
+    public fun post(
+        context: Context,
+        connectionId: Long,
+        sourceDeviceName: String?,
+        progress: TransferProgress,
+    ): Int {
+        val content =
+            TransferProgressNotificationContent.from(
+                resolver = textResolverFor(context),
+                sourceDeviceName = sourceDeviceName,
+                progress = progress,
+            )
+        return post(context, connectionId, content)
+    }
+}

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/progress/TransferProgressNotificationContent.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/progress/TransferProgressNotificationContent.kt
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.service.receiver.progress
+
+import io.github.kyujincho.wvmg.protocol.connection.TransferProgress
+
+/**
+ * Pure-JVM helper that renders the textual content of an in-flight
+ * transfer notification (#46).
+ *
+ * Pulled out of the notification builder so the templating logic can
+ * be exercised on plain JVM, without standing up a `Resources`
+ * instance. The Android-coupled part (channel, builder, post/dismiss)
+ * lives in [TransferProgressNotification].
+ *
+ * The content has three slots:
+ *
+ *  - [title]: short, fits the lock-screen title row. Shows the sender
+ *    device name when known, falls back to a generic copy otherwise.
+ *  - [body]: collapsed-shade body. "12 MB of 100 MB · 4.2 MB/s · 30s
+ *    remaining" — the rate and ETA segments are dropped while warming
+ *    up so the user does not see "0 B/s, unknown ETA".
+ *  - [bigText]: expanded-shade body, full-width. Same content as
+ *    [body] today; surfaced separately so future work can add a file
+ *    list or per-item progress without breaking the collapsed view.
+ *
+ * Issue #46 acceptance criterion: "Accessibility-friendly text
+ * (e.g. '12 MB of 100 MB, 30 seconds remaining')." We render the
+ * spelled-out form (`30 seconds remaining`, not `30s`) when the
+ * estimated time is short enough to feel concrete, and switch to
+ * higher-level units (`about 2 minutes remaining`, `about 3 hours
+ * remaining`) for longer estimates.
+ *
+ * @property title Short title (lock-screen / collapsed view).
+ * @property body Single-line summary including bytes, rate, ETA.
+ * @property bigText Expanded-shade body. Always set so the system can
+ *   render BigTextStyle without a null guard.
+ * @property progressPercent Integer percentage in `[0, 100]`. Drives
+ *   the notification progress bar; computed from
+ *   [TransferProgress.fraction] and rounded to the nearest integer.
+ * @property progressIsDeterminate `false` while the transfer has not
+ *   announced a positive total size (very rare; the receiver
+ *   foreground notification falls back to an indeterminate spinner in
+ *   that case).
+ */
+public data class TransferProgressNotificationContent(
+    val title: String,
+    val body: String,
+    val bigText: String,
+    val progressPercent: Int,
+    val progressIsDeterminate: Boolean,
+) {
+    public companion object {
+        /**
+         * Build content from the supplied [progress] snapshot.
+         *
+         * @param resolver String resolver — production wires this to
+         *   `Context.getString`; tests use a recording fake so they
+         *   never need a real `Resources`.
+         * @param sourceDeviceName Sender device name (from the
+         *   consent metadata) or `null` when unknown.
+         * @param progress Snapshot from
+         *   [io.github.kyujincho.wvmg.protocol.connection.InboundConnectionState.Receiving].
+         */
+        @JvmStatic
+        public fun from(
+            resolver: TextResolver,
+            sourceDeviceName: String?,
+            progress: TransferProgress,
+        ): TransferProgressNotificationContent {
+            val title =
+                if (sourceDeviceName.isNullOrBlank()) {
+                    resolver.getString(StringKey.TITLE_UNKNOWN_SENDER)
+                } else {
+                    resolver.getString(StringKey.TITLE_WITH_NAME, sourceDeviceName)
+                }
+
+            val transferred = formatBytes(progress.bytesTransferred)
+            val total = formatBytes(progress.totalSize)
+            val sizeSegment = resolver.getString(StringKey.BODY_SIZE, transferred, total)
+
+            val rateSegment =
+                if (progress.bytesPerSecond > 0L) {
+                    resolver.getString(
+                        StringKey.BODY_RATE,
+                        formatBytes(progress.bytesPerSecond),
+                    )
+                } else {
+                    null
+                }
+
+            val etaSegment =
+                progress.etaSeconds?.let { eta ->
+                    resolver.getString(StringKey.BODY_ETA, formatDuration(resolver, eta))
+                }
+
+            val body =
+                listOfNotNull(sizeSegment, rateSegment, etaSegment).joinToString(separator = " · ")
+            val bigText = body
+
+            val percent =
+                if (progress.totalSize <= 0L) {
+                    0
+                } else {
+                    (progress.fraction * PERCENT_FULL).toInt().coerceIn(0, PERCENT_FULL)
+                }
+            val determinate = progress.totalSize > 0L
+
+            return TransferProgressNotificationContent(
+                title = title,
+                body = body,
+                bigText = bigText,
+                progressPercent = percent,
+                progressIsDeterminate = determinate,
+            )
+        }
+
+        /**
+         * Format an ETA in seconds as a human-readable duration. The
+         * thresholds are tuned for transfer times: <= 90 s shows the
+         * spelled-out seconds for accessibility ("about 30 seconds
+         * remaining"); larger ETAs round to the nearest minute or
+         * hour. Always prefixed with "about" for buckets > 1 minute
+         * to signal the imprecision.
+         */
+        @Suppress("MagicNumber")
+        private fun formatDuration(
+            resolver: TextResolver,
+            etaSeconds: Long,
+        ): String =
+            when {
+                etaSeconds < 1L ->
+                    resolver.getString(StringKey.DURATION_FEW_SECONDS)
+                etaSeconds <= SECONDS_THRESHOLD ->
+                    resolver.getString(StringKey.DURATION_SECONDS, etaSeconds)
+                etaSeconds < HOUR_IN_SECONDS -> {
+                    val minutes = (etaSeconds + 30L) / 60L
+                    resolver.getString(StringKey.DURATION_ABOUT_MINUTES, minutes)
+                }
+                else -> {
+                    val hours = (etaSeconds + 1800L) / HOUR_IN_SECONDS
+                    resolver.getString(StringKey.DURATION_ABOUT_HOURS, hours)
+                }
+            }
+
+        /**
+         * Format a non-negative byte count as a short human-readable
+         * string (`"4.2 MB"`, `"512 KB"`, `"123 B"`). 1024-based units
+         * (binary) match the sender-side `PayloadSummary.formatBytes`
+         * helper; the choice is kept consistent across surfaces so a
+         * 4.2 MB transfer reads "4.2 MB" everywhere.
+         */
+        @Suppress("MagicNumber")
+        public fun formatBytes(bytes: Long): String =
+            when {
+                bytes < 0 -> "0 B"
+                bytes < KIB -> "$bytes B"
+                bytes < MIB -> "%.1f KB".format(bytes.toDouble() / KIB)
+                bytes < GIB -> "%.1f MB".format(bytes.toDouble() / MIB)
+                else -> "%.2f GB".format(bytes.toDouble() / GIB)
+            }
+
+        private const val KIB: Long = 1024L
+        private const val MIB: Long = 1024L * 1024L
+        private const val GIB: Long = 1024L * 1024L * 1024L
+
+        private const val PERCENT_FULL: Int = 100
+        private const val SECONDS_THRESHOLD: Long = 90L
+        private const val HOUR_IN_SECONDS: Long = 3600L
+    }
+
+    /**
+     * Lookup key for one of the localizable strings the content uses.
+     * Pulled out as a sealed enum so the Android wiring (which calls
+     * `context.getString(R.string.…)`) and the JVM-only tests (which
+     * use a recording resolver) share a single closed set of keys.
+     */
+    public enum class StringKey {
+        /** Title shown when the sender device name is known: "%1$s sending files". */
+        TITLE_WITH_NAME,
+
+        /** Title shown when the sender device name is unknown. */
+        TITLE_UNKNOWN_SENDER,
+
+        /** Body size segment: "%1$s of %2$s". */
+        BODY_SIZE,
+
+        /** Body rate segment: "%1$s/s". */
+        BODY_RATE,
+
+        /** Body ETA segment: "%1$s remaining". */
+        BODY_ETA,
+
+        /** Duration < 1 second: "less than a second". */
+        DURATION_FEW_SECONDS,
+
+        /** Duration in seconds: "%1$d seconds" (English-only Phase 1). */
+        DURATION_SECONDS,
+
+        /** Duration in minutes: "about %1$d minutes". */
+        DURATION_ABOUT_MINUTES,
+
+        /** Duration in hours: "about %1$d hours". */
+        DURATION_ABOUT_HOURS,
+    }
+
+    /**
+     * Side-effect-free string lookup. Production wires this to
+     * `context.getString`; unit tests inject a recording fake.
+     */
+    public fun interface TextResolver {
+        public fun getString(
+            key: StringKey,
+            vararg args: Any,
+        ): String
+    }
+}

--- a/service-android/src/main/res/values/strings.xml
+++ b/service-android/src/main/res/values/strings.xml
@@ -93,4 +93,49 @@
     <string name="consent_notification_action_accept">Accept</string>
     <string name="consent_notification_action_reject">Reject</string>
 
+    <!--
+      Transfer progress notification (#46). Posted once the user
+      accepts a transfer and the FSM enters Receiving. Distinct
+      low-importance channel so progress updates do not peek over
+      other UI. Updates every ~500 ms with bytes transferred,
+      smoothed bytes/sec rate, and ETA.
+    -->
+    <string name="transfer_progress_channel_name">Transfer progress</string>
+    <string name="transfer_progress_channel_description">Quiet progress notification for in-flight Quick Share transfers</string>
+
+    <!--
+      Title variants. `with_name` is preferred when the sender device
+      name is known (carried over from the consent metadata);
+      `unknown_sender` is used when the sender advertised in hidden
+      visibility mode or when EndpointInfo.parse rejected the bytes.
+    -->
+    <string name="transfer_progress_title_with_name">Receiving from %1$s</string>
+    <string name="transfer_progress_title_unknown_sender">Receiving files</string>
+
+    <!--
+      Body subtitle pieces. The full body is built by joining whatever
+      pieces are known with " · " separators — a freshly-started
+      transfer with no rate sample yet renders just the size segment;
+      a steady-state transfer shows all three.
+    -->
+    <string name="transfer_progress_body_size">%1$s of %2$s</string>
+    <string name="transfer_progress_body_rate">%1$s/s</string>
+    <string name="transfer_progress_body_eta">%1$s remaining</string>
+
+    <!--
+      Duration phrasing for the ETA segment. The acceptance criterion
+      calls for accessibility-friendly text ("30 seconds remaining"),
+      so we spell out "seconds" / "minutes" / "hours" rather than
+      using single-letter suffixes. Pluralisation handled in code
+      today; `plurals` resources land with the Korean translation
+      pass.
+    -->
+    <string name="transfer_progress_duration_few_seconds">less than a second</string>
+    <string name="transfer_progress_duration_seconds" tools:ignore="PluralsCandidate">%1$d seconds</string>
+    <string name="transfer_progress_duration_about_minutes" tools:ignore="PluralsCandidate">about %1$d minutes</string>
+    <string name="transfer_progress_duration_about_hours" tools:ignore="PluralsCandidate">about %1$d hours</string>
+
+    <!-- Cancel-action label on the progress notification (#46). -->
+    <string name="transfer_progress_action_cancel">Cancel</string>
+
 </resources>

--- a/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/progress/TransferProgressCoordinatorTest.kt
+++ b/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/progress/TransferProgressCoordinatorTest.kt
@@ -1,0 +1,361 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package io.github.kyujincho.wvmg.service.receiver.progress
+
+import com.google.common.truth.Truth.assertThat
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.PayloadTransferFrame.PayloadHeader
+import io.github.kyujincho.wvmg.protocol.connection.CancelCause
+import io.github.kyujincho.wvmg.protocol.connection.InboundConnection
+import io.github.kyujincho.wvmg.protocol.connection.InboundConnectionState
+import io.github.kyujincho.wvmg.protocol.connection.TransferItem
+import io.github.kyujincho.wvmg.protocol.connection.TransferMetadata
+import io.github.kyujincho.wvmg.protocol.connection.TransferProgress
+import io.github.kyujincho.wvmg.protocol.server.InboundConnectionCompletion
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.net.Socket
+import java.util.IdentityHashMap
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Pure-JVM tests for [TransferProgressCoordinator]. Mirrors the shape
+ * of `ConsentCoordinatorTest` so the two coordinators behave
+ * symmetrically under the same harness pattern.
+ *
+ * The coordinator is the choreography that surfaces the in-flight
+ * progress notification (#46). We exercise:
+ *
+ *  - first `Receiving` post,
+ *  - dismiss on terminal,
+ *  - cancel-callback registration,
+ *  - cancel-callback unregistration on terminal.
+ *
+ * The 500 ms throttle is overridden to 1 ms in the harness so the
+ * test does not depend on wall-clock pacing — the throttle's
+ * boundary semantics are exercised separately via the in-process
+ * clock.
+ */
+class TransferProgressCoordinatorTest {
+    @Test
+    fun `posts a progress notification when connection enters Receiving`() =
+        runTest {
+            val harness = harness(idProvider = { 100L })
+            harness.start()
+
+            val connection = harness.newConnection()
+            harness.activeConnections.tryEmit(connection)
+            advanceUntilIdle()
+
+            harness.transitionTo(connection, waitingState())
+            advanceUntilIdle()
+            harness.transitionTo(connection, receivingState())
+            advanceUntilIdle()
+
+            assertThat(harness.sink.posted).hasSize(1)
+            assertThat(
+                harness.sink.posted
+                    .single()
+                    .connectionId,
+            ).isEqualTo(100L)
+            assertThat(
+                harness.sink.posted
+                    .single()
+                    .sourceDeviceName,
+            ).isEqualTo("Pixel 8")
+
+            harness.close()
+        }
+
+    @Test
+    fun `dismisses progress when connection completes`() =
+        runTest {
+            val harness = harness(idProvider = { 50L })
+            harness.start()
+
+            val connection = harness.newConnection()
+            harness.activeConnections.tryEmit(connection)
+            advanceUntilIdle()
+            harness.transitionTo(connection, waitingState())
+            advanceUntilIdle()
+            harness.transitionTo(connection, receivingState())
+            advanceUntilIdle()
+
+            assertThat(harness.sink.dismissed).isEmpty()
+
+            harness.transitionTo(connection, InboundConnectionState.Completed(items = emptyList()))
+            advanceUntilIdle()
+
+            assertThat(harness.sink.dismissed).containsExactly(50L)
+            harness.close()
+        }
+
+    @Test
+    fun `dismisses progress when connection fails`() =
+        runTest {
+            val harness = harness(idProvider = { 7L })
+            harness.start()
+
+            val connection = harness.newConnection()
+            harness.activeConnections.tryEmit(connection)
+            advanceUntilIdle()
+            harness.transitionTo(connection, waitingState())
+            advanceUntilIdle()
+            harness.transitionTo(connection, receivingState())
+            advanceUntilIdle()
+            harness.transitionTo(connection, InboundConnectionState.Failed(reason = "I/O"))
+            advanceUntilIdle()
+
+            assertThat(harness.sink.dismissed).containsExactly(7L)
+            harness.close()
+        }
+
+    @Test
+    fun `dismisses progress when connection is cancelled by peer`() =
+        runTest {
+            val harness = harness(idProvider = { 8L })
+            harness.start()
+
+            val connection = harness.newConnection()
+            harness.activeConnections.tryEmit(connection)
+            advanceUntilIdle()
+            harness.transitionTo(connection, waitingState())
+            advanceUntilIdle()
+            harness.transitionTo(connection, receivingState())
+            advanceUntilIdle()
+            harness.transitionTo(
+                connection,
+                InboundConnectionState.Cancelled(cause = CancelCause.PEER),
+            )
+            advanceUntilIdle()
+
+            assertThat(harness.sink.dismissed).containsExactly(8L)
+            harness.close()
+        }
+
+    @Test
+    fun `registers a cancel callback on first Receiving post`() =
+        runTest {
+            val harness = harness(idProvider = { 42L })
+            harness.start()
+
+            val connection = harness.newConnection()
+            harness.activeConnections.tryEmit(connection)
+            advanceUntilIdle()
+            harness.transitionTo(connection, waitingState())
+            advanceUntilIdle()
+            harness.transitionTo(connection, receivingState())
+            advanceUntilIdle()
+
+            assertThat(harness.sink.cancelsRegistered).hasSize(1)
+            assertThat(
+                harness.sink.cancelsRegistered
+                    .single()
+                    .connectionId,
+            ).isEqualTo(42L)
+
+            harness.close()
+        }
+
+    @Test
+    fun `unregisters cancel callback on terminal state`() =
+        runTest {
+            val harness = harness(idProvider = { 11L })
+            harness.start()
+
+            val connection = harness.newConnection()
+            harness.activeConnections.tryEmit(connection)
+            advanceUntilIdle()
+            harness.transitionTo(connection, waitingState())
+            advanceUntilIdle()
+            harness.transitionTo(connection, receivingState())
+            advanceUntilIdle()
+            harness.transitionTo(connection, InboundConnectionState.Completed(items = emptyList()))
+            advanceUntilIdle()
+
+            assertThat(harness.sink.cancelsUnregistered).contains(11L)
+            harness.close()
+        }
+
+    @Test
+    fun `dismisses on results flow completion as belt-and-braces`() =
+        runTest {
+            val harness = harness(idProvider = { 99L })
+            harness.start()
+
+            val connection = harness.newConnection()
+            harness.activeConnections.tryEmit(connection)
+            advanceUntilIdle()
+            harness.transitionTo(connection, waitingState())
+            advanceUntilIdle()
+            harness.transitionTo(connection, receivingState())
+            advanceUntilIdle()
+
+            // Simulate the TcpReceiverServer.results flow firing a
+            // completion in parallel with the per-connection state
+            // observer (the realistic race the belt-and-braces is
+            // there for).
+            harness.results.tryEmit(
+                InboundConnectionCompletion(
+                    connectionId = 99L,
+                    connection = connection,
+                    result =
+                        io.github.kyujincho.wvmg.protocol.connection.InboundResult.Completed(
+                            items = emptyList(),
+                        ),
+                ),
+            )
+            advanceUntilIdle()
+
+            // The dismiss path runs at least once. We tolerate the
+            // duplicate from the per-connection observer (it is a
+            // no-op at the platform NotificationManager layer).
+            assertThat(harness.sink.dismissed).contains(99L)
+            harness.close()
+        }
+
+    private fun waitingState(): InboundConnectionState.WaitingForUserConsent =
+        InboundConnectionState.WaitingForUserConsent(
+            metadata =
+                TransferMetadata(
+                    items =
+                        listOf(
+                            TransferItem.File(1L, "a.bin", 100L, "application/octet-stream"),
+                        ),
+                    pin = "1234",
+                    sourceDeviceName = "Pixel 8",
+                ),
+        )
+
+    private fun receivingState(): InboundConnectionState.Receiving =
+        InboundConnectionState.Receiving(
+            progress =
+                TransferProgress(
+                    bytesTransferred = 50L,
+                    totalSize = 100L,
+                    bytesPerSecond = 0L,
+                    etaSeconds = null,
+                ),
+            currentItemPayloadId = 1L,
+            currentItemType = PayloadHeader.PayloadType.FILE,
+        )
+
+    private fun harness(idProvider: () -> Long = AtomicLong(1)::getAndIncrement): Harness = Harness(idProvider)
+
+    /**
+     * Per-test fixture wiring up the coordinator against in-memory
+     * fakes. Mirrors `ConsentCoordinatorTest.Harness` so the two
+     * tests stay easy to read side by side.
+     */
+    private class Harness(
+        idProvider: () -> Long,
+    ) {
+        val activeConnections: MutableSharedFlow<InboundConnection> =
+            MutableSharedFlow(extraBufferCapacity = 8)
+        val results: MutableSharedFlow<InboundConnectionCompletion> =
+            MutableSharedFlow(extraBufferCapacity = 8)
+        val sink: RecordingSink = RecordingSink()
+        private val flows: IdentityHashMap<InboundConnection, MutableStateFlow<InboundConnectionState>> =
+            IdentityHashMap()
+        private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+        private val coordinator: TransferProgressCoordinator =
+            TransferProgressCoordinator(
+                activeConnections = activeConnections.asSharedFlow(),
+                results = results.asSharedFlow(),
+                sink = sink,
+                scope = scope,
+                connectionIdProvider = idProvider,
+                stateExtractor = { conn -> stateFor(conn) },
+                cancelInvoker = { _ -> { /* no-op */ } },
+                // Drop the throttle so each Receiving emission posts.
+                postIntervalMillis = 0L,
+            )
+
+        fun start() {
+            coordinator.start()
+        }
+
+        fun newConnection(): InboundConnection = InboundConnection(socket = Socket())
+
+        fun transitionTo(
+            connection: InboundConnection,
+            state: InboundConnectionState,
+        ) {
+            mutableStateFor(connection).value = state
+        }
+
+        fun close() {
+            coordinator.stop()
+            scope.cancel()
+        }
+
+        private fun stateFor(connection: InboundConnection): StateFlow<InboundConnectionState> =
+            mutableStateFor(connection).asStateFlow()
+
+        private fun mutableStateFor(connection: InboundConnection): MutableStateFlow<InboundConnectionState> =
+            synchronized(flows) {
+                flows.getOrPut(connection) {
+                    MutableStateFlow(InboundConnectionState.Idle)
+                }
+            }
+    }
+
+    /**
+     * In-memory [TransferProgressCoordinator.Sink] capturing every
+     * post / dismiss / cancel-registration call in order.
+     */
+    private class RecordingSink : TransferProgressCoordinator.Sink {
+        data class Post(
+            val connectionId: Long,
+            val sourceDeviceName: String?,
+            val progress: TransferProgress,
+        )
+
+        data class CancelRegistration(
+            val connectionId: Long,
+            val onCancel: () -> Unit,
+        )
+
+        val posted: MutableList<Post> = mutableListOf()
+        val dismissed: MutableList<Long> = mutableListOf()
+        val cancelsRegistered: MutableList<CancelRegistration> = mutableListOf()
+        val cancelsUnregistered: MutableList<Long> = mutableListOf()
+
+        override fun postProgress(
+            connectionId: Long,
+            sourceDeviceName: String?,
+            progress: TransferProgress,
+        ) {
+            posted += Post(connectionId, sourceDeviceName, progress)
+        }
+
+        override fun dismissProgress(connectionId: Long) {
+            dismissed += connectionId
+        }
+
+        override fun registerCancel(
+            connectionId: Long,
+            onCancel: () -> Unit,
+        ) {
+            cancelsRegistered += CancelRegistration(connectionId, onCancel)
+        }
+
+        override fun unregisterCancel(connectionId: Long) {
+            cancelsUnregistered += connectionId
+        }
+    }
+}

--- a/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/progress/TransferProgressNotificationContentTest.kt
+++ b/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/progress/TransferProgressNotificationContentTest.kt
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.service.receiver.progress
+
+import com.google.common.truth.Truth.assertThat
+import io.github.kyujincho.wvmg.protocol.connection.TransferProgress
+import org.junit.jupiter.api.Test
+
+/**
+ * JVM-only tests for the textual content of the in-flight transfer
+ * notification (#46).
+ *
+ * The format is the most likely to drift between revisions (English
+ * copy edits, ETA bucket tuning), so pinning it here lets the
+ * Android-side wiring evolve without breaking the rendered string.
+ *
+ * The tests use a recording [TransferProgressNotificationContent.TextResolver]
+ * so we never need a real `Resources`. The resolver echoes a printf
+ * of the key + args, which makes assertions trivial to read.
+ */
+class TransferProgressNotificationContentTest {
+    @Test
+    fun `title uses sender device name when present`() {
+        val content =
+            TransferProgressNotificationContent.from(
+                resolver = englishResolver(),
+                sourceDeviceName = "Pixel 8",
+                progress = quietProgress(50, 100),
+            )
+        assertThat(content.title).isEqualTo("Receiving from Pixel 8")
+    }
+
+    @Test
+    fun `title falls back when device name is null`() {
+        val content =
+            TransferProgressNotificationContent.from(
+                resolver = englishResolver(),
+                sourceDeviceName = null,
+                progress = quietProgress(50, 100),
+            )
+        assertThat(content.title).isEqualTo("Receiving files")
+    }
+
+    @Test
+    fun `title falls back when device name is blank`() {
+        val content =
+            TransferProgressNotificationContent.from(
+                resolver = englishResolver(),
+                sourceDeviceName = "  ",
+                progress = quietProgress(50, 100),
+            )
+        assertThat(content.title).isEqualTo("Receiving files")
+    }
+
+    @Test
+    fun `body shows only size segment while warming up (no rate yet)`() {
+        val content =
+            TransferProgressNotificationContent.from(
+                resolver = englishResolver(),
+                sourceDeviceName = null,
+                progress =
+                    TransferProgress(
+                        bytesTransferred = 1024L,
+                        totalSize = 100L * 1024L * 1024L,
+                        bytesPerSecond = 0L,
+                        etaSeconds = null,
+                    ),
+            )
+        // Just the size segment — no rate, no ETA.
+        assertThat(content.body).isEqualTo("1.0 KB of 100.0 MB")
+    }
+
+    @Test
+    fun `body shows size, rate, and ETA when steady-state`() {
+        val content =
+            TransferProgressNotificationContent.from(
+                resolver = englishResolver(),
+                sourceDeviceName = null,
+                progress =
+                    TransferProgress.of(
+                        bytesTransferred = 50L * 1024L * 1024L,
+                        totalSize = 100L * 1024L * 1024L,
+                        bytesPerSecond = 5L * 1024L * 1024L,
+                    ),
+            )
+        // 50 MB of 100 MB · 5 MB/s · 10 seconds remaining
+        assertThat(content.body).contains("50.0 MB of 100.0 MB")
+        assertThat(content.body).contains("5.0 MB/s")
+        assertThat(content.body).contains("10 seconds remaining")
+    }
+
+    @Test
+    fun `body uses about-minutes phrasing for medium ETAs`() {
+        val content =
+            TransferProgressNotificationContent.from(
+                resolver = englishResolver(),
+                sourceDeviceName = null,
+                // 50 MB remaining at 100 KB/s = 524 s ≈ 9 min.
+                progress =
+                    TransferProgress.of(
+                        bytesTransferred = 0L,
+                        totalSize = 50L * 1024L * 1024L,
+                        bytesPerSecond = 100L * 1024L,
+                    ),
+            )
+        assertThat(content.body).contains("about")
+        assertThat(content.body).contains("minutes")
+        assertThat(content.body).contains("remaining")
+    }
+
+    @Test
+    fun `body uses about-hours phrasing for long ETAs`() {
+        val content =
+            TransferProgressNotificationContent.from(
+                resolver = englishResolver(),
+                sourceDeviceName = null,
+                // 5 GB at 100 KB/s ≈ 14 hours.
+                progress =
+                    TransferProgress.of(
+                        bytesTransferred = 0L,
+                        totalSize = 5L * 1024L * 1024L * 1024L,
+                        bytesPerSecond = 100L * 1024L,
+                    ),
+            )
+        assertThat(content.body).contains("about")
+        assertThat(content.body).contains("hours")
+    }
+
+    @Test
+    fun `progressPercent reflects fraction rounded to nearest integer`() {
+        val content =
+            TransferProgressNotificationContent.from(
+                resolver = englishResolver(),
+                sourceDeviceName = null,
+                progress = quietProgress(33, 100),
+            )
+        assertThat(content.progressPercent).isEqualTo(33)
+        assertThat(content.progressIsDeterminate).isTrue()
+    }
+
+    @Test
+    fun `progress is indeterminate when totalSize is zero`() {
+        val content =
+            TransferProgressNotificationContent.from(
+                resolver = englishResolver(),
+                sourceDeviceName = null,
+                progress = TransferProgress.UNKNOWN,
+            )
+        assertThat(content.progressIsDeterminate).isFalse()
+        assertThat(content.progressPercent).isEqualTo(0)
+    }
+
+    @Test
+    fun `formatBytes produces stable strings across tier boundaries`() {
+        // Keep this tight so a tier-boundary change is caught.
+        assertThat(TransferProgressNotificationContent.formatBytes(0)).isEqualTo("0 B")
+        assertThat(TransferProgressNotificationContent.formatBytes(123)).isEqualTo("123 B")
+        assertThat(TransferProgressNotificationContent.formatBytes(1024)).isEqualTo("1.0 KB")
+        assertThat(TransferProgressNotificationContent.formatBytes(1024L * 1024L)).isEqualTo("1.0 MB")
+        assertThat(TransferProgressNotificationContent.formatBytes(1024L * 1024L * 1024L)).isEqualTo("1.00 GB")
+    }
+
+    private fun quietProgress(
+        transferred: Long,
+        total: Long,
+    ): TransferProgress =
+        TransferProgress(
+            bytesTransferred = transferred,
+            totalSize = total,
+            bytesPerSecond = 0L,
+            etaSeconds = null,
+        )
+
+    /**
+     * Recording resolver that mirrors the English copy in
+     * `service-android/src/main/res/values/strings.xml`. Pinned here
+     * so the test suite is the single source of truth for the
+     * rendered output — a stray copy edit in `strings.xml` will
+     * still be caught by the human-eyed locale review, while the
+     * unit tests stay deterministic.
+     */
+    private fun englishResolver(): TransferProgressNotificationContent.TextResolver =
+        TransferProgressNotificationContent.TextResolver { key, args ->
+            when (key) {
+                TransferProgressNotificationContent.StringKey.TITLE_WITH_NAME ->
+                    "Receiving from ${args[0]}"
+                TransferProgressNotificationContent.StringKey.TITLE_UNKNOWN_SENDER ->
+                    "Receiving files"
+                TransferProgressNotificationContent.StringKey.BODY_SIZE ->
+                    "${args[0]} of ${args[1]}"
+                TransferProgressNotificationContent.StringKey.BODY_RATE ->
+                    "${args[0]}/s"
+                TransferProgressNotificationContent.StringKey.BODY_ETA ->
+                    "${args[0]} remaining"
+                TransferProgressNotificationContent.StringKey.DURATION_FEW_SECONDS ->
+                    "less than a second"
+                TransferProgressNotificationContent.StringKey.DURATION_SECONDS ->
+                    "${args[0]} seconds"
+                TransferProgressNotificationContent.StringKey.DURATION_ABOUT_MINUTES ->
+                    "about ${args[0]} minutes"
+                TransferProgressNotificationContent.StringKey.DURATION_ABOUT_HOURS ->
+                    "about ${args[0]} hours"
+            }
+        }
+}


### PR DESCRIPTION
Closes #46.

## Summary

Adds smoothed bytes/sec rate + ETA to the in-flight transfer state and surfaces it in the receiver foreground notification and the sender UI.

- **core-protocol**: new `TransferProgress` value type and `TransferRateEstimator` (EMA with 1.5 s half-life). Both connection drivers feed the estimator on every chunk and publish the smoothed rate / ETA back through `InboundConnectionState.Receiving` / `OutboundConnectionState.Sending`. Existing `bytesReceived` / `bytesSent` / `totalSize` accessors are preserved as convenience reads onto the new `progress` field, so consumers that did not opt into the rate-aware shape keep compiling.
- **service-android**: new `TransferProgressNotification` on a low-importance `transfer_progress` channel with a determinate progress bar, smoothed rate, ETA, and a Cancel action. The Cancel action routes through `ConsentBroadcastReceiver` to the live `InboundConnection.cancel` via the new `TransferCancelRegistry`. `TransferProgressCoordinator` mirrors `ConsentCoordinator`'s shape and throttles notification updates to ~500 ms (issue acceptance).
- **app**: `SendActivity` renders rate + ETA in the existing status panel via the new `SendProgressFormatter`; phrasing uses spelled-out duration buckets (`30 seconds remaining`, `about 5 minutes remaining`) for accessibility, matching the issue's acceptance criterion.

## Acceptance criteria

- [x] During an active transfer, foreground-service notification updates every ~500 ms with progress %.
- [x] Rate calculated as exponential moving average of recent bytes/second (smooths over jitter).
- [x] ETA = `(total - transferred) / current_rate` (with sane null fallbacks for warming-up / done states).
- [x] Notification has a Cancel action.
- [x] Accessibility-friendly text (`12 MB of 100 MB · 4.2 MB/s · 30 seconds remaining`).

## Tests

- `TransferProgressTest` — ETA invariants, fraction clamping, constructor validation.
- `TransferRateEstimatorTest` — steady-state convergence, warming-up zero, long idle gap reset, non-monotonic clock, edge cases.
- `TransferProgressNotificationContentTest` — body templating, ETA bucket selection, indeterminate fallback.
- `TransferProgressCoordinatorTest` — post on Receiving, dismiss on terminal, cancel-callback registration, results-flow belt-and-braces.

## Test plan

- [ ] Receiver: send a large file (>100 MB) over Wi-Fi LAN; verify the foreground notification shows progress bar, rate, and ETA, updating ~every 500 ms.
- [ ] Receiver: tap the Cancel action mid-transfer; verify the connection terminates cleanly (CancelFrame on the wire) and the notification dismisses.
- [ ] Sender: send a large file; verify the SendActivity status panel renders rate + ETA in the same format.
- [ ] Verify accessibility: open TalkBack and confirm "30 seconds remaining" reads naturally vs "30s remaining".