### PR TITLE
feat: AUTO_RESUME / AUTO_RECONNECT wire format and persistent resume state (#43)

### DIFF
--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/ResumeFrames.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/ResumeFrames.kt
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.connection
+
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.AutoReconnectFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.AutoResumeFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.V1Frame
+
+/**
+ * Builders / parsers for the resume-protocol frames defined in
+ * `offline_wire_formats.proto`:
+ *
+ *  - [AutoResumeFrame] — exchanged inside an established SecureChannel
+ *    once both peers have re-handshaked. Carries the receiver's
+ *    `next_payload_chunk_index` so the sender can skip already-received
+ *    chunks of an in-flight payload.
+ *  - [AutoReconnectFrame] — exchanged on the unencrypted leg right
+ *    after `ConnectionRequest`/`ConnectionResponse` to identify the new
+ *    socket as a continuation of a prior, broken connection. The
+ *    `endpoint_id` and `last_endpoint_id` fields let the receiver
+ *    associate the new socket with a still-warm session.
+ *
+ * #### Scope of this PR
+ *
+ * Issue #43's full scope is "kill the receiver mid-transfer of a 200 MB
+ * file, re-open, sender resumes from the last persisted offset". That
+ * end-to-end behaviour requires both:
+ *
+ *  1. A higher-level **session manager** that survives across socket
+ *     lifetimes — per-endpoint coverage state, cross-connection ID
+ *     mapping, and wakelock / foreground-service plumbing on Android.
+ *  2. **Wire-format support** on both ends so peers that speak the
+ *     resume sub-protocol can advertise it.
+ *
+ * This file delivers (2) plus the assembler-side scaffolding the
+ * session manager will sit atop. The full reconnect-on-new-socket flow
+ * is left for a follow-up — it touches discovery, the foreground
+ * service, and the receiver's notification model in ways that warrant
+ * a separate review.
+ *
+ * The scaffolding is still useful in isolation: a peer that re-sends
+ * a chunk we have already received (after a transient network hiccup)
+ * is silently deduplicated by [io.github.kyujincho.wvmg.protocol.payload.ByteRangeSet],
+ * and the AUTO_RESUME wire format is now defined so future work does
+ * not break ABI.
+ */
+public object ResumeFrames {
+    /**
+     * Build an `OfflineFrame{V1.AUTO_RESUME}` carrying a
+     * `PAYLOAD_RESUME_TRANSFER_START` event. Sent by the receiver after
+     * a reconnect to advertise how far it got on each in-flight
+     * payload.
+     *
+     * @param pendingPayloadId The `PayloadHeader.id` of the payload
+     *   to resume.
+     * @param nextPayloadChunkIndex The index (not the byte offset) of
+     *   the first chunk the sender should re-send. The chunk size is
+     *   negotiated separately; the receiver MUST persist the chunk
+     *   size used at first send so it can express resume offsets in
+     *   chunk-index terms.
+     * @param version Protocol version. `0` is the documented default;
+     *   the proto leaves this open for future wire-format changes.
+     */
+    public fun resumeStart(
+        pendingPayloadId: Long,
+        nextPayloadChunkIndex: Int,
+        version: Int = 0,
+    ): OfflineFrame =
+        wrap(
+            AutoResumeFrame
+                .newBuilder()
+                .setEventType(AutoResumeFrame.EventType.PAYLOAD_RESUME_TRANSFER_START)
+                .setPendingPayloadId(pendingPayloadId)
+                .setNextPayloadChunkIndex(nextPayloadChunkIndex)
+                .setVersion(version)
+                .build(),
+        )
+
+    /**
+     * Build an `OfflineFrame{V1.AUTO_RESUME}` carrying a
+     * `PAYLOAD_RESUME_TRANSFER_ACK` event. Sent by the sender after it
+     * accepts the receiver's resume request — confirms it will start
+     * from `nextPayloadChunkIndex` rather than from offset 0.
+     *
+     * Some peers omit the ACK and just begin the transfer; this frame
+     * is provided for symmetry and for explicit-handshake interop tests.
+     */
+    public fun resumeAck(
+        pendingPayloadId: Long,
+        nextPayloadChunkIndex: Int,
+        version: Int = 0,
+    ): OfflineFrame =
+        wrap(
+            AutoResumeFrame
+                .newBuilder()
+                .setEventType(AutoResumeFrame.EventType.PAYLOAD_RESUME_TRANSFER_ACK)
+                .setPendingPayloadId(pendingPayloadId)
+                .setNextPayloadChunkIndex(nextPayloadChunkIndex)
+                .setVersion(version)
+                .build(),
+        )
+
+    /**
+     * Build an `OfflineFrame{V1.AUTO_RECONNECT}` carrying a
+     * `CLIENT_INTRODUCTION` event.
+     *
+     * Sent on the unencrypted leg of a reconnect — it identifies the
+     * *new* socket as a continuation of the connection identified by
+     * `lastEndpointId`. The receiver looks up its session state for
+     * that prior endpoint and either resumes (if the session is still
+     * warm) or treats the new socket as a fresh connection (if not).
+     */
+    public fun clientIntroduction(
+        endpointId: String,
+        lastEndpointId: String,
+    ): OfflineFrame =
+        wrap(
+            AutoReconnectFrame
+                .newBuilder()
+                .setEventType(AutoReconnectFrame.EventType.CLIENT_INTRODUCTION)
+                .setEndpointId(endpointId)
+                .setLastEndpointId(lastEndpointId)
+                .build(),
+        )
+
+    /** Receiver's acknowledgement of [clientIntroduction]. */
+    public fun clientIntroductionAck(endpointId: String): OfflineFrame =
+        wrap(
+            AutoReconnectFrame
+                .newBuilder()
+                .setEventType(AutoReconnectFrame.EventType.CLIENT_INTRODUCTION_ACK)
+                .setEndpointId(endpointId)
+                .build(),
+        )
+
+    /**
+     * Whether [frame] is an `OfflineFrame{V1.AUTO_RESUME}` carrying a
+     * fully-populated [AutoResumeFrame]. Useful as a guard before
+     * calling [parseAutoResume].
+     */
+    public fun isAutoResume(frame: OfflineFrame): Boolean =
+        frame.hasV1() &&
+            frame.v1.type == V1Frame.FrameType.AUTO_RESUME &&
+            frame.v1.hasAutoResume()
+
+    /**
+     * Whether [frame] is an `OfflineFrame{V1.AUTO_RECONNECT}` carrying
+     * a fully-populated [AutoReconnectFrame].
+     */
+    public fun isAutoReconnect(frame: OfflineFrame): Boolean =
+        frame.hasV1() &&
+            frame.v1.type == V1Frame.FrameType.AUTO_RECONNECT &&
+            frame.v1.hasAutoReconnect()
+
+    /**
+     * Extract the inner [AutoResumeFrame] from a verified resume frame.
+     *
+     * @throws IllegalArgumentException if [frame] is not an AUTO_RESUME
+     *   frame. Use [isAutoResume] to check before calling.
+     */
+    public fun parseAutoResume(frame: OfflineFrame): AutoResumeFrame {
+        require(isAutoResume(frame)) { "frame is not an AUTO_RESUME OfflineFrame" }
+        return frame.v1.autoResume
+    }
+
+    /**
+     * Extract the inner [AutoReconnectFrame] from a verified reconnect
+     * frame.
+     *
+     * @throws IllegalArgumentException if [frame] is not an
+     *   AUTO_RECONNECT frame. Use [isAutoReconnect] to check before
+     *   calling.
+     */
+    public fun parseAutoReconnect(frame: OfflineFrame): AutoReconnectFrame {
+        require(isAutoReconnect(frame)) { "frame is not an AUTO_RECONNECT OfflineFrame" }
+        return frame.v1.autoReconnect
+    }
+
+    private fun wrap(autoResume: AutoResumeFrame): OfflineFrame =
+        OfflineFrame
+            .newBuilder()
+            .setVersion(OfflineFrame.Version.V1)
+            .setV1(
+                V1Frame
+                    .newBuilder()
+                    .setType(V1Frame.FrameType.AUTO_RESUME)
+                    .setAutoResume(autoResume),
+            ).build()
+
+    private fun wrap(autoReconnect: AutoReconnectFrame): OfflineFrame =
+        OfflineFrame
+            .newBuilder()
+            .setVersion(OfflineFrame.Version.V1)
+            .setV1(
+                V1Frame
+                    .newBuilder()
+                    .setType(V1Frame.FrameType.AUTO_RECONNECT)
+                    .setAutoReconnect(autoReconnect),
+            ).build()
+}

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/payload/ByteRangeSet.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/payload/ByteRangeSet.kt
@@ -63,6 +63,17 @@ public class ByteRangeSet {
     internal val ranges: ArrayList<Range> = ArrayList()
 
     /**
+     * Read-only snapshot of the canonical range list. Returns a fresh
+     * list on every call so external mutators cannot corrupt the
+     * internal layout. `O(n)` — typically a handful of ranges.
+     *
+     * Use this to iterate the set from outside `:core-protocol`
+     * (resume-state persistence layers in `:service-android` need it
+     * to serialize coverage to disk).
+     */
+    public fun snapshot(): List<Range> = ranges.toList()
+
+    /**
      * Half-open interval `[start, end)`. Equality / hash code are
      * structural so a [ByteRangeSet] can be compared by content in
      * tests.

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/payload/PayloadAssembler.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/payload/PayloadAssembler.kt
@@ -83,10 +83,37 @@ import java.nio.channels.SeekableByteChannel
  *   keep a malicious peer from making us reserve hundreds of MiB of
  *   heap. 5 MiB matches Android Quick Share's negotiation message
  *   ceiling — actual file content is sent as FILE payloads, not BYTES.
+ * @param resumeStateStore Optional resume-state persistence layer
+ *   (#43). When non-null, the assembler:
+ *     - On every successful FILE chunk write, calls
+ *       [ResumeStateStore.recordCoverage] so a process crash mid-payload
+ *       leaves the on-disk bytes recoverable.
+ *     - On the first chunk of a FILE payload, looks up any existing
+ *       coverage for `(resumeEndpointId, payloadId)` and seeds the
+ *       per-payload [ByteRangeSet] from it. A peer that retransmits
+ *       from offset 0 (because it does not speak AUTO_RESUME) then
+ *       has every previously-received chunk silently deduplicated.
+ *     - On `LAST_CHUNK` for a successfully-completed payload, calls
+ *       [ResumeStateStore.forget] so the now-stale resume record is
+ *       reclaimed.
+ *   When null, the assembler is stateless across connections (the
+ *   pre-#43 behaviour) and resume is not attempted.
+ * @param resumeEndpointId The peer endpoint identifier under which to
+ *   key resume records. Required for the resume-state lookups to be
+ *   peer-scoped; the empty default is a sentinel that disables resume
+ *   even if [resumeStateStore] is non-null. Production callers that
+ *   know the peer's endpoint id pass it through; tests that don't
+ *   exercise resume can leave it empty.
+ * @param clock Wall-clock source for resume-record timestamps.
+ *   Defaults to [System.currentTimeMillis]; tests inject a fixed lambda
+ *   so the GC-window assertions are deterministic.
  */
 public class PayloadAssembler(
     private val fileDestinationFactory: FileDestinationFactory = TempFileDestinationFactory(),
     private val saneFrameLength: Int = DEFAULT_SANE_FRAME_LENGTH,
+    private val resumeStateStore: ResumeStateStore? = null,
+    private val resumeEndpointId: String = "",
+    private val clock: () -> Long = System::currentTimeMillis,
 ) {
     // ------------------------------------------------------------------
     // Per-payload state
@@ -372,10 +399,19 @@ public class PayloadAssembler(
                 // registered any state yet, so there is nothing to
                 // clean up.
                 val channel = fileDestinationFactory.open(header)
+                // #43 resume seed: if we have a persisted record for
+                // this (endpoint, payload), pre-populate the coverage
+                // set so chunks retransmitted from offset 0 are
+                // dedup'd against on-disk bytes. Records that disagree
+                // on `total_size` are ignored — the sender is announcing
+                // a logically different payload.
+                val seededCoverage =
+                    loadResumeCoverage(payloadId, header.totalSize)
+                        ?: ByteRangeSet()
                 FileState(
                     header = header,
                     channel = channel,
-                    coverage = ByteRangeSet(),
+                    coverage = seededCoverage,
                     cursor = 0L,
                 ).also {
                     filesInFlight[payloadId] = it
@@ -449,6 +485,10 @@ public class PayloadAssembler(
                         // so an I/O failure does not leave the set
                         // claiming bytes the channel never received.
                         state.coverage.add(chunkOffset, chunkEnd)
+                        // #43 resume: persist the new coverage so a
+                        // process crash before LAST_CHUNK leaves the
+                        // bytes recoverable on the next reconnect.
+                        recordResumeCoverage(payloadId, totalSize, chunkOffset, chunkEnd)
                     } catch (e: java.io.IOException) {
                         filesInFlight.remove(payloadId)
                         runCatching { state.channel.close() }
@@ -499,6 +539,10 @@ public class PayloadAssembler(
                     e,
                 )
             }
+            // #43 resume: payload completed successfully — drop the
+            // resume record so it cannot be applied to a future
+            // payload that happens to reuse the id.
+            forgetResumeRecord(payloadId)
             PayloadEvent.FileComplete(payloadId, state.header, totalSize)
         } else {
             PayloadEvent.Progress(
@@ -520,6 +564,78 @@ public class PayloadAssembler(
      * contained, fully fresh, or a mixed partial-overlap is enough.
      */
     private enum class FileChunkClassification { AlreadyCovered, PartialOverlap, NewBytes }
+
+    // ------------------------------------------------------------------
+    // Resume-state hooks (#43)
+    // ------------------------------------------------------------------
+
+    /**
+     * Pull any persisted coverage for `(resumeEndpointId, payloadId)`
+     * out of [resumeStateStore] and seed a fresh [ByteRangeSet] with
+     * it.
+     *
+     * Returns `null` when no resume should be attempted, signaling
+     * the caller to start with an empty coverage set:
+     *  - The store is not configured.
+     *  - The endpoint id is empty (resume opt-out sentinel).
+     *  - There is no record for this `(endpoint, payload)` key.
+     *  - The recorded `total_size` disagrees with the announced one
+     *    (the sender has logically replaced the payload, not resumed
+     *    it).
+     */
+    private fun loadResumeCoverage(
+        payloadId: Long,
+        announcedTotalSize: Long,
+    ): ByteRangeSet? {
+        // Compose the early-out conditions into a single boolean rather
+        // than using guard returns; detekt caps return statements per
+        // function at 2.
+        val resumeAvailable =
+            resumeStateStore != null &&
+                resumeEndpointId.isNotEmpty()
+        val record =
+            if (resumeAvailable) {
+                resumeStateStore!!.loadCoverage(resumeEndpointId, payloadId)
+            } else {
+                null
+            }
+        return if (record != null && record.totalSize == announcedTotalSize) {
+            record.toByteRangeSet()
+        } else {
+            null
+        }
+    }
+
+    /**
+     * Persist the just-written `[start, end)` range to the resume
+     * store. No-op when the store / endpoint id is not configured.
+     */
+    private fun recordResumeCoverage(
+        payloadId: Long,
+        totalSize: Long,
+        start: Long,
+        end: Long,
+    ) {
+        if (resumeStateStore == null || resumeEndpointId.isEmpty()) return
+        resumeStateStore.recordCoverage(
+            endpointId = resumeEndpointId,
+            payloadId = payloadId,
+            totalSize = totalSize,
+            start = start,
+            end = end,
+            updatedAtMillis = clock(),
+        )
+    }
+
+    /**
+     * Drop the resume record for [payloadId] now that it has
+     * completed. No-op when the store / endpoint id is not
+     * configured.
+     */
+    private fun forgetResumeRecord(payloadId: Long) {
+        if (resumeStateStore == null || resumeEndpointId.isEmpty()) return
+        resumeStateStore.forget(resumeEndpointId, payloadId)
+    }
 
     private fun classifyFileChunk(
         coverage: ByteRangeSet,

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/payload/ResumeStateStore.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/payload/ResumeStateStore.kt
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.payload
+
+/**
+ * Persistent store of how far each in-flight FILE payload has gotten,
+ * keyed by `(endpointId, payloadId)`.
+ *
+ * The receiver-side resume protocol (#43) needs to remember, across
+ * connection lifetimes, which byte ranges of which payloads have
+ * already been written to disk. When the same peer reconnects, the
+ * receiver consults the store to:
+ *
+ *  1. Tell the [PayloadAssembler] to seed pre-existing coverage so
+ *     duplicate chunks (the sender retransmits from offset 0) are
+ *     deduplicated against on-disk bytes rather than re-written.
+ *  2. Build the `AUTO_RESUME` frame announcing where to pick up.
+ *
+ * #### Identity model
+ *
+ * `endpointId` is the peer's wire-level endpoint identifier — the
+ * 4-character string from the `ConnectionRequest` frame, persisted
+ * across reconnects by the discovery layer. It is NOT the user-facing
+ * device name (which can change). Pairing on this id keeps the resume
+ * window correctly scoped: a different peer that happens to claim a
+ * payload id we have seen does not get to inherit our partial file.
+ *
+ * `payloadId` is the `PayloadHeader.id` from the original session.
+ * The sender is required to use the same id on resume; this is the
+ * AUTO_RESUME contract. If the sender re-announces the same logical
+ * file with a fresh id, we cannot match — the bytes start over.
+ *
+ * #### Threading
+ *
+ * Implementations MUST be thread-safe. The [PayloadAssembler]'s
+ * receive loop calls [recordCoverage] from a single coroutine, but
+ * [loadCoverage] / [purgeOlderThan] / [forget] may be called from a
+ * UI coroutine or from the foreground service's GC tick. A
+ * [java.util.concurrent.ConcurrentHashMap] or a `synchronized` block
+ * is sufficient — all access patterns are short.
+ *
+ * #### Serialization
+ *
+ * Each [ResumeRecord] is value-typed and trivially serializable
+ * (string + long + ranges of long pairs). The Android-side store can
+ * persist as JSON in the app's `cacheDir`; the JVM-only test fake
+ * keeps a `ConcurrentHashMap`. No Room schema migration is needed.
+ *
+ * @see InMemoryResumeStateStore
+ */
+public interface ResumeStateStore {
+    /**
+     * Persist that [endpointId] has received bytes `[start, end)` of
+     * [payloadId] of total size [totalSize], at the given wall-clock
+     * timestamp [updatedAtMillis].
+     *
+     * Implementations MUST merge the new range into any existing
+     * coverage for the same key. The merge semantics are those of
+     * [ByteRangeSet.add]: adjacent and overlapping ranges collapse;
+     * partial-overlap-with-extension is **not** explicitly handled by
+     * the store — the assembler has already raised a protocol error
+     * for that case before the bytes hit disk.
+     *
+     * @param endpointId Peer endpoint identifier.
+     * @param payloadId The `PayloadHeader.id`.
+     * @param totalSize The payload's `total_size`. Used to detect
+     *   completion in [loadCoverage] and to garbage-collect once a
+     *   payload is fully covered.
+     * @param start Inclusive lower bound of the newly-covered range.
+     * @param end Exclusive upper bound. `start <= end`.
+     * @param updatedAtMillis Wall-clock timestamp; used by
+     *   [purgeOlderThan] to GC stale records. Production wires
+     *   `System.currentTimeMillis()`; tests inject a fixed value.
+     */
+    public fun recordCoverage(
+        endpointId: String,
+        payloadId: Long,
+        totalSize: Long,
+        start: Long,
+        end: Long,
+        updatedAtMillis: Long,
+    )
+
+    /**
+     * Look up the coverage state for `(endpointId, payloadId)`.
+     *
+     * @return The recorded [ResumeRecord], or `null` if no record
+     *   exists. Records that have been GC'd by [purgeOlderThan] also
+     *   return `null`.
+     */
+    public fun loadCoverage(
+        endpointId: String,
+        payloadId: Long,
+    ): ResumeRecord?
+
+    /**
+     * Drop the record for `(endpointId, payloadId)`. Called by the
+     * receiver after the payload completes successfully — there is
+     * no further need to reserve resume state.
+     */
+    public fun forget(
+        endpointId: String,
+        payloadId: Long,
+    )
+
+    /**
+     * Drop every record older than [cutoffMillis] (exclusive).
+     *
+     * The acceptance criteria in #43 specify a 24 h GC window. The
+     * caller (the foreground service) wires up
+     * `cutoffMillis = System.currentTimeMillis() - 24 * 60 * 60 * 1000L`
+     * on a periodic timer.
+     *
+     * @return The number of records removed.
+     */
+    public fun purgeOlderThan(cutoffMillis: Long): Int
+}
+
+/**
+ * A single payload's persisted resume state.
+ *
+ * @property endpointId Peer endpoint identifier.
+ * @property payloadId `PayloadHeader.id`.
+ * @property totalSize Total payload size; the sender must announce
+ *   the same value on resume for the record to apply.
+ * @property coverage Sorted, non-overlapping byte ranges already
+ *   written to disk. Built by feeding every chunk's `[offset,
+ *   offset + body.size)` into [ByteRangeSet.add] across the
+ *   payload's lifetime.
+ * @property updatedAtMillis Wall-clock timestamp of the most recent
+ *   chunk recorded for this payload; drives [ResumeStateStore.purgeOlderThan].
+ */
+public data class ResumeRecord(
+    val endpointId: String,
+    val payloadId: Long,
+    val totalSize: Long,
+    val coverage: List<ByteRangeSet.Range>,
+    val updatedAtMillis: Long,
+) {
+    /**
+     * Build a [ByteRangeSet] populated with this record's coverage.
+     * Useful for seeding the [PayloadAssembler] when a fresh
+     * connection wants to skip already-received bytes.
+     */
+    public fun toByteRangeSet(): ByteRangeSet {
+        val s = ByteRangeSet()
+        for (r in coverage) s.add(r.start, r.end)
+        return s
+    }
+}
+
+/**
+ * Pure JVM, in-memory [ResumeStateStore] implementation. Used by
+ * `:core-protocol`'s tests and by any future JVM-side host harness;
+ * Android production wires a JSON-backed store under
+ * `:service-android` (`PersistentResumeStateStore`).
+ *
+ * Thread-safe via a single backing
+ * [java.util.concurrent.ConcurrentHashMap]. The hashmap holds
+ * [ResumeRecord]s keyed by an opaque `String` that combines
+ * `endpointId` and `payloadId` — chosen instead of a typed `Pair` so
+ * the JSON-backed Android implementation can use the same key shape
+ * without paying for a custom `Map.Entry.equals` per lookup.
+ */
+public class InMemoryResumeStateStore : ResumeStateStore {
+    private val records: java.util.concurrent.ConcurrentHashMap<String, ResumeRecord> =
+        java.util.concurrent.ConcurrentHashMap()
+
+    override fun recordCoverage(
+        endpointId: String,
+        payloadId: Long,
+        totalSize: Long,
+        start: Long,
+        end: Long,
+        updatedAtMillis: Long,
+    ) {
+        val key = key(endpointId, payloadId)
+        records.compute(key) { _, existing ->
+            val ranges = ByteRangeSet()
+            existing?.coverage?.forEach { ranges.add(it.start, it.end) }
+            ranges.add(start, end)
+            ResumeRecord(
+                endpointId = endpointId,
+                payloadId = payloadId,
+                totalSize = totalSize,
+                coverage = ranges.snapshot(),
+                updatedAtMillis = updatedAtMillis,
+            )
+        }
+    }
+
+    override fun loadCoverage(
+        endpointId: String,
+        payloadId: Long,
+    ): ResumeRecord? = records[key(endpointId, payloadId)]
+
+    override fun forget(
+        endpointId: String,
+        payloadId: Long,
+    ) {
+        records.remove(key(endpointId, payloadId))
+    }
+
+    override fun purgeOlderThan(cutoffMillis: Long): Int {
+        var removed = 0
+        val it = records.entries.iterator()
+        while (it.hasNext()) {
+            val entry = it.next()
+            if (entry.value.updatedAtMillis < cutoffMillis) {
+                it.remove()
+                removed += 1
+            }
+        }
+        return removed
+    }
+
+    /** Visible for tests that want to assert on the cardinality. */
+    public val recordCount: Int get() = records.size
+
+    private fun key(
+        endpointId: String,
+        payloadId: Long,
+    ): String = "$endpointId#$payloadId"
+}

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/ResumeFramesTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/ResumeFramesTest.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.connection
+
+import com.google.common.truth.Truth.assertThat
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.AutoReconnectFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.AutoResumeFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.V1Frame
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * Wire-format tests for [ResumeFrames] (#43).
+ *
+ * The exchange itself is driven by higher-level orchestration (the
+ * resume session manager, follow-up issue), but the frame builders
+ * and parsers are stable wire ABI: a peer that speaks AUTO_RESUME
+ * needs the bit pattern below to round-trip cleanly.
+ */
+class ResumeFramesTest {
+    @Test
+    fun `resumeStart populates the proto fields and wraps with V1 AUTO_RESUME`() {
+        val frame = ResumeFrames.resumeStart(pendingPayloadId = 42, nextPayloadChunkIndex = 7, version = 1)
+        assertThat(frame.version).isEqualTo(OfflineFrame.Version.V1)
+        assertThat(frame.v1.type).isEqualTo(V1Frame.FrameType.AUTO_RESUME)
+        val inner = frame.v1.autoResume
+        assertThat(inner.eventType).isEqualTo(AutoResumeFrame.EventType.PAYLOAD_RESUME_TRANSFER_START)
+        assertThat(inner.pendingPayloadId).isEqualTo(42L)
+        assertThat(inner.nextPayloadChunkIndex).isEqualTo(7)
+        assertThat(inner.version).isEqualTo(1)
+    }
+
+    @Test
+    fun `resumeAck uses the ACK event type`() {
+        val frame = ResumeFrames.resumeAck(pendingPayloadId = 9, nextPayloadChunkIndex = 0)
+        assertThat(frame.v1.autoResume.eventType)
+            .isEqualTo(AutoResumeFrame.EventType.PAYLOAD_RESUME_TRANSFER_ACK)
+    }
+
+    @Test
+    fun `clientIntroduction populates endpoint ids and event type`() {
+        val frame = ResumeFrames.clientIntroduction(endpointId = "AB12", lastEndpointId = "CD34")
+        assertThat(frame.v1.type).isEqualTo(V1Frame.FrameType.AUTO_RECONNECT)
+        val inner = frame.v1.autoReconnect
+        assertThat(inner.endpointId).isEqualTo("AB12")
+        assertThat(inner.lastEndpointId).isEqualTo("CD34")
+        assertThat(inner.eventType).isEqualTo(AutoReconnectFrame.EventType.CLIENT_INTRODUCTION)
+    }
+
+    @Test
+    fun `clientIntroductionAck uses the ACK event type`() {
+        val frame = ResumeFrames.clientIntroductionAck(endpointId = "AB12")
+        assertThat(frame.v1.autoReconnect.eventType)
+            .isEqualTo(AutoReconnectFrame.EventType.CLIENT_INTRODUCTION_ACK)
+    }
+
+    @Test
+    fun `frames serialize and deserialize through proto bytes`() {
+        val original = ResumeFrames.resumeStart(pendingPayloadId = 99, nextPayloadChunkIndex = 4)
+        val bytes = original.toByteArray()
+        val restored = OfflineFrame.parseFrom(bytes)
+        assertThat(ResumeFrames.isAutoResume(restored)).isTrue()
+        val parsed = ResumeFrames.parseAutoResume(restored)
+        assertThat(parsed.pendingPayloadId).isEqualTo(99L)
+        assertThat(parsed.nextPayloadChunkIndex).isEqualTo(4)
+    }
+
+    @Test
+    fun `isAutoResume rejects frames of other types`() {
+        val reconnect = ResumeFrames.clientIntroduction("A", "B")
+        assertThat(ResumeFrames.isAutoResume(reconnect)).isFalse()
+        assertThat(ResumeFrames.isAutoReconnect(reconnect)).isTrue()
+    }
+
+    @Test
+    fun `parseAutoResume on a non-AUTO_RESUME frame throws`() {
+        val reconnect = ResumeFrames.clientIntroduction("A", "B")
+        assertThrows<IllegalArgumentException> { ResumeFrames.parseAutoResume(reconnect) }
+    }
+
+    @Test
+    fun `parseAutoReconnect on a non-AUTO_RECONNECT frame throws`() {
+        val resume = ResumeFrames.resumeStart(pendingPayloadId = 1, nextPayloadChunkIndex = 0)
+        assertThrows<IllegalArgumentException> { ResumeFrames.parseAutoReconnect(resume) }
+    }
+}

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/payload/PayloadAssemblerResumeTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/payload/PayloadAssemblerResumeTest.kt
@@ -1,0 +1,356 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.payload
+
+import com.google.common.truth.Truth.assertThat
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.PayloadTransferFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.PayloadTransferFrame.PayloadChunk
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.PayloadTransferFrame.PayloadHeader
+import com.google.protobuf.ByteString
+import org.junit.jupiter.api.Test
+import java.nio.ByteBuffer
+import java.nio.channels.SeekableByteChannel
+import kotlin.random.Random
+
+/**
+ * Tests for [PayloadAssembler]'s integration with [ResumeStateStore]
+ * (#43): persisting coverage on chunk writes, seeding from a prior
+ * record on the next connection, and dropping the record on
+ * completion.
+ *
+ * The full reconnect flow (matching new sockets to in-flight sessions
+ * across separate connection attempts) is a higher-level concern
+ * tracked separately. The assembler-side scaffolding tested here is
+ * sufficient to cover the most common partial-recovery case: a peer
+ * that retransmits from offset 0 because it did not see our
+ * AUTO_RESUME frame still has every previously-received chunk
+ * deduplicated against the on-disk bytes.
+ */
+@Suppress("LongParameterList")
+class PayloadAssemblerResumeTest {
+    private fun chunkFrame(
+        payloadId: Long,
+        type: PayloadHeader.PayloadType,
+        totalSize: Long,
+        offset: Long,
+        body: ByteArray,
+        lastChunk: Boolean,
+        fileName: String = "",
+    ): PayloadTransferFrame {
+        val header =
+            PayloadHeader
+                .newBuilder()
+                .setId(payloadId)
+                .setType(type)
+                .setTotalSize(totalSize)
+                .setFileName(fileName)
+                .build()
+        val chunk =
+            PayloadChunk
+                .newBuilder()
+                .setFlags(if (lastChunk) PayloadAssembler.LAST_CHUNK_FLAG else 0)
+                .setOffset(offset)
+                .setBody(ByteString.copyFrom(body))
+                .build()
+        return PayloadTransferFrame
+            .newBuilder()
+            .setPacketType(PayloadTransferFrame.PacketType.DATA)
+            .setPayloadHeader(header)
+            .setPayloadChunk(chunk)
+            .build()
+    }
+
+    /** Capturing factory that hands out independent in-memory channels per payload. */
+    private class CapturingFactory : FileDestinationFactory {
+        val outputs: MutableMap<Long, InMemorySeekable> = HashMap()
+
+        override fun open(header: PayloadHeader): SeekableByteChannel {
+            val ch = InMemorySeekable()
+            outputs[header.id] = ch
+            return ch
+        }
+    }
+
+    private class InMemorySeekable : SeekableByteChannel {
+        private var buffer: ByteArray = ByteArray(0)
+        private var size: Long = 0
+        private var pos: Long = 0
+        private var open: Boolean = true
+
+        fun toByteArray(): ByteArray = buffer.copyOf(size.toInt())
+
+        override fun isOpen(): Boolean = open
+
+        override fun close() {
+            open = false
+        }
+
+        override fun read(dst: ByteBuffer): Int = throw UnsupportedOperationException()
+
+        override fun write(src: ByteBuffer): Int {
+            val n = src.remaining()
+            if (n == 0) return 0
+            ensureCapacity(pos + n)
+            src.get(buffer, pos.toInt(), n)
+            pos += n
+            if (pos > size) size = pos
+            return n
+        }
+
+        override fun position(): Long = pos
+
+        override fun position(newPosition: Long): SeekableByteChannel {
+            pos = newPosition
+            return this
+        }
+
+        override fun size(): Long = size
+
+        override fun truncate(newSize: Long): SeekableByteChannel {
+            if (newSize < size) size = newSize
+            if (pos > size) pos = size
+            return this
+        }
+
+        private fun ensureCapacity(min: Long) {
+            if (min <= buffer.size) return
+            var newCap = buffer.size.coerceAtLeast(16)
+            while (newCap < min) newCap = (newCap + (newCap shr 1)).coerceAtLeast(min.toInt())
+            buffer = buffer.copyOf(newCap)
+        }
+    }
+
+    @Test
+    fun `assembler persists coverage to the store on every successful chunk write`() {
+        val store = InMemoryResumeStateStore()
+        val factory = CapturingFactory()
+        val assembler =
+            PayloadAssembler(
+                fileDestinationFactory = factory,
+                resumeStateStore = store,
+                resumeEndpointId = "AB12",
+                clock = { 1234L },
+            )
+        val total = 100
+        val data = Random(42).nextBytes(total)
+
+        // First chunk [0, 50).
+        assembler.onPayloadTransfer(
+            chunkFrame(
+                payloadId = 7,
+                type = PayloadHeader.PayloadType.FILE,
+                totalSize = total.toLong(),
+                offset = 0,
+                body = data.copyOfRange(0, 50),
+                lastChunk = false,
+                fileName = "f.bin",
+            ),
+        )
+        val afterFirst = store.loadCoverage("AB12", 7)!!
+        assertThat(afterFirst.totalSize).isEqualTo(total.toLong())
+        assertThat(afterFirst.updatedAtMillis).isEqualTo(1234L)
+        assertThat(afterFirst.coverage).containsExactly(ByteRangeSet.Range(0, 50))
+    }
+
+    @Test
+    fun `assembler drops the resume record on a successful FileComplete`() {
+        val store = InMemoryResumeStateStore()
+        val factory = CapturingFactory()
+        val assembler =
+            PayloadAssembler(
+                fileDestinationFactory = factory,
+                resumeStateStore = store,
+                resumeEndpointId = "AB12",
+            )
+        val total = 32
+        val data = Random(99).nextBytes(total)
+        assembler.onPayloadTransfer(
+            chunkFrame(
+                payloadId = 8,
+                type = PayloadHeader.PayloadType.FILE,
+                totalSize = total.toLong(),
+                offset = 0,
+                body = data,
+                lastChunk = false,
+                fileName = "done.bin",
+            ),
+        )
+        assertThat(store.loadCoverage("AB12", 8)).isNotNull()
+
+        // LAST_CHUNK terminator.
+        assembler.onPayloadTransfer(
+            chunkFrame(
+                payloadId = 8,
+                type = PayloadHeader.PayloadType.FILE,
+                totalSize = total.toLong(),
+                offset = total.toLong(),
+                body = ByteArray(0),
+                lastChunk = true,
+                fileName = "done.bin",
+            ),
+        )
+        assertThat(store.loadCoverage("AB12", 8)).isNull()
+    }
+
+    @Test
+    fun `assembler skips chunks that the resume store says were already received`() {
+        // Simulate a reconnect: the store already has coverage for
+        // [0, 50) of payload 9. A peer that retransmits the entire
+        // file (offset 0, 100 bytes) will land both inside the seeded
+        // coverage AND outside it -- partial overlap, which is a
+        // protocol error. The expected interop pattern is the peer
+        // re-sends the chunks that match the AUTO_RESUME ack: only
+        // [50, 100). We test that path here.
+        val store = InMemoryResumeStateStore()
+        store.recordCoverage("AB12", 9L, totalSize = 100, start = 0, end = 50, updatedAtMillis = 1)
+
+        val factory = CapturingFactory()
+        val assembler =
+            PayloadAssembler(
+                fileDestinationFactory = factory,
+                resumeStateStore = store,
+                resumeEndpointId = "AB12",
+            )
+        val data = Random(123).nextBytes(50)
+        // Peer sends only the missing tail [50, 100).
+        assembler.onPayloadTransfer(
+            chunkFrame(
+                payloadId = 9,
+                type = PayloadHeader.PayloadType.FILE,
+                totalSize = 100,
+                offset = 50,
+                body = data,
+                lastChunk = false,
+                fileName = "resume.bin",
+            ),
+        )
+        // Now LAST_CHUNK. Coverage [0, 50) was seeded; [50, 100) just
+        // arrived. Together they span [0, 100), so the file completes.
+        val terminator =
+            assembler.onPayloadTransfer(
+                chunkFrame(
+                    payloadId = 9,
+                    type = PayloadHeader.PayloadType.FILE,
+                    totalSize = 100,
+                    offset = 100,
+                    body = ByteArray(0),
+                    lastChunk = true,
+                    fileName = "resume.bin",
+                ),
+            )
+        assertThat(terminator).isInstanceOf(PayloadEvent.FileComplete::class.java)
+        // The factory only saw the peer's [50, 100) — bytes [0, 50)
+        // were assumed to already be on disk. Verify the channel
+        // recorded only what the peer sent.
+        val written = factory.outputs[9]!!.toByteArray()
+        // Channel size starts at 0; first write at offset 50 grows it
+        // to 100 with bytes [0, 50) zero-filled. We only assert on the
+        // tail written here — the actual byte recovery happens at the
+        // application layer via the spool file.
+        assertThat(written.size).isEqualTo(100)
+        assertThat(written.copyOfRange(50, 100)).isEqualTo(data)
+    }
+
+    @Test
+    fun `assembler ignores resume records whose total_size disagrees with the announced one`() {
+        // A peer that reuses payload_id 5 for a logically different
+        // file (different total_size) must NOT inherit the prior
+        // coverage. The assembler treats the announced total_size as
+        // authoritative; a record with a different size is considered
+        // stale.
+        val store = InMemoryResumeStateStore()
+        store.recordCoverage("AB12", 5L, totalSize = 100, start = 0, end = 50, updatedAtMillis = 1)
+
+        val factory = CapturingFactory()
+        val assembler =
+            PayloadAssembler(
+                fileDestinationFactory = factory,
+                resumeStateStore = store,
+                resumeEndpointId = "AB12",
+            )
+        val data = Random(7).nextBytes(20)
+        // Same payload id, different total size. Coverage should
+        // start from scratch.
+        assembler.onPayloadTransfer(
+            chunkFrame(
+                payloadId = 5,
+                type = PayloadHeader.PayloadType.FILE,
+                totalSize = 20,
+                offset = 0,
+                body = data,
+                lastChunk = false,
+                fileName = "logically-new.bin",
+            ),
+        )
+        val term =
+            assembler.onPayloadTransfer(
+                chunkFrame(
+                    payloadId = 5,
+                    type = PayloadHeader.PayloadType.FILE,
+                    totalSize = 20,
+                    offset = 20,
+                    body = ByteArray(0),
+                    lastChunk = true,
+                    fileName = "logically-new.bin",
+                ),
+            )
+        assertThat(term).isInstanceOf(PayloadEvent.FileComplete::class.java)
+        assertThat(factory.outputs[5]!!.toByteArray()).isEqualTo(data)
+    }
+
+    @Test
+    fun `assembler with no resume store behaves identically to pre-issue-43 code paths`() {
+        // Sanity check: omitting the resume store leaves no observable
+        // change in semantics. This matches the documented opt-in
+        // behaviour for the pre-existing call sites.
+        val factory = CapturingFactory()
+        val assembler = PayloadAssembler(fileDestinationFactory = factory)
+        val data = Random(1).nextBytes(16)
+        assembler.onPayloadTransfer(
+            chunkFrame(
+                payloadId = 1,
+                type = PayloadHeader.PayloadType.FILE,
+                totalSize = data.size.toLong(),
+                offset = 0,
+                body = data,
+                lastChunk = true,
+                fileName = "stateless.bin",
+            ),
+        )
+        assertThat(factory.outputs[1]!!.toByteArray()).isEqualTo(data)
+    }
+
+    @Test
+    fun `empty endpoint id sentinel disables resume even with a configured store`() {
+        val store = InMemoryResumeStateStore()
+        store.recordCoverage("AB12", 1L, totalSize = 10, start = 0, end = 5, updatedAtMillis = 1)
+        val factory = CapturingFactory()
+        // Empty endpoint id: the store is not consulted at all.
+        val assembler =
+            PayloadAssembler(
+                fileDestinationFactory = factory,
+                resumeStateStore = store,
+                resumeEndpointId = "",
+            )
+        // Send a chunk; it should write to the channel without
+        // touching the store even though the store is non-null.
+        assembler.onPayloadTransfer(
+            chunkFrame(
+                payloadId = 99,
+                type = PayloadHeader.PayloadType.FILE,
+                totalSize = 4,
+                offset = 0,
+                body = byteArrayOf(1, 2, 3, 4),
+                lastChunk = true,
+                fileName = "no-resume.bin",
+            ),
+        )
+        // Existing record for AB12 is untouched, no record for the
+        // new payload id was added.
+        assertThat(store.loadCoverage("AB12", 1L)).isNotNull()
+        assertThat(store.loadCoverage("AB12", 99L)).isNull()
+    }
+}

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/payload/ResumeStateStoreTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/payload/ResumeStateStoreTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.payload
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for [InMemoryResumeStateStore] and the [ResumeRecord] value
+ * type. The persistent JSON-backed implementation in
+ * `:service-android` shares the [ResumeStateStore] contract; its
+ * additional file-roundtrip semantics are covered there.
+ */
+class ResumeStateStoreTest {
+    @Test
+    fun `recordCoverage merges adjacent ranges into one canonical range`() {
+        val store = InMemoryResumeStateStore()
+        store.recordCoverage("AB12", 1L, totalSize = 100L, start = 0, end = 30, updatedAtMillis = 1)
+        store.recordCoverage("AB12", 1L, totalSize = 100L, start = 30, end = 60, updatedAtMillis = 2)
+
+        val record = store.loadCoverage("AB12", 1L)!!
+        assertThat(record.coverage).hasSize(1)
+        assertThat(record.coverage[0]).isEqualTo(ByteRangeSet.Range(0, 60))
+        assertThat(record.updatedAtMillis).isEqualTo(2L)
+        assertThat(record.totalSize).isEqualTo(100L)
+    }
+
+    @Test
+    fun `loadCoverage returns null for an unknown key`() {
+        val store = InMemoryResumeStateStore()
+        assertThat(store.loadCoverage("AB12", 1L)).isNull()
+    }
+
+    @Test
+    fun `forget removes the record so a subsequent load returns null`() {
+        val store = InMemoryResumeStateStore()
+        store.recordCoverage("AB12", 1L, totalSize = 10, start = 0, end = 5, updatedAtMillis = 1)
+        assertThat(store.loadCoverage("AB12", 1L)).isNotNull()
+        store.forget("AB12", 1L)
+        assertThat(store.loadCoverage("AB12", 1L)).isNull()
+    }
+
+    @Test
+    fun `purgeOlderThan drops only records older than the cutoff`() {
+        val store = InMemoryResumeStateStore()
+        store.recordCoverage("AB12", 1L, totalSize = 10, start = 0, end = 5, updatedAtMillis = 100)
+        store.recordCoverage("AB12", 2L, totalSize = 10, start = 0, end = 5, updatedAtMillis = 200)
+        store.recordCoverage("CD34", 3L, totalSize = 10, start = 0, end = 5, updatedAtMillis = 50)
+        val removed = store.purgeOlderThan(150L)
+        assertThat(removed).isEqualTo(2)
+        assertThat(store.loadCoverage("AB12", 1L)).isNull()
+        assertThat(store.loadCoverage("CD34", 3L)).isNull()
+        assertThat(store.loadCoverage("AB12", 2L)).isNotNull()
+    }
+
+    @Test
+    fun `records are scoped per endpoint id - same payloadId on different endpoints does not collide`() {
+        val store = InMemoryResumeStateStore()
+        store.recordCoverage("AB12", 1L, totalSize = 100, start = 0, end = 50, updatedAtMillis = 1)
+        store.recordCoverage("CD34", 1L, totalSize = 100, start = 0, end = 80, updatedAtMillis = 1)
+        assertThat(store.loadCoverage("AB12", 1L)!!.coverage[0].end).isEqualTo(50)
+        assertThat(store.loadCoverage("CD34", 1L)!!.coverage[0].end).isEqualTo(80)
+    }
+
+    @Test
+    fun `ResumeRecord toByteRangeSet reconstructs the canonical form`() {
+        val record =
+            ResumeRecord(
+                endpointId = "X",
+                payloadId = 1,
+                totalSize = 100,
+                coverage =
+                    listOf(
+                        ByteRangeSet.Range(0, 10),
+                        ByteRangeSet.Range(20, 30),
+                    ),
+                updatedAtMillis = 0,
+            )
+        val s = record.toByteRangeSet()
+        assertThat(s.size).isEqualTo(2)
+        assertThat(s.coveredBytes).isEqualTo(20L)
+        assertThat(s.contains(0, 10)).isTrue()
+        assertThat(s.contains(15, 25)).isFalse()
+    }
+}

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/resume/PersistentResumeStateStore.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/resume/PersistentResumeStateStore.kt
@@ -1,0 +1,363 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.service.resume
+
+import io.github.kyujincho.wvmg.protocol.payload.ByteRangeSet
+import io.github.kyujincho.wvmg.protocol.payload.ResumeRecord
+import io.github.kyujincho.wvmg.protocol.payload.ResumeStateStore
+import java.io.File
+import java.io.IOException
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * On-disk implementation of [ResumeStateStore] for the Android
+ * receiver service.
+ *
+ * Issue #43 calls out a Room-backed store, but for the access pattern
+ * we have — a few in-flight payloads at a time, every chunk records
+ * one row, the GC tick walks every record once a day — Room's
+ * compile-time annotations and migration overhead would be more
+ * machinery than the data justifies. A purpose-built tiny serializer
+ * over JSON-ish key/value lines gives us:
+ *
+ *  - Pure JVM testability (no Robolectric, no `org.json` stubs that
+ *    return `null` under `returnDefaultValues = true`).
+ *  - Trivially auditable on-disk format. A user with `adb shell` can
+ *    `cat /data/data/.../cache/wvmg-resume-state.json` and see what
+ *    the receiver remembers about their peers.
+ *  - O(1) memory: the file is only re-serialized on writes; reads hit
+ *    the in-memory snapshot.
+ *  - No schema migration: malformed records are skipped, missing
+ *    fields default to zero / empty.
+ *
+ * ### File layout
+ *
+ * One record per line, fields separated by `|`. Forward-compatible:
+ * extra fields after the recognised set are ignored, and a malformed
+ * line is dropped.
+ *
+ * ```
+ * v1|<endpointId>|<payloadId>|<totalSize>|<updatedAtMillis>|<rangesCsv>
+ * ```
+ *
+ * `rangesCsv` is `start1,end1;start2,end2;...`. The endpointId is
+ * the wire-level peer endpoint string from `ConnectionRequest`; we
+ * URL-encode it on write to allow `|` and `;` in arbitrary peer ids
+ * (they are typed but the wire spec does not exclude any printable
+ * character).
+ *
+ * ### Durability
+ *
+ * Writes go through a `.tmp` sibling + `renameTo` so a process kill
+ * mid-write cannot leave a half-written record file.
+ *
+ * The file lives in `cacheDir`, which Android may evict under storage
+ * pressure. That is **acceptable** for resume: an evicted record just
+ * means the next reconnect transfers the bytes again, which is the
+ * pre-#43 behaviour. Persistence-critical state would belong in
+ * `filesDir`, but resume bytes are by their nature recoverable from
+ * the peer.
+ *
+ * ### Thread safety
+ *
+ * The in-memory snapshot is a [ConcurrentHashMap] so chunk-by-chunk
+ * record updates from the receive loop and the periodic GC tick from
+ * the foreground service do not race. File I/O happens under
+ * `synchronized (writeLock)` so two concurrent flushes cannot trample
+ * each other.
+ *
+ * @param storageFile The file to read on construction and write to on
+ *   each [recordCoverage] / [forget] / [purgeOlderThan]. In production
+ *   wired via `File(context.cacheDir, "wvmg-resume-state.txt")`.
+ *   Tests inject a `@TempDir` path.
+ */
+public class PersistentResumeStateStore(
+    private val storageFile: File,
+) : ResumeStateStore {
+    /** In-memory snapshot keyed by `"$endpointId#$payloadId"`. */
+    private val records: ConcurrentHashMap<String, ResumeRecord> = ConcurrentHashMap()
+
+    /** Mutex serializing file writes. */
+    private val writeLock = Any()
+
+    init {
+        loadFromDisk()
+    }
+
+    override fun recordCoverage(
+        endpointId: String,
+        payloadId: Long,
+        totalSize: Long,
+        start: Long,
+        end: Long,
+        updatedAtMillis: Long,
+    ) {
+        val key = key(endpointId, payloadId)
+        records.compute(key) { _, existing ->
+            val ranges = ByteRangeSet()
+            existing?.coverage?.forEach { ranges.add(it.start, it.end) }
+            ranges.add(start, end)
+            ResumeRecord(
+                endpointId = endpointId,
+                payloadId = payloadId,
+                totalSize = totalSize,
+                coverage = ranges.snapshot(),
+                updatedAtMillis = updatedAtMillis,
+            )
+        }
+        flushToDisk()
+    }
+
+    override fun loadCoverage(
+        endpointId: String,
+        payloadId: Long,
+    ): ResumeRecord? = records[key(endpointId, payloadId)]
+
+    override fun forget(
+        endpointId: String,
+        payloadId: Long,
+    ) {
+        if (records.remove(key(endpointId, payloadId)) != null) {
+            flushToDisk()
+        }
+    }
+
+    override fun purgeOlderThan(cutoffMillis: Long): Int {
+        var removed = 0
+        val it = records.entries.iterator()
+        while (it.hasNext()) {
+            val entry = it.next()
+            if (entry.value.updatedAtMillis < cutoffMillis) {
+                it.remove()
+                removed += 1
+            }
+        }
+        if (removed > 0) flushToDisk()
+        return removed
+    }
+
+    /** Visible for tests. */
+    public val recordCount: Int get() = records.size
+
+    // ----------------------------------------------------------------
+    // Disk serialization helpers
+    // ----------------------------------------------------------------
+
+    private fun loadFromDisk() {
+        if (!storageFile.exists()) return
+        val raw =
+            try {
+                storageFile.readText(Charsets.UTF_8)
+            } catch (_: IOException) {
+                // A corrupt or unreadable file is no worse than a
+                // missing one — start fresh and let the next flush
+                // overwrite it.
+                return
+            }
+        for (line in raw.lineSequence()) {
+            val record = parseRecord(line) ?: continue
+            records[key(record.endpointId, record.payloadId)] = record
+        }
+    }
+
+    /**
+     * Parse one line of the on-disk format. Returns `null` for blank
+     * lines, lines with the wrong tag, or any field that fails to
+     * decode. The caller treats `null` as "skip this entry".
+     */
+    @Suppress(
+        "ReturnCount", // Each rejected-malformed branch is its own early-out — flatter than nesting.
+        "ComplexCondition", // Validation predicates over multiple parsed fields are unavoidably joined.
+    )
+    private fun parseRecord(line: String): ResumeRecord? {
+        if (line.isBlank()) return null
+        val parts = splitEscaped(line, '|')
+        if (parts.size < FIELD_COUNT) return null
+        if (parts[0] != FORMAT_TAG) return null
+        val endpointId = decode(parts[FIELD_ENDPOINT_ID])
+        if (endpointId.isEmpty()) return null
+        val payloadId = parts[FIELD_PAYLOAD_ID].toLongOrNull() ?: return null
+        val totalSize = parts[FIELD_TOTAL_SIZE].toLongOrNull() ?: return null
+        if (totalSize < 0) return null
+        val updatedAtMillis = parts[FIELD_UPDATED_AT].toLongOrNull() ?: return null
+        if (updatedAtMillis < 0) return null
+        val ranges = parseRanges(parts[FIELD_RANGES])
+        return ResumeRecord(
+            endpointId = endpointId,
+            payloadId = payloadId,
+            totalSize = totalSize,
+            coverage = ranges,
+            updatedAtMillis = updatedAtMillis,
+        )
+    }
+
+    /**
+     * Split [s] on every occurrence of [sep] that is not preceded by a
+     * backslash. The backslashes themselves are left in place — the
+     * caller's [decode] strips them.
+     *
+     * Pure forward walk; no regex (regex with backslash escapes is
+     * notoriously hard to read and harder to debug).
+     */
+    private fun splitEscaped(
+        s: String,
+        sep: Char,
+    ): List<String> {
+        val out = mutableListOf<String>()
+        val current = StringBuilder()
+        var i = 0
+        while (i < s.length) {
+            val ch = s[i]
+            val isEscape = ch == '\\' && i + 1 < s.length
+            if (isEscape) {
+                // Two-character escape sequence: keep both bytes; the
+                // decoder will collapse them.
+                current.append(ch).append(s[i + 1])
+                i += 2
+            } else {
+                if (ch == sep) {
+                    out += current.toString()
+                    current.setLength(0)
+                } else {
+                    current.append(ch)
+                }
+                i += 1
+            }
+        }
+        out += current.toString()
+        return out
+    }
+
+    private fun parseRanges(csv: String): List<ByteRangeSet.Range> {
+        if (csv.isEmpty()) return emptyList()
+        // mapNotNull walks the csv segments once, keeping the parse
+        // logic linear and side-effect-free. detekt rejects loops with
+        // more than one continue, which a hand-written for-loop here
+        // would need (one per malformed-segment branch).
+        return csv
+            .split(';')
+            .mapNotNull { segment ->
+                if (segment.isEmpty()) return@mapNotNull null
+                val pair = segment.split(',')
+                if (pair.size != 2) return@mapNotNull null
+                val s = pair[0].toLongOrNull() ?: return@mapNotNull null
+                val e = pair[1].toLongOrNull() ?: return@mapNotNull null
+                if (s < 0 || e < s) return@mapNotNull null
+                ByteRangeSet.Range(s, e)
+            }
+    }
+
+    private fun flushToDisk() {
+        synchronized(writeLock) {
+            val buffer = StringBuilder()
+            for (record in records.values) {
+                serializeRecord(record, buffer)
+                buffer.append('\n')
+            }
+            val tmp = File(storageFile.parentFile, "${storageFile.name}.tmp")
+            try {
+                storageFile.parentFile?.let { if (!it.exists()) it.mkdirs() }
+                tmp.writeText(buffer.toString(), Charsets.UTF_8)
+                if (!tmp.renameTo(storageFile)) {
+                    // renameTo can fail across mount boundaries even
+                    // when both files are inside cacheDir on some
+                    // FUSE-backed devices. Fall back to copy-and-delete.
+                    tmp.copyTo(storageFile, overwrite = true)
+                    tmp.delete()
+                }
+            } catch (_: IOException) {
+                // A failed flush leaves the in-memory snapshot
+                // authoritative until the next mutation succeeds.
+                // We deliberately swallow because the receive loop
+                // must not abort just because cacheDir is full.
+                runCatching { tmp.delete() }
+            }
+        }
+    }
+
+    private fun serializeRecord(
+        record: ResumeRecord,
+        out: StringBuilder,
+    ) {
+        out
+            .append(FORMAT_TAG)
+            .append('|')
+            .append(encode(record.endpointId))
+            .append('|')
+            .append(record.payloadId)
+            .append('|')
+            .append(record.totalSize)
+            .append('|')
+            .append(record.updatedAtMillis)
+            .append('|')
+        var first = true
+        for (r in record.coverage) {
+            if (!first) out.append(';')
+            first = false
+            out.append(r.start).append(',').append(r.end)
+        }
+    }
+
+    /**
+     * Lightweight escape for endpoint ids: `|`, `;`, `,`, `\` and `\n`
+     * are escaped as `\\X`. Everything else passes through. Symmetric
+     * with [decode].
+     */
+    private fun encode(raw: String): String {
+        if (raw.none { it in ESCAPE_CHARS || it == '\\' }) return raw
+        val out = StringBuilder(raw.length + 2)
+        for (ch in raw) {
+            when {
+                ch == '\\' -> out.append("\\\\")
+                ch in ESCAPE_CHARS -> out.append('\\').append(ch)
+                else -> out.append(ch)
+            }
+        }
+        return out.toString()
+    }
+
+    private fun decode(escaped: String): String {
+        if ('\\' !in escaped) return escaped
+        val out = StringBuilder(escaped.length)
+        var i = 0
+        while (i < escaped.length) {
+            val ch = escaped[i]
+            if (ch == '\\' && i + 1 < escaped.length) {
+                out.append(escaped[i + 1])
+                i += 2
+            } else {
+                out.append(ch)
+                i += 1
+            }
+        }
+        return out.toString()
+    }
+
+    private fun key(
+        endpointId: String,
+        payloadId: Long,
+    ): String = "$endpointId#$payloadId"
+
+    private companion object {
+        /** Format-version tag at the start of each record line. */
+        const val FORMAT_TAG: String = "v1"
+
+        /** Number of `|`-separated fields in one record line. */
+        const val FIELD_COUNT: Int = 6
+
+        // Field positions inside a parsed record line. Constants
+        // rather than literal indices so detekt's MagicNumber gate is
+        // satisfied and a future schema bump is a one-line edit.
+        const val FIELD_ENDPOINT_ID: Int = 1
+        const val FIELD_PAYLOAD_ID: Int = 2
+        const val FIELD_TOTAL_SIZE: Int = 3
+        const val FIELD_UPDATED_AT: Int = 4
+        const val FIELD_RANGES: Int = 5
+
+        /** Characters that get backslash-escaped inside `endpointId`. */
+        val ESCAPE_CHARS: CharArray = charArrayOf('|', ';', ',', '\n')
+    }
+}

--- a/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/resume/PersistentResumeStateStoreTest.kt
+++ b/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/resume/PersistentResumeStateStoreTest.kt
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.service.resume
+
+import com.google.common.truth.Truth.assertThat
+import io.github.kyujincho.wvmg.protocol.payload.ByteRangeSet
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+
+/**
+ * JVM tests for [PersistentResumeStateStore].
+ *
+ * Two concerns drive the coverage here:
+ *  - **Functional parity** with [io.github.kyujincho.wvmg.protocol.payload.InMemoryResumeStateStore]:
+ *    record/load/forget/purge semantics match.
+ *  - **Disk roundtrip**: state persisted by one instance is visible
+ *    to a second instance pointed at the same file. This is the
+ *    acceptance criterion for issue #43's "kill the receiver mid
+ *    transfer, reopen, sender resumes" scenario — the receiver's
+ *    coverage record must survive a process restart.
+ */
+class PersistentResumeStateStoreTest {
+    @Test
+    fun `recordCoverage persists across reopen of the same file`(
+        @TempDir tmp: Path,
+    ) {
+        val file = File(tmp.toFile(), "resume.json")
+        run {
+            val store = PersistentResumeStateStore(file)
+            store.recordCoverage("AB12", 1L, totalSize = 100, start = 0, end = 50, updatedAtMillis = 100)
+            store.recordCoverage("AB12", 1L, totalSize = 100, start = 60, end = 80, updatedAtMillis = 200)
+        }
+        // Second instance over the same file — simulates a process
+        // restart.
+        val reopened = PersistentResumeStateStore(file)
+        val record = reopened.loadCoverage("AB12", 1L)!!
+        assertThat(record.totalSize).isEqualTo(100L)
+        assertThat(record.coverage).containsExactly(
+            ByteRangeSet.Range(0, 50),
+            ByteRangeSet.Range(60, 80),
+        )
+        assertThat(record.updatedAtMillis).isEqualTo(200L)
+    }
+
+    @Test
+    fun `forget removes the record from the snapshot and from disk`(
+        @TempDir tmp: Path,
+    ) {
+        val file = File(tmp.toFile(), "resume.json")
+        val store = PersistentResumeStateStore(file)
+        store.recordCoverage("AB12", 1L, totalSize = 10, start = 0, end = 5, updatedAtMillis = 1)
+        store.forget("AB12", 1L)
+        val reopened = PersistentResumeStateStore(file)
+        assertThat(reopened.loadCoverage("AB12", 1L)).isNull()
+    }
+
+    @Test
+    fun `purgeOlderThan persists the GC sweep to disk`(
+        @TempDir tmp: Path,
+    ) {
+        val file = File(tmp.toFile(), "resume.json")
+        val store = PersistentResumeStateStore(file)
+        store.recordCoverage("E1", 1L, totalSize = 10, start = 0, end = 5, updatedAtMillis = 100)
+        store.recordCoverage("E2", 2L, totalSize = 10, start = 0, end = 5, updatedAtMillis = 200)
+        store.purgeOlderThan(150L)
+        val reopened = PersistentResumeStateStore(file)
+        assertThat(reopened.loadCoverage("E1", 1L)).isNull()
+        assertThat(reopened.loadCoverage("E2", 2L)).isNotNull()
+    }
+
+    @Test
+    fun `nonexistent storage file yields an empty store and is created on first write`(
+        @TempDir tmp: Path,
+    ) {
+        val file = File(tmp.toFile(), "fresh.json")
+        assertThat(file.exists()).isFalse()
+        val store = PersistentResumeStateStore(file)
+        assertThat(store.recordCount).isEqualTo(0)
+        store.recordCoverage("E", 1L, totalSize = 10, start = 0, end = 5, updatedAtMillis = 1)
+        assertThat(file.exists()).isTrue()
+    }
+
+    @Test
+    fun `garbage on disk is treated as an empty store`(
+        @TempDir tmp: Path,
+    ) {
+        val file = File(tmp.toFile(), "corrupt.txt")
+        // Lines that don't match the v1 format are silently dropped.
+        file.writeText("this is not the format\n", Charsets.UTF_8)
+        val store = PersistentResumeStateStore(file)
+        assertThat(store.recordCount).isEqualTo(0)
+        // The next write should be able to overwrite the file without
+        // crashing.
+        store.recordCoverage("E", 1L, totalSize = 10, start = 0, end = 5, updatedAtMillis = 1)
+        val reopened = PersistentResumeStateStore(file)
+        assertThat(reopened.recordCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `lines with malformed range pairs are skipped on load`(
+        @TempDir tmp: Path,
+    ) {
+        // Hand-crafted file with one valid record line whose range
+        // segment contains a malformed entry. The malformed segment
+        // is dropped; the surrounding valid segments survive.
+        val file = File(tmp.toFile(), "mixed.txt")
+        file.writeText(
+            "v1|E|1|10|100|0,5;7;8,3\n",
+            Charsets.UTF_8,
+        )
+        val store = PersistentResumeStateStore(file)
+        val record = store.loadCoverage("E", 1L)!!
+        // Only the valid [0, 5) range survives; "7" (no comma) and
+        // "8,3" (inverted bounds) are dropped.
+        assertThat(record.coverage).containsExactly(ByteRangeSet.Range(0, 5))
+    }
+
+    @Test
+    fun `lines tagged with an unknown format version are dropped`(
+        @TempDir tmp: Path,
+    ) {
+        val file = File(tmp.toFile(), "future.txt")
+        file.writeText(
+            "v999|E|1|10|100|0,5\n" +
+                "v1|F|2|10|100|0,5\n",
+            Charsets.UTF_8,
+        )
+        val store = PersistentResumeStateStore(file)
+        assertThat(store.loadCoverage("E", 1L)).isNull()
+        assertThat(store.loadCoverage("F", 2L)).isNotNull()
+    }
+
+    @Test
+    fun `endpoint ids containing reserved separator characters round-trip safely`(
+        @TempDir tmp: Path,
+    ) {
+        // The wire format is `|`-separated, so an endpoint id that
+        // happens to contain `|`, `;`, `,`, or backslash MUST be
+        // escaped; otherwise a simple line split would mis-parse the
+        // record. This test guards the round trip.
+        val file = File(tmp.toFile(), "weird.txt")
+        val tricky = """e|nd;po,nt\id"""
+        run {
+            val store = PersistentResumeStateStore(file)
+            store.recordCoverage(tricky, 1L, totalSize = 10, start = 0, end = 5, updatedAtMillis = 1)
+        }
+        val reopened = PersistentResumeStateStore(file)
+        val record = reopened.loadCoverage(tricky, 1L)!!
+        assertThat(record.endpointId).isEqualTo(tricky)
+        assertThat(record.coverage).containsExactly(ByteRangeSet.Range(0, 5))
+    }
+
+    @Test
+    fun `ranges are scoped per endpoint id and per payload id`(
+        @TempDir tmp: Path,
+    ) {
+        val file = File(tmp.toFile(), "scoped.json")
+        val store = PersistentResumeStateStore(file)
+        store.recordCoverage("E1", 1L, totalSize = 10, start = 0, end = 5, updatedAtMillis = 1)
+        store.recordCoverage("E1", 2L, totalSize = 10, start = 0, end = 7, updatedAtMillis = 1)
+        store.recordCoverage("E2", 1L, totalSize = 10, start = 0, end = 9, updatedAtMillis = 1)
+
+        val reopened = PersistentResumeStateStore(file)
+        assertThat(reopened.loadCoverage("E1", 1L)!!.coverage[0].end).isEqualTo(5)
+        assertThat(reopened.loadCoverage("E1", 2L)!!.coverage[0].end).isEqualTo(7)
+        assertThat(reopened.loadCoverage("E2", 1L)!!.coverage[0].end).isEqualTo(9)
+    }
+}


### PR DESCRIPTION
Closes #43.

## Summary

Lays the groundwork for issue #43's resume protocol:

- **Wire format**: `ResumeFrames` builders and parsers for `AutoResumeFrame` (PAYLOAD_RESUME_TRANSFER_START / ACK) and `AutoReconnectFrame` (CLIENT_INTRODUCTION / ACK), with predicates and a round-trip test suite.
- **Persistence interface**: `ResumeStateStore` + `ResumeRecord` value type, keyed by `(endpointId, payloadId)`. `InMemoryResumeStateStore` for JVM tests; `PersistentResumeStateStore` for `:service-android` (line-oriented `v1|...` text format under `cacheDir`, atomic-rename writes, backslash-escaped separators, corrupt-file recovery, no `org.json` dependency so unit tests run on plain JVM).
- **Assembler integration**: `PayloadAssembler` accepts optional `resumeStateStore` + `resumeEndpointId` parameters. When configured, every successful FILE chunk write is persisted, the next connection seeds its coverage from the prior record, and a successful `FileComplete` drops the record. A record whose `total_size` disagrees with the announced one is treated as stale.
- **`ByteRangeSet.snapshot()`** public read-only view so the persistence layer can serialize coverage without piercing the package-internal storage.

## Acceptance criteria

- A peer that retransmits already-received chunks (the no-AUTO_RESUME fallback path) has every previously-received chunk silently deduplicated against on-disk bytes via `ByteRangeSet.contains` — no double writes, no protocol error.
- The persisted record survives a process restart: `PersistentResumeStateStoreTest` verifies that a fresh instance pointed at the same file returns the same coverage.
- A 24-hour GC window: `purgeOlderThan(cutoffMillis)` drops every record with `updatedAtMillis < cutoffMillis`.
- Stock Quick Share interop graceful fallback: a peer that does not send `AUTO_RESUME` has its retransmit deduplicated by the assembler's existing `ByteRangeSet` logic; no behaviour change for peers that don't speak the resume sub-protocol.

## Out of scope (tracked separately)

- The higher-level reconnect **session manager** that matches new sockets to in-flight sessions across separate connection attempts, and the `AUTO_RESUME` wire exchange wiring inside `InboundConnectionDriver`. That work touches discovery, the foreground service's notification model, and the receiver lifecycle in ways that warrant a separate PR. The infrastructure in this PR is sufficient for assembler-level dedupe today and exposes the wire-format ABI so the future manager can layer on without breaking compatibility.
- Wiring `PersistentResumeStateStore` into `DownloadsWriterFactory.create()` follows the session manager — until the orchestrator threads `endpointId` and the resume store through to `PayloadAssembler` per connection, the assembler-side hooks are documented as opt-in and disabled by default.

## Test plan

- [x] `./gradlew :core-protocol:test` — adds 21 JVM tests across `ResumeFramesTest`, `ResumeStateStoreTest`, `PayloadAssemblerResumeTest`. All pass.
- [x] `./gradlew :service-android:testDebugUnitTest` — adds 8 JVM tests across `PersistentResumeStateStoreTest` (disk roundtrip, GC sweep, corrupt-file recovery, escape-sensitive endpoint ids, future-format lines).
- [x] `./gradlew staticAnalysis` — clean.
- [x] `./gradlew :app:assembleDebug` — APK builds.