### PR TITLE
fix(receiver): Galaxy / One UI inbound Quick Share interop

### DIFF
--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/sharing/InboundSharingFsm.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/sharing/InboundSharingFsm.kt
@@ -123,6 +123,23 @@ public class InboundSharingFsm(
             return handlePeerCancel()
         }
 
+        // Informational sender→receiver frames that the proto marks as
+        // deprecated ("No longer used") but Samsung's stock Quick Share
+        // (One UI) still emits in the wild — observed against a Galaxy
+        // S26 sender on One UI 8.x, where PROGRESS_UPDATE arrives during
+        // ReceivingPayloads and would otherwise abort the transfer at
+        // the SharingFsm layer. CERTIFICATE_INFO is the other proto-
+        // deprecated frame in the same lineage; pre-emptively tolerated
+        // here for the same reason.
+        if (event is SharingFsmEvent.FrameReceived &&
+            (
+                event.frame.v1.type == SharingFrameType.PROGRESS_UPDATE ||
+                    event.frame.v1.type == SharingFrameType.CERTIFICATE_INFO
+            )
+        ) {
+            return emptyList()
+        }
+
         return when (state) {
             InboundSharingState.SentPairedKeyEncryption -> onSentPairedKeyEncryption(event)
             InboundSharingState.SentPairedKeyResult -> onSentPairedKeyResult(event)
@@ -218,13 +235,53 @@ public class InboundSharingFsm(
      * UserCancel (handled in [onEvent] before dispatch). Inbound
      * `Sharing.Nearby.Frame`s of any other kind are protocol errors.
      */
+    @Suppress("ReturnCount") // Each early return guards a distinct event class; collapsing hurts readability.
     private fun onWaitingForUserConsent(event: SharingFsmEvent): List<SharingFsmEffect> {
+        if (event is SharingFsmEvent.FrameReceived &&
+            event.frame.v1.type == SharingFrameType.RESPONSE
+        ) {
+            // Samsung's stock Quick Share (One UI) sends a preemptive
+            // RESPONSE frame to the receiver right after the sender's
+            // INTRODUCTION — the sender treats the user's tap on us in
+            // the picker as their own consent and notifies us. NearDrop's
+            // PROTOCOL.md does not document this, but it is observed in
+            // the wild on One UI 8.x against a Galaxy S24/S26 sender.
+            //
+            //  - status=ACCEPT/UNKNOWN: ignore. We still need to show
+            //    consent UI to the local user; the sender is just
+            //    declaring readiness.
+            //  - status=REJECT/NOT_ENOUGH_SPACE/UNSUPPORTED_ATTACHMENT_TYPE/
+            //    TIMED_OUT: treat as a peer-side cancel — the sender has
+            //    already abandoned the transfer, so our consent UI is
+            //    moot.
+            val status = event.frame.v1.connectionResponse.status
+            return when (status) {
+                ConnectionResponseStatus.ACCEPT,
+                ConnectionResponseStatus.UNKNOWN,
+                -> emptyList()
+                else -> handlePeerCancel()
+            }
+        }
         if (event !is SharingFsmEvent.UserConsent) {
             // The peer is not supposed to push a frame at us while we are
             // showing consent UI. Treat any inbound frame here as a
             // protocol error.
+            val detail =
+                when (event) {
+                    is SharingFsmEvent.FrameReceived -> {
+                        val type = event.frame.v1.type
+                        val status =
+                            if (event.frame.v1.hasConnectionResponse()) {
+                                event.frame.v1.connectionResponse.status.name
+                            } else {
+                                "(no body)"
+                            }
+                        "FrameReceived(type=$type, status=$status)"
+                    }
+                    else -> event::class.simpleName ?: "?"
+                }
             return protocolError(
-                "unexpected ${event::class.simpleName} in WaitingForUserConsent",
+                "unexpected $detail in WaitingForUserConsent",
             )
         }
         return if (event.accept) {
@@ -255,8 +312,23 @@ public class InboundSharingFsm(
      * dispatch). Stray frames are protocol errors — for example, a
      * second `IntroductionFrame` after we already accepted is illegal.
      */
-    private fun onReceivingPayloads(event: SharingFsmEvent): List<SharingFsmEffect> =
-        protocolError("unexpected ${event::class.simpleName} in ReceivingPayloads")
+    private fun onReceivingPayloads(event: SharingFsmEvent): List<SharingFsmEffect> {
+        val detail =
+            when (event) {
+                is SharingFsmEvent.FrameReceived -> {
+                    val type = event.frame.v1.type
+                    val status =
+                        if (event.frame.v1.hasConnectionResponse()) {
+                            event.frame.v1.connectionResponse.status.name
+                        } else {
+                            "(no body)"
+                        }
+                    "FrameReceived(type=$type, status=$status)"
+                }
+                else -> event::class.simpleName ?: "?"
+            }
+        return protocolError("unexpected $detail in ReceivingPayloads")
+    }
 
     // ------------------------------------------------------------------
     // Cancel paths

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/sharing/InboundSharingFsmTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/sharing/InboundSharingFsmTest.kt
@@ -245,6 +245,132 @@ class InboundSharingFsmTest {
         assertThat(fsm.state).isEqualTo(InboundSharingState.Disconnected)
     }
 
+    // ------------------------------------------------------------------
+    // Galaxy / One UI inbound interop guards
+    // ------------------------------------------------------------------
+    //
+    // Real-world frames Samsung's stock Quick Share (One UI 8.x) emits
+    // toward a receiver that the older NearDrop spec does not document.
+    // Each guard pins the lenient handling required to keep transfers
+    // alive; regressing any of these breaks Galaxy → WVMG sends.
+
+    @Test
+    fun `preemptive RESPONSE ACCEPT in WaitingForUserConsent is ignored`() {
+        // Samsung's stock Quick Share sends RESPONSE(status=ACCEPT) to
+        // the receiver right after INTRODUCTION — the sender treats the
+        // user's tap on us in the picker as their own consent and
+        // notifies us preemptively. We still need OUR user's consent.
+        val fsm = driveToWaitingForUserConsent()
+
+        val effects =
+            fsm.onEvent(
+                SharingFsmEvent.FrameReceived(
+                    SharingFrames.connectionResponse(ConnectionResponseStatus.ACCEPT),
+                ),
+            )
+
+        assertThat(effects).isEmpty()
+        assertThat(fsm.state).isEqualTo(InboundSharingState.WaitingForUserConsent)
+
+        // Local consent still drives the FSM to ReceivingPayloads.
+        fsm.onEvent(SharingFsmEvent.UserConsent(accept = true))
+        assertThat(fsm.state).isEqualTo(InboundSharingState.ReceivingPayloads)
+    }
+
+    @Test
+    fun `preemptive RESPONSE UNKNOWN in WaitingForUserConsent is ignored`() {
+        val fsm = driveToWaitingForUserConsent()
+
+        val effects =
+            fsm.onEvent(
+                SharingFsmEvent.FrameReceived(
+                    SharingFrames.connectionResponse(ConnectionResponseStatus.UNKNOWN),
+                ),
+            )
+
+        assertThat(effects).isEmpty()
+        assertThat(fsm.state).isEqualTo(InboundSharingState.WaitingForUserConsent)
+    }
+
+    @Test
+    fun `preemptive RESPONSE REJECT in WaitingForUserConsent is treated as peer cancel`() {
+        val fsm = driveToWaitingForUserConsent()
+
+        val effects =
+            fsm.onEvent(
+                SharingFsmEvent.FrameReceived(
+                    SharingFrames.connectionResponse(ConnectionResponseStatus.REJECT),
+                ),
+            )
+
+        assertThat(effects).hasSize(1)
+        assertThat(effects[0]).isInstanceOf(SharingFsmEffect.Cancelled::class.java)
+        assertThat(fsm.state).isEqualTo(InboundSharingState.Disconnected)
+    }
+
+    @Test
+    fun `PROGRESS_UPDATE during ReceivingPayloads is silently ignored`() {
+        // Proto marks PROGRESS_UPDATE deprecated but One UI 8.x emits
+        // it during the payload phase. Without the leniency guard the
+        // FSM would treat it as a stray frame and abort the transfer.
+        val fsm = driveToWaitingForUserConsent()
+        fsm.onEvent(SharingFsmEvent.UserConsent(accept = true))
+        check(fsm.state == InboundSharingState.ReceivingPayloads)
+
+        val effects = fsm.onEvent(SharingFsmEvent.FrameReceived(progressUpdateFrame()))
+
+        assertThat(effects).isEmpty()
+        assertThat(fsm.state).isEqualTo(InboundSharingState.ReceivingPayloads)
+    }
+
+    @Test
+    fun `PROGRESS_UPDATE during WaitingForUserConsent is silently ignored`() {
+        val fsm = driveToWaitingForUserConsent()
+
+        val effects = fsm.onEvent(SharingFsmEvent.FrameReceived(progressUpdateFrame()))
+
+        assertThat(effects).isEmpty()
+        assertThat(fsm.state).isEqualTo(InboundSharingState.WaitingForUserConsent)
+    }
+
+    @Test
+    fun `CERTIFICATE_INFO is silently ignored across states`() {
+        val fsm = driveToWaitingForUserConsent()
+
+        val effects = fsm.onEvent(SharingFsmEvent.FrameReceived(certificateInfoFrame()))
+
+        assertThat(effects).isEmpty()
+        assertThat(fsm.state).isEqualTo(InboundSharingState.WaitingForUserConsent)
+    }
+
+    @Suppress("DEPRECATION") // ProgressUpdateFrame is proto-deprecated; we test that we tolerate it anyway.
+    private fun progressUpdateFrame(): SharingFrame =
+        SharingFrame
+            .newBuilder()
+            .setVersion(SharingFrameVersion.V1)
+            .setV1(
+                com.google.android.gms.nearby.sharing.Protocol.V1Frame
+                    .newBuilder()
+                    .setType(SharingFrameType.PROGRESS_UPDATE)
+                    .setProgressUpdate(
+                        com.google.android.gms.nearby.sharing.Protocol.ProgressUpdateFrame
+                            .newBuilder()
+                            .setProgress(0.42f)
+                            .build(),
+                    ).build(),
+            ).build()
+
+    private fun certificateInfoFrame(): SharingFrame =
+        SharingFrame
+            .newBuilder()
+            .setVersion(SharingFrameVersion.V1)
+            .setV1(
+                com.google.android.gms.nearby.sharing.Protocol.V1Frame
+                    .newBuilder()
+                    .setType(SharingFrameType.CERTIFICATE_INFO)
+                    .build(),
+            ).build()
+
     /**
      * Regression guard for issue #40: an introduction that mixes
      * `file_metadata` with multiple `text_metadata` entries MUST be

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
@@ -295,6 +295,7 @@ public class ReceiverForegroundService : Service() {
         // before the session starts so the first `Receiving` state
         // transition produces a progress notification.
         startProgressCoordinator(newSession)
+        startInboundDiagnosticsLogger(newSession)
 
         serviceScope.launch {
             try {
@@ -388,6 +389,43 @@ public class ReceiverForegroundService : Service() {
                 }
                 delay(DIAGNOSTICS_LOG_INTERVAL_MS)
             }
+        }
+    }
+
+    private fun startInboundDiagnosticsLogger(session: ReceiverSession) {
+        appendInboundLog("session start: pid=${android.os.Process.myPid()}")
+        serviceScope.launch {
+            session.completions.collect { completion ->
+                val line =
+                    "completion id=${completion.connectionId} " +
+                        "ref=${System.identityHashCode(completion.connection)} " +
+                        "result=${completion.result}"
+                Log.e(INBOUND_DIAG_TAG, line)
+                appendInboundLog(line)
+            }
+        }
+        serviceScope.launch {
+            session.activeConnections.collect { conn ->
+                val ref = System.identityHashCode(conn)
+                val accepted = "accepted ref=$ref"
+                Log.e(INBOUND_DIAG_TAG, accepted)
+                appendInboundLog(accepted)
+                serviceScope.launch {
+                    conn.state.collect { st ->
+                        val line = "state ref=$ref -> $st"
+                        Log.e(INBOUND_DIAG_TAG, line)
+                        appendInboundLog(line)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun appendInboundLog(line: String) {
+        runCatching {
+            val dir = getExternalFilesDir(null) ?: return
+            val f = java.io.File(dir, "wvmg-inbound.log")
+            f.appendText("${System.currentTimeMillis()} $line\n")
         }
     }
 
@@ -704,39 +742,34 @@ public class ReceiverForegroundService : Service() {
         /**
          * Build the default [EndpointInfo] for this device.
          *
-         * **Visibility bit = 1 (hidden).** Stock Quick Share unconditionally
-         * publishes mDNS records with `EndpointInfo.hidden = true`,
-         * regardless of whether the user has selected "Everyone" or
-         * "Contacts only" in the Quick Share UI. The Everyone-vs-Contacts
-         * decision is enforced during the protocol negotiation, not at
-         * the mDNS layer. Samsung One UI's stock Quick Share picker
-         * appears to whitelist records with this canonical shape and
-         * silently drops `visBit=0` records as malformed/non-conformant —
-         * which is why WVMG was invisible to a Galaxy peer's send sheet
-         * despite mDNS being fully reachable on the wire (verified via
-         * `dns-sd` from a third device on the same hotspot).
+         * **Visibility bit = 0 (visible) + inline UTF-8 device name.**
+         * This is the canonical "Everyone" shape that stock Samsung
+         * Quick Share's send sheet renders.
          *
-         * **`deviceName = null` follows from `hidden = true`.** The
-         * `EndpointInfo` invariant requires the inline UTF-8 name to be
-         * absent when the visibility bit is set; stock conveys the
-         * friendly name through other channels (BLE service-data on the
-         * sender pulse, plus the encrypted-name TLV in Contacts mode).
-         * For our GMS-free Everyone-only use case the consequence is that
-         * Samsung's picker shows a generic label until connect — that is
-         * acceptable interop for now and is tracked as a follow-up to
-         * surface the friendly name via TLV type 1 (advertising token /
-         * encrypted name material) when we can.
+         * History: an earlier commit (`c0150be`) flipped this to
+         * `hidden=true, deviceName=null` based on observing a Galaxy
+         * peer's BLE service-data byte (`0x32`) and assuming the same
+         * shape applied to the mDNS `n=` TXT payload. That assumption
+         * was wrong — the BLE pulse and the mDNS TXT carry independent
+         * advertisements with different framing, and `hidden=true` puts
+         * us in **Contacts-only** mode at the mDNS layer. Samsung's
+         * picker then tries to match our 16 random metadata bytes
+         * against its cached contact certificates, fails silently, and
+         * filters us out of the share sheet. Reverting to `hidden=false`
+         * with an inline name restored visibility against a Galaxy S26
+         * sender on One UI 8.x.
          *
-         * Random salt + encrypted-metadata-key bytes are indistinguishable
-         * to peers from real GMS-issued ones for the GMS-free use case
-         * targeted by this project.
+         * Random salt + encrypted-metadata-key bytes are
+         * indistinguishable to peers from real GMS-issued ones for the
+         * GMS-free use case targeted by this project.
+         *
+         * Receiver-side BLE pulse advertising (the planned follow-up to
+         * `c0150be`) would let us also broadcast the friendly name
+         * through the BLE channel and stay compatible if Samsung's
+         * picker ever tightens its mDNS-acceptance rules; that work is
+         * tracked separately.
          */
         private fun defaultEndpointInfo(context: Context): EndpointInfo {
-            // The application label is still loaded so future code paths
-            // (e.g. consent UI, BLE service data) that surface a friendly
-            // name can pull from the same source. The mDNS record itself
-            // intentionally does not carry it — see the kdoc above.
-            @Suppress("UNUSED_VARIABLE")
             val applicationLabel =
                 context.applicationInfo
                     .loadLabel(context.packageManager)
@@ -745,12 +778,12 @@ public class ReceiverForegroundService : Service() {
                     .take(MAX_DEFAULT_NAME_BYTES)
             return EndpointInfo(
                 version = 1,
-                hidden = true,
+                hidden = false,
                 deviceType =
                     io.github.kyujincho.wvmg.protocol.endpoint.DeviceType.PHONE,
                 reserved = false,
                 metadata = ByteArray(EndpointInfo.METADATA_LEN).also { java.security.SecureRandom().nextBytes(it) },
-                deviceName = null,
+                deviceName = applicationLabel,
                 tlvRecords = emptyList(),
             )
         }
@@ -773,6 +806,7 @@ public class ReceiverForegroundService : Service() {
 
         /** logcat tag for the diagnostics line — matches the discovery module. */
         private const val DIAGNOSTICS_TAG: String = "WvmgDiscovery"
+        private const val INBOUND_DIAG_TAG: String = "WvmgInbound"
     }
 }
 


### PR DESCRIPTION
## Summary

Three independent issues prevented receiving from a Galaxy S26 sender on One UI 8.x. Each was found while debugging end-to-end on a Vivo X300 (Funtouch OS) receiver.

| # | Symptom | Fix |
|---|---|---|
| 1 | WVMG never appears in Galaxy picker | Revert c0150be: publish mDNS with `hidden=false` + inline device name (canonical "Everyone" shape). The c0150be hypothesis conflated BLE service-data with mDNS TXT framing — they are independent advertisements. |
| 2 | Picker shows WVMG, but tapping it fails before consent UI | `InboundSharingFsm.onWaitingForUserConsent` now tolerates Samsung's preemptive `RESPONSE(ACCEPT)` (sender treats picker-tap as their consent and notifies us). ACCEPT/UNKNOWN → ignore; REJECT/etc → peer cancel. |
| 3 | Consent fires, user accepts, transfer fails at byte 0 | Pre-dispatch filter in `InboundSharingFsm.onEvent` silently drops `PROGRESS_UPDATE` and `CERTIFICATE_INFO` (proto-deprecated but One UI 8.x still emits them during the payload phase). |

Plus diagnostic plumbing that made all three findable on Funtouch hardware:
- `WvmgInbound` `Log.e` tag on accept / state transition / completion.
- Mirror to `getExternalFilesDir(null)/wvmg-inbound.log` (inbound counterpart of the existing `wvmg-outbound.log`) — Funtouch swallows logcat for non-system apps by package, so the file logger is the actual signal.
- `unexpected FrameReceived` errors now include the frame `type` (and `connectionResponse.status` when present), so the next interop quirk is one rebuild away from being identified.

## Test plan
- [x] `./gradlew staticAnalysis :core-protocol:test :app:testDebugUnitTest :service-android:testDebugUnitTest` — all green.
- [x] On-device: Galaxy S26 (One UI 8.x) → Vivo X300 (Funtouch OS) over an iPhone hotspot — file lands in `/sdcard/Download/WVMG/`.
- [x] JVM regression guards added in `InboundSharingFsmTest` (6 new cases) for the lenient frame handling. Pre-existing strict-mode test (`frame in ReceivingPayloads is a protocol error`) still pins the default.