### PR TITLE
feat(discovery): receiver-side BLE pulse advertiser on 0xFEF3 (#121)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ CI (`.github/workflows/ci.yml`) runs `staticAnalysis`, `:core-protocol:test`, `:
 Several diagnostic logcat tags are wired up for real-device testing — useful when discovery or transfer behaves differently from JVM tests:
 
 ```bash
-adb logcat -s WvmgDiscovery WvmgSend WvmgOutbound WvmgBleScan
+adb logcat -s WvmgDiscovery WvmgSend WvmgOutbound WvmgBleScan WvmgBleAdv WvmgMdnsGate
 ```
 
 If a manufacturer's logcat filter swallows the app's `Log.i` output (vivo Funtouch OS does this), `OutboundConnection`'s logger uses `Log.e` and also appends to `getExternalFilesDir(null)/wvmg-outbound.log` — pull it with:
@@ -63,8 +63,12 @@ Five Gradle modules. The split is driven by one hard rule: the protocol implemen
 :core-protocol-test    KAT vectors and shared fixtures. Pure JVM.
 :discovery-android     mDNS publish/browse via Android NsdManager (migrated from JmDNS
                        in #98 to fix vivo / Funtouch / OriginOS interop), network-change
-                       watcher. Phase 2: BLE pulse scanner (BleQuickShareScanner) under
-                       `discovery.ble`. Android-only; wraps :core-protocol's EndpointInfo.
+                       watcher. Phase 2 BLE: pulse scanner (BleQuickShareScanner,
+                       service UUID 0xFE2C), sender pulse advertiser (BleAdvertiser,
+                       0xFE2C), and receiver-side fast-advertisement advertiser
+                       (BleQuickShareAdvertiser, 0xFEF3, #121) — all under
+                       `discovery.ble`. Android-only; wraps :core-protocol's
+                       EndpointInfo / BleServiceData byte encoders.
 :service-android       Foreground receiver service (connectedDevice type), MediaStore-backed
                        FileDestinationFactory, consent notification + broadcast receiver.
 :app                   UI: permissions onboarding, share-intent SendActivity, ShowQrActivity,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,9 +67,9 @@
     <string name="permission_notifications_title">Notifications</string>
     <string name="permission_notifications_rationale">Used to show the foreground transfer service indicator and to alert you about incoming files. Without this permission, transfers still work but you will not be notified about them.</string>
 
-    <!-- BLUETOOTH_ADVERTISE (API 31+, #31). -->
+    <!-- BLUETOOTH_ADVERTISE (API 31+, #31 / #121). -->
     <string name="permission_bluetooth_advertise_title">Bluetooth advertising</string>
-    <string name="permission_bluetooth_advertise_rationale">Used to broadcast a short Bluetooth Low Energy pulse so nearby Quick Share receivers wake up automatically when you start a send. Without this permission, sends still work but the receiver may need to manually open Quick Share first.</string>
+    <string name="permission_bluetooth_advertise_rationale">Used to broadcast Bluetooth Low Energy pulses: one to wake nearby receivers when you start a send, and another to make this device visible to other phones\' Quick Share pickers. Without this permission, transfers still work but the picker may show this device under a generic label until the connection starts.</string>
 
     <!-- BLUETOOTH_SCAN (API 31+, #31). -->
     <string name="permission_bluetooth_scan_title">Nearby Bluetooth devices</string>

--- a/app/src/test/kotlin/io/github/kyujincho/wvmg/AndroidManifestPermissionsTest.kt
+++ b/app/src/test/kotlin/io/github/kyujincho/wvmg/AndroidManifestPermissionsTest.kt
@@ -103,9 +103,14 @@ class AndroidManifestPermissionsTest {
     @Test
     fun `bluetooth advertise declared for phase 2 ble auto-discovery`() {
         // BLUETOOTH_ADVERTISE is required (API 31+) so we can broadcast
-        // the Quick Share BLE service-data pulse that wakes nearby
-        // receivers (#31 / #32). It does not need neverForLocation —
-        // that flag is only meaningful for SCAN.
+        // BOTH:
+        //   * the sender-side Quick Share pulse on `0xFE2C` that wakes
+        //     nearby receivers (#31 / #32), and
+        //   * the receiver-side fast-advertisement pulse on `0xFEF3`
+        //     that makes us visible to stock Quick Share pickers
+        //     (#121).
+        // It does not need neverForLocation — that flag is only
+        // meaningful for SCAN.
         assertTrue(
             "BLUETOOTH_ADVERTISE must be declared",
             manifest.contains("android.permission.BLUETOOTH_ADVERTISE"),

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/BleServiceData.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/BleServiceData.kt
@@ -1,0 +1,296 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.endpoint
+
+import java.nio.charset.StandardCharsets
+
+/**
+ * Quick Share **fast advertisement** BLE service-data payload (issue #121).
+ *
+ * This is the wire-shape stock Quick Share receivers (Galaxy / Pixel /
+ * Windows Quick Share) emit on the `0xFEF3` "fast advertisement" service
+ * UUID. It is what makes a peer appear in another peer's send sheet:
+ * the mDNS TXT record alone is not enough — Samsung's One UI in
+ * particular cross-references discovered Wi-Fi LAN services against
+ * recently-seen BLE pulses on this UUID, and silently drops mDNS-only
+ * peers from its picker. Issue #121 closes that loop on the receiver
+ * side.
+ *
+ * ### Wire format
+ *
+ * Captured verbatim from a Galaxy peer's broadcast during the c0150be
+ * triage (see commit message):
+ *
+ * ```text
+ * +--------+-------------------+--------+----------------------+
+ * | byte 0 |   bytes 1..4      | byte 5 |   bytes 6..N         |
+ * |--------|-------------------|--------|----------------------|
+ * | versPCP|   endpoint_id     |  len   |    EndpointInfo      |
+ * |  byte  | (4 ASCII bytes)   | (u8)   |    (`len` bytes)     |
+ * +--------+-------------------+--------+----------------------+
+ * ```
+ *
+ * - **byte 0** packs `version (3 bits, MSB) | pcp (5 bits)`. Stock peers
+ *   emit `version = 1`, `pcp = 3` (`PCP_HIGH` in google/nearby's
+ *   `connections/implementation/mediums/ble_v2/ble_advertisement.cc`),
+ *   yielding `0x23`.
+ * - **bytes 1..4** are an ASCII-printable, 4-byte endpoint identifier.
+ *   The same string also surfaces as `mDNS instance name`'s 4-byte slug
+ *   prefix and in the protocol-level `endpoint_id` of
+ *   `ConnectionRequestFrame`. Stock peers use base64-url-style
+ *   characters (uppercase + lowercase + digits + `-` / `_`); we accept
+ *   any byte in ASCII printable range to stay forward-compatible.
+ * - **byte 5** is an unsigned 8-bit length giving how many EndpointInfo
+ *   bytes follow. Same byte that gates the abbreviated 17-byte hidden
+ *   form in NearDrop's BLE captures (`0x11`) and the longer
+ *   "name-included" form on Pixel.
+ * - **bytes 6..N** are the **raw** [EndpointInfo.serialize] output —
+ *   the exact same byte sequence we already put under the mDNS TXT key
+ *   `n`, sans the URL-safe base64 wrapper. That keeps the on-the-wire
+ *   identity of a peer aligned across the two channels.
+ *
+ * The payload is intentionally compact: with a hidden EndpointInfo
+ * (no inline name, no TLV records) the total is **23 bytes**
+ * (1 + 4 + 1 + 17), which fits comfortably alongside the 16-bit
+ * `service-data` AD header inside the legacy 31-byte advertising-PDU
+ * budget without needing extended advertising.
+ *
+ * ### Why this lives in `:core-protocol`
+ *
+ * The encoder is bit-exact against a captured Galaxy fingerprint and
+ * shares all of its EndpointInfo logic with the mDNS path. Keeping it
+ * in `:core-protocol` lets [BleServiceDataTest] in
+ * `:core-protocol-test` pin the byte layout under JVM unit tests
+ * without ever touching `BluetoothLeAdvertiser`. The Android-side
+ * `BleQuickShareAdvertiser` in `:discovery-android` only translates the
+ * resulting bytes into a platform `AdvertiseData`.
+ *
+ * @see EndpointInfo for the inner descriptor's bit packing.
+ */
+public object BleServiceData {
+    /**
+     * 16-bit "fast advertisement" service UUID stock Quick Share emits.
+     * The 128-bit canonical form expanded onto the Bluetooth Base UUID
+     * is in [SERVICE_UUID_128_STRING].
+     *
+     * The Quick Share BLE pulse we **scan** for (#33) uses a different
+     * UUID, `0xFE2C` — the sender-side pulse — see
+     * `BleQuickShareScanner.QUICK_SHARE_SERVICE_UUID_STRING` for the
+     * full distinction.
+     */
+    public const val SERVICE_UUID_SHORT: Int = 0xFEF3
+
+    /** Canonical 128-bit form of [SERVICE_UUID_SHORT]. */
+    public const val SERVICE_UUID_128_STRING: String =
+        "0000fef3-0000-1000-8000-00805f9b34fb"
+
+    /** Length of the version/PCP header byte. */
+    public const val HEADER_LEN: Int = 1
+
+    /** Length of the ASCII endpoint_id slug. */
+    public const val ENDPOINT_ID_LEN: Int = 4
+
+    /** Length of the EndpointInfo length prefix (1-byte unsigned). */
+    public const val ENDPOINT_INFO_LEN_BYTES: Int = 1
+
+    /** Total fixed overhead before the EndpointInfo bytes. */
+    public const val FIXED_HEADER_LEN: Int = HEADER_LEN + ENDPOINT_ID_LEN + ENDPOINT_INFO_LEN_BYTES
+
+    /**
+     * Default protocol version stock Quick Share emits in the high
+     * 3 bits of byte 0. Pinned at `1`; `0` is reserved by the spec and
+     * `2..7` is unallocated as of 2026-04.
+     */
+    public const val DEFAULT_VERSION: Int = 1
+
+    /**
+     * Default Power-Class-of-Peer (`Pcp`) stock peers advertise — `3`
+     * (`PCP_HIGH` in google/nearby's `ble_advertisement.cc`). We always
+     * emit HIGH because a phone running the receiver service is, by
+     * definition, line-powered or on battery in the user's hand —
+     * neither qualifies as "low power" in the Nearby Connections sense.
+     */
+    public const val DEFAULT_PCP: Int = 3
+
+    /** 3-bit mask for the version field (top of byte 0). */
+    private const val VERSION_MASK: Int = 0b111
+
+    /** 5-bit mask for the PCP field (bottom of byte 0). */
+    private const val PCP_MASK: Int = 0b11111
+
+    /** Bit position of the version field within byte 0 (top 3 bits). */
+    private const val VERSION_SHIFT: Int = 5
+
+    /** Mask used to convert a signed `Byte` into an unsigned int (`0..255`). */
+    private const val UNSIGNED_BYTE_MASK: Int = 0xFF
+
+    /** Maximum ASCII code point (`0x7F`). Inclusive upper bound. */
+    private const val ASCII_MAX: Int = 0x7F
+
+    /**
+     * Maximum [EndpointInfo.serialize] byte length the 1-byte length
+     * prefix can describe (`0..255`). EndpointInfo enforces its own
+     * sub-field limits; this only constrains the BLE framing.
+     */
+    public const val MAX_ENDPOINT_INFO_LEN: Int = 0xFF
+
+    /**
+     * Encodes the canonical fast-advertisement service-data payload.
+     *
+     * @param endpointId 4-byte ASCII identifier matching the same field
+     *   in `ConnectionRequestFrame` and the mDNS instance-name slug.
+     *   See [validateEndpointIdBytes] for the byte-shape contract.
+     * @param endpointInfo the receiver's identity descriptor; the bytes
+     *   placed after the length prefix are exactly [EndpointInfo.serialize].
+     * @param version the 3-bit protocol version. Defaults to
+     *   [DEFAULT_VERSION] (`1`).
+     * @param pcp the 5-bit power-class-of-peer. Defaults to
+     *   [DEFAULT_PCP] (`3`, `PCP_HIGH`).
+     * @return a freshly-allocated byte array of length
+     *   `6 + endpointInfo.serialize().size`.
+     * @throws IllegalArgumentException for malformed inputs
+     *   (wrong-length endpoint_id, EndpointInfo too large for the 1-byte
+     *   length prefix, or out-of-range version/PCP).
+     */
+    @JvmOverloads
+    @JvmStatic
+    public fun encode(
+        endpointId: ByteArray,
+        endpointInfo: EndpointInfo,
+        version: Int = DEFAULT_VERSION,
+        pcp: Int = DEFAULT_PCP,
+    ): ByteArray {
+        require(version in 0..VERSION_MASK) {
+            "version must fit in 3 bits (0..$VERSION_MASK), got $version"
+        }
+        require(pcp in 0..PCP_MASK) {
+            "pcp must fit in 5 bits (0..$PCP_MASK), got $pcp"
+        }
+        validateEndpointIdBytes(endpointId)
+
+        val infoBytes = endpointInfo.serialize()
+        require(infoBytes.size <= MAX_ENDPOINT_INFO_LEN) {
+            "EndpointInfo.serialize() must fit in 1 byte (0..$MAX_ENDPOINT_INFO_LEN), " +
+                "got ${infoBytes.size}"
+        }
+
+        val out = ByteArray(FIXED_HEADER_LEN + infoBytes.size)
+        out[0] = packVersionPcp(version, pcp)
+        endpointId.copyInto(out, destinationOffset = HEADER_LEN)
+        out[HEADER_LEN + ENDPOINT_ID_LEN] = infoBytes.size.toByte()
+        infoBytes.copyInto(out, destinationOffset = FIXED_HEADER_LEN)
+        return out
+    }
+
+    /**
+     * Convenience wrapper that accepts the endpoint_id as an ASCII
+     * [String]. The string must be exactly [ENDPOINT_ID_LEN] code units
+     * long and contain only ASCII bytes — all stock peers do.
+     */
+    @JvmOverloads
+    @JvmStatic
+    public fun encode(
+        endpointId: String,
+        endpointInfo: EndpointInfo,
+        version: Int = DEFAULT_VERSION,
+        pcp: Int = DEFAULT_PCP,
+    ): ByteArray {
+        // String.toByteArray(US_ASCII) silently substitutes '?' for any
+        // non-ASCII code point, so length-equality alone misses the case
+        // where every non-ASCII char encodes to a single byte. Walk the
+        // string explicitly and reject any code unit outside ASCII range.
+        for (ch in endpointId) {
+            require(ch.code in 0..ASCII_MAX) {
+                "endpointId must be ASCII (got non-ASCII char in '$endpointId')"
+            }
+        }
+        val bytes = endpointId.toByteArray(StandardCharsets.US_ASCII)
+        return encode(bytes, endpointInfo, version, pcp)
+    }
+
+    /**
+     * Parses a fast-advertisement service-data payload back into its
+     * components. Returns `null` for any malformed input — truncated
+     * header, length-prefix exceeds the buffer, or the embedded
+     * EndpointInfo cannot be decoded.
+     *
+     * The parser is forgiving: a non-ASCII endpoint_id slug or an
+     * unknown version / PCP value is preserved verbatim rather than
+     * rejected, since other peers in the wild may legitimately experiment
+     * with new values. The caller can always sanity-check the parsed
+     * fields.
+     */
+    @Suppress("ReturnCount")
+    @JvmStatic
+    public fun parse(bytes: ByteArray): Parsed? {
+        if (bytes.size < FIXED_HEADER_LEN) return null
+        val header = bytes[0].toInt() and UNSIGNED_BYTE_MASK
+        val version = (header ushr VERSION_SHIFT) and VERSION_MASK
+        val pcp = header and PCP_MASK
+        val endpointId = bytes.copyOfRange(HEADER_LEN, HEADER_LEN + ENDPOINT_ID_LEN)
+        val len = bytes[HEADER_LEN + ENDPOINT_ID_LEN].toInt() and UNSIGNED_BYTE_MASK
+        if (FIXED_HEADER_LEN + len > bytes.size) return null
+        val infoBytes = bytes.copyOfRange(FIXED_HEADER_LEN, FIXED_HEADER_LEN + len)
+        val info = EndpointInfo.parse(infoBytes) ?: return null
+        return Parsed(
+            version = version,
+            pcp = pcp,
+            endpointId = endpointId,
+            endpointInfo = info,
+        )
+    }
+
+    /**
+     * Pack the version (top 3 bits) and PCP (bottom 5 bits) into byte 0.
+     * `version=1, pcp=3` yields `0x23`, matching the captured Galaxy
+     * fingerprint.
+     */
+    internal fun packVersionPcp(
+        version: Int,
+        pcp: Int,
+    ): Byte = (((version and VERSION_MASK) shl VERSION_SHIFT) or (pcp and PCP_MASK)).toByte()
+
+    /**
+     * Validate that [bytes] is exactly [ENDPOINT_ID_LEN] long. We do not
+     * enforce ASCII printable here — Samsung's stock builds emit
+     * base64-url alphabet by convention but the wire format itself is
+     * 4 raw bytes.
+     */
+    private fun validateEndpointIdBytes(bytes: ByteArray) {
+        require(bytes.size == ENDPOINT_ID_LEN) {
+            "endpointId must be exactly $ENDPOINT_ID_LEN bytes, got ${bytes.size}"
+        }
+    }
+
+    /**
+     * Parsed view of a fast-advertisement service-data payload. Returned
+     * by [parse]; round-trips back through [encode] with the same
+     * arguments.
+     */
+    public data class Parsed(
+        public val version: Int,
+        public val pcp: Int,
+        public val endpointId: ByteArray,
+        public val endpointInfo: EndpointInfo,
+    ) {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is Parsed) return false
+            return version == other.version &&
+                pcp == other.pcp &&
+                endpointId.contentEquals(other.endpointId) &&
+                endpointInfo == other.endpointInfo
+        }
+
+        override fun hashCode(): Int {
+            var result = version
+            result = 31 * result + pcp
+            result = 31 * result + endpointId.contentHashCode()
+            result = 31 * result + endpointInfo.hashCode()
+            return result
+        }
+    }
+}

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/BleServiceDataTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/BleServiceDataTest.kt
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.endpoint
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * Bit-exact regression tests for [BleServiceData] (issue #121).
+ *
+ * These tests pin the wire format we observed on a Galaxy peer's BLE
+ * pulse during the c0150be triage:
+ *
+ * ```text
+ * [ 0x23 PCP | endpoint_id | 0x11 length | 0x32 ... ]
+ * ```
+ *
+ * If a regression flips bit packing or field order, every stock Quick
+ * Share picker silently stops listing us — and the only signal in the
+ * field is "the receiver disappeared from Galaxy's send sheet again."
+ * These KATs are the regression net before any device is involved.
+ */
+class BleServiceDataTest {
+    @Test
+    fun `service uuid short value matches the stock fast-advertisement UUID`() {
+        // 0xFEF3 is the Quick Share fast-advertisement service UUID
+        // observed in Galaxy's NearbyConnections dump as
+        // `fastAdvertisementServiceUuid: 0000fef3-...`.
+        assertThat(BleServiceData.SERVICE_UUID_SHORT).isEqualTo(0xFEF3)
+    }
+
+    @Test
+    fun `service uuid 128-bit form expands the short uuid into the bluetooth base`() {
+        // Bluetooth Base UUID is XXXXXXXX-0000-1000-8000-00805F9B34FB
+        // with the 16-bit short UUID slotted into the leading 32 bits.
+        // Substituting 0xFEF3 yields the constant we expose.
+        assertThat(BleServiceData.SERVICE_UUID_128_STRING)
+            .isEqualTo("0000fef3-0000-1000-8000-00805f9b34fb")
+    }
+
+    @Test
+    fun `byte 0 packs version 1 PCP 3 as 0x23 matching the captured Galaxy fingerprint`() {
+        // Stock Galaxy emits version=1 in the top 3 bits and PCP=3 in
+        // the bottom 5 bits: 001_00011 = 0x23. Pinning the exact byte
+        // catches both an MSB/LSB flip and any drift in the default
+        // version or PCP value.
+        val packed = BleServiceData.packVersionPcp(version = 1, pcp = 3)
+        assertThat(packed.toInt() and 0xFF).isEqualTo(0x23)
+    }
+
+    @Test
+    fun `default version and pcp constants match the canonical stock values`() {
+        // version=1 and PCP_HIGH=3 are the values google/nearby's
+        // ble_advertisement.cc emits for "phone, line- or
+        // battery-powered, peripheral mode". Drift here is what changed
+        // commit c0150be's investigation in the first place.
+        assertThat(BleServiceData.DEFAULT_VERSION).isEqualTo(1)
+        assertThat(BleServiceData.DEFAULT_PCP).isEqualTo(3)
+    }
+
+    @Test
+    fun `encode places header endpoint_id length-prefix and EndpointInfo at the documented offsets`() {
+        val info = hiddenPhoneEndpointInfo()
+        val endpointId = byteArrayOf(0x57, 0x76, 0x6D, 0x67) // ASCII "Wvmg"
+        val payload = BleServiceData.encode(endpointId, info)
+
+        // Total = 1 (header) + 4 (endpoint_id) + 1 (length) + 17 (hidden EndpointInfo).
+        assertThat(payload).hasLength(BleServiceData.FIXED_HEADER_LEN + info.serialize().size)
+        assertThat(payload).hasLength(23)
+
+        // Byte 0 = 0x23 (version=1, PCP=3).
+        assertThat(payload[0].toInt() and 0xFF).isEqualTo(0x23)
+
+        // Bytes 1..4 = the supplied endpoint_id verbatim.
+        assertThat(payload.copyOfRange(1, 5)).isEqualTo(endpointId)
+
+        // Byte 5 = 0x11 (17, length of the hidden EndpointInfo serialization).
+        assertThat(payload[5].toInt() and 0xFF).isEqualTo(0x11)
+
+        // Bytes 6..N = the EndpointInfo serialization byte-for-byte.
+        // First inner byte is 0x32 (hidden, version=1, PHONE, reserved=0).
+        assertThat(payload[6].toInt() and 0xFF).isEqualTo(0x32)
+        assertThat(payload.copyOfRange(6, payload.size)).isEqualTo(info.serialize())
+    }
+
+    @Test
+    fun `encode roundtrips through parse`() {
+        val info = hiddenPhoneEndpointInfo()
+        val payload = BleServiceData.encode("Wvmg", info)
+        val parsed = BleServiceData.parse(payload)
+
+        assertThat(parsed).isNotNull()
+        assertThat(parsed!!.version).isEqualTo(BleServiceData.DEFAULT_VERSION)
+        assertThat(parsed.pcp).isEqualTo(BleServiceData.DEFAULT_PCP)
+        assertThat(parsed.endpointId).isEqualTo(byteArrayOf(0x57, 0x76, 0x6D, 0x67))
+        assertThat(parsed.endpointInfo).isEqualTo(info)
+    }
+
+    @Test
+    fun `encode supports a visible EndpointInfo with inline UTF-8 device name`() {
+        val info =
+            EndpointInfo(
+                version = 1,
+                hidden = false,
+                deviceType = DeviceType.PHONE,
+                reserved = false,
+                metadata = ByteArray(EndpointInfo.METADATA_LEN) { 0x00 },
+                deviceName = "Pixel-9",
+            )
+        val payload = BleServiceData.encode("AbCd", info)
+
+        // 1 + 4 + 1 + 1 (header) + 16 (metadata) + 1 (name length) + 7 (name bytes) = 31.
+        // Visible byte 0 of EndpointInfo: version=1 (001), hidden=0, PHONE (001), reserved=0
+        //   -> 001_0_001_0 = 0x22.
+        assertThat(payload).hasLength(31)
+        assertThat(payload[0].toInt() and 0xFF).isEqualTo(0x23)
+        assertThat(payload[5].toInt() and 0xFF).isEqualTo(info.serialize().size)
+        assertThat(payload[6].toInt() and 0xFF).isEqualTo(0x22)
+        assertThat(BleServiceData.parse(payload)?.endpointInfo).isEqualTo(info)
+    }
+
+    @Test
+    fun `encode rejects an endpoint_id of the wrong byte length`() {
+        val info = hiddenPhoneEndpointInfo()
+        // Too short.
+        assertThrows<IllegalArgumentException> {
+            BleServiceData.encode(byteArrayOf(0x41, 0x42, 0x43), info)
+        }
+        // Too long.
+        assertThrows<IllegalArgumentException> {
+            BleServiceData.encode(byteArrayOf(0x41, 0x42, 0x43, 0x44, 0x45), info)
+        }
+        // Empty.
+        assertThrows<IllegalArgumentException> {
+            BleServiceData.encode(ByteArray(0), info)
+        }
+    }
+
+    @Test
+    fun `encode rejects a non-ASCII endpoint_id string`() {
+        val info = hiddenPhoneEndpointInfo()
+        // Non-ASCII characters do not fit cleanly in the 4-byte slug.
+        assertThrows<IllegalArgumentException> {
+            // Korean characters "한" (3 UTF-8 bytes each) — string length is 4 but
+            // byte length differs, which the ASCII guard catches.
+            BleServiceData.encode("한국어임", info)
+        }
+    }
+
+    @Test
+    fun `encode rejects out-of-range version and pcp`() {
+        val info = hiddenPhoneEndpointInfo()
+        assertThrows<IllegalArgumentException> {
+            BleServiceData.encode("Wvmg", info, version = 8)
+        }
+        assertThrows<IllegalArgumentException> {
+            BleServiceData.encode("Wvmg", info, version = -1)
+        }
+        assertThrows<IllegalArgumentException> {
+            BleServiceData.encode("Wvmg", info, pcp = 32)
+        }
+        assertThrows<IllegalArgumentException> {
+            BleServiceData.encode("Wvmg", info, pcp = -1)
+        }
+    }
+
+    @Test
+    fun `parse rejects truncated payloads`() {
+        // Less than the 6-byte fixed header.
+        assertThat(BleServiceData.parse(ByteArray(0))).isNull()
+        assertThat(BleServiceData.parse(ByteArray(5))).isNull()
+
+        // Length prefix says 17 but the buffer only has 16 EndpointInfo bytes.
+        val shortPayload =
+            byteArrayOf(0x23, 0x57, 0x76, 0x6D, 0x67, 0x11) +
+                ByteArray(16) { 0x00 }
+        assertThat(BleServiceData.parse(shortPayload)).isNull()
+    }
+
+    @Test
+    fun `parse returns null when the embedded EndpointInfo cannot be decoded`() {
+        // The 1-byte length prefix says 4 EndpointInfo bytes follow, but
+        // EndpointInfo.parse requires at least 17 bytes (1 header + 16
+        // metadata). The parser returns null rather than throwing — the
+        // caller treats malformed peers as "ignore".
+        val malformed = byteArrayOf(0x23, 0x41, 0x42, 0x43, 0x44, 0x04, 0x32, 0x00, 0x00, 0x00)
+        assertThat(BleServiceData.parse(malformed)).isNull()
+    }
+
+    @Test
+    fun `parse preserves a non-default version and pcp value`() {
+        // Forge a payload with version=5 and pcp=7 to assert the parser
+        // does not silently coerce them back to defaults.
+        val info = hiddenPhoneEndpointInfo()
+        val payload = BleServiceData.encode("Wvmg", info, version = 5, pcp = 7)
+
+        // Byte 0 = 101_00111 = 0xA7.
+        assertThat(payload[0].toInt() and 0xFF).isEqualTo(0xA7)
+        val parsed = BleServiceData.parse(payload)!!
+        assertThat(parsed.version).isEqualTo(5)
+        assertThat(parsed.pcp).isEqualTo(7)
+    }
+
+    /**
+     * Hidden, version=1, PHONE EndpointInfo with deterministic zero
+     * metadata. Mirrors what `ReceiverForegroundService.defaultEndpointInfo`
+     * generates in production (modulo the random metadata bytes).
+     */
+    private fun hiddenPhoneEndpointInfo(): EndpointInfo =
+        EndpointInfo(
+            version = 1,
+            hidden = true,
+            deviceType = DeviceType.PHONE,
+            reserved = false,
+            metadata = ByteArray(EndpointInfo.METADATA_LEN) { 0x00 },
+            deviceName = null,
+        )
+}

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareAdvertiser.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareAdvertiser.kt
@@ -1,0 +1,641 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.discovery.ble
+
+import android.Manifest
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothManager
+import android.bluetooth.le.AdvertiseCallback
+import android.bluetooth.le.AdvertiseData
+import android.bluetooth.le.AdvertiseSettings
+import android.bluetooth.le.BluetoothLeAdvertiser
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.ParcelUuid
+import android.util.Log
+import androidx.annotation.RequiresApi
+import androidx.annotation.RequiresPermission
+import androidx.core.content.ContextCompat
+import io.github.kyujincho.wvmg.protocol.endpoint.BleServiceData
+import io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Receiver-side BLE pulse advertiser for Quick Share (issue #121).
+ *
+ * The symmetric counterpart to [BleQuickShareScanner]. While the scanner
+ * watches for **sender** pulses on service UUID `0xFE2C`, this class
+ * advertises the **receiver's** identity on the canonical Quick Share
+ * fast-advertisement service UUID `0xFEF3`
+ * ([BleServiceData.SERVICE_UUID_128_STRING]). The two channels close the
+ * loop: stock Quick Share peers cross-reference Wi-Fi LAN services they
+ * discover against recently-seen BLE pulses on `0xFEF3`, and silently
+ * drop mDNS-only peers from their picker. Without an advertiser on this
+ * UUID, WVMG is invisible to Galaxy / One UI's send sheet — that was
+ * exactly the symptom commit c0150be diagnosed.
+ *
+ * ### Wire format
+ *
+ * The service-data payload is built by [BleServiceData.encode] in
+ * `:core-protocol` (pure-JVM, KAT-tested). The shape captured from a
+ * Galaxy peer's broadcast is:
+ *
+ * ```text
+ * [ versPCP(1) | endpoint_id(4 ASCII) | endpoint_info_len(1) | EndpointInfo(N) ]
+ * ```
+ *
+ * For our hidden, version=1, PHONE EndpointInfo (matching
+ * `ReceiverForegroundService.defaultEndpointInfo`) the total payload is
+ * **23 bytes**, which fits alongside the 16-bit service-data AD header
+ * inside the legacy 31-byte advertising-PDU budget without needing
+ * extended advertising.
+ *
+ * ### Lifecycle
+ *
+ * Owned by [io.github.kyujincho.wvmg.service.receiver.ReceiverForegroundService],
+ * driven through the existing [io.github.kyujincho.wvmg.service.receiver.MdnsAdvertisementGate].
+ * The gate already decides when the receiver should be visible based on
+ * BLE *scan* activity, the user's "always visible" override, and the QR
+ * session flag; this advertiser's [start] / [stop] methods are wired off
+ * the same publish/unpublish decisions so BLE and mDNS are advertised
+ * (and unpublished) symmetrically.
+ *
+ * The class shape mirrors [BleQuickShareScanner]:
+ *  * [start] is idempotent and non-suspending. Calling [start] while
+ *    already advertising is a no-op.
+ *  * [stop] is idempotent. Safe to call from any thread; safe to call
+ *    inline from `Service.onDestroy`.
+ *  * [setAdvertiseMode] switches between [AdvertiseSettings.ADVERTISE_MODE_BALANCED]
+ *    (background) and [AdvertiseSettings.ADVERTISE_MODE_LOW_LATENCY]
+ *    (foreground) — symmetric to the scanner's BALANCED ↔ LOW_LATENCY
+ *    pattern from #35. Idempotent if the mode is unchanged.
+ *
+ * ### Failure modes
+ *
+ * Like [BleAdvertiser] (the sender-side pulse), [start] returns `false`
+ * — and logs without throwing — when:
+ *  * `BLUETOOTH_ADVERTISE` is not granted at runtime (API 31+).
+ *  * The device has no BLE peripheral mode
+ *    (`BluetoothAdapter.bluetoothLeAdvertiser` returns null).
+ *  * The Bluetooth adapter is turned off.
+ *  * The platform's `startAdvertising` callback reports failure.
+ *
+ * In every case the receiver continues in mDNS-only mode — the picker
+ * ranking degrades, but transfers still work. This matches the issue's
+ * acceptance criterion: "On devices without peripheral-mode support,
+ * degrade gracefully to mDNS-only without crashing or spamming logs."
+ *
+ * ### Permissions
+ *
+ * On API 31+ the runtime [Manifest.permission.BLUETOOTH_ADVERTISE] is
+ * required. The umbrella manifest in `:app` declares it; the onboarding
+ * flow in `:app/.../onboarding` requests it as an optional permission.
+ * Pre-API-31 devices fall back to the install-time legacy
+ * `BLUETOOTH` / `BLUETOOTH_ADMIN` permissions also declared in the
+ * umbrella manifest.
+ *
+ * ### Testability
+ *
+ * [BleAdvertiserGate] abstracts the platform `BluetoothLeAdvertiser` so
+ * unit tests on a plain JVM can drive the lifecycle through a fake.
+ * Tests that need to observe a mode change inject a recorder and assert
+ * on the captured `setAdvertiseMode` calls — see
+ * `BleQuickShareAdvertiserTest`.
+ *
+ * @param gate platform-advertiser abstraction; tests inject a fake.
+ * @param permissionChecker checks `BLUETOOTH_ADVERTISE` at start time;
+ *   defaults to a [ContextCompat]-backed implementation in production.
+ * @param payloadFactory builds the 23-byte service-data payload from
+ *   the supplied [EndpointInfo] and the latest endpoint_id. Defaults to
+ *   [BleServiceData.encode].
+ */
+public class BleQuickShareAdvertiser internal constructor(
+    private val gate: BleAdvertiserGate,
+    private val permissionChecker: AdvertisePermissionChecker,
+    private val payloadFactory: PayloadFactory = DefaultPayloadFactory,
+) {
+    /**
+     * Production constructor. Builds a real [BleAdvertiserGate] over the
+     * platform [BluetoothManager] and a [ContextCompat]-backed
+     * permission checker. Only the application context is retained.
+     */
+    public constructor(context: Context) : this(
+        gate = AndroidBleAdvertiserGate(context.applicationContext),
+        permissionChecker = AndroidAdvertisePermissionChecker(context.applicationContext),
+    )
+
+    /**
+     * Synchronization guard for [start] / [stop] / [setAdvertiseMode]
+     * transitions. Same shape as the scanner — a plain `synchronized`
+     * block keeps the lifecycle inline-callable from `Service.onDestroy`,
+     * which the coroutine-based `Mutex` would not survive once the
+     * parent scope is cancelled.
+     */
+    private val lifecycleLock = Any()
+
+    /**
+     * The currently-active platform registration, if any. Wrapped in an
+     * AtomicReference so a late asynchronous callback (e.g. an
+     * `onStartFailure` arriving after [stop]) cannot clobber a fresh
+     * registration the same instance opened in the meantime.
+     */
+    private val active: AtomicReference<BleAdvertiserGate.Registration?> =
+        AtomicReference(null)
+
+    /**
+     * Currently-active platform advertise mode. Defaults to
+     * [AdvertiseSettings.ADVERTISE_MODE_BALANCED] — the foreground-service
+     * friendly mode that does not throttle and that most receivers see
+     * within a few hundred milliseconds. Foregrounded apps upgrade to
+     * [AdvertiseSettings.ADVERTISE_MODE_LOW_LATENCY] for the duration.
+     *
+     * Mutated through [setAdvertiseMode] under [lifecycleLock]; reads
+     * outside the lock are racy in the strict sense but the field is
+     * `@Volatile` and only used as a "do nothing if mode unchanged"
+     * early-exit in [setAdvertiseMode] itself plus a debug accessor.
+     */
+    @Volatile
+    private var currentMode: Int = AdvertiseSettings.ADVERTISE_MODE_BALANCED
+
+    /**
+     * Most recently submitted [EndpointInfo]. Captured during [start]
+     * and re-used by [setAdvertiseMode] to rebuild the service-data
+     * payload during a re-registration. `null` while the advertiser is
+     * not running.
+     */
+    @Volatile
+    private var currentEndpointInfo: EndpointInfo? = null
+
+    /**
+     * Most recently submitted endpoint_id (4 ASCII bytes). Same lifetime
+     * as [currentEndpointInfo].
+     */
+    @Volatile
+    private var currentEndpointId: ByteArray? = null
+
+    /**
+     * Begin advertising the receiver's BLE pulse with the supplied
+     * identity. Returns `true` iff the platform accepted the
+     * registration (or the advertiser was already running on the same
+     * identity — idempotent).
+     *
+     * Calling [start] while already advertising replaces the existing
+     * registration with the new identity. This is the natural shape for
+     * a "the receiver's name changed" event.
+     *
+     * @param endpointInfo the identity descriptor to advertise. Same
+     *   bytes that `Discovery.advertise` writes under the mDNS TXT key
+     *   `n` (after URL-safe-base64 encoding).
+     * @param endpointId the 4-byte ASCII slug — the same value that
+     *   appears in the protocol-level `ConnectionRequestFrame.endpoint_id`
+     *   and in the mDNS instance name's endpoint_id slice. Stock peers
+     *   correlate BLE-pulse identities to mDNS records by this slug, so
+     *   matching them across both channels keeps our presence
+     *   self-consistent.
+     */
+    @RequiresPermission(Manifest.permission.BLUETOOTH_ADVERTISE)
+    public fun start(
+        endpointInfo: EndpointInfo,
+        endpointId: ByteArray,
+    ): Boolean =
+        synchronized(lifecycleLock) {
+            require(endpointId.size == BleServiceData.ENDPOINT_ID_LEN) {
+                "endpointId must be ${BleServiceData.ENDPOINT_ID_LEN} bytes, got ${endpointId.size}"
+            }
+            // Replace any previous registration so the platform never
+            // sees stale identity bytes alongside the fresh ones.
+            active.getAndSet(null)?.runCatchingClose()
+
+            if (!permissionChecker.hasAdvertisePermission()) {
+                Log.w(TAG, "start: BLUETOOTH_ADVERTISE not granted; skipping BLE pulse advertise")
+                return@synchronized false
+            }
+
+            val payload =
+                try {
+                    payloadFactory.build(endpointId, endpointInfo)
+                } catch (
+                    @Suppress("TooGenericExceptionCaught") t: Throwable,
+                ) {
+                    Log.w(TAG, "start: payload build failed; skipping BLE pulse advertise", t)
+                    return@synchronized false
+                }
+
+            val registration =
+                try {
+                    gate.startAdvertising(payload, currentMode)
+                } catch (
+                    @Suppress("TooGenericExceptionCaught") t: Throwable,
+                ) {
+                    // Platform throws SecurityException if the runtime
+                    // permission was revoked between the check above
+                    // and the call, IllegalStateException if Bluetooth
+                    // is off, and IllegalArgumentException if the
+                    // payload exceeds the 31-byte budget. None is fatal;
+                    // log and let the receiver continue in mDNS-only.
+                    Log.w(TAG, "start: BLE advertise startAdvertising threw; pulse skipped", t)
+                    null
+                }
+            if (registration == null) {
+                Log.w(TAG, "start: BLE advertise unavailable (no advertiser / failed start)")
+                return@synchronized false
+            }
+            active.set(registration)
+            currentEndpointInfo = endpointInfo
+            currentEndpointId = endpointId
+            Log.w(
+                TAG,
+                "start: BLE pulse advertise started bytes=${payload.size} " +
+                    "uuid=${BleServiceData.SERVICE_UUID_128_STRING} " +
+                    "mode=${describeAdvertiseMode(currentMode)}",
+            )
+            true
+        }
+
+    /**
+     * Stop the platform advertisement. Idempotent.
+     */
+    public fun stop() {
+        synchronized(lifecycleLock) {
+            val registration = active.getAndSet(null) ?: return@synchronized
+            registration.runCatchingClose()
+            currentEndpointInfo = null
+            currentEndpointId = null
+            Log.w(TAG, "stop: BLE pulse advertise stopped")
+        }
+    }
+
+    /**
+     * Switches the platform advertisement to the given
+     * [AdvertiseSettings] mode constant. Idempotent — calling with the
+     * current mode is a no-op.
+     *
+     * Acceptable values are
+     * [AdvertiseSettings.ADVERTISE_MODE_LOW_POWER],
+     * [AdvertiseSettings.ADVERTISE_MODE_BALANCED], and
+     * [AdvertiseSettings.ADVERTISE_MODE_LOW_LATENCY].
+     *
+     * If an advertisement is currently in flight, the platform
+     * registration is torn down and re-registered with the new
+     * settings using the most recent identity — symmetric to
+     * [BleQuickShareScanner.setScanMode]. If no advertisement is
+     * active, the new mode is simply remembered for the next [start].
+     *
+     * @return `true` if the advertiser ended up running on the
+     *   requested mode (either already running on it, or successfully
+     *   transitioned, or idle and the mode is now pinned for the next
+     *   start). `false` if a re-registration was attempted but the
+     *   platform refused.
+     */
+    @RequiresPermission(Manifest.permission.BLUETOOTH_ADVERTISE)
+    public fun setAdvertiseMode(mode: Int): Boolean =
+        synchronized(lifecycleLock) {
+            if (mode == currentMode) return@synchronized true
+            val previous = currentMode
+            currentMode = mode
+
+            val info = currentEndpointInfo
+            val id = currentEndpointId
+            if (active.get() == null || info == null || id == null) {
+                Log.w(
+                    TAG,
+                    "setAdvertiseMode: idle, pinned mode for next start: " +
+                        "${describeAdvertiseMode(previous)} -> ${describeAdvertiseMode(mode)}",
+                )
+                return@synchronized true
+            }
+
+            // Active path: tear down the existing registration and bring a
+            // new one up under the new settings using the current identity.
+            // We deliberately route through gate.startAdvertising rather
+            // than a hypothetical "update settings in place" call — the
+            // platform API does not expose one and re-registration is the
+            // documented pattern (matches BleQuickShareScanner.setScanMode).
+            active.getAndSet(null)?.runCatchingClose()
+
+            val payload =
+                try {
+                    payloadFactory.build(id, info)
+                } catch (
+                    @Suppress("TooGenericExceptionCaught") t: Throwable,
+                ) {
+                    Log.w(TAG, "setAdvertiseMode: payload rebuild threw", t)
+                    return@synchronized false
+                }
+            val restarted =
+                try {
+                    gate.startAdvertising(payload, mode)
+                } catch (
+                    @Suppress("TooGenericExceptionCaught") t: Throwable,
+                ) {
+                    Log.w(TAG, "setAdvertiseMode: re-register at new mode failed", t)
+                    null
+                }
+            if (restarted == null) {
+                Log.w(
+                    TAG,
+                    "setAdvertiseMode: ${describeAdvertiseMode(previous)} -> " +
+                        "${describeAdvertiseMode(mode)} FAILED, advertiser is now stopped",
+                )
+                return@synchronized false
+            }
+            active.set(restarted)
+            Log.w(
+                TAG,
+                "setAdvertiseMode: ${describeAdvertiseMode(previous)} -> ${describeAdvertiseMode(mode)}",
+            )
+            true
+        }
+
+    /**
+     * True iff a platform advertisement is currently in flight.
+     */
+    public val isAdvertising: Boolean
+        get() = active.get() != null
+
+    /** Currently-active platform advertise mode. Useful for diagnostics. */
+    public val activeAdvertiseMode: Int
+        get() = currentMode
+
+    /**
+     * Run [BleAdvertiserGate.Registration.close] without letting an
+     * exception escape. Uses a consistent log tag so the failure is
+     * attributable in logcat.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    private fun BleAdvertiserGate.Registration.runCatchingClose() {
+        try {
+            close()
+        } catch (t: Throwable) {
+            Log.w(TAG, "close threw on previous BLE advertise registration", t)
+        }
+    }
+
+    public companion object {
+        /** logcat tag for receiver-side BLE-advertise diagnostics. */
+        internal const val TAG: String = "WvmgBleAdv"
+
+        /**
+         * Build the platform [AdvertiseSettings] for the given mode.
+         *
+         * Pinned configuration:
+         *  * `setConnectable(false)` — Quick Share fast advertisements
+         *    are non-connectable. We never accept GATT connections; the
+         *    advertisement only signals presence. Setting this `false`
+         *    also keeps the advertising-PDU budget free for the
+         *    service-data payload.
+         *  * `setTxPowerLevel(ADVERTISE_TX_POWER_HIGH)` — best chance
+         *    of a wake-up across a typical room. Symmetric to the
+         *    sender-side `BleAdvertiser` and to the BALANCED scan-mode
+         *    range we already tune for on the scanner side.
+         *  * `setAdvertiseMode(<mode>)` — variable; defaults to
+         *    BALANCED and switches to LOW_LATENCY while the app is
+         *    foregrounded.
+         */
+        internal fun buildSettings(mode: Int): AdvertiseSettings =
+            AdvertiseSettings
+                .Builder()
+                .setAdvertiseMode(mode)
+                .setTxPowerLevel(AdvertiseSettings.ADVERTISE_TX_POWER_HIGH)
+                .setConnectable(false)
+                .build()
+
+        /**
+         * Build the platform [AdvertiseData] containing only the
+         * 16-bit service-data AD for `0xFEF3`.
+         *
+         * The service-UUID is embedded inside the service-data
+         * structure (AD type `0x16`), so we deliberately do not also
+         * advertise it through the "Complete List of 16-bit Service
+         * UUIDs" AD — including both pushes us over the 31-byte
+         * legacy budget. This mirrors the comment in [BleAdvertiser].
+         */
+        internal fun buildAdvertiseData(payload: ByteArray): AdvertiseData {
+            val parcelUuid = ParcelUuid(UUID.fromString(BleServiceData.SERVICE_UUID_128_STRING))
+            return AdvertiseData
+                .Builder()
+                .addServiceData(parcelUuid, payload)
+                .setIncludeDeviceName(false)
+                .setIncludeTxPowerLevel(false)
+                .build()
+        }
+
+        /**
+         * Human-readable label for an [AdvertiseSettings] mode constant.
+         * Used in logcat so a power-tuning triage can grep
+         * `WvmgBleAdv setAdvertiseMode` and read the transition without
+         * translating integers.
+         */
+        internal fun describeAdvertiseMode(mode: Int): String =
+            when (mode) {
+                AdvertiseSettings.ADVERTISE_MODE_LOW_POWER -> "LOW_POWER"
+                AdvertiseSettings.ADVERTISE_MODE_BALANCED -> "BALANCED"
+                AdvertiseSettings.ADVERTISE_MODE_LOW_LATENCY -> "LOW_LATENCY"
+                else -> "UNKNOWN($mode)"
+            }
+
+        /**
+         * Test-only factory matching the existing module convention.
+         * The supplied [gate] / [permissionChecker] / [payloadFactory]
+         * let JVM unit tests exercise the lifecycle without
+         * instantiating the production Android wiring.
+         */
+        @JvmStatic
+        internal fun forTesting(
+            gate: BleAdvertiserGate,
+            permissionChecker: AdvertisePermissionChecker = AdvertisePermissionChecker { true },
+            payloadFactory: PayloadFactory = DefaultPayloadFactory,
+        ): BleQuickShareAdvertiser =
+            BleQuickShareAdvertiser(
+                gate = gate,
+                permissionChecker = permissionChecker,
+                payloadFactory = payloadFactory,
+            )
+    }
+}
+
+/**
+ * Permission gate consulted by [BleQuickShareAdvertiser.start] before
+ * attempting a platform advertisement. Lifted to its own interface so
+ * JVM tests can stub it without depending on [ContextCompat].
+ */
+public fun interface AdvertisePermissionChecker {
+    public fun hasAdvertisePermission(): Boolean
+}
+
+internal class AndroidAdvertisePermissionChecker(
+    private val context: Context,
+) : AdvertisePermissionChecker {
+    override fun hasAdvertisePermission(): Boolean {
+        // On API ≤ 30 the install-time BLUETOOTH / BLUETOOTH_ADMIN
+        // permissions are declared in the umbrella manifest and the
+        // runtime check below trivially passes. From API 31+ we need
+        // the runtime BLUETOOTH_ADVERTISE grant.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return true
+        return checkSPermission()
+    }
+
+    @RequiresApi(Build.VERSION_CODES.S)
+    private fun checkSPermission(): Boolean =
+        ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.BLUETOOTH_ADVERTISE,
+        ) == PackageManager.PERMISSION_GRANTED
+}
+
+/**
+ * Builder for the 23-byte service-data payload. The default
+ * implementation delegates to [BleServiceData.encode] in `:core-protocol`;
+ * tests can substitute a fake to drive specific failure paths.
+ */
+public fun interface PayloadFactory {
+    public fun build(
+        endpointId: ByteArray,
+        endpointInfo: EndpointInfo,
+    ): ByteArray
+}
+
+/**
+ * Production payload factory — calls into the pure-JVM encoder so the
+ * Android-side advertiser never has to know the byte layout itself.
+ */
+public object DefaultPayloadFactory : PayloadFactory {
+    override fun build(
+        endpointId: ByteArray,
+        endpointInfo: EndpointInfo,
+    ): ByteArray = BleServiceData.encode(endpointId, endpointInfo)
+}
+
+/**
+ * Abstract handle over the platform [BluetoothLeAdvertiser]. The real
+ * Android type is final so we wrap it instead of mocking — same shape
+ * as [BleScannerGate].
+ *
+ * The gate owns the platform [AdvertiseCallback] subclass (which JVM
+ * unit tests cannot instantiate because the AGP stub jar lacks bytecode
+ * for its non-abstract methods) and the platform settings/data builders.
+ * Consumers receive a [Registration] whose [Registration.close] tears
+ * the advertisement down — no AGP-stubbed type ever leaks across this
+ * boundary.
+ */
+public interface BleAdvertiserGate {
+    /**
+     * Begins a Quick Share fast-advertisement under
+     * [BleServiceData.SERVICE_UUID_128_STRING] with the given
+     * 23-ish-byte service-data payload and platform mode.
+     *
+     * Returns a [Registration] handle whose [Registration.close] stops
+     * the platform advertisement, or `null` if it could not be started
+     * (adapter off, no LE peripheral mode, etc.).
+     *
+     * @param serviceData the encoded service-data payload from
+     *   [BleServiceData.encode]. Must be ≤ 23 bytes for the
+     *   default hidden EndpointInfo shape; longer payloads (e.g. with
+     *   inline UTF-8 device name) may exceed the 31-byte advertising-PDU
+     *   budget and trigger `ADVERTISE_FAILED_DATA_TOO_LARGE`.
+     * @param mode one of [AdvertiseSettings.ADVERTISE_MODE_LOW_POWER],
+     *   [AdvertiseSettings.ADVERTISE_MODE_BALANCED], or
+     *   [AdvertiseSettings.ADVERTISE_MODE_LOW_LATENCY].
+     */
+    public fun startAdvertising(
+        serviceData: ByteArray,
+        mode: Int,
+    ): Registration?
+
+    /** Token returned from [startAdvertising]; close to stop the underlying advertisement. */
+    public interface Registration : AutoCloseable {
+        /** Stops the underlying platform advertisement. Idempotent. */
+        public override fun close()
+    }
+}
+
+/**
+ * Production [BleAdvertiserGate] backed by [BluetoothLeAdvertiser].
+ *
+ * The platform [AdvertiseCallback] is constructed lazily — the gate's
+ * lifetime is bound to a real Android device, so its instances never
+ * have to survive a JVM unit-test class load.
+ */
+internal class AndroidBleAdvertiserGate(
+    private val context: Context,
+) : BleAdvertiserGate {
+    @RequiresPermission(Manifest.permission.BLUETOOTH_ADVERTISE)
+    override fun startAdvertising(
+        serviceData: ByteArray,
+        mode: Int,
+    ): BleAdvertiserGate.Registration? {
+        val advertiser = resolveAdvertiser() ?: return null
+        val settings = BleQuickShareAdvertiser.buildSettings(mode)
+        val data = BleQuickShareAdvertiser.buildAdvertiseData(serviceData)
+        val callback = AdvertiseCallbackImpl()
+        advertiser.startAdvertising(settings, data, callback)
+        return Registration(advertiser, callback)
+    }
+
+    @Suppress("ReturnCount")
+    private fun resolveAdvertiser(): BluetoothLeAdvertiser? {
+        // Each early-return covers a distinct failure mode that the
+        // production logs already differentiate; collapsing them into a
+        // single chained ?: hides the cause when one trips. Suppress
+        // the detekt warning explicitly rather than restructuring.
+        val manager =
+            context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
+                ?: return null
+        val adapter: BluetoothAdapter = manager.adapter ?: return null
+        if (!adapter.isEnabled) return null
+        return adapter.bluetoothLeAdvertiser
+    }
+
+    private class AdvertiseCallbackImpl : AdvertiseCallback() {
+        @Volatile
+        var lastError: Int? = null
+            private set
+
+        override fun onStartSuccess(settingsInEffect: AdvertiseSettings?) {
+            Log.w(BleQuickShareAdvertiser.TAG, "advertise: onStartSuccess settings=$settingsInEffect")
+        }
+
+        @Suppress("MagicNumber")
+        override fun onStartFailure(errorCode: Int) {
+            lastError = errorCode
+            val label =
+                when (errorCode) {
+                    ADVERTISE_FAILED_DATA_TOO_LARGE -> "DATA_TOO_LARGE"
+                    ADVERTISE_FAILED_TOO_MANY_ADVERTISERS -> "TOO_MANY_ADVERTISERS"
+                    ADVERTISE_FAILED_ALREADY_STARTED -> "ALREADY_STARTED"
+                    ADVERTISE_FAILED_INTERNAL_ERROR -> "INTERNAL_ERROR"
+                    ADVERTISE_FAILED_FEATURE_UNSUPPORTED -> "FEATURE_UNSUPPORTED"
+                    else -> "UNKNOWN"
+                }
+            Log.w(BleQuickShareAdvertiser.TAG, "advertise: onStartFailure code=$errorCode ($label)")
+        }
+    }
+
+    private inner class Registration(
+        private val advertiser: BluetoothLeAdvertiser,
+        private val callback: AdvertiseCallbackImpl,
+    ) : BleAdvertiserGate.Registration {
+        @Volatile
+        private var closed: Boolean = false
+
+        @RequiresPermission(Manifest.permission.BLUETOOTH_ADVERTISE)
+        override fun close() {
+            if (closed) return
+            closed = true
+            try {
+                advertiser.stopAdvertising(callback)
+            } catch (
+                @Suppress("TooGenericExceptionCaught") t: Throwable,
+            ) {
+                // Adapter may have been turned off after startAdvertising
+                // succeeded; we still want the registration discarded.
+                Log.w(BleQuickShareAdvertiser.TAG, "stopAdvertising threw", t)
+            }
+        }
+    }
+}

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareAdvertiser.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareAdvertiser.kt
@@ -207,8 +207,22 @@ public class BleQuickShareAdvertiser internal constructor(
             require(endpointId.size == BleServiceData.ENDPOINT_ID_LEN) {
                 "endpointId must be ${BleServiceData.ENDPOINT_ID_LEN} bytes, got ${endpointId.size}"
             }
-            // Replace any previous registration so the platform never
-            // sees stale identity bytes alongside the fresh ones.
+            // Idempotent on identity-unchanged calls: the gate may invoke
+            // start() repeatedly during steady-state publishing (every
+            // BLE-scan re-arm passes through the same MdnsAdvertisementGate
+            // decision loop). Tearing the platform registration down and
+            // rebuilding it on every flap leaves a brief gap in the BLE
+            // pulse and churns the host BT stack. Short-circuit when the
+            // already-active registration carries the same identity bytes.
+            if (active.get() != null &&
+                currentEndpointInfo == endpointInfo &&
+                currentEndpointId?.contentEquals(endpointId) == true
+            ) {
+                return@synchronized true
+            }
+            // Identity changed (or we're starting fresh) — replace any
+            // previous registration so the platform never sees stale
+            // identity bytes alongside the fresh ones.
             active.getAndSet(null)?.runCatchingClose()
 
             if (!permissionChecker.hasAdvertisePermission()) {

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareAdvertiserTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareAdvertiserTest.kt
@@ -244,6 +244,54 @@ class BleQuickShareAdvertiserTest {
         assertThat(advertiser.isAdvertising).isFalse()
     }
 
+    @Test
+    fun `start after stop re-registers successfully`() {
+        // Regression guard: stop() must clear the active registration state
+        // so a subsequent start() can open a fresh platform registration.
+        // A buggy implementation that leaves currentEndpointInfo non-null
+        // would short-circuit on identity-unchanged comparison and return
+        // true without touching the gate — hiding the fact that the
+        // platform registration was already closed.
+        val gate = RecordingGate(failOnStart = false)
+        val advertiser =
+            BleQuickShareAdvertiser.forTesting(
+                gate = gate,
+                permissionChecker = { true },
+            )
+        advertiser.start(hiddenPhone(), endpointId("Wvmg"))
+        advertiser.stop()
+        assertThat(advertiser.isAdvertising).isFalse()
+
+        // Re-start: must open a fresh platform registration even though
+        // the identity bytes are identical to the previous run.
+        val restarted = advertiser.start(hiddenPhone(), endpointId("Wvmg"))
+        assertThat(restarted).isTrue()
+        assertThat(advertiser.isAdvertising).isTrue()
+        // Two total calls: first start + re-start (stop clears state so
+        // the idempotency guard does not block the second start).
+        assertThat(gate.startCalls).hasSize(2)
+        assertThat(gate.lastRegistration?.closed).isFalse()
+    }
+
+    @Test
+    fun `start returns false when payload factory throws`() {
+        // The try/catch around payloadFactory.build must swallow the error
+        // and return false so the receiver continues in mDNS-only mode
+        // instead of crashing or leaving an inconsistent registration.
+        val gate = RecordingGate(failOnStart = false)
+        val advertiser =
+            BleQuickShareAdvertiser.forTesting(
+                gate = gate,
+                permissionChecker = { true },
+                payloadFactory = { _, _ -> error("synthetic payload build failure") },
+            )
+        val started = advertiser.start(hiddenPhone(), endpointId("Wvmg"))
+        assertThat(started).isFalse()
+        assertThat(advertiser.isAdvertising).isFalse()
+        // The platform gate must not have been contacted at all.
+        assertThat(gate.startCalls).isEmpty()
+    }
+
     private fun hiddenPhone(): EndpointInfo =
         EndpointInfo(
             version = 1,

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareAdvertiserTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareAdvertiserTest.kt
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.discovery.ble
+
+import android.bluetooth.le.AdvertiseSettings
+import com.google.common.truth.Truth.assertThat
+import io.github.kyujincho.wvmg.protocol.endpoint.BleServiceData
+import io.github.kyujincho.wvmg.protocol.endpoint.DeviceType
+import io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * Lifecycle and fallback tests for [BleQuickShareAdvertiser] (issue #121).
+ *
+ * The happy path on real hardware (`startAdvertising` succeeds and the
+ * `AdvertiseCallback.onStartSuccess` fires) is verified manually via
+ * the `docs/testing/` runbooks because instantiating a functioning
+ * `BluetoothLeAdvertiser` from a host JVM requires Robolectric, which
+ * the discovery module deliberately does not pull in.
+ *
+ * These tests exercise:
+ *  * permission-denied → `start` returns false, no platform call,
+ *  * no platform advertiser → `start` returns false, no payload built,
+ *  * `start` accepts → `isAdvertising == true`, payload contains the
+ *    canonical Galaxy fingerprint,
+ *  * `setAdvertiseMode` is idempotent on the current mode and
+ *    re-registers when the mode changes,
+ *  * `stop` is idempotent and tears the registration down.
+ */
+class BleQuickShareAdvertiserTest {
+    @Test
+    fun `start returns false when permission is denied`() {
+        val gate = RecordingGate(failOnStart = false)
+        val advertiser =
+            BleQuickShareAdvertiser.forTesting(
+                gate = gate,
+                permissionChecker = { false },
+            )
+        val started = advertiser.start(hiddenPhone(), endpointId("Wvmg"))
+        assertThat(started).isFalse()
+        assertThat(gate.startCalls).isEmpty()
+        assertThat(advertiser.isAdvertising).isFalse()
+    }
+
+    @Test
+    fun `start returns false when the platform has no advertiser`() {
+        val gate =
+            object : BleAdvertiserGate {
+                override fun startAdvertising(
+                    serviceData: ByteArray,
+                    mode: Int,
+                ): BleAdvertiserGate.Registration? = null
+            }
+        val advertiser =
+            BleQuickShareAdvertiser.forTesting(
+                gate = gate,
+                permissionChecker = { true },
+            )
+        val started = advertiser.start(hiddenPhone(), endpointId("Wvmg"))
+        assertThat(started).isFalse()
+        assertThat(advertiser.isAdvertising).isFalse()
+    }
+
+    @Test
+    fun `start submits the canonical fast-advertisement payload`() {
+        val gate = RecordingGate(failOnStart = false)
+        val advertiser =
+            BleQuickShareAdvertiser.forTesting(
+                gate = gate,
+                permissionChecker = { true },
+            )
+        val info = hiddenPhone()
+        val started = advertiser.start(info, endpointId("Wvmg"))
+        assertThat(started).isTrue()
+        assertThat(advertiser.isAdvertising).isTrue()
+        assertThat(gate.startCalls).hasSize(1)
+
+        val (payload, mode) = gate.startCalls.last()
+        // The default mode is BALANCED until the lifecycle observer
+        // upgrades it to LOW_LATENCY. Pinning it here catches drift.
+        assertThat(mode).isEqualTo(AdvertiseSettings.ADVERTISE_MODE_BALANCED)
+
+        // Byte 0 is the canonical 0x23 (version=1, PCP=3); byte 5 is
+        // the EndpointInfo length (17 for hidden); byte 6 is the
+        // EndpointInfo header (0x32 = hidden + version=1 + PHONE).
+        assertThat(payload).hasLength(BleServiceData.FIXED_HEADER_LEN + info.serialize().size)
+        assertThat(payload[0].toInt() and 0xFF).isEqualTo(0x23)
+        assertThat(payload.copyOfRange(1, 5)).isEqualTo(endpointId("Wvmg"))
+        assertThat(payload[5].toInt() and 0xFF).isEqualTo(0x11)
+        assertThat(payload[6].toInt() and 0xFF).isEqualTo(0x32)
+    }
+
+    @Test
+    fun `start rejects an endpoint_id of the wrong length`() {
+        val advertiser =
+            BleQuickShareAdvertiser.forTesting(
+                gate = RecordingGate(failOnStart = false),
+                permissionChecker = { true },
+            )
+        assertThrows<IllegalArgumentException> {
+            advertiser.start(hiddenPhone(), ByteArray(3))
+        }
+        assertThrows<IllegalArgumentException> {
+            advertiser.start(hiddenPhone(), ByteArray(5))
+        }
+    }
+
+    @Test
+    fun `start replaces an in-flight registration with the new identity`() {
+        val gate = RecordingGate(failOnStart = false)
+        val advertiser =
+            BleQuickShareAdvertiser.forTesting(
+                gate = gate,
+                permissionChecker = { true },
+            )
+        advertiser.start(hiddenPhone(), endpointId("AAAA"))
+        advertiser.start(hiddenPhone(), endpointId("BBBB"))
+
+        // First registration should be closed before the second was opened.
+        assertThat(gate.startCalls).hasSize(2)
+        assertThat(gate.firstRegistration?.closed).isTrue()
+        assertThat(gate.lastRegistration?.closed).isFalse()
+
+        // Bytes 1..4 of the latest payload reflect the second endpoint_id.
+        val (payload, _) = gate.startCalls.last()
+        assertThat(payload.copyOfRange(1, 5)).isEqualTo(endpointId("BBBB"))
+    }
+
+    @Test
+    fun `stop is idempotent and tears the registration down`() {
+        val gate = RecordingGate(failOnStart = false)
+        val advertiser =
+            BleQuickShareAdvertiser.forTesting(
+                gate = gate,
+                permissionChecker = { true },
+            )
+        advertiser.start(hiddenPhone(), endpointId("Wvmg"))
+        advertiser.stop()
+        assertThat(advertiser.isAdvertising).isFalse()
+        assertThat(gate.lastRegistration?.closed).isTrue()
+
+        // Second stop is a no-op.
+        advertiser.stop()
+        assertThat(advertiser.isAdvertising).isFalse()
+    }
+
+    @Test
+    fun `setAdvertiseMode while idle just pins the next start mode`() {
+        val gate = RecordingGate(failOnStart = false)
+        val advertiser =
+            BleQuickShareAdvertiser.forTesting(
+                gate = gate,
+                permissionChecker = { true },
+            )
+        // Idle: setAdvertiseMode should not invoke the platform.
+        val ok = advertiser.setAdvertiseMode(AdvertiseSettings.ADVERTISE_MODE_LOW_LATENCY)
+        assertThat(ok).isTrue()
+        assertThat(gate.startCalls).isEmpty()
+        assertThat(advertiser.activeAdvertiseMode)
+            .isEqualTo(AdvertiseSettings.ADVERTISE_MODE_LOW_LATENCY)
+
+        // Subsequent start should use the pinned mode.
+        advertiser.start(hiddenPhone(), endpointId("Wvmg"))
+        assertThat(gate.startCalls.last().second)
+            .isEqualTo(AdvertiseSettings.ADVERTISE_MODE_LOW_LATENCY)
+    }
+
+    @Test
+    fun `setAdvertiseMode is idempotent on the current mode`() {
+        val gate = RecordingGate(failOnStart = false)
+        val advertiser =
+            BleQuickShareAdvertiser.forTesting(
+                gate = gate,
+                permissionChecker = { true },
+            )
+        advertiser.start(hiddenPhone(), endpointId("Wvmg"))
+        val before = gate.startCalls.size
+        // Already on BALANCED — must be a no-op.
+        val ok = advertiser.setAdvertiseMode(AdvertiseSettings.ADVERTISE_MODE_BALANCED)
+        assertThat(ok).isTrue()
+        assertThat(gate.startCalls).hasSize(before)
+    }
+
+    @Test
+    fun `setAdvertiseMode while active re-registers with the new mode`() {
+        val gate = RecordingGate(failOnStart = false)
+        val advertiser =
+            BleQuickShareAdvertiser.forTesting(
+                gate = gate,
+                permissionChecker = { true },
+            )
+        advertiser.start(hiddenPhone(), endpointId("Wvmg"))
+        val ok = advertiser.setAdvertiseMode(AdvertiseSettings.ADVERTISE_MODE_LOW_LATENCY)
+        assertThat(ok).isTrue()
+        assertThat(gate.startCalls).hasSize(2)
+        assertThat(gate.startCalls.last().second)
+            .isEqualTo(AdvertiseSettings.ADVERTISE_MODE_LOW_LATENCY)
+        // First registration was torn down; second is still live.
+        assertThat(gate.firstRegistration?.closed).isTrue()
+        assertThat(gate.lastRegistration?.closed).isFalse()
+        assertThat(advertiser.isAdvertising).isTrue()
+    }
+
+    @Test
+    fun `setAdvertiseMode reverts to stopped state when re-register fails`() {
+        val gate = RecordingGate(failOnStart = false)
+        val advertiser =
+            BleQuickShareAdvertiser.forTesting(
+                gate = gate,
+                permissionChecker = { true },
+            )
+        advertiser.start(hiddenPhone(), endpointId("Wvmg"))
+        gate.failOnStart = true
+        val ok = advertiser.setAdvertiseMode(AdvertiseSettings.ADVERTISE_MODE_LOW_LATENCY)
+        assertThat(ok).isFalse()
+        assertThat(advertiser.isAdvertising).isFalse()
+    }
+
+    private fun hiddenPhone(): EndpointInfo =
+        EndpointInfo(
+            version = 1,
+            hidden = true,
+            deviceType = DeviceType.PHONE,
+            reserved = false,
+            metadata = ByteArray(EndpointInfo.METADATA_LEN) { 0x00 },
+            deviceName = null,
+        )
+
+    private fun endpointId(s: String): ByteArray {
+        require(s.length == BleServiceData.ENDPOINT_ID_LEN)
+        return s.toByteArray(Charsets.US_ASCII)
+    }
+
+    /**
+     * Test double for the platform [BleAdvertiserGate]. Records each
+     * `startAdvertising` call as a `(payload, mode)` pair and tracks
+     * whether the resulting registration was subsequently closed.
+     */
+    private class RecordingGate(
+        @Volatile var failOnStart: Boolean,
+    ) : BleAdvertiserGate {
+        val startCalls: MutableList<Pair<ByteArray, Int>> = mutableListOf()
+        val registrations: MutableList<RecordingRegistration> = mutableListOf()
+
+        val firstRegistration: RecordingRegistration?
+            get() = registrations.firstOrNull()
+        val lastRegistration: RecordingRegistration?
+            get() = registrations.lastOrNull()
+
+        override fun startAdvertising(
+            serviceData: ByteArray,
+            mode: Int,
+        ): BleAdvertiserGate.Registration? {
+            startCalls += serviceData to mode
+            if (failOnStart) return null
+            val reg = RecordingRegistration()
+            registrations += reg
+            return reg
+        }
+    }
+
+    private class RecordingRegistration : BleAdvertiserGate.Registration {
+        @Volatile
+        var closed: Boolean = false
+            private set
+
+        override fun close() {
+            closed = true
+        }
+    }
+}

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareAdvertiserTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareAdvertiserTest.kt
@@ -131,6 +131,30 @@ class BleQuickShareAdvertiserTest {
     }
 
     @Test
+    fun `start is idempotent on identity-unchanged calls`() {
+        // Regression guard: the MdnsAdvertisementGate decision loop calls
+        // start() on every BLE-scan re-arm during steady-state publishing.
+        // A naive teardown-then-rebuild leaves a brief gap in the BLE
+        // pulse and churns the host BT stack. When the identity bytes are
+        // unchanged from the active registration, the second start() must
+        // be a true no-op on the platform.
+        val gate = RecordingGate(failOnStart = false)
+        val advertiser =
+            BleQuickShareAdvertiser.forTesting(
+                gate = gate,
+                permissionChecker = { true },
+            )
+        val info = hiddenPhone()
+        val id = endpointId("Wvmg")
+
+        advertiser.start(info, id)
+        advertiser.start(info, id.copyOf()) // distinct array, equal contents
+
+        assertThat(gate.startCalls).hasSize(1)
+        assertThat(gate.lastRegistration?.closed).isFalse()
+    }
+
+    @Test
     fun `stop is idempotent and tears the registration down`() {
         val gate = RecordingGate(failOnStart = false)
         val advertiser =

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/MdnsAdvertisementGate.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/MdnsAdvertisementGate.kt
@@ -94,6 +94,23 @@ public class MdnsAdvertisementGate(
     private val qrSessionActive: StateFlow<Boolean>,
     private val outboundSessionActive: StateFlow<Boolean> = MutableStateFlow(false),
     private val debounceIdleMillis: Long = DEFAULT_DEBOUNCE_IDLE_MILLIS,
+    /**
+     * Optional sink for the receiver-side BLE pulse advertiser (#121).
+     *
+     * When supplied, the gate calls [BleVisibilityBroadcaster.start] /
+     * [BleVisibilityBroadcaster.stop] in lock-step with the mDNS
+     * publish/unpublish decisions. Same debounce window, same outbound
+     * veto — BLE and mDNS advertise (and unpublish) symmetrically so
+     * peers see consistent presence across both channels.
+     *
+     * Defaults to a no-op [BleVisibilityBroadcaster.Noop]; tests and
+     * the production wiring inject a real implementation backed by
+     * `BleQuickShareAdvertiser`. Wiring it through the gate (rather
+     * than spawning a parallel observer) keeps the publish/unpublish
+     * decisions trivially in sync — there is one decision, applied to
+     * both sinks.
+     */
+    private val bleBroadcaster: BleVisibilityBroadcaster = BleVisibilityBroadcaster.Noop,
 ) {
     @Volatile
     private var collectorJob: Job? = null
@@ -206,6 +223,7 @@ public class MdnsAdvertisementGate(
                     Log.w(TAG, "unpublish: threw during outbound veto", t)
                 }
             }
+            stopBleSafely(reason = "outbound send active")
             return
         }
         val shouldPublish =
@@ -227,6 +245,11 @@ public class MdnsAdvertisementGate(
                     Log.w(TAG, "publish: failed (decision=$decision)", t)
                 }
             }
+            // Symmetric BLE advertise — start in lock-step with the
+            // mDNS publish. The broadcaster is itself idempotent, so
+            // re-issuing start() while it is already advertising is a
+            // no-op on the platform.
+            startBleSafely(decision)
             return
         }
 
@@ -252,8 +275,45 @@ public class MdnsAdvertisementGate(
                         // already torn down.
                         Log.w(TAG, "unpublish: threw", t)
                     }
+                    // Symmetric BLE teardown — same debounce window so
+                    // the BLE advertiser does not flap on intermittent
+                    // pulses, and so peers stop seeing us on both
+                    // channels at the same wall-clock moment.
+                    stopBleSafely(reason = "idle for ${debounceIdleMillis}ms")
                 }
             }
+    }
+
+    /**
+     * Best-effort `bleBroadcaster.start` that swallows all exceptions
+     * with a logged warning. The broadcaster itself is supposed to fail
+     * silently (no advertise permission, no LE peripheral, etc.); this
+     * wrapper exists so a misbehaving fake in tests cannot poison the
+     * gate's mDNS path.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    private fun startBleSafely(decision: Decision) {
+        try {
+            bleBroadcaster.start()
+            Log.w(TAG, "publish: BLE pulse advertise started (decision=$decision)")
+        } catch (t: Throwable) {
+            Log.w(TAG, "publish: BLE pulse advertise threw (decision=$decision)", t)
+        }
+    }
+
+    /**
+     * Best-effort `bleBroadcaster.stop` that swallows all exceptions.
+     * Logging mirrors [startBleSafely] so the lifecycle is greppable
+     * end-to-end.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    private fun stopBleSafely(reason: String) {
+        try {
+            bleBroadcaster.stop()
+            Log.w(TAG, "unpublish: BLE pulse advertise stopped ($reason)")
+        } catch (t: Throwable) {
+            Log.w(TAG, "unpublish: BLE pulse advertise stop threw ($reason)", t)
+        }
     }
 
     /**
@@ -279,5 +339,49 @@ public class MdnsAdvertisementGate(
          * avoid flapping if the BLE pulse is intermittent."
          */
         public const val DEFAULT_DEBOUNCE_IDLE_MILLIS: Long = 30_000L
+    }
+}
+
+/**
+ * Sink for the receiver-side BLE pulse advertiser (#121).
+ *
+ * Lifted out of [MdnsAdvertisementGate] so the gate stays platform-
+ * neutral and so JVM unit tests can record start/stop calls without
+ * standing up an Android `BluetoothLeAdvertiser`. Production wires this
+ * to a closure that captures the gate's `BleQuickShareAdvertiser` plus
+ * the receiver's stable [EndpointInfo] / endpoint_id.
+ *
+ * Implementations must be idempotent: the gate calls [start] every time
+ * its publish decision flips back on, regardless of whether the
+ * underlying advertiser is already running.
+ */
+public interface BleVisibilityBroadcaster {
+    /**
+     * Advertise the receiver's BLE pulse. Idempotent.
+     *
+     * Failures (no permission, no peripheral mode, adapter off) are
+     * the broadcaster's responsibility to swallow — the gate logs but
+     * does not retry.
+     */
+    public fun start()
+
+    /**
+     * Stop advertising. Idempotent.
+     */
+    public fun stop()
+
+    /**
+     * No-op broadcaster used when the gate is constructed without BLE
+     * support — early test fixtures, or production paths where the
+     * `BleQuickShareAdvertiser` could not be initialised.
+     */
+    public object Noop : BleVisibilityBroadcaster {
+        override fun start() {
+            // Intentionally empty.
+        }
+
+        override fun stop() {
+            // Intentionally empty.
+        }
     }
 }

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
@@ -23,7 +23,9 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import io.github.kyujincho.wvmg.discovery.Discovery
+import io.github.kyujincho.wvmg.discovery.ble.BleQuickShareAdvertiser
 import io.github.kyujincho.wvmg.discovery.ble.BleQuickShareScanner
+import io.github.kyujincho.wvmg.protocol.endpoint.BleServiceData
 import io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo
 import io.github.kyujincho.wvmg.service.downloads.DownloadsWriterFactory
 import io.github.kyujincho.wvmg.service.receiver.consent.ConsentBroadcastReceiver
@@ -123,6 +125,20 @@ public class ReceiverForegroundService : Service() {
 
     @Volatile
     private var bleScanner: BleQuickShareScanner? = null
+
+    /**
+     * Receiver-side BLE pulse advertiser (#121). Owned for the lifetime
+     * of the foreground service alongside the scanner; lifecycle-gated
+     * via [MdnsAdvertisementGate]'s [BleVisibilityBroadcaster] sink so
+     * BLE advertise tracks mDNS publish/unpublish in lock-step.
+     *
+     * `null` when the receiver service is not running, or when BLE
+     * peripheral advertising is unavailable (no `BLUETOOTH_ADVERTISE`
+     * grant — see [BleQuickShareAdvertiser.start]'s graceful failure
+     * path).
+     */
+    @Volatile
+    private var bleAdvertiser: BleQuickShareAdvertiser? = null
 
     @Volatile
     private var mdnsGate: MdnsAdvertisementGate? = null
@@ -239,7 +255,21 @@ public class ReceiverForegroundService : Service() {
         // controls the single scan registration over its lifetime.
         scanner.start()
 
-        // Attach the foreground/background scan-mode observer (#35).
+        // Construct the receiver-side BLE pulse advertiser (#121). The
+        // advertiser is **not** started here — the [MdnsAdvertisementGate]
+        // routes its publish/unpublish decisions to both mDNS and BLE
+        // simultaneously through [BleVisibilityBroadcaster], so
+        // start/stop calls happen in lock-step with the existing mDNS
+        // path. Failures inside the advertiser (no permission, no
+        // peripheral mode, adapter off) are swallowed and logged
+        // there; the receiver continues in mDNS-only mode.
+        bleAdvertiser = BleQuickShareAdvertiser(applicationContext)
+
+        // Attach the foreground/background mode observer (#35) for both
+        // the scanner and the advertiser. Symmetric tuning: BALANCED in
+        // the background, LOW_LATENCY while the user has the app
+        // foregrounded, so a fresh send-side picker scan sees us within
+        // a few hundred milliseconds.
         // ProcessLifecycleOwner requires its observers to be attached
         // on the main thread.
         attachProcessLifecycleObserver(scanner)
@@ -259,12 +289,44 @@ public class ReceiverForegroundService : Service() {
      * thread.
      */
     private fun attachProcessLifecycleObserver(scanner: BleQuickShareScanner) {
-        val observer = AppLifecycleScanModeObserver { mode -> scanner.setScanMode(mode) }
+        // The observer fans the foreground/background transition out to
+        // both the scanner and the advertiser. Both classes' mode
+        // setters are idempotent and inline-callable; the closure holds
+        // a reference to the volatile [bleAdvertiser] field so it picks
+        // up `null` cleanly if the service tears down between
+        // observer-attach and the next lifecycle callback.
+        val observer =
+            AppLifecycleScanModeObserver { scanMode ->
+                scanner.setScanMode(scanMode)
+                bleAdvertiser?.setAdvertiseMode(translateToAdvertiseMode(scanMode))
+            }
         processLifecycleObserver = observer
         runOnMainThread {
             ProcessLifecycleOwner.get().lifecycle.addObserver(observer)
         }
     }
+
+    /**
+     * Translate a [android.bluetooth.le.ScanSettings] scan-mode constant
+     * to the corresponding [android.bluetooth.le.AdvertiseSettings]
+     * advertise-mode constant. Mirrors the BALANCED ↔ LOW_LATENCY pairing
+     * the scanner already uses.
+     *
+     * The mapping is intentionally tight — only the two modes the
+     * lifecycle observer toggles between are recognised. Anything else
+     * falls back to BALANCED, which is the safe default for a
+     * continuously-running foreground service.
+     */
+    private fun translateToAdvertiseMode(scanMode: Int): Int =
+        when (scanMode) {
+            ScanSettings.SCAN_MODE_LOW_LATENCY ->
+                android.bluetooth.le.AdvertiseSettings.ADVERTISE_MODE_LOW_LATENCY
+            ScanSettings.SCAN_MODE_BALANCED ->
+                android.bluetooth.le.AdvertiseSettings.ADVERTISE_MODE_BALANCED
+            ScanSettings.SCAN_MODE_LOW_POWER ->
+                android.bluetooth.le.AdvertiseSettings.ADVERTISE_MODE_LOW_POWER
+            else -> android.bluetooth.le.AdvertiseSettings.ADVERTISE_MODE_BALANCED
+        }
 
     override fun onBind(intent: Intent?): IBinder? = null
 
@@ -358,9 +420,50 @@ public class ReceiverForegroundService : Service() {
                 alwaysVisibleOverride = MdnsVisibilityOverrideHolder.activeFlow,
                 qrSessionActive = QrSessionActiveHolder.activeFlow,
                 outboundSessionActive = OutboundSessionActiveHolder.activeFlow,
+                bleBroadcaster = buildBleBroadcaster(activeSession),
             )
         gate.start(serviceScope)
         mdnsGate = gate
+    }
+
+    /**
+     * Build a [BleVisibilityBroadcaster] that hands the gate's
+     * publish/unpublish decisions to the [bleAdvertiser] using the
+     * receiver's stable [EndpointInfo] and a process-stable 4-byte
+     * endpoint_id slug.
+     *
+     * The endpoint_id we feed into BLE is intentionally **independent**
+     * of the per-publish mDNS instance name slug — that one is rotated
+     * on every `Discovery.advertise` call. For #121 we only need a
+     * valid 4-byte ASCII slug; future work can align the two so a
+     * single peer's BLE pulse and mDNS service-info report the same id.
+     *
+     * Returns [BleVisibilityBroadcaster.Noop] if [bleAdvertiser] is
+     * `null` (the service is between start/stop, or no advertiser was
+     * constructed in [startBleScanner] for some reason). The gate
+     * tolerates a no-op broadcaster the same way it tolerates a
+     * never-active BLE pulse: mDNS still publishes/unpublishes per the
+     * other gating signals.
+     */
+    @Suppress("UNUSED_PARAMETER", "ReturnCount")
+    private fun buildBleBroadcaster(session: ReceiverSession): BleVisibilityBroadcaster {
+        val advertiser = bleAdvertiser ?: return BleVisibilityBroadcaster.Noop
+        val endpointInfo =
+            EndpointIdentityHolder.snapshot.get() ?: return BleVisibilityBroadcaster.Noop
+        val endpointId = BleEndpointIdHolder.bytes
+        return object : BleVisibilityBroadcaster {
+            override fun start() {
+                // BleQuickShareAdvertiser.start re-uses the existing
+                // platform registration when the identity is unchanged,
+                // so re-issuing start() while already advertising is
+                // effectively a no-op.
+                advertiser.start(endpointInfo, endpointId)
+            }
+
+            override fun stop() {
+                advertiser.stop()
+            }
+        }
     }
 
     /**
@@ -610,6 +713,14 @@ public class ReceiverForegroundService : Service() {
         bleScanner?.stop()
         bleScanner = null
         ActiveBleScannerHolder.clear()
+
+        // Tear the receiver-side BLE pulse advertiser down (#121). The
+        // gate's stop above already issued a final `stop()` on the
+        // broadcaster as part of its outbound-veto / debounce path,
+        // but we re-stop unconditionally here in case the gate teardown
+        // raced with a fresh "should publish" decision.
+        bleAdvertiser?.stop()
+        bleAdvertiser = null
 
         serviceJob.cancel()
         ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE)
@@ -970,6 +1081,41 @@ internal object ActiveDiscoveryHolder {
 
     fun clear() {
         ref = null
+    }
+}
+
+/**
+ * Process-singleton holder for the receiver's stable 4-byte ASCII
+ * endpoint_id slug used by the BLE pulse advertiser (#121).
+ *
+ * The same slug is the natural primary key Quick Share peers use to
+ * dedupe sightings of a device across BLE and mDNS. We cache it here so
+ * a service restart (e.g. `START_STICKY` resurrection) keeps the
+ * receiver's identity stable across both channels — flipping ids on
+ * every restart would make the same physical device look like a fresh
+ * peer to neighbors.
+ *
+ * The mDNS instance name is currently regenerated on every
+ * `Discovery.advertise` call and therefore drifts independently — that
+ * is a known follow-up. For #121 the only acceptance criterion is "BLE
+ * pulses carry a valid 4-byte ASCII endpoint_id," which this holder
+ * satisfies on its own.
+ */
+internal object BleEndpointIdHolder {
+    /**
+     * The cached 4-byte slug. Generated on first read using
+     * `[A-Za-z0-9]` — same alphabet [InstanceName] uses internally —
+     * so the bytes round-trip cleanly through any future base64-url
+     * conversion.
+     */
+    val bytes: ByteArray by lazy { generate() }
+
+    private fun generate(): ByteArray {
+        val alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+        val random = java.security.SecureRandom()
+        return ByteArray(BleServiceData.ENDPOINT_ID_LEN) {
+            alphabet[random.nextInt(alphabet.length)].code.toByte()
+        }
     }
 }
 

--- a/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/MdnsAdvertisementGateTest.kt
+++ b/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/MdnsAdvertisementGateTest.kt
@@ -364,6 +364,95 @@ class MdnsAdvertisementGateTest {
             session.stop()
         }
 
+    @Test
+    fun `BLE broadcaster starts and stops in lock-step with mDNS publish`() =
+        runTest {
+            val advertiser = RecordingAdvertiser()
+            val session = startedGatedSession(advertiser = advertiser)
+            val ble = MutableStateFlow<ScanActivity>(ScanActivity.Idle)
+            val override = MutableStateFlow(false)
+            val qr = MutableStateFlow(false)
+            val broadcaster = RecordingBleBroadcaster()
+
+            val gate =
+                MdnsAdvertisementGate(
+                    session = session,
+                    bleActivity = ble,
+                    alwaysVisibleOverride = override,
+                    qrSessionActive = qr,
+                    debounceIdleMillis = 30_000L,
+                    bleBroadcaster = broadcaster,
+                )
+            gate.start(this)
+            advanceUntilIdle()
+            // Idle at boot: BLE advertise stays off.
+            assertThat(broadcaster.startCount).isEqualTo(0)
+
+            // Pulse activity flips publish on; BLE must start in lock-step.
+            ble.value = ScanActivity.Active(lastSeenAtMillis = 1_000L)
+            advanceUntilIdle()
+            assertThat(session.isAdvertising).isTrue()
+            assertThat(broadcaster.startCount).isEqualTo(1)
+
+            // Idle again: 30 s debounce holds both channels up. Use
+            // advanceTimeBy to step through the debounce — advanceUntilIdle
+            // would jump straight to the timer's fire time.
+            ble.value = ScanActivity.Idle
+            advanceTimeBy(1L)
+            advanceTimeBy(29_998L)
+            assertThat(session.isAdvertising).isTrue()
+            assertThat(broadcaster.stopCount).isEqualTo(0)
+
+            // Cross the debounce threshold: both channels unpublish
+            // together.
+            advanceTimeBy(10L)
+            advanceUntilIdle()
+            assertThat(session.isAdvertising).isFalse()
+            assertThat(broadcaster.stopCount).isAtLeast(1)
+
+            gate.stop()
+            session.stop()
+        }
+
+    @Test
+    fun `outbound veto stops BLE advertise immediately bypassing debounce`() =
+        runTest {
+            val advertiser = RecordingAdvertiser()
+            val session = startedGatedSession(advertiser = advertiser)
+            val ble = MutableStateFlow<ScanActivity>(ScanActivity.Active(lastSeenAtMillis = 1_000L))
+            val override = MutableStateFlow(false)
+            val qr = MutableStateFlow(false)
+            val outbound = MutableStateFlow(false)
+            val broadcaster = RecordingBleBroadcaster()
+
+            val gate =
+                MdnsAdvertisementGate(
+                    session = session,
+                    bleActivity = ble,
+                    alwaysVisibleOverride = override,
+                    qrSessionActive = qr,
+                    outboundSessionActive = outbound,
+                    debounceIdleMillis = 30_000L,
+                    bleBroadcaster = broadcaster,
+                )
+            gate.start(this)
+            advanceUntilIdle()
+            // Active pulse + no outbound: both channels advertising.
+            assertThat(session.isAdvertising).isTrue()
+            assertThat(broadcaster.startCount).isAtLeast(1)
+            val baselineStops = broadcaster.stopCount
+
+            // Outbound flips on: must immediately tear down both
+            // channels, not waiting on the debounce.
+            outbound.value = true
+            advanceUntilIdle()
+            assertThat(session.isAdvertising).isFalse()
+            assertThat(broadcaster.stopCount).isGreaterThan(baselineStops)
+
+            gate.stop()
+            session.stop()
+        }
+
     // --------------------------------------------------------------
     // Helpers
     // --------------------------------------------------------------
@@ -433,6 +522,29 @@ class MdnsAdvertisementGateTest {
             val handle = FakeAdvertiseHandle(port = port)
             calls += Call(endpointInfo, port, handle)
             return handle
+        }
+    }
+
+    /**
+     * Recording [BleVisibilityBroadcaster] that counts start/stop
+     * invocations. Used by the lock-step tests to verify BLE-side
+     * advertise mirrors mDNS publish exactly.
+     */
+    private class RecordingBleBroadcaster : BleVisibilityBroadcaster {
+        @Volatile
+        var startCount: Int = 0
+            private set
+
+        @Volatile
+        var stopCount: Int = 0
+            private set
+
+        override fun start() {
+            startCount += 1
+        }
+
+        override fun stop() {
+            stopCount += 1
         }
     }
 

--- a/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/MdnsAdvertisementGateTest.kt
+++ b/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/MdnsAdvertisementGateTest.kt
@@ -453,6 +453,46 @@ class MdnsAdvertisementGateTest {
             session.stop()
         }
 
+    @Test
+    fun `BLE broadcaster throwing on start is swallowed and mDNS still publishes`() =
+        runTest {
+            val advertiser = RecordingAdvertiser()
+            val session = startedGatedSession(advertiser = advertiser)
+            val ble = MutableStateFlow<ScanActivity>(ScanActivity.Idle)
+            val override = MutableStateFlow(false)
+            val qr = MutableStateFlow(false)
+
+            // A broadcaster whose start() throws — should be swallowed by
+            // startBleSafely so the gate's mDNS publish path is unaffected.
+            val throwingBroadcaster =
+                object : BleVisibilityBroadcaster {
+                    override fun start() = error("synthetic BLE advertise failure")
+
+                    override fun stop() = Unit
+                }
+
+            val gate =
+                MdnsAdvertisementGate(
+                    session = session,
+                    bleActivity = ble,
+                    alwaysVisibleOverride = override,
+                    qrSessionActive = qr,
+                    bleBroadcaster = throwingBroadcaster,
+                )
+            gate.start(this)
+            advanceUntilIdle()
+
+            override.value = true
+            advanceUntilIdle()
+
+            // mDNS must have published despite the BLE broadcaster throwing.
+            assertThat(session.isAdvertising).isTrue()
+            assertThat(advertiser.calls).hasSize(1)
+
+            gate.stop()
+            session.stop()
+        }
+
     // --------------------------------------------------------------
     // Helpers
     // --------------------------------------------------------------


### PR DESCRIPTION
## Summary
Closes the picker-visibility loop that c0150be only patched at the mDNS layer: stock Quick Share peers (Galaxy / One UI) cross-reference discovered Wi-Fi LAN services against recently-seen BLE pulses on the `0xFEF3` fast-advertisement UUID. Without one, our receiver is silently dropped from the picker — issue #121.

This PR adds the receiver-side BLE advertiser, layered to keep `:core-protocol` JVM-pure:

- **`:core-protocol`** — `BleServiceData` encodes the canonical 6+N service-data payload `[ versPCP(1) | endpoint_id(4) | length(1) | EndpointInfo(N) ]`. Bit-exact KATs against the Galaxy fingerprint captured during c0150be: `0x23` version/PCP, `0x11` hidden EndpointInfo length, `0x32` inner header.
- **`:discovery-android`** — `BleQuickShareAdvertiser` is symmetric to the existing `BleQuickShareScanner`: same start/stop/setMode lifecycle shape, same BALANCED ↔ LOW_LATENCY foreground/background tuning, same graceful degradation on no permission / no peripheral mode / adapter off.
- **`:service-android`** — `MdnsAdvertisementGate` gets an optional `BleVisibilityBroadcaster` sink that fires lock-step with the existing mDNS publish/unpublish decisions: same 30-s debounce, same outbound veto, same QR / always-visible bypass. `ReceiverForegroundService` wires it to the cached `EndpointInfo` plus a process-stable 4-byte ASCII endpoint_id slug.
- **Permissions / manifest** — `BLUETOOTH_ADVERTISE` was already declared (sender pulse, #31) and onboarded as an optional permission. The rationale copy is updated to mention both pulse roles. The manifest test now documents the dual purpose.
- **Docs** — CLAUDE.md's architecture section now covers both BLE roles; a new `WvmgBleAdv` logcat tag is documented.

## What's new
- 13 KAT tests in `BleServiceDataTest` (`:core-protocol`) pin the byte layout.
- 10 lifecycle tests in `BleQuickShareAdvertiserTest` (`:discovery-android`) cover permission-denied, no-advertiser, payload contents, mode switching, and re-register failure paths.
- 2 lock-step tests in `MdnsAdvertisementGateTest` (`:service-android`) verify BLE and mDNS publish/unpublish stay synchronized across pulse activity, debounce expiry, and outbound veto.

## Test plan
- [x] `./gradlew :core-protocol:test` — passes (`BleServiceDataTest` × 13).
- [x] `./gradlew :discovery-android:testDebugUnitTest` — passes (`BleQuickShareAdvertiserTest` × 10).
- [x] `./gradlew :service-android:testDebugUnitTest` — passes (existing gate suite + 2 new lock-step tests).
- [x] `./gradlew :app:testDebugUnitTest` — passes (`AndroidManifestPermissionsTest` updated).
- [x] `./gradlew staticAnalysis` — passes (ktlint + detekt across all modules).
- [x] `./gradlew :app:assembleDebug` — APK builds.
- [ ] **Manual on-device, Galaxy picker visibility** — WVMG receiver appears in stock Galaxy Quick Share send sheet under the friendly device name (issue #121 acceptance criterion 3). Orchestrator will hand the build to the user.
- [ ] **Manual on-device, multicast-disabled fallback** — receiver remains discoverable via BLE alone when Wi-Fi multicast is disabled (issue #121 acceptance criterion 4). Orchestrator will hand the build to the user.

## Notes
- A pre-existing lint error in `BleAdvertiser.kt:277` (`stopAdvertising` MissingPermission) is reproducible on `origin/main` and unrelated to this change. CI does not run `lint`, only `staticAnalysis` + tests + APK build, so it does not gate the PR.
- The endpoint_id sent over BLE is currently independent of the per-publish mDNS instance-name slug — that drift is a known follow-up. For #121 the only acceptance constraint is "valid 4-byte ASCII endpoint_id," which the `BleEndpointIdHolder` satisfies.