### PR TITLE
feat(medium): bandwidth-upgrade framework with pluggable MediumProvider

### DIFF
--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeFrames.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeFrames.kt
@@ -1,0 +1,278 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.connection
+
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.BandwidthUpgradeNegotiationFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.BandwidthUpgradeNegotiationFrame.UpgradePathInfo
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.V1Frame
+import com.google.protobuf.ByteString
+import io.github.kyujincho.wvmg.protocol.medium.Medium
+import io.github.kyujincho.wvmg.protocol.medium.UpgradePathCredentials
+
+/**
+ * Builders for `OfflineFrame{V1, BANDWIDTH_UPGRADE_NEGOTIATION}` shapes.
+ *
+ * Quick Share's bandwidth-upgrade dance is a six-event protocol on top
+ * of `BandwidthUpgradeNegotiationFrame.event_type`:
+ *
+ *   1. **`UPGRADE_PATH_AVAILABLE`** — server side. "Here are the
+ *      credentials for the new transport." Carries an
+ *      [UpgradePathInfo] describing which medium and the per-medium
+ *      bring-up parameters.
+ *   2. **`CLIENT_INTRODUCTION`** — client side. After the client has
+ *      reconnected on the new medium, it sends its endpoint id over
+ *      the new socket so the server can map the new connection back
+ *      to the original one.
+ *   3. **`CLIENT_INTRODUCTION_ACK`** — server side. ACKs the
+ *      introduction.
+ *   4. **`LAST_WRITE_TO_PRIOR_CHANNEL`** — either side, on the OLD
+ *      transport. "I am about to stop writing on the old socket." The
+ *      sender flushes pending writes, then sends this and stops.
+ *   5. **`SAFE_TO_CLOSE_PRIOR_CHANNEL`** — either side, on the OLD
+ *      transport. "I have observed your LAST_WRITE; you can FIN now."
+ *   6. **`UPGRADE_FAILURE`** — either side. Aborts the upgrade and
+ *      tells the peer we are staying on the current transport.
+ *
+ * Builders here are pure functions: no I/O, no state. The orchestrator
+ * (Phase 4 sub-issue #54 wires up the actual transport swap) drives the
+ * sequence; the FSM in
+ * [io.github.kyujincho.wvmg.protocol.medium.BandwidthUpgradeNegotiator]
+ * owns the state transitions.
+ *
+ * ### Per-medium credential serialization
+ *
+ * The builders fan out on the [UpgradePathCredentials] subtype so each
+ * Phase 4 sub-issue (#49–#53) only has to add one arm here when its
+ * adapter lands. Today only [UpgradePathCredentials.Generic] (no extra
+ * fields) and [UpgradePathCredentials.WifiLan] (IP + port) are wired
+ * up; that's enough to validate the framework end-to-end with a
+ * loopback test.
+ */
+public object BandwidthUpgradeFrames {
+    /**
+     * Build `OfflineFrame{BANDWIDTH_UPGRADE_NEGOTIATION{
+     * event_type=UPGRADE_PATH_AVAILABLE, upgrade_path_info=...}}`.
+     *
+     * @param credentials Server-side bring-up parameters returned by
+     *   [io.github.kyujincho.wvmg.protocol.medium.MediumProvider.prepareUpgrade].
+     */
+    public fun upgradePathAvailable(credentials: UpgradePathCredentials): OfflineFrame {
+        val info = encodeCredentials(credentials)
+        return wrap(
+            BandwidthUpgradeNegotiationFrame
+                .newBuilder()
+                .setEventType(BandwidthUpgradeNegotiationFrame.EventType.UPGRADE_PATH_AVAILABLE)
+                .setUpgradePathInfo(info)
+                .build(),
+        )
+    }
+
+    /**
+     * Build `OfflineFrame{BANDWIDTH_UPGRADE_NEGOTIATION{
+     * event_type=CLIENT_INTRODUCTION, client_introduction=...}}`.
+     *
+     * @param endpointId The sender's endpoint id (matches the
+     *   `endpoint_id` we sent in our original `ConnectionRequest`); the
+     *   server keys the upgraded socket back to the original session
+     *   on this value.
+     * @param lastEndpointId Optional: the previous endpoint id when
+     *   reusing one across upgrade attempts. Default empty (matches
+     *   `google/nearby` for fresh sessions).
+     */
+    public fun clientIntroduction(
+        endpointId: String,
+        lastEndpointId: String = "",
+    ): OfflineFrame {
+        val intro =
+            BandwidthUpgradeNegotiationFrame.ClientIntroduction
+                .newBuilder()
+                .setEndpointId(endpointId)
+                .setLastEndpointId(lastEndpointId)
+                .build()
+        return wrap(
+            BandwidthUpgradeNegotiationFrame
+                .newBuilder()
+                .setEventType(BandwidthUpgradeNegotiationFrame.EventType.CLIENT_INTRODUCTION)
+                .setClientIntroduction(intro)
+                .build(),
+        )
+    }
+
+    /**
+     * Build `OfflineFrame{BANDWIDTH_UPGRADE_NEGOTIATION{
+     * event_type=CLIENT_INTRODUCTION_ACK}}`.
+     *
+     * Server-side ACK of [clientIntroduction]. The proto's
+     * `ClientIntroductionAck` message has no fields today; the helper
+     * still constructs an empty instance so the `oneof` slot is set
+     * (without it, some Quick Share validators read an absent
+     * sub-message as malformed).
+     */
+    public fun clientIntroductionAck(): OfflineFrame =
+        wrap(
+            BandwidthUpgradeNegotiationFrame
+                .newBuilder()
+                .setEventType(BandwidthUpgradeNegotiationFrame.EventType.CLIENT_INTRODUCTION_ACK)
+                .setClientIntroductionAck(
+                    BandwidthUpgradeNegotiationFrame.ClientIntroductionAck.getDefaultInstance(),
+                ).build(),
+        )
+
+    /**
+     * Build `OfflineFrame{BANDWIDTH_UPGRADE_NEGOTIATION{
+     * event_type=LAST_WRITE_TO_PRIOR_CHANNEL}}`.
+     *
+     * Sent on the OLD transport before stopping writes on it. Pairs
+     * with [safeToClosePriorChannel].
+     */
+    public fun lastWriteToPriorChannel(): OfflineFrame =
+        wrap(
+            BandwidthUpgradeNegotiationFrame
+                .newBuilder()
+                .setEventType(BandwidthUpgradeNegotiationFrame.EventType.LAST_WRITE_TO_PRIOR_CHANNEL)
+                .build(),
+        )
+
+    /**
+     * Build `OfflineFrame{BANDWIDTH_UPGRADE_NEGOTIATION{
+     * event_type=SAFE_TO_CLOSE_PRIOR_CHANNEL, safe_to_close_prior_channel=...}}`.
+     *
+     * Sent on the OLD transport once the peer's LAST_WRITE has been
+     * observed. The `sta_frequency` parameter, when present, hints to
+     * the peer at the Wi-Fi STA frequency in MHz so a Wi-Fi-Direct
+     * group owner can pick a non-conflicting channel; defaults to -1
+     * ("not set / no hint").
+     */
+    public fun safeToClosePriorChannel(staFrequency: Int = STA_FREQUENCY_NOT_SET): OfflineFrame {
+        val safe =
+            BandwidthUpgradeNegotiationFrame.SafeToClosePriorChannel
+                .newBuilder()
+                .setStaFrequency(staFrequency)
+                .build()
+        return wrap(
+            BandwidthUpgradeNegotiationFrame
+                .newBuilder()
+                .setEventType(BandwidthUpgradeNegotiationFrame.EventType.SAFE_TO_CLOSE_PRIOR_CHANNEL)
+                .setSafeToClosePriorChannel(safe)
+                .build(),
+        )
+    }
+
+    /**
+     * Build `OfflineFrame{BANDWIDTH_UPGRADE_NEGOTIATION{
+     * event_type=UPGRADE_FAILURE, upgrade_path_info{medium=...}}}`.
+     *
+     * Either side: aborts the upgrade. The proto carries the failed
+     * medium back via `upgrade_path_info.medium` so the peer can
+     * exclude that medium from any retry.
+     */
+    public fun upgradeFailure(medium: Medium): OfflineFrame {
+        val info =
+            UpgradePathInfo
+                .newBuilder()
+                .setMedium(medium.toUpgradePathMedium())
+                .build()
+        return wrap(
+            BandwidthUpgradeNegotiationFrame
+                .newBuilder()
+                .setEventType(BandwidthUpgradeNegotiationFrame.EventType.UPGRADE_FAILURE)
+                .setUpgradePathInfo(info)
+                .build(),
+        )
+    }
+
+    /**
+     * Decode an [UpgradePathInfo] back into the matching
+     * [UpgradePathCredentials]. Returns `null` for an unsupported
+     * medium ([Medium.fromUpgradePathMedium] result is `null`) or for
+     * a credentials shape this module does not yet know how to parse —
+     * Phase 4 sub-issues add new arms here as they land.
+     */
+    public fun decodeCredentials(info: UpgradePathInfo): UpgradePathCredentials? {
+        val medium = Medium.fromUpgradePathMedium(info.medium) ?: return null
+        return when (medium) {
+            Medium.WIFI_LAN -> {
+                if (info.hasWifiLanSocket()) {
+                    UpgradePathCredentials.WifiLan(
+                        ipAddress = info.wifiLanSocket.ipAddress.toByteArray(),
+                        port = info.wifiLanSocket.wifiPort,
+                    )
+                } else {
+                    UpgradePathCredentials.Generic(medium)
+                }
+            }
+            // Phase 4 sub-issues (#49–#53) plug the remaining arms in
+            // here as their adapters land. Until then we report Generic
+            // so the upper layers can at least see that *some* path
+            // was advertised; the provider will reject it on adopt
+            // because it doesn't carry meaningful credentials.
+            //
+            // NOTE: BLE_L2CAP is in this list for completeness even
+            // though it cannot appear on `UpgradePathInfo.medium` (the
+            // proto reserves wire number 10 there). The path that
+            // builds the wire frame for BLE_L2CAP must use the
+            // discovery-medium path instead — see Phase 4 #52.
+            Medium.WIFI_DIRECT,
+            Medium.WIFI_HOTSPOT,
+            Medium.WIFI_AWARE,
+            Medium.BLUETOOTH,
+            Medium.BLE_L2CAP,
+            Medium.BLE,
+            Medium.WEB_RTC,
+            -> UpgradePathCredentials.Generic(medium)
+        }
+    }
+
+    /**
+     * Encode a credentials value into [UpgradePathInfo]. Inverse of
+     * [decodeCredentials]; same per-medium switch shape.
+     */
+    private fun encodeCredentials(credentials: UpgradePathCredentials): UpgradePathInfo {
+        val builder =
+            UpgradePathInfo
+                .newBuilder()
+                .setMedium(credentials.medium.toUpgradePathMedium())
+        when (credentials) {
+            is UpgradePathCredentials.Generic -> Unit // Medium-only; nothing extra to set.
+            is UpgradePathCredentials.WifiLan -> {
+                builder.setWifiLanSocket(
+                    UpgradePathInfo.WifiLanSocket
+                        .newBuilder()
+                        .setIpAddress(ByteString.copyFrom(credentials.ipAddress))
+                        .setWifiPort(credentials.port)
+                        .build(),
+                )
+            }
+        }
+        return builder.build()
+    }
+
+    /**
+     * Wrap an inner [BandwidthUpgradeNegotiationFrame] in the
+     * V1/OfflineFrame envelope. Hoisted so every builder above is one
+     * line of structural shape.
+     */
+    private fun wrap(inner: BandwidthUpgradeNegotiationFrame): OfflineFrame =
+        OfflineFrame
+            .newBuilder()
+            .setVersion(OfflineFrame.Version.V1)
+            .setV1(
+                V1Frame
+                    .newBuilder()
+                    .setType(V1Frame.FrameType.BANDWIDTH_UPGRADE_NEGOTIATION)
+                    .setBandwidthUpgradeNegotiation(inner)
+                    .build(),
+            ).build()
+
+    /**
+     * Sentinel value matching the proto's "field not set" semantics
+     * for `SafeToClosePriorChannel.sta_frequency`. The proto declares
+     * the field as `optional int32` with no default; -1 is what
+     * `google/nearby` uses.
+     */
+    public const val STA_FREQUENCY_NOT_SET: Int = -1
+}

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/InboundConnection.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/InboundConnection.kt
@@ -7,6 +7,7 @@ package io.github.kyujincho.wvmg.protocol.connection
 
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.V1Frame
+import io.github.kyujincho.wvmg.protocol.medium.MediumRegistry
 import io.github.kyujincho.wvmg.protocol.payload.FileDestinationFactory
 import io.github.kyujincho.wvmg.protocol.payload.PayloadProtocolException
 import io.github.kyujincho.wvmg.protocol.transport.EndOfFrameStream
@@ -109,6 +110,17 @@ import java.security.SecureRandom
 public class InboundConnection(
     private val socket: Socket,
     private val secureRandom: SecureRandom = SecureRandom(),
+    /**
+     * Registry of [io.github.kyujincho.wvmg.protocol.medium.MediumProvider]s
+     * used to intersect against the peer's advertised
+     * `ConnectionRequestFrame.mediums` and pick a target for
+     * `BANDWIDTH_UPGRADE_NEGOTIATION`. Defaults to
+     * [MediumRegistry.DefaultWifiLan] (Wi-Fi LAN only) which preserves
+     * the project's pre-Phase-4 behaviour exactly. Phase 4 sub-issues
+     * #49–#53 register per-medium providers; #54 wires the actual
+     * transport swap into the dispatch loop.
+     */
+    private val mediumRegistry: MediumRegistry = MediumRegistry.DefaultWifiLan,
 ) {
     private val mutableState: MutableStateFlow<InboundConnectionState> =
         MutableStateFlow(InboundConnectionState.Idle)
@@ -210,6 +222,7 @@ public class InboundConnection(
                 externalEvents = externalEvents,
                 mutableState = mutableState,
                 factory = factory,
+                mediumRegistry = mediumRegistry,
                 onHandshakeComplete = ::markHandshakeComplete,
             )
 

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/InboundConnectionDriver.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/InboundConnectionDriver.kt
@@ -13,6 +13,8 @@ import io.github.kyujincho.wvmg.protocol.crypto.D2DRole
 import io.github.kyujincho.wvmg.protocol.crypto.pin.PinDerivation
 import io.github.kyujincho.wvmg.protocol.crypto.securemessage.SecureChannel
 import io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo
+import io.github.kyujincho.wvmg.protocol.medium.Medium
+import io.github.kyujincho.wvmg.protocol.medium.MediumRegistry
 import io.github.kyujincho.wvmg.protocol.payload.FileDestinationFactory
 import io.github.kyujincho.wvmg.protocol.payload.PayloadAssembler
 import io.github.kyujincho.wvmg.protocol.payload.PayloadEvent
@@ -65,6 +67,7 @@ internal class InboundConnectionDriver(
     private val externalEvents: Channel<ExternalEvent>,
     private val mutableState: MutableStateFlow<InboundConnectionState>,
     private val factory: FileDestinationFactory,
+    private val mediumRegistry: MediumRegistry = MediumRegistry.DefaultWifiLan,
     private val onHandshakeComplete: () -> Unit = {},
     /**
      * Wall-clock source for the rate estimator. Defaults to
@@ -129,6 +132,27 @@ internal class InboundConnectionDriver(
     private var sourceDeviceName: String? = null
 
     /**
+     * Mediums the peer advertised on `ConnectionRequestFrame.mediums`,
+     * decoded into the domain enum. Empty before step 1; populated as
+     * soon as the unencrypted ConnectionRequest arrives. Phase 4
+     * sub-issue #54 reads this back via [chosenUpgradeMedium] (and the
+     * registry's ladder) to drive the upgrade decision.
+     */
+    private var peerSupportedMediums: Set<Medium> = emptySet()
+
+    /**
+     * The medium the registry selected as the best upgrade target for
+     * this connection — i.e. the highest-priority entry shared by both
+     * peers, per the ladder. `null` when the intersection is just
+     * Wi-Fi LAN (no upgrade is meaningful) or empty. Read by
+     * #54 when wiring the upgrade swap; exposed `internal` so tests
+     * in this module can assert the selection without poking at the
+     * driver's private state.
+     */
+    internal var chosenUpgradeMedium: Medium? = null
+        private set
+
+    /**
      * Drive the entire receiver-side lifecycle. Returns the terminal
      * [InboundResult]; throws on coroutine cancellation (handled by
      * the caller).
@@ -153,6 +177,23 @@ internal class InboundConnectionDriver(
                 ?.endpointInfo
                 ?.toByteArray()
                 ?.let { EndpointInfo.parse(it)?.deviceName }
+
+        // Decode the peer's advertised mediums (Phase 4 framework). The
+        // intersection with our local registry's supportedMediums(),
+        // resolved by the registry's ladder, picks the upgrade target.
+        // We do not act on the choice here — #54 wires the actual
+        // BANDWIDTH_UPGRADE_NEGOTIATION send — but stashing the result
+        // makes the chosen medium observable by tests today and gives
+        // #54 a single field to read.
+        peerSupportedMediums =
+            initialFrame.v1.connectionRequest.mediumsList
+                .mapNotNull { Medium.fromConnectionRequestMedium(it) }
+                .toSet()
+        val chosen = mediumRegistry.selectBestUpgrade(peerSupportedMediums)
+        // WIFI_LAN is the discovery medium; selecting it means "stay on
+        // the current transport". Treat that as `null` so callers do
+        // not interpret it as an upgrade trigger.
+        chosenUpgradeMedium = chosen?.takeIf { it != Medium.WIFI_LAN }
 
         // Step 2: UKEY2 server handshake.
         val handshake = Ukey2Server.performHandshake(transport, secureRandom)
@@ -359,6 +400,19 @@ internal class InboundConnectionDriver(
                 publishCancelled(CancelCause.PEER)
                 InboundResult.Cancelled(CancelCause.PEER)
             }
+        }
+
+        if (frame.hasV1() &&
+            frame.v1.type == V1Frame.FrameType.BANDWIDTH_UPGRADE_NEGOTIATION
+        ) {
+            // Inbound BANDWIDTH_UPGRADE_NEGOTIATION on the receiver
+            // side: stock Quick Share senders do not initiate the
+            // upgrade (the protocol gives the SERVER role to the
+            // receiver), so this branch fires only when the peer is a
+            // non-conforming implementation. Phase 4 sub-issue #54
+            // wires the negotiator FSM in here; today we observe the
+            // event and drop it.
+            return null
         }
 
         if (!frame.hasV1() || frame.v1.type != V1Frame.FrameType.PAYLOAD_TRANSFER) {

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnection.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnection.kt
@@ -5,6 +5,7 @@
  */
 package io.github.kyujincho.wvmg.protocol.connection
 
+import io.github.kyujincho.wvmg.protocol.medium.MediumRegistry
 import io.github.kyujincho.wvmg.protocol.payload.PayloadProtocolException
 import io.github.kyujincho.wvmg.protocol.transport.EndOfFrameStream
 import io.github.kyujincho.wvmg.protocol.ukey2.Ukey2HandshakeException
@@ -129,6 +130,15 @@ import java.security.SecureRandom
  *   PairedKeyEncryption fill bytes, the SecureChannel IVs, and the
  *   per-frame `payload_id` choices. Tests inject a deterministic
  *   stub; production uses a fresh [SecureRandom].
+ * @param mediumRegistry Registry of [io.github.kyujincho.wvmg.protocol.medium.MediumProvider]s
+ *   used to populate `ConnectionRequestFrame.mediums` (the set of
+ *   transports we are willing to upgrade to via
+ *   `BANDWIDTH_UPGRADE_NEGOTIATION`). Defaults to
+ *   [MediumRegistry.DefaultWifiLan] which advertises Wi-Fi LAN only —
+ *   functionally identical to NearDrop's fixed shape and the value the
+ *   project shipped before Phase 4. Phase 4 sub-issues #49–#53 each
+ *   register a per-medium provider; #54 wires the registry into the
+ *   actual upgrade swap.
  */
 @Suppress("LongParameterList") // The public constructor has many knobs but every one is needed by the spec.
 public class OutboundConnection(
@@ -139,6 +149,7 @@ public class OutboundConnection(
     private val qrCodeHandshakeData: ByteArray? = null,
     private val connectTimeoutMillis: Int = DEFAULT_CONNECT_TIMEOUT_MILLIS,
     private val secureRandom: SecureRandom = SecureRandom(),
+    private val mediumRegistry: MediumRegistry = MediumRegistry.DefaultWifiLan,
     /**
      * Optional structured-log sink. The driver invokes it at every
      * lifecycle phase boundary (TCP connect, UKEY2 client/server init,
@@ -276,6 +287,7 @@ public class OutboundConnection(
                 endpointInfo = endpointInfo,
                 qrCodeHandshakeData = qrCodeHandshakeData,
                 files = files,
+                mediumRegistry = mediumRegistry,
                 onHandshakeComplete = ::markHandshakeComplete,
                 logger = logger,
             )

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionDriver.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionDriver.kt
@@ -12,6 +12,7 @@ import io.github.kyujincho.wvmg.protocol.crypto.D2DKeyDerivation
 import io.github.kyujincho.wvmg.protocol.crypto.D2DRole
 import io.github.kyujincho.wvmg.protocol.crypto.pin.PinDerivation
 import io.github.kyujincho.wvmg.protocol.crypto.securemessage.SecureChannel
+import io.github.kyujincho.wvmg.protocol.medium.MediumRegistry
 import io.github.kyujincho.wvmg.protocol.payload.PayloadAssembler
 import io.github.kyujincho.wvmg.protocol.payload.PayloadEvent
 import io.github.kyujincho.wvmg.protocol.payload.PayloadTransferEncoder
@@ -69,6 +70,7 @@ internal class OutboundConnectionDriver(
     private val endpointInfo: ByteArray,
     private val qrCodeHandshakeData: ByteArray?,
     private val files: List<FileSource>,
+    private val mediumRegistry: MediumRegistry = MediumRegistry.DefaultWifiLan,
     private val onHandshakeComplete: () -> Unit = {},
     private val logger: (String) -> Unit = {},
     /**
@@ -114,9 +116,22 @@ internal class OutboundConnectionDriver(
         )
         val transport = FramedConnection(socket).also { framedConnection = it }
 
-        // Step 1: send unencrypted ConnectionRequest.
+        // Step 1: send unencrypted ConnectionRequest. The mediums set
+        // is sourced from the registry's supportedMediums(); the encoder
+        // ensures WIFI_LAN is always present (it IS the discovery
+        // medium today). Phase 4's per-medium adapters extend the set
+        // by registering against the registry; absent any extra
+        // provider this is functionally identical to the previous
+        // hard-coded `[WIFI_LAN]`.
+        val advertisedMediums = mediumRegistry.supportedMediums()
+        logger("step 1: advertising mediums=$advertisedMediums")
         transport.sendFrame(
-            OutboundFrames.connectionRequest(endpointId, endpointInfo).toByteArray(),
+            OutboundFrames
+                .connectionRequest(
+                    endpointId = endpointId,
+                    endpointInfo = endpointInfo,
+                    supportedMediums = advertisedMediums,
+                ).toByteArray(),
         )
         logger("step 1: sent ConnectionRequest, awaiting Ukey2ServerInit")
 
@@ -544,6 +559,24 @@ internal class OutboundConnectionDriver(
             // protocol error — Quick Share receivers can sometimes
             // hang up early after acknowledging.
             return cancelFromPeer()
+        }
+
+        if (frame.hasV1() &&
+            frame.v1.type == V1Frame.FrameType.BANDWIDTH_UPGRADE_NEGOTIATION
+        ) {
+            // Inbound BANDWIDTH_UPGRADE_NEGOTIATION: the receiver wants
+            // to switch transports. Phase 4 (#48–#54) wires the
+            // negotiator FSM in here; today we observe the event and
+            // drop it (the peer falls back to staying on Wi-Fi LAN
+            // when no UPGRADE_PATH_AVAILABLE answer arrives). Logging
+            // it makes the eventual integration test predicate easy
+            // to write.
+            logger(
+                "fsm: inbound BANDWIDTH_UPGRADE_NEGOTIATION event_type=" +
+                    frame.v1.bandwidthUpgradeNegotiation.eventType +
+                    " (no negotiator wired yet; ignored)",
+            )
+            return null
         }
 
         if (!frame.hasV1() || frame.v1.type != V1Frame.FrameType.PAYLOAD_TRANSFER) {

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundFrames.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundFrames.kt
@@ -11,6 +11,7 @@ import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.Offl
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OsInfo
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.V1Frame
 import com.google.protobuf.ByteString
+import io.github.kyujincho.wvmg.protocol.medium.Medium
 
 /**
  * Builders for the small set of `OfflineFrame` messages that
@@ -50,13 +51,19 @@ internal object OutboundFrames {
     fun connectionRequest(
         endpointId: String,
         endpointInfo: ByteArray,
+        supportedMediums: Set<Medium> = setOf(Medium.WIFI_LAN),
     ): OfflineFrame {
         // Match NearDrop's ConnectionRequestFrame shape. Stock Quick Share
         // closes the socket immediately if these fields are absent — only
         // endpoint_id and endpoint_info is not enough on Android 14+:
-        //   * mediums = [WIFI_LAN] tells the receiver which transport this
-        //     connection is using; absence of any medium hits a validation
-        //     in Nearby Connections that rejects the request.
+        //   * mediums = [WIFI_LAN, ...] tells the receiver which transports
+        //     this device can negotiate up to. WIFI_LAN is mandatory because
+        //     it IS the discovery medium for every Quick Share connection
+        //     today; absence of any medium hits a validation in Nearby
+        //     Connections that rejects the request. Phase 4 (#48–#54) adds
+        //     the BANDWIDTH_UPGRADE_NEGOTIATION machinery that lets us
+        //     advertise more than just WIFI_LAN here — the orchestrator
+        //     populates this set from the MediumRegistry's supportedMediums().
         //   * keep_alive_interval / timeout are read by the receiver to
         //     decide its own KEEP_ALIVE cadence. We advertise 10 s / 10 min
         //     — PROTOCOL.md documents stock Android emitting KEEP_ALIVE
@@ -66,16 +73,26 @@ internal object OutboundFrames {
         //     Samsung Quick Share) still inspect it. Setting it to the
         //     empty string keeps modern peers happy and gives legacy peers
         //     a defined value to read.
-        val request =
+        //
+        // Always include WIFI_LAN even if the caller forgot — it is the
+        // current connection's medium. Sort the proto-side enum values so
+        // the wire encoding is deterministic for tests and for KAT-style
+        // regression detection.
+        val withWifiLan = supportedMediums + Medium.WIFI_LAN
+        val mediumProtoValues =
+            withWifiLan
+                .map { it.toConnectionRequestMedium() }
+                .sortedBy { it.number }
+        val builder =
             ConnectionRequestFrame
                 .newBuilder()
                 .setEndpointId(endpointId)
                 .setEndpointName("")
                 .setEndpointInfo(ByteString.copyFrom(endpointInfo))
-                .addMediums(ConnectionRequestFrame.Medium.WIFI_LAN)
                 .setKeepAliveIntervalMillis(KEEP_ALIVE_INTERVAL_MILLIS)
                 .setKeepAliveTimeoutMillis(KEEP_ALIVE_TIMEOUT_MILLIS)
-                .build()
+        for (m in mediumProtoValues) builder.addMediums(m)
+        val request = builder.build()
         return OfflineFrame
             .newBuilder()
             .setVersion(OfflineFrame.Version.V1)

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/medium/BandwidthUpgradeNegotiator.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/medium/BandwidthUpgradeNegotiator.kt
@@ -1,0 +1,471 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.medium
+
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.BandwidthUpgradeNegotiationFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.V1Frame
+
+/**
+ * Pure FSM for the `BANDWIDTH_UPGRADE_NEGOTIATION` event sequence.
+ *
+ * Events in (`BandwidthUpgradeEvent`), effects out
+ * (`BandwidthUpgradeEffect`). The negotiator owns no I/O — same shape
+ * as `OutboundSharingFsm` / `InboundSharingFsm`. The orchestrator
+ * (`OutboundConnection` / `InboundConnection`, via the registry's
+ * provider) feeds it inbound frames and externally-driven decisions
+ * ("start the upgrade"); the negotiator returns a list of effects the
+ * orchestrator applies to the wire and the transport.
+ *
+ * ### Roles
+ *
+ *  - **Server role.** The receiver. Initiates the upgrade by emitting
+ *    [BandwidthUpgradeEffect.SendFrame] of `UPGRADE_PATH_AVAILABLE`,
+ *    waits for `CLIENT_INTRODUCTION`, ACKs it, then runs the
+ *    `LAST_WRITE` / `SAFE_TO_CLOSE` exchange.
+ *  - **Client role.** The sender. Waits for `UPGRADE_PATH_AVAILABLE`,
+ *    asks the orchestrator to adopt the new transport via
+ *    [BandwidthUpgradeEffect.AdoptTransport], then sends
+ *    `CLIENT_INTRODUCTION`, waits for the ACK, runs the `LAST_WRITE` /
+ *    `SAFE_TO_CLOSE` exchange.
+ *
+ * ### Why a single FSM for both roles
+ *
+ * The events are role-symmetric: every wire event goes through the
+ * same parser, and the effect each transition produces depends only on
+ * the current state and the role. Splitting into two FSMs would force
+ * the orchestrator to track a third "which negotiator should I
+ * forward to" boolean, which buys nothing.
+ *
+ * ### Default-off framework
+ *
+ * The negotiator is **not** automatically wired into the connection
+ * lifecycles. The orchestrator instantiates one (with the chosen
+ * [Medium]) only when the receiver decides to upgrade or when the
+ * sender observes an inbound `UPGRADE_PATH_AVAILABLE`. Today (Phase 1)
+ * neither path fires, so the FSM exists for the per-medium adapters in
+ * #49–#53 to plug into. The unit tests in this PR exercise the FSM in
+ * isolation; #54 wires it into the connection drivers.
+ */
+public class BandwidthUpgradeNegotiator(
+    public val role: Role,
+    public val medium: Medium,
+    public val endpointId: String,
+) {
+    public var state: State = State.Idle
+        private set
+
+    /**
+     * Drive the FSM with one event. Returns the list of effects to
+     * apply, in order; `SendFrame` always precedes any state change
+     * the orchestrator needs to react to (so wire bytes go out before
+     * the transport swap begins).
+     */
+    @Suppress("CyclomaticComplexMethod") // One arm per (state, event) pair is the cleanest dispatch.
+    public fun onEvent(event: BandwidthUpgradeEvent): List<BandwidthUpgradeEffect> {
+        val current = state
+        val (next, effects) = transition(current, event)
+        state = next
+        return effects
+    }
+
+    private fun transition(
+        current: State,
+        event: BandwidthUpgradeEvent,
+    ): Pair<State, List<BandwidthUpgradeEffect>> =
+        when (event) {
+            is BandwidthUpgradeEvent.Start -> handleStart(current, event)
+            is BandwidthUpgradeEvent.FrameReceived -> handleFrameReceived(current, event)
+            BandwidthUpgradeEvent.AdoptSucceeded -> handleAdoptSucceeded(current)
+            is BandwidthUpgradeEvent.AdoptFailed -> handleAdoptFailed(current, event.reason)
+            is BandwidthUpgradeEvent.PrepareFailed -> handlePrepareFailed(current, event.reason)
+            BandwidthUpgradeEvent.PriorChannelDrained -> handlePriorChannelDrained(current)
+            BandwidthUpgradeEvent.Abort -> abort(current, "abort requested by orchestrator")
+        }
+
+    private fun handleStart(
+        current: State,
+        event: BandwidthUpgradeEvent.Start,
+    ): Pair<State, List<BandwidthUpgradeEffect>> {
+        if (current != State.Idle) {
+            return protocolError(current, "Start event in non-Idle state $current")
+        }
+        return when (role) {
+            Role.SERVER ->
+                State.AwaitingClientIntroduction to
+                    listOf(
+                        BandwidthUpgradeEffect.SendFrame(
+                            io.github.kyujincho.wvmg.protocol.connection.BandwidthUpgradeFrames
+                                .upgradePathAvailable(event.credentials),
+                        ),
+                    )
+            Role.CLIENT ->
+                // Client cannot Start; it reacts to the server's
+                // UPGRADE_PATH_AVAILABLE. Treat as protocol error so
+                // wiring bugs surface loudly.
+                protocolError(current, "Client received Start; only server may initiate")
+        }
+    }
+
+    private fun handleFrameReceived(
+        current: State,
+        event: BandwidthUpgradeEvent.FrameReceived,
+    ): Pair<State, List<BandwidthUpgradeEffect>> {
+        val v1 = event.frame.v1
+        if (v1.type != V1Frame.FrameType.BANDWIDTH_UPGRADE_NEGOTIATION) {
+            return protocolError(current, "Non-BANDWIDTH_UPGRADE frame in negotiator: ${v1.type}")
+        }
+        val inner = v1.bandwidthUpgradeNegotiation
+        return when (inner.eventType) {
+            BandwidthUpgradeNegotiationFrame.EventType.UPGRADE_PATH_AVAILABLE ->
+                handleUpgradePathAvailable(current, inner)
+            BandwidthUpgradeNegotiationFrame.EventType.CLIENT_INTRODUCTION ->
+                handleClientIntroduction(current)
+            BandwidthUpgradeNegotiationFrame.EventType.CLIENT_INTRODUCTION_ACK ->
+                handleClientIntroductionAck(current)
+            BandwidthUpgradeNegotiationFrame.EventType.LAST_WRITE_TO_PRIOR_CHANNEL ->
+                handleLastWriteToPriorChannel(current)
+            BandwidthUpgradeNegotiationFrame.EventType.SAFE_TO_CLOSE_PRIOR_CHANNEL ->
+                handleSafeToClosePriorChannel(current)
+            BandwidthUpgradeNegotiationFrame.EventType.UPGRADE_FAILURE ->
+                handleUpgradeFailure(current)
+            // Per the proto: UPGRADE_PATH_REQUEST is server-side and
+            // optional (the receiver asks the sender for its path
+            // capabilities). Our framework drives selection from the
+            // ConnectionRequestFrame.mediums set instead, so this
+            // event is currently unsupported. UNKNOWN_EVENT_TYPE is
+            // the proto default.
+            BandwidthUpgradeNegotiationFrame.EventType.UPGRADE_PATH_REQUEST,
+            BandwidthUpgradeNegotiationFrame.EventType.UNKNOWN_EVENT_TYPE,
+            null,
+            -> protocolError(current, "Unsupported event_type ${inner.eventType}")
+        }
+    }
+
+    @Suppress("ReturnCount") // Three guard clauses, one happy path; flattening is less readable.
+    private fun handleUpgradePathAvailable(
+        current: State,
+        inner: BandwidthUpgradeNegotiationFrame,
+    ): Pair<State, List<BandwidthUpgradeEffect>> {
+        if (role != Role.CLIENT) {
+            return protocolError(current, "Server received UPGRADE_PATH_AVAILABLE")
+        }
+        if (current != State.Idle) {
+            return protocolError(current, "UPGRADE_PATH_AVAILABLE in state $current")
+        }
+        val credentials =
+            io.github.kyujincho.wvmg.protocol.connection.BandwidthUpgradeFrames
+                .decodeCredentials(inner.upgradePathInfo)
+                ?: return protocolError(
+                    current,
+                    "Cannot decode upgrade credentials for medium ${inner.upgradePathInfo.medium}",
+                )
+        return State.AdoptingTransport(credentials) to
+            listOf(BandwidthUpgradeEffect.AdoptTransport(credentials))
+    }
+
+    private fun handleAdoptSucceeded(current: State): Pair<State, List<BandwidthUpgradeEffect>> {
+        if (role != Role.CLIENT || current !is State.AdoptingTransport) {
+            return protocolError(current, "AdoptSucceeded in role=$role state=$current")
+        }
+        return State.AwaitingIntroductionAck to
+            listOf(
+                BandwidthUpgradeEffect.SendFrame(
+                    io.github.kyujincho.wvmg.protocol.connection.BandwidthUpgradeFrames
+                        .clientIntroduction(endpointId),
+                ),
+            )
+    }
+
+    private fun handleAdoptFailed(
+        current: State,
+        reason: String,
+    ): Pair<State, List<BandwidthUpgradeEffect>> {
+        if (role != Role.CLIENT || current !is State.AdoptingTransport) {
+            return protocolError(current, "AdoptFailed in role=$role state=$current")
+        }
+        return State.Failed(reason) to
+            listOf(
+                BandwidthUpgradeEffect.SendFrame(
+                    io.github.kyujincho.wvmg.protocol.connection.BandwidthUpgradeFrames
+                        .upgradeFailure(medium),
+                ),
+                BandwidthUpgradeEffect.UpgradeAborted(reason),
+            )
+    }
+
+    private fun handlePrepareFailed(
+        current: State,
+        reason: String,
+    ): Pair<State, List<BandwidthUpgradeEffect>> {
+        if (role != Role.SERVER) {
+            return protocolError(current, "Client received PrepareFailed")
+        }
+        return State.Failed(reason) to
+            listOf(
+                BandwidthUpgradeEffect.SendFrame(
+                    io.github.kyujincho.wvmg.protocol.connection.BandwidthUpgradeFrames
+                        .upgradeFailure(medium),
+                ),
+                BandwidthUpgradeEffect.UpgradeAborted(reason),
+            )
+    }
+
+    private fun handleClientIntroduction(current: State): Pair<State, List<BandwidthUpgradeEffect>> {
+        if (role != Role.SERVER || current != State.AwaitingClientIntroduction) {
+            return protocolError(current, "CLIENT_INTRODUCTION in role=$role state=$current")
+        }
+        return State.LastWritePending to
+            listOf(
+                BandwidthUpgradeEffect.SendFrame(
+                    io.github.kyujincho.wvmg.protocol.connection.BandwidthUpgradeFrames
+                        .clientIntroductionAck(),
+                ),
+                BandwidthUpgradeEffect.SendFrame(
+                    io.github.kyujincho.wvmg.protocol.connection.BandwidthUpgradeFrames
+                        .lastWriteToPriorChannel(),
+                ),
+            )
+    }
+
+    private fun handleClientIntroductionAck(current: State): Pair<State, List<BandwidthUpgradeEffect>> {
+        if (role != Role.CLIENT || current != State.AwaitingIntroductionAck) {
+            return protocolError(current, "CLIENT_INTRODUCTION_ACK in role=$role state=$current")
+        }
+        return State.LastWritePending to
+            listOf(
+                BandwidthUpgradeEffect.SendFrame(
+                    io.github.kyujincho.wvmg.protocol.connection.BandwidthUpgradeFrames
+                        .lastWriteToPriorChannel(),
+                ),
+            )
+    }
+
+    private fun handleLastWriteToPriorChannel(current: State): Pair<State, List<BandwidthUpgradeEffect>> {
+        // Either side: peer told us "no more writes from me on the
+        // old transport". Once OUR own pipeline drains we send
+        // SAFE_TO_CLOSE; that drain notification arrives via
+        // PriorChannelDrained.
+        return when (current) {
+            State.LastWritePending,
+            State.AwaitingPeerLastWrite,
+            ->
+                State.AwaitingDrain to emptyList()
+            else -> protocolError(current, "LAST_WRITE_TO_PRIOR_CHANNEL in state $current")
+        }
+    }
+
+    private fun handlePriorChannelDrained(current: State): Pair<State, List<BandwidthUpgradeEffect>> {
+        if (current != State.AwaitingDrain) {
+            return protocolError(current, "PriorChannelDrained in state $current")
+        }
+        return State.AwaitingSafeToClose to
+            listOf(
+                BandwidthUpgradeEffect.SendFrame(
+                    io.github.kyujincho.wvmg.protocol.connection.BandwidthUpgradeFrames
+                        .safeToClosePriorChannel(),
+                ),
+            )
+    }
+
+    private fun handleSafeToClosePriorChannel(current: State): Pair<State, List<BandwidthUpgradeEffect>> {
+        if (current != State.AwaitingSafeToClose) {
+            return protocolError(current, "SAFE_TO_CLOSE_PRIOR_CHANNEL in state $current")
+        }
+        return State.Completed to listOf(BandwidthUpgradeEffect.UpgradeCompleted)
+    }
+
+    @Suppress("UnusedParameter") // Symmetry with the other dispatch helpers; aids future state-aware policy.
+    private fun handleUpgradeFailure(current: State): Pair<State, List<BandwidthUpgradeEffect>> =
+        State.Failed("Peer sent UPGRADE_FAILURE") to
+            listOf(BandwidthUpgradeEffect.UpgradeAborted("Peer sent UPGRADE_FAILURE"))
+
+    @Suppress("UnusedParameter") // Symmetry with the other dispatch helpers; aids future state-aware policy.
+    private fun abort(
+        current: State,
+        reason: String,
+    ): Pair<State, List<BandwidthUpgradeEffect>> =
+        State.Failed(reason) to
+            listOf(
+                BandwidthUpgradeEffect.SendFrame(
+                    io.github.kyujincho.wvmg.protocol.connection.BandwidthUpgradeFrames
+                        .upgradeFailure(medium),
+                ),
+                BandwidthUpgradeEffect.UpgradeAborted(reason),
+            )
+
+    @Suppress("UnusedParameter") // Symmetry with the other dispatch helpers; aids future state-aware policy.
+    private fun protocolError(
+        current: State,
+        reason: String,
+    ): Pair<State, List<BandwidthUpgradeEffect>> =
+        State.Failed(reason) to
+            listOf(BandwidthUpgradeEffect.ProtocolError(reason))
+
+    /** Sender-or-receiver role for this negotiation. */
+    public enum class Role {
+        /** Receiver: chooses the new medium and emits credentials. */
+        SERVER,
+
+        /** Sender: adopts the new medium and sends `CLIENT_INTRODUCTION`. */
+        CLIENT,
+    }
+
+    /** Negotiator state. */
+    public sealed interface State {
+        /** Initial. */
+        public object Idle : State
+
+        /** SERVER waiting for `CLIENT_INTRODUCTION` on the new transport. */
+        public object AwaitingClientIntroduction : State
+
+        /**
+         * CLIENT has parsed `UPGRADE_PATH_AVAILABLE` and asked the
+         * provider to bring up the new transport. Carries the
+         * credentials so the orchestrator can recover them on retry.
+         */
+        public data class AdoptingTransport(
+            val credentials: UpgradePathCredentials,
+        ) : State
+
+        /** CLIENT has sent `CLIENT_INTRODUCTION` and awaits the ACK. */
+        public object AwaitingIntroductionAck : State
+
+        /** Either side: waiting for the orchestrator to flush old-channel writes. */
+        public object LastWritePending : State
+
+        /** Either side: peer's LAST_WRITE has not arrived yet. (Same target as LastWritePending; transient.) */
+        public object AwaitingPeerLastWrite : State
+
+        /** Either side: pipeline draining; SAFE_TO_CLOSE not yet sent. */
+        public object AwaitingDrain : State
+
+        /** Either side: SAFE_TO_CLOSE sent, awaiting peer's. */
+        public object AwaitingSafeToClose : State
+
+        /** Terminal: upgrade succeeded. */
+        public object Completed : State
+
+        /** Terminal: upgrade failed; we stay on the current transport. */
+        public data class Failed(
+            val reason: String,
+        ) : State
+    }
+}
+
+/**
+ * Events the negotiator FSM accepts.
+ */
+public sealed interface BandwidthUpgradeEvent {
+    /**
+     * SERVER only: start the upgrade. The orchestrator has chosen
+     * [credentials] (typically by intersecting the peer's mediums
+     * with the local registry and picking via the ladder, then asking
+     * [MediumProvider.prepareUpgrade] for the credentials).
+     */
+    public data class Start(
+        val credentials: UpgradePathCredentials,
+    ) : BandwidthUpgradeEvent
+
+    /**
+     * Inbound `OfflineFrame{BANDWIDTH_UPGRADE_NEGOTIATION}` received
+     * on the **current** transport (or, post-CLIENT_INTRODUCTION, on
+     * the **new** transport — that's the orchestrator's
+     * responsibility to multiplex).
+     */
+    public data class FrameReceived(
+        val frame: OfflineFrame,
+    ) : BandwidthUpgradeEvent
+
+    /**
+     * CLIENT only: [MediumProvider.adoptUpgrade] returned a non-null
+     * transport.
+     */
+    public object AdoptSucceeded : BandwidthUpgradeEvent
+
+    /**
+     * CLIENT only: [MediumProvider.adoptUpgrade] returned `null` or
+     * threw. The framework converts this into an `UPGRADE_FAILURE` on
+     * the wire.
+     */
+    public data class AdoptFailed(
+        val reason: String,
+    ) : BandwidthUpgradeEvent
+
+    /**
+     * SERVER only: [MediumProvider.prepareUpgrade] returned `null` or
+     * threw before the FSM was started. Handed in as an event so the
+     * orchestrator can recover the abort sequence (UPGRADE_FAILURE +
+     * teardown) through the same effect channel.
+     */
+    public data class PrepareFailed(
+        val reason: String,
+    ) : BandwidthUpgradeEvent
+
+    /**
+     * Either side: the orchestrator has finished writing on the old
+     * channel and is ready to send `SAFE_TO_CLOSE`. The orchestrator
+     * is responsible for fielding LAST_WRITE_TO_PRIOR_CHANNEL on the
+     * old channel and emitting this once its own writer queue is
+     * drained.
+     */
+    public object PriorChannelDrained : BandwidthUpgradeEvent
+
+    /** Either side: caller-driven abort. */
+    public object Abort : BandwidthUpgradeEvent
+}
+
+/**
+ * Effects the negotiator emits.
+ */
+public sealed interface BandwidthUpgradeEffect {
+    /**
+     * Send [frame] on the appropriate transport. The orchestrator
+     * picks "old" vs "new" based on the negotiator state at emission
+     * time:
+     *
+     *  - `UPGRADE_PATH_AVAILABLE` → old transport (the only one
+     *    available pre-introduction).
+     *  - `CLIENT_INTRODUCTION` → new transport (the client just
+     *    opened it; the server is parked there awaiting it).
+     *  - `CLIENT_INTRODUCTION_ACK` → new transport.
+     *  - `LAST_WRITE_TO_PRIOR_CHANNEL` / `SAFE_TO_CLOSE_PRIOR_CHANNEL`
+     *    → old transport.
+     *  - `UPGRADE_FAILURE` → whichever transport is still available.
+     */
+    public data class SendFrame(
+        val frame: OfflineFrame,
+    ) : BandwidthUpgradeEffect
+
+    /**
+     * CLIENT only: the orchestrator should call
+     * [MediumProvider.adoptUpgrade] with [credentials], then feed back
+     * either [BandwidthUpgradeEvent.AdoptSucceeded] or
+     * [BandwidthUpgradeEvent.AdoptFailed].
+     */
+    public data class AdoptTransport(
+        val credentials: UpgradePathCredentials,
+    ) : BandwidthUpgradeEffect
+
+    /** Terminal: the upgrade completed; orchestrator may swap transports. */
+    public object UpgradeCompleted : BandwidthUpgradeEffect
+
+    /** Terminal: the upgrade failed; orchestrator stays on the current transport. */
+    public data class UpgradeAborted(
+        val reason: String,
+    ) : BandwidthUpgradeEffect
+
+    /**
+     * Terminal-ish: the FSM observed an event it cannot validate.
+     * Surfaced as a separate effect (rather than rolled into
+     * [UpgradeAborted]) so the orchestrator can log it differently —
+     * a protocol error indicates a bug or malicious peer, while
+     * [UpgradeAborted] is the regular fallback path.
+     */
+    public data class ProtocolError(
+        val reason: String,
+    ) : BandwidthUpgradeEffect
+}

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/medium/Medium.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/medium/Medium.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.medium
+
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.BandwidthUpgradeNegotiationFrame.UpgradePathInfo
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.ConnectionRequestFrame
+
+/**
+ * Pure-Kotlin domain enum mirroring the wire-level `Medium` enums used
+ * by `ConnectionRequestFrame.Medium` and
+ * `BandwidthUpgradeNegotiationFrame.UpgradePathInfo.Medium`.
+ *
+ * Every Quick Share medium that the framework is willing to surface to
+ * adapters has exactly one entry here. The two proto enums are
+ * structurally identical (same wire numbers and names) but live in
+ * different message scopes; routing both through this single domain enum
+ * keeps the adapter contract — [MediumProvider] — independent of which
+ * proto field a value is being read from or written to.
+ *
+ * Adapters in `:discovery-android` (Phase 4 sub-issues #49–#53) declare
+ * their support against this enum; the framework converts to the
+ * appropriate proto enum at the wire boundary.
+ *
+ * The wire-numbers field is asserted by [MediumWireMappingTest] so the
+ * mapping cannot drift if a future proto vendoring renumbers an entry.
+ *
+ * @property wireNumber Wire number shared by both proto enums for this
+ *   medium. Stable across the proto's history (see Quick Share's
+ *   `LINT.IfChange` annotations on the enum).
+ */
+public enum class Medium(
+    public val wireNumber: Int,
+) {
+    /** Bluetooth RFCOMM / OBEX. Wire number 2. */
+    BLUETOOTH(2),
+
+    /** Wi-Fi Hotspot (soft-AP). Wire number 3. */
+    WIFI_HOTSPOT(3),
+
+    /** BLE GATT (used for discovery, not bulk transfer). Wire number 4. */
+    BLE(4),
+
+    /** Wi-Fi LAN — the default medium for every connection today. Wire number 5. */
+    WIFI_LAN(5),
+
+    /** Wi-Fi Aware (NAN). Wire number 6. */
+    WIFI_AWARE(6),
+
+    /** Wi-Fi Direct (P2P). Wire number 8. */
+    WIFI_DIRECT(8),
+
+    /** WebRTC (data channel; non-cellular). Wire number 9. */
+    WEB_RTC(9),
+
+    /** BLE L2CAP CoC. Wire number 10. */
+    BLE_L2CAP(10),
+    ;
+
+    /**
+     * Project this domain entry onto the wire-level
+     * [ConnectionRequestFrame.Medium] used by the opening handshake.
+     */
+    public fun toConnectionRequestMedium(): ConnectionRequestFrame.Medium =
+        // forNumber returns null only if a future proto removes the
+        // value; we vendor the proto verbatim so this is dead in
+        // practice. Treat as a programmer error if it ever fires.
+        ConnectionRequestFrame.Medium.forNumber(wireNumber)
+            ?: error("ConnectionRequestFrame.Medium has no value with wire number $wireNumber for $name")
+
+    /**
+     * Project this domain entry onto the wire-level
+     * [UpgradePathInfo.Medium] used by `BANDWIDTH_UPGRADE_NEGOTIATION`.
+     *
+     * Returns `null` for mediums whose wire number is reserved on
+     * `UpgradePathInfo.Medium` and therefore cannot appear as a
+     * bandwidth-upgrade target. Today only [BLE_L2CAP] (wire number
+     * 10, declared `// 10 is reserved.` in the proto) hits this path;
+     * the codec layer treats a `null` here as "this medium cannot be
+     * advertised as an upgrade target" and the caller must fall
+     * through to the next ladder rung.
+     */
+    public fun toUpgradePathMediumOrNull(): UpgradePathInfo.Medium? = UpgradePathInfo.Medium.forNumber(wireNumber)
+
+    /**
+     * Strict variant of [toUpgradePathMediumOrNull]. Throws if the
+     * medium has no `UpgradePathInfo.Medium` value — used by the FSM
+     * and the frame builders, which reach this path only after the
+     * registry's selection has already ruled out non-upgradable
+     * mediums (BLE/BLE_L2CAP cannot be picked because they decode to
+     * `null` on [toUpgradePathMediumOrNull] in the round-trip; the
+     * registry's `selectBestUpgrade` is the right gate).
+     */
+    public fun toUpgradePathMedium(): UpgradePathInfo.Medium =
+        toUpgradePathMediumOrNull()
+            ?: error("UpgradePathInfo.Medium has no value with wire number $wireNumber for $name")
+
+    public companion object {
+        /**
+         * Resolve a [ConnectionRequestFrame.Medium] back to a domain
+         * [Medium]. Returns `null` for `UNKNOWN_MEDIUM`, the legacy
+         * `MDNS` (1), `NFC` (7), `USB` (11), `WEB_RTC_NON_CELLULAR` (12),
+         * and `AWDL` (13) — none of which are in scope for this Android
+         * port (Apple-side interop is explicitly excluded; #5).
+         */
+        public fun fromConnectionRequestMedium(value: ConnectionRequestFrame.Medium): Medium? =
+            entries.firstOrNull { it.wireNumber == value.number }
+
+        /**
+         * Resolve an [UpgradePathInfo.Medium] back to a domain [Medium].
+         * Same semantics as [fromConnectionRequestMedium] — returns
+         * `null` for unsupported values rather than throwing, so
+         * receiver-side handling of an unknown-medium upgrade frame is
+         * a clean drop rather than a protocol error.
+         */
+        public fun fromUpgradePathMedium(value: UpgradePathInfo.Medium): Medium? =
+            entries.firstOrNull { it.wireNumber == value.number }
+    }
+}

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/medium/MediumLadder.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/medium/MediumLadder.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.medium
+
+/**
+ * Ordered preference list used to pick **one** medium out of the
+ * intersection between the local device's supported set and the peer's
+ * advertised set on `ConnectionRequestFrame.mediums`.
+ *
+ * The order encodes the project's bandwidth-vs-availability heuristic:
+ *
+ *  1. **Wi-Fi LAN** — fastest path that exists today; default.
+ *  2. **Wi-Fi Hotspot** — same bandwidth ceiling as LAN, but requires
+ *     standing up a soft-AP (slow on cold start).
+ *  3. **Wi-Fi Direct** — peer-to-peer Wi-Fi, no router in the middle.
+ *  4. **Wi-Fi Aware** — newer, but coverage is patchy on shipping
+ *     devices (API 26+ and only on a subset of chips).
+ *  5. **WebRTC** — internet-relayed; only relevant when both peers
+ *     have connectivity but no shared LAN.
+ *  6. **BLE L2CAP** — meaningful throughput on the LE radio (≈ 1 Mbps
+ *     on BT 5+); preferred over RFCOMM for the file-transfer phase.
+ *  7. **Bluetooth (RFCOMM)** — slowest of the bulk-transfer mediums but
+ *     extremely widely supported; the universal fallback.
+ *  8. **BLE (GATT)** — discovery-only in practice; left in the ladder
+ *     so a future "tiny payload over GATT" path stays expressible.
+ *
+ * The default is exposed as [Default]; a per-call override can be
+ * passed to [MediumRegistry.selectBestUpgrade] when integration tests
+ * or specific UX flows want a different ordering (e.g. forcing a
+ * Wi-Fi-Direct-first run).
+ */
+public class MediumLadder(
+    /**
+     * Mediums in descending preference order.
+     *
+     * The list is `distinct`-ed in the constructor so accidentally
+     * duplicate entries do not affect selection. Empty lists are
+     * permitted (and produce [MediumRegistry.selectBestUpgrade] returning
+     * `null` for every input).
+     */
+    rungs: List<Medium>,
+) {
+    public val rungs: List<Medium> = rungs.distinct()
+
+    /**
+     * Pick the highest-priority medium from [candidates]. Returns
+     * `null` when the intersection is empty (i.e. no candidate appears
+     * on the ladder).
+     *
+     * Order of [candidates] is irrelevant: the ladder controls the
+     * outcome.
+     */
+    public fun pickBest(candidates: Set<Medium>): Medium? = rungs.firstOrNull { it in candidates }
+
+    public companion object {
+        /**
+         * Project default. See class KDoc for the ordering rationale.
+         */
+        @JvmStatic
+        public val Default: MediumLadder =
+            MediumLadder(
+                listOf(
+                    Medium.WIFI_LAN,
+                    Medium.WIFI_HOTSPOT,
+                    Medium.WIFI_DIRECT,
+                    Medium.WIFI_AWARE,
+                    Medium.WEB_RTC,
+                    Medium.BLE_L2CAP,
+                    Medium.BLUETOOTH,
+                    Medium.BLE,
+                ),
+            )
+    }
+}

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/medium/MediumProvider.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/medium/MediumProvider.kt
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.medium
+
+/**
+ * Pluggable per-medium adapter. One implementation per Quick Share
+ * transport (Wi-Fi LAN, Wi-Fi Direct, Wi-Fi Hotspot, Bluetooth RFCOMM,
+ * BLE L2CAP, Wi-Fi Aware, …).
+ *
+ * The framework — [io.github.kyujincho.wvmg.protocol.connection.OutboundConnection]
+ * and [io.github.kyujincho.wvmg.protocol.connection.InboundConnection],
+ * via [MediumRegistry] — calls into a provider in three places:
+ *
+ *  1. **Capability advertisement** ([isSupported]) at connection start.
+ *     Drives `ConnectionRequestFrame.mediums` on the sender side and
+ *     intersection on the receiver side.
+ *  2. **Upgrade preparation** ([prepareUpgrade], server role only) when
+ *     the receiver decides to switch transports. The provider returns
+ *     the credentials the sender will need to reconnect on the new
+ *     medium; the framework wraps them in
+ *     `BANDWIDTH_UPGRADE_NEGOTIATION{UPGRADE_PATH_AVAILABLE}`.
+ *  3. **Upgrade adoption** ([adoptUpgrade], client role only) once the
+ *     sender has parsed an `UPGRADE_PATH_AVAILABLE` frame. The
+ *     provider does whatever IO it needs (open a Wi-Fi Direct group,
+ *     connect to the new SSID, open the RFCOMM socket, …) and returns
+ *     a fresh transport for the framework to swap in.
+ *
+ * Phase 4 sub-issues #49–#53 each ship a single provider for their
+ * medium. None of them touches the orchestrator — the registry
+ * dispatch keeps the framework code constant as the medium count
+ * grows.
+ *
+ * ### Why this lives in :core-protocol (no `android.*`)
+ *
+ * The interface itself never opens a socket, never pokes Wi-Fi, never
+ * looks at Bluetooth — it just asks "are you available?" / "give me
+ * credentials" / "use these credentials". Concrete implementations
+ * are perfectly free to live in `:discovery-android` (or another
+ * Android-only module) and depend on `WifiManager`, `BluetoothManager`,
+ * etc. The framework consumes them through this interface and never
+ * sees the Android types.
+ *
+ * The single transport the provider returns from [adoptUpgrade] is
+ * declared as a sealed marker type ([UpgradedTransport]) so per-medium
+ * implementations can ship their own concrete subclass without leaking
+ * an Android socket type into `:core-protocol`. Phase 4 sub-issues
+ * (#49–#53) extend the marker as needed.
+ */
+public interface MediumProvider {
+    /** The medium this provider implements. Stable across the JVM lifetime. */
+    public val medium: Medium
+
+    /**
+     * Returns true iff this device is currently capable of using
+     * [medium]. Examples:
+     *
+     *  - Wi-Fi LAN: device is on a Wi-Fi network with a routable IP.
+     *  - Wi-Fi Direct: hardware supports P2P and the user has not
+     *    revoked NEARBY_WIFI_DEVICES permission.
+     *  - Bluetooth RFCOMM: Bluetooth is on, the local adapter is
+     *    discoverable, and BLUETOOTH_CONNECT is granted.
+     *
+     * The framework calls this at the start of every connection
+     * lifecycle (cheap, must be O(1)). Providers MUST NOT block; if a
+     * capability check needs an async probe, the provider should keep
+     * a cached result that the OS update broadcasts invalidate.
+     */
+    public fun isSupported(): Boolean
+
+    /**
+     * **Server role.** Stand up the medium and produce the credentials
+     * the peer needs to connect.
+     *
+     * Called by the framework after the receiver has decided to send
+     * `UPGRADE_PATH_AVAILABLE`. Returning `null` means "I cannot
+     * upgrade right now after all" and causes the framework to fall
+     * back to the next medium in the ladder, or stay on the current
+     * medium if no fallback is possible.
+     *
+     * The framework wraps the returned credentials in an
+     * `UpgradePathInfo` proto via the per-medium serializer in
+     * [io.github.kyujincho.wvmg.protocol.connection.BandwidthUpgradeFrames];
+     * sub-issues #49–#53 each add a new arm there.
+     *
+     * Default: returns `null` (provider does not support being the
+     * server side of an upgrade). Wi-Fi LAN's provider trivially
+     * implements this by reading the receiver-side bind address; other
+     * providers do real I/O (open a soft-AP, advertise an RFCOMM
+     * service record, etc.).
+     */
+    public suspend fun prepareUpgrade(): UpgradePathCredentials? = null
+
+    /**
+     * **Client role.** Adopt the credentials the peer just sent, do
+     * whatever bring-up the medium requires, and hand the framework
+     * back a transport ready for the SecureChannel to wrap.
+     *
+     * Called by the framework after the sender has parsed
+     * `UPGRADE_PATH_AVAILABLE`. Returning `null` aborts the upgrade
+     * (the framework stays on the current medium and surfaces an
+     * `UPGRADE_FAILURE` to the peer).
+     *
+     * Default: returns `null`. The Wi-Fi LAN provider implements this
+     * by re-resolving the receiver-side IP/port and opening a fresh
+     * `Socket`; other providers do their medium-specific bring-up.
+     *
+     * @param credentials The peer-supplied bring-up parameters. The
+     *   provider MUST validate that
+     *   `credentials.medium == this.medium`; the framework does not
+     *   enforce the match because intermediate code paths could
+     *   theoretically route mismatched values during a fallback.
+     */
+    public suspend fun adoptUpgrade(credentials: UpgradePathCredentials): UpgradedTransport? = null
+}
+
+/**
+ * Marker type for a transport produced by [MediumProvider.adoptUpgrade].
+ *
+ * Concrete subtypes live in the per-medium adapter modules (e.g.
+ * `:discovery-android` for Phase 4 sub-issues) so this module never
+ * imports `android.*` or `java.net.Socket`-derived types it cannot
+ * own. The framework treats every value here as opaque until the
+ * SecureChannel is rebuilt around it — that's the responsibility of
+ * the orchestrator's upgrade hook (added in #54 once at least one
+ * non-Wi-Fi-LAN provider exists).
+ *
+ * Implementations SHOULD be `data class` / `value class` shaped so
+ * they round-trip cleanly through equality checks in tests. The
+ * minimum useful subtype is described by [Generic] which simply
+ * wraps a [Medium] — convenient for the unit tests in this module
+ * and as a placeholder while the per-medium adapters land.
+ */
+public interface UpgradedTransport {
+    /** Which medium this transport was opened over. */
+    public val medium: Medium
+
+    /**
+     * Stub transport carrying nothing more than the medium type.
+     *
+     * Used by [MediumProvider]s that do not yet have a real socket to
+     * return (e.g. fixtures, partial Phase 4 implementations). Real
+     * adapters will return their own subtype carrying a `Socket` /
+     * `BluetoothSocket` / `L2CapChannel` / etc.
+     */
+    public data class Generic(
+        override val medium: Medium,
+    ) : UpgradedTransport
+}

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/medium/MediumRegistry.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/medium/MediumRegistry.kt
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.medium
+
+/**
+ * Pluggable registry of [MediumProvider]s.
+ *
+ * The framework
+ * ([io.github.kyujincho.wvmg.protocol.connection.OutboundConnection] /
+ * [io.github.kyujincho.wvmg.protocol.connection.InboundConnection])
+ * holds exactly one of these per process. The registry is the only
+ * surface the orchestrator needs to know about; per-medium adapters
+ * (Phase 4 sub-issues #49–#53) just register themselves.
+ *
+ * Two responsibilities:
+ *
+ *  1. **Capability advertisement** — [supportedMediums] expands every
+ *     registered provider's [MediumProvider.isSupported] into the set
+ *     used to populate `ConnectionRequestFrame.mediums` on the sender
+ *     side and to intersect the peer's mediums on the receiver side.
+ *  2. **Provider lookup** — [providerFor] retrieves the registered
+ *     adapter for a chosen medium, used by [selectBestUpgrade] when
+ *     the framework is ready to perform the bandwidth-upgrade
+ *     handshake.
+ *
+ * Stays empty by default so the framework's behaviour is unchanged
+ * when no Phase 4 medium is wired up — see [DefaultWifiLan] for the
+ * Phase 1 default that mirrors today's "Wi-Fi LAN only" surface.
+ *
+ * Thread-safety: providers are inserted at construction time only; the
+ * registry itself is immutable after construction. Look-up paths are
+ * lock-free and safe to call from any thread.
+ */
+public class MediumRegistry(
+    providers: List<MediumProvider> = emptyList(),
+    /**
+     * Ladder used to break ties when multiple mediums are present in
+     * the intersection between the local and peer-supported sets.
+     * Defaults to [MediumLadder.Default]. Tests override to lock the
+     * pick on a deterministic medium.
+     */
+    public val ladder: MediumLadder = MediumLadder.Default,
+) {
+    /**
+     * Indexed view of the registered providers. Two providers
+     * registering the same [MediumProvider.medium] is a programmer
+     * error — `require` rather than silently dropping the duplicate
+     * because the alternative would be order-dependent and unsurprising
+     * fields like `[providerFor]` would silently return one or the
+     * other.
+     */
+    private val providers: Map<Medium, MediumProvider>
+
+    init {
+        val map = HashMap<Medium, MediumProvider>(providers.size)
+        for (provider in providers) {
+            require(map.put(provider.medium, provider) == null) {
+                "Duplicate MediumProvider for ${provider.medium}"
+            }
+        }
+        this.providers = map
+    }
+
+    /**
+     * Set of mediums whose providers report [MediumProvider.isSupported] true
+     * **and** are registered with this instance. Recomputed on every
+     * call: [MediumProvider.isSupported] may flip with OS-level state
+     * changes (Wi-Fi off, Bluetooth off, …) and the framework expects
+     * a fresh snapshot at the start of every connection lifecycle.
+     */
+    public fun supportedMediums(): Set<Medium> =
+        providers.values
+            .asSequence()
+            .filter { it.isSupported() }
+            .map { it.medium }
+            .toSet()
+
+    /**
+     * Return the registered provider for [medium], or `null` when no
+     * provider was registered for it. Note this does NOT consult
+     * [MediumProvider.isSupported]; the caller is responsible for
+     * ordering the check (almost always `provider.isSupported()` after
+     * `providerFor`).
+     */
+    public fun providerFor(medium: Medium): MediumProvider? = providers[medium]
+
+    /**
+     * Whether the registry has any provider registered, regardless of
+     * support state. Used as a cheap gate for code paths that should
+     * stay dormant when no Phase 4 medium has been wired up.
+     */
+    public fun isEmpty(): Boolean = providers.isEmpty()
+
+    /**
+     * Intersect the local supported set with the peer's advertised
+     * mediums and return the highest-priority entry per [ladder].
+     *
+     * Returns `null` when the intersection is empty (no shared medium)
+     * or when [ladder] does not contain any of the intersection
+     * members.
+     *
+     * @param peerSupported The peer's advertised set, decoded from
+     *   `ConnectionRequestFrame.mediums`.
+     * @param ladderOverride Optional per-call ladder override; defaults
+     *   to the one supplied at construction.
+     */
+    public fun selectBestUpgrade(
+        peerSupported: Set<Medium>,
+        ladderOverride: MediumLadder = ladder,
+    ): Medium? {
+        val intersection = supportedMediums().intersect(peerSupported)
+        if (intersection.isEmpty()) return null
+        return ladderOverride.pickBest(intersection)
+    }
+
+    public companion object {
+        /**
+         * The Phase 1 default: a registry with a single trivial
+         * Wi-Fi-LAN provider. Mirrors today's hard-coded behaviour and
+         * is what [io.github.kyujincho.wvmg.protocol.connection.OutboundConnection]
+         * and [io.github.kyujincho.wvmg.protocol.connection.InboundConnection]
+         * use when the caller does not supply their own registry.
+         *
+         * The provider here returns no upgrade credentials and adopts
+         * none — Wi-Fi LAN is the **discovery** medium today, so there
+         * is nothing to "upgrade to". Keeping it in the registry just
+         * makes `ConnectionRequestFrame.mediums` advertise WIFI_LAN as
+         * a medium the device supports, which matches what NearDrop
+         * has hard-coded since day one.
+         */
+        @JvmStatic
+        public val DefaultWifiLan: MediumRegistry =
+            MediumRegistry(
+                providers = listOf(WifiLanDefaultProvider),
+            )
+
+        /**
+         * Trivial Wi-Fi-LAN provider used by [DefaultWifiLan]. Reports
+         * supported = true unconditionally (the orchestrator already
+         * has a TCP socket open by the time we ask, so Wi-Fi is by
+         * definition reachable) and offers no upgrade path.
+         */
+        private object WifiLanDefaultProvider : MediumProvider {
+            override val medium: Medium = Medium.WIFI_LAN
+
+            override fun isSupported(): Boolean = true
+        }
+    }
+}

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/medium/UpgradePathCredentials.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/medium/UpgradePathCredentials.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.medium
+
+/**
+ * Per-medium credentials carried in a `BANDWIDTH_UPGRADE_NEGOTIATION`
+ * `UPGRADE_PATH_AVAILABLE` frame.
+ *
+ * Each Quick Share medium ships its own bring-up parameters (an SSID +
+ * password for Hotspot, a MAC address for Bluetooth RFCOMM, etc.). The
+ * proto encodes these as a `oneof` on `UpgradePathInfo`; this sealed
+ * interface mirrors that shape in pure Kotlin so [MediumProvider]
+ * implementations can hand the framework an opaque value object that
+ * the wire-encoder layer translates into the right proto fields without
+ * any per-medium framework-side branching.
+ *
+ * Phase 4 sub-issues #49–#53 each add the Kotlin data class their
+ * adapter needs and the matching encoder/decoder hop in
+ * [io.github.kyujincho.wvmg.protocol.connection.BandwidthUpgradeFrames].
+ * Until then, [Generic] covers tests and any provider that has no
+ * extra parameters beyond the medium type itself (e.g. Wi-Fi LAN, where
+ * the discovery layer already advertised the IP and port).
+ */
+public sealed interface UpgradePathCredentials {
+    /** The medium these credentials describe. */
+    public val medium: Medium
+
+    /**
+     * Catch-all credentials carrying nothing beyond the medium type.
+     * Useful for tests and for mediums whose bring-up parameters are
+     * fully derivable from out-of-band state already known to the peer
+     * (e.g. Wi-Fi LAN where the receiver's IP / port were already on
+     * the discovery record).
+     */
+    public data class Generic(
+        override val medium: Medium,
+    ) : UpgradePathCredentials
+
+    /**
+     * Wi-Fi LAN credentials — the receiver-side IP address and port
+     * the sender should reconnect to after the upgrade. Present so a
+     * future "discover over BLE, transfer over Wi-Fi LAN" path can
+     * reuse the framework end-to-end without inventing a side channel.
+     *
+     * @param ipAddress IPv4 (4 bytes) or IPv6 (16 bytes) network-order
+     *   address bytes, matching `UpgradePathInfo.WifiLanSocket.ip_address`.
+     * @param port TCP port, matching `UpgradePathInfo.WifiLanSocket.wifi_port`.
+     */
+    public data class WifiLan(
+        val ipAddress: ByteArray,
+        val port: Int,
+    ) : UpgradePathCredentials {
+        override val medium: Medium = Medium.WIFI_LAN
+
+        // ByteArray on a data class needs structural equality wired up
+        // explicitly — the auto-generated equals/hashCode would compare
+        // by reference, which makes WifiLan a poor map key and breaks
+        // unit tests that build two instances from the same source.
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is WifiLan) return false
+            return port == other.port && ipAddress.contentEquals(other.ipAddress)
+        }
+
+        override fun hashCode(): Int {
+            var result = ipAddress.contentHashCode()
+            result = 31 * result + port
+            return result
+        }
+    }
+}

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeFramesTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeFramesTest.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.connection
+
+import com.google.common.truth.Truth.assertThat
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.BandwidthUpgradeNegotiationFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.V1Frame
+import io.github.kyujincho.wvmg.protocol.medium.Medium
+import io.github.kyujincho.wvmg.protocol.medium.UpgradePathCredentials
+import org.junit.jupiter.api.Test
+
+class BandwidthUpgradeFramesTest {
+    @Test
+    fun `upgradePathAvailable carries medium and credentials`() {
+        val frame =
+            BandwidthUpgradeFrames.upgradePathAvailable(
+                UpgradePathCredentials.WifiLan(
+                    ipAddress = byteArrayOf(192.toByte(), 168.toByte(), 1, 42),
+                    port = 4433,
+                ),
+            )
+        val parsed = parse(frame)
+        assertThat(parsed.eventType).isEqualTo(BandwidthUpgradeNegotiationFrame.EventType.UPGRADE_PATH_AVAILABLE)
+        assertThat(parsed.upgradePathInfo.medium.number).isEqualTo(Medium.WIFI_LAN.wireNumber)
+        assertThat(parsed.upgradePathInfo.hasWifiLanSocket()).isTrue()
+        assertThat(parsed.upgradePathInfo.wifiLanSocket.wifiPort).isEqualTo(4433)
+        assertThat(
+            parsed.upgradePathInfo.wifiLanSocket.ipAddress
+                .toByteArray(),
+        ).isEqualTo(byteArrayOf(192.toByte(), 168.toByte(), 1, 42))
+    }
+
+    @Test
+    fun `upgradePathAvailable supports Generic credentials (medium-only)`() {
+        val frame =
+            BandwidthUpgradeFrames.upgradePathAvailable(
+                UpgradePathCredentials.Generic(Medium.WIFI_DIRECT),
+            )
+        val parsed = parse(frame)
+        assertThat(parsed.upgradePathInfo.medium.number).isEqualTo(Medium.WIFI_DIRECT.wireNumber)
+        assertThat(parsed.upgradePathInfo.hasWifiLanSocket()).isFalse()
+    }
+
+    @Test
+    fun `clientIntroduction round-trips through OfflineFrame`() {
+        val frame = BandwidthUpgradeFrames.clientIntroduction("ABCD")
+        val parsed = parse(frame)
+        assertThat(parsed.eventType).isEqualTo(BandwidthUpgradeNegotiationFrame.EventType.CLIENT_INTRODUCTION)
+        assertThat(parsed.clientIntroduction.endpointId).isEqualTo("ABCD")
+    }
+
+    @Test
+    fun `clientIntroductionAck has the ack sub-message set`() {
+        val frame = BandwidthUpgradeFrames.clientIntroductionAck()
+        val parsed = parse(frame)
+        assertThat(parsed.eventType).isEqualTo(BandwidthUpgradeNegotiationFrame.EventType.CLIENT_INTRODUCTION_ACK)
+        assertThat(parsed.hasClientIntroductionAck()).isTrue()
+    }
+
+    @Test
+    fun `safeToClosePriorChannel defaults to STA_FREQUENCY_NOT_SET`() {
+        val frame = BandwidthUpgradeFrames.safeToClosePriorChannel()
+        val parsed = parse(frame)
+        assertThat(parsed.safeToClosePriorChannel.staFrequency)
+            .isEqualTo(BandwidthUpgradeFrames.STA_FREQUENCY_NOT_SET)
+    }
+
+    @Test
+    fun `lastWriteToPriorChannel sets the event type without payload`() {
+        val frame = BandwidthUpgradeFrames.lastWriteToPriorChannel()
+        val parsed = parse(frame)
+        assertThat(parsed.eventType).isEqualTo(BandwidthUpgradeNegotiationFrame.EventType.LAST_WRITE_TO_PRIOR_CHANNEL)
+    }
+
+    @Test
+    fun `upgradeFailure carries the failed medium back to the peer`() {
+        val frame = BandwidthUpgradeFrames.upgradeFailure(Medium.WIFI_DIRECT)
+        val parsed = parse(frame)
+        assertThat(parsed.eventType).isEqualTo(BandwidthUpgradeNegotiationFrame.EventType.UPGRADE_FAILURE)
+        assertThat(parsed.upgradePathInfo.medium.number).isEqualTo(Medium.WIFI_DIRECT.wireNumber)
+    }
+
+    @Test
+    fun `decodeCredentials round-trips Wi-Fi LAN`() {
+        val original =
+            UpgradePathCredentials.WifiLan(
+                ipAddress = byteArrayOf(10, 0, 0, 1),
+                port = 8000,
+            )
+        val frame = BandwidthUpgradeFrames.upgradePathAvailable(original)
+        val parsed = parse(frame)
+        val decoded = BandwidthUpgradeFrames.decodeCredentials(parsed.upgradePathInfo)
+        assertThat(decoded).isEqualTo(original)
+    }
+
+    @Test
+    fun `decodeCredentials returns Generic for not-yet-implemented mediums`() {
+        val frame = BandwidthUpgradeFrames.upgradePathAvailable(UpgradePathCredentials.Generic(Medium.BLUETOOTH))
+        val parsed = parse(frame)
+        val decoded = BandwidthUpgradeFrames.decodeCredentials(parsed.upgradePathInfo)
+        assertThat(decoded).isEqualTo(UpgradePathCredentials.Generic(Medium.BLUETOOTH))
+    }
+
+    @Test
+    fun `every builder produces a V1 BANDWIDTH_UPGRADE_NEGOTIATION envelope`() {
+        val frames =
+            listOf(
+                BandwidthUpgradeFrames.upgradePathAvailable(UpgradePathCredentials.Generic(Medium.WIFI_LAN)),
+                BandwidthUpgradeFrames.clientIntroduction("ABCD"),
+                BandwidthUpgradeFrames.clientIntroductionAck(),
+                BandwidthUpgradeFrames.lastWriteToPriorChannel(),
+                BandwidthUpgradeFrames.safeToClosePriorChannel(),
+                BandwidthUpgradeFrames.upgradeFailure(Medium.WIFI_DIRECT),
+            )
+        for (frame in frames) {
+            assertThat(frame.version).isEqualTo(OfflineFrame.Version.V1)
+            assertThat(frame.v1.type).isEqualTo(V1Frame.FrameType.BANDWIDTH_UPGRADE_NEGOTIATION)
+            assertThat(frame.v1.hasBandwidthUpgradeNegotiation()).isTrue()
+        }
+    }
+
+    private fun parse(frame: OfflineFrame): BandwidthUpgradeNegotiationFrame {
+        // Round-trip through serialization so the test catches any
+        // wrap helper that forgets to set a oneof slot.
+        val bytes = frame.toByteArray()
+        return OfflineFrame.parseFrom(bytes).v1.bandwidthUpgradeNegotiation
+    }
+}

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/ConnectionRequestMediumsTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/ConnectionRequestMediumsTest.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.connection
+
+import com.google.common.truth.Truth.assertThat
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.ConnectionRequestFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame
+import io.github.kyujincho.wvmg.protocol.medium.Medium
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins the `ConnectionRequestFrame.mediums` field shape. Two
+ * invariants:
+ *
+ *   1. Default behaviour (no mediums passed) advertises Wi-Fi LAN
+ *      only — functionally identical to the project's pre-Phase-4
+ *      hard-coded shape and to NearDrop.
+ *   2. Multiple mediums survive the wire round-trip and Wi-Fi LAN is
+ *      always present (it IS the discovery medium today; absence
+ *      breaks Android 14+ Nearby Connections validation).
+ */
+class ConnectionRequestMediumsTest {
+    @Test
+    fun `default ConnectionRequest advertises Wi-Fi LAN only`() {
+        val frame = OutboundFrames.connectionRequest("ABCD", ByteArray(0))
+        val mediums = parseRequest(frame).mediumsList.map { it.number }
+        assertThat(mediums).containsExactly(Medium.WIFI_LAN.wireNumber)
+    }
+
+    @Test
+    fun `caller-supplied mediums all reach the wire`() {
+        val frame =
+            OutboundFrames.connectionRequest(
+                endpointId = "ABCD",
+                endpointInfo = ByteArray(0),
+                supportedMediums =
+                    setOf(Medium.WIFI_LAN, Medium.WIFI_DIRECT, Medium.BLE_L2CAP),
+            )
+        val numbers = parseRequest(frame).mediumsList.map { it.number }.toSet()
+        assertThat(numbers).containsExactly(
+            Medium.WIFI_LAN.wireNumber,
+            Medium.WIFI_DIRECT.wireNumber,
+            Medium.BLE_L2CAP.wireNumber,
+        )
+    }
+
+    @Test
+    fun `Wi-Fi LAN is always implicitly present`() {
+        // Even a caller that forgets WIFI_LAN must end up advertising
+        // it because it IS the discovery medium for the current
+        // socket — Android 14+ Nearby Connections rejects absence of
+        // it as malformed.
+        val frame =
+            OutboundFrames.connectionRequest(
+                endpointId = "ABCD",
+                endpointInfo = ByteArray(0),
+                supportedMediums = setOf(Medium.BLUETOOTH),
+            )
+        val numbers = parseRequest(frame).mediumsList.map { it.number }.toSet()
+        assertThat(numbers).contains(Medium.WIFI_LAN.wireNumber)
+        assertThat(numbers).contains(Medium.BLUETOOTH.wireNumber)
+    }
+
+    @Test
+    fun `wire ordering is deterministic by Medium number`() {
+        val frame =
+            OutboundFrames.connectionRequest(
+                endpointId = "ABCD",
+                endpointInfo = ByteArray(0),
+                supportedMediums =
+                    setOf(Medium.BLE_L2CAP, Medium.WIFI_LAN, Medium.BLUETOOTH),
+            )
+        val numbers = parseRequest(frame).mediumsList.map { it.number }
+        assertThat(numbers).isInOrder()
+    }
+
+    @Test
+    fun `keep_alive fields and endpoint_id survive the change`() {
+        // Sanity: pinning the mediums field must not have regressed
+        // the four other fields ConnectionRequestFrame is expected to
+        // populate (One UI 8.0.5 silent-FIN guards live here).
+        val frame = OutboundFrames.connectionRequest("XYZW", ByteArray(0))
+        val req = parseRequest(frame)
+        assertThat(req.endpointId).isEqualTo("XYZW")
+        assertThat(req.endpointName).isEqualTo("")
+        assertThat(req.keepAliveIntervalMillis).isEqualTo(10_000)
+        assertThat(req.keepAliveTimeoutMillis).isEqualTo(600_000)
+    }
+
+    private fun parseRequest(frame: OfflineFrame): ConnectionRequestFrame {
+        val bytes = frame.toByteArray()
+        return OfflineFrame.parseFrom(bytes).v1.connectionRequest
+    }
+}

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/medium/BandwidthUpgradeNegotiatorTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/medium/BandwidthUpgradeNegotiatorTest.kt
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.medium
+
+import com.google.common.truth.Truth.assertThat
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.BandwidthUpgradeNegotiationFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.V1Frame
+import io.github.kyujincho.wvmg.protocol.connection.BandwidthUpgradeFrames
+import org.junit.jupiter.api.Test
+
+/**
+ * Coverage for [BandwidthUpgradeNegotiator].
+ *
+ * The FSM is the source of truth for the BANDWIDTH_UPGRADE_NEGOTIATION
+ * event sequence. The orchestrator integration (transport swap) lives
+ * outside the FSM and is exercised separately by Phase 4 sub-issue #54.
+ */
+class BandwidthUpgradeNegotiatorTest {
+    private val endpointId = "ABCD"
+    private val medium = Medium.WIFI_DIRECT
+    private val credentials: UpgradePathCredentials = UpgradePathCredentials.Generic(medium)
+
+    @Test
+    fun `server initiates by sending UPGRADE_PATH_AVAILABLE on Start`() {
+        val fsm =
+            BandwidthUpgradeNegotiator(
+                role = BandwidthUpgradeNegotiator.Role.SERVER,
+                medium = medium,
+                endpointId = endpointId,
+            )
+        val effects = fsm.onEvent(BandwidthUpgradeEvent.Start(credentials))
+        val sent = effects.singleSendFrame()
+        assertThat(sent.eventType).isEqualTo(BandwidthUpgradeNegotiationFrame.EventType.UPGRADE_PATH_AVAILABLE)
+        assertThat(fsm.state).isEqualTo(BandwidthUpgradeNegotiator.State.AwaitingClientIntroduction)
+    }
+
+    @Test
+    fun `client cannot initiate via Start`() {
+        val fsm =
+            BandwidthUpgradeNegotiator(
+                role = BandwidthUpgradeNegotiator.Role.CLIENT,
+                medium = medium,
+                endpointId = endpointId,
+            )
+        val effects = fsm.onEvent(BandwidthUpgradeEvent.Start(credentials))
+        assertThat(effects).contains(
+            BandwidthUpgradeEffect.ProtocolError("Client received Start; only server may initiate"),
+        )
+        assertThat(fsm.state).isInstanceOf(BandwidthUpgradeNegotiator.State.Failed::class.java)
+    }
+
+    @Test
+    fun `client adopts on UPGRADE_PATH_AVAILABLE`() {
+        val fsm =
+            BandwidthUpgradeNegotiator(
+                role = BandwidthUpgradeNegotiator.Role.CLIENT,
+                medium = medium,
+                endpointId = endpointId,
+            )
+        val pathFrame = BandwidthUpgradeFrames.upgradePathAvailable(credentials)
+        val effects = fsm.onEvent(BandwidthUpgradeEvent.FrameReceived(pathFrame))
+        val adopt = effects.filterIsInstance<BandwidthUpgradeEffect.AdoptTransport>().single()
+        assertThat(adopt.credentials.medium).isEqualTo(medium)
+        assertThat(fsm.state).isInstanceOf(BandwidthUpgradeNegotiator.State.AdoptingTransport::class.java)
+    }
+
+    @Test
+    fun `client sends CLIENT_INTRODUCTION after AdoptSucceeded`() {
+        val fsm = clientPostAdopt()
+        val effects = fsm.onEvent(BandwidthUpgradeEvent.AdoptSucceeded)
+        val sent = effects.singleSendFrame()
+        assertThat(sent.eventType).isEqualTo(BandwidthUpgradeNegotiationFrame.EventType.CLIENT_INTRODUCTION)
+        assertThat(sent.clientIntroduction.endpointId).isEqualTo(endpointId)
+        assertThat(fsm.state).isEqualTo(BandwidthUpgradeNegotiator.State.AwaitingIntroductionAck)
+    }
+
+    @Test
+    fun `client emits UPGRADE_FAILURE on AdoptFailed`() {
+        val fsm = clientPostAdopt()
+        val effects = fsm.onEvent(BandwidthUpgradeEvent.AdoptFailed("hotspot did not come up"))
+        val sent = effects.filterIsInstance<BandwidthUpgradeEffect.SendFrame>().single()
+        val parsed = sent.frame.v1.bandwidthUpgradeNegotiation
+        assertThat(parsed.eventType).isEqualTo(BandwidthUpgradeNegotiationFrame.EventType.UPGRADE_FAILURE)
+        assertThat(parsed.upgradePathInfo.medium.number).isEqualTo(medium.wireNumber)
+        assertThat(effects).contains(BandwidthUpgradeEffect.UpgradeAborted("hotspot did not come up"))
+        assertThat(fsm.state).isInstanceOf(BandwidthUpgradeNegotiator.State.Failed::class.java)
+    }
+
+    @Test
+    fun `server emits CLIENT_INTRODUCTION_ACK plus LAST_WRITE on receiving CLIENT_INTRODUCTION`() {
+        val fsm = serverPostStart()
+        val intro = BandwidthUpgradeFrames.clientIntroduction(endpointId)
+        val effects = fsm.onEvent(BandwidthUpgradeEvent.FrameReceived(intro))
+        val sent = effects.filterIsInstance<BandwidthUpgradeEffect.SendFrame>()
+        val types =
+            sent.map { it.frame.v1.bandwidthUpgradeNegotiation.eventType }
+        assertThat(types)
+            .containsExactly(
+                BandwidthUpgradeNegotiationFrame.EventType.CLIENT_INTRODUCTION_ACK,
+                BandwidthUpgradeNegotiationFrame.EventType.LAST_WRITE_TO_PRIOR_CHANNEL,
+            ).inOrder()
+        assertThat(fsm.state).isEqualTo(BandwidthUpgradeNegotiator.State.LastWritePending)
+    }
+
+    @Test
+    fun `client transitions LastWritePending after receiving CLIENT_INTRODUCTION_ACK`() {
+        val fsm = clientPostIntroduction()
+        val ack = BandwidthUpgradeFrames.clientIntroductionAck()
+        val effects = fsm.onEvent(BandwidthUpgradeEvent.FrameReceived(ack))
+        val sent = effects.singleSendFrame()
+        assertThat(sent.eventType).isEqualTo(BandwidthUpgradeNegotiationFrame.EventType.LAST_WRITE_TO_PRIOR_CHANNEL)
+        assertThat(fsm.state).isEqualTo(BandwidthUpgradeNegotiator.State.LastWritePending)
+    }
+
+    @Test
+    fun `safe-to-close exchange completes the upgrade`() {
+        // Walk a server through to AwaitingDrain, send the drain
+        // notification, then deliver SAFE_TO_CLOSE and assert Completed.
+        val fsm = serverPostStart()
+        fsm.onEvent(BandwidthUpgradeEvent.FrameReceived(BandwidthUpgradeFrames.clientIntroduction(endpointId)))
+        // Receive the peer's LAST_WRITE on the old channel.
+        fsm.onEvent(BandwidthUpgradeEvent.FrameReceived(BandwidthUpgradeFrames.lastWriteToPriorChannel()))
+        // Orchestrator says: own writer is drained. FSM emits SAFE_TO_CLOSE.
+        val drainEffects = fsm.onEvent(BandwidthUpgradeEvent.PriorChannelDrained)
+        assertThat(drainEffects.singleSendFrame().eventType)
+            .isEqualTo(BandwidthUpgradeNegotiationFrame.EventType.SAFE_TO_CLOSE_PRIOR_CHANNEL)
+        // Peer's SAFE_TO_CLOSE arrives → Completed.
+        val finalEffects =
+            fsm.onEvent(BandwidthUpgradeEvent.FrameReceived(BandwidthUpgradeFrames.safeToClosePriorChannel()))
+        assertThat(finalEffects).containsExactly(BandwidthUpgradeEffect.UpgradeCompleted)
+        assertThat(fsm.state).isEqualTo(BandwidthUpgradeNegotiator.State.Completed)
+    }
+
+    @Test
+    fun `inbound UPGRADE_FAILURE aborts on either role`() {
+        val fsm = clientPostAdopt()
+        val failure = BandwidthUpgradeFrames.upgradeFailure(medium)
+        val effects = fsm.onEvent(BandwidthUpgradeEvent.FrameReceived(failure))
+        assertThat(effects).contains(BandwidthUpgradeEffect.UpgradeAborted("Peer sent UPGRADE_FAILURE"))
+        assertThat(fsm.state).isInstanceOf(BandwidthUpgradeNegotiator.State.Failed::class.java)
+    }
+
+    @Test
+    fun `Abort emits UPGRADE_FAILURE and transitions to Failed`() {
+        val fsm = serverPostStart()
+        val effects = fsm.onEvent(BandwidthUpgradeEvent.Abort)
+        val sent = effects.filterIsInstance<BandwidthUpgradeEffect.SendFrame>().single()
+        assertThat(sent.frame.v1.bandwidthUpgradeNegotiation.eventType)
+            .isEqualTo(BandwidthUpgradeNegotiationFrame.EventType.UPGRADE_FAILURE)
+        assertThat(effects).contains(BandwidthUpgradeEffect.UpgradeAborted("abort requested by orchestrator"))
+        assertThat(fsm.state).isInstanceOf(BandwidthUpgradeNegotiator.State.Failed::class.java)
+    }
+
+    @Test
+    fun `non-BANDWIDTH_UPGRADE frame produces ProtocolError`() {
+        val fsm = serverPostStart()
+        val keepAlive =
+            OfflineFrame
+                .newBuilder()
+                .setVersion(OfflineFrame.Version.V1)
+                .setV1(
+                    V1Frame
+                        .newBuilder()
+                        .setType(V1Frame.FrameType.KEEP_ALIVE)
+                        .build(),
+                ).build()
+        val effects = fsm.onEvent(BandwidthUpgradeEvent.FrameReceived(keepAlive))
+        assertThat(effects.filterIsInstance<BandwidthUpgradeEffect.ProtocolError>()).isNotEmpty()
+        assertThat(fsm.state).isInstanceOf(BandwidthUpgradeNegotiator.State.Failed::class.java)
+    }
+
+    @Test
+    fun `server PrepareFailed before Start emits UPGRADE_FAILURE and Aborted`() {
+        val fsm =
+            BandwidthUpgradeNegotiator(
+                role = BandwidthUpgradeNegotiator.Role.SERVER,
+                medium = medium,
+                endpointId = endpointId,
+            )
+        val effects = fsm.onEvent(BandwidthUpgradeEvent.PrepareFailed("hotspot capability denied"))
+        val sent = effects.filterIsInstance<BandwidthUpgradeEffect.SendFrame>().single()
+        assertThat(sent.frame.v1.bandwidthUpgradeNegotiation.eventType)
+            .isEqualTo(BandwidthUpgradeNegotiationFrame.EventType.UPGRADE_FAILURE)
+        assertThat(effects).contains(BandwidthUpgradeEffect.UpgradeAborted("hotspot capability denied"))
+    }
+
+    private fun serverPostStart(): BandwidthUpgradeNegotiator {
+        val fsm =
+            BandwidthUpgradeNegotiator(
+                role = BandwidthUpgradeNegotiator.Role.SERVER,
+                medium = medium,
+                endpointId = endpointId,
+            )
+        fsm.onEvent(BandwidthUpgradeEvent.Start(credentials))
+        return fsm
+    }
+
+    private fun clientPostAdopt(): BandwidthUpgradeNegotiator {
+        val fsm =
+            BandwidthUpgradeNegotiator(
+                role = BandwidthUpgradeNegotiator.Role.CLIENT,
+                medium = medium,
+                endpointId = endpointId,
+            )
+        val pathFrame = BandwidthUpgradeFrames.upgradePathAvailable(credentials)
+        fsm.onEvent(BandwidthUpgradeEvent.FrameReceived(pathFrame))
+        return fsm
+    }
+
+    private fun clientPostIntroduction(): BandwidthUpgradeNegotiator {
+        val fsm = clientPostAdopt()
+        fsm.onEvent(BandwidthUpgradeEvent.AdoptSucceeded)
+        return fsm
+    }
+
+    private fun List<BandwidthUpgradeEffect>.singleSendFrame(): BandwidthUpgradeNegotiationFrame {
+        val sent = filterIsInstance<BandwidthUpgradeEffect.SendFrame>().single()
+        return sent.frame.v1.bandwidthUpgradeNegotiation
+    }
+}

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/medium/MediumLadderTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/medium/MediumLadderTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.medium
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class MediumLadderTest {
+    @Test
+    fun `pickBest returns the highest-priority candidate`() {
+        val ladder =
+            MediumLadder(
+                listOf(
+                    Medium.WIFI_LAN,
+                    Medium.WIFI_DIRECT,
+                    Medium.BLE_L2CAP,
+                    Medium.BLUETOOTH,
+                ),
+            )
+        val pick =
+            ladder.pickBest(
+                setOf(Medium.BLUETOOTH, Medium.WIFI_DIRECT, Medium.BLE_L2CAP),
+            )
+        assertThat(pick).isEqualTo(Medium.WIFI_DIRECT)
+    }
+
+    @Test
+    fun `pickBest returns null when intersection is empty`() {
+        val ladder = MediumLadder(listOf(Medium.WIFI_LAN, Medium.WIFI_DIRECT))
+        assertThat(ladder.pickBest(setOf(Medium.BLUETOOTH))).isNull()
+    }
+
+    @Test
+    fun `pickBest returns null on empty ladder`() {
+        val ladder = MediumLadder(emptyList())
+        assertThat(ladder.pickBest(setOf(Medium.WIFI_LAN))).isNull()
+    }
+
+    @Test
+    fun `default ladder ranks Wi-Fi LAN first`() {
+        assertThat(MediumLadder.Default.rungs.first()).isEqualTo(Medium.WIFI_LAN)
+    }
+
+    @Test
+    fun `default ladder includes every domain medium`() {
+        // Future-proof: if a new Medium is added without being placed
+        // on the default ladder, the registry's selectBestUpgrade
+        // would silently never pick it. Make that explicit.
+        assertThat(MediumLadder.Default.rungs.toSet()).isEqualTo(Medium.entries.toSet())
+    }
+
+    @Test
+    fun `duplicate rungs are coalesced`() {
+        val ladder =
+            MediumLadder(
+                listOf(Medium.WIFI_LAN, Medium.WIFI_DIRECT, Medium.WIFI_LAN),
+            )
+        assertThat(ladder.rungs).containsExactly(Medium.WIFI_LAN, Medium.WIFI_DIRECT).inOrder()
+    }
+}

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/medium/MediumRegistryTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/medium/MediumRegistryTest.kt
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.medium
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class MediumRegistryTest {
+    /**
+     * Test fixture: a [MediumProvider] whose support state is
+     * controllable from the test body.
+     */
+    private class FakeProvider(
+        override val medium: Medium,
+        var supported: Boolean = true,
+    ) : MediumProvider {
+        override fun isSupported(): Boolean = supported
+    }
+
+    @Test
+    fun `default registry advertises Wi-Fi LAN only`() {
+        val supported = MediumRegistry.DefaultWifiLan.supportedMediums()
+        assertThat(supported).containsExactly(Medium.WIFI_LAN)
+    }
+
+    @Test
+    fun `default registry is not empty`() {
+        // isEmpty() reports the registry's "no provider at all" state,
+        // which the orchestrator uses as a cheap gate. The default
+        // shipped Wi-Fi LAN provider counts.
+        assertThat(MediumRegistry.DefaultWifiLan.isEmpty()).isFalse()
+    }
+
+    @Test
+    fun `supportedMediums excludes providers reporting isSupported false`() {
+        val wifi = FakeProvider(Medium.WIFI_LAN, supported = true)
+        val direct = FakeProvider(Medium.WIFI_DIRECT, supported = false)
+        val registry = MediumRegistry(listOf(wifi, direct))
+        assertThat(registry.supportedMediums()).containsExactly(Medium.WIFI_LAN)
+    }
+
+    @Test
+    fun `supportedMediums tracks runtime support flips`() {
+        val direct = FakeProvider(Medium.WIFI_DIRECT, supported = true)
+        val registry = MediumRegistry(listOf(direct))
+        assertThat(registry.supportedMediums()).containsExactly(Medium.WIFI_DIRECT)
+        direct.supported = false
+        assertThat(registry.supportedMediums()).isEmpty()
+    }
+
+    @Test
+    fun `providerFor returns null for unregistered medium`() {
+        val registry = MediumRegistry(listOf(FakeProvider(Medium.WIFI_LAN)))
+        assertThat(registry.providerFor(Medium.BLE_L2CAP)).isNull()
+    }
+
+    @Test
+    fun `duplicate provider for same medium is rejected`() {
+        val ex =
+            assertThrows<IllegalArgumentException> {
+                MediumRegistry(
+                    listOf(
+                        FakeProvider(Medium.WIFI_LAN),
+                        FakeProvider(Medium.WIFI_LAN),
+                    ),
+                )
+            }
+        assertThat(ex).hasMessageThat().contains("Duplicate")
+    }
+
+    @Test
+    fun `selectBestUpgrade returns null when intersection is empty`() {
+        val registry =
+            MediumRegistry(
+                listOf(
+                    FakeProvider(Medium.WIFI_LAN),
+                    FakeProvider(Medium.WIFI_DIRECT),
+                ),
+            )
+        val pick = registry.selectBestUpgrade(setOf(Medium.BLUETOOTH))
+        assertThat(pick).isNull()
+    }
+
+    @Test
+    fun `selectBestUpgrade picks via ladder ordering`() {
+        val registry =
+            MediumRegistry(
+                listOf(
+                    FakeProvider(Medium.WIFI_LAN),
+                    FakeProvider(Medium.WIFI_DIRECT),
+                    FakeProvider(Medium.BLE_L2CAP),
+                ),
+                ladder =
+                    MediumLadder(
+                        listOf(
+                            Medium.WIFI_DIRECT,
+                            Medium.BLE_L2CAP,
+                            Medium.WIFI_LAN,
+                        ),
+                    ),
+            )
+        val pick =
+            registry.selectBestUpgrade(
+                setOf(Medium.BLE_L2CAP, Medium.WIFI_LAN, Medium.WIFI_DIRECT),
+            )
+        assertThat(pick).isEqualTo(Medium.WIFI_DIRECT)
+    }
+
+    @Test
+    fun `selectBestUpgrade respects a per-call ladder override`() {
+        val registry =
+            MediumRegistry(
+                listOf(
+                    FakeProvider(Medium.WIFI_LAN),
+                    FakeProvider(Medium.WIFI_DIRECT),
+                    FakeProvider(Medium.BLUETOOTH),
+                ),
+            )
+        val override = MediumLadder(listOf(Medium.BLUETOOTH, Medium.WIFI_LAN))
+        val pick =
+            registry.selectBestUpgrade(
+                peerSupported = setOf(Medium.WIFI_DIRECT, Medium.WIFI_LAN, Medium.BLUETOOTH),
+                ladderOverride = override,
+            )
+        assertThat(pick).isEqualTo(Medium.BLUETOOTH)
+    }
+
+    @Test
+    fun `selectBestUpgrade ignores peer-only mediums we do not support`() {
+        // The local registry supports only Wi-Fi LAN; the peer
+        // advertises a richer set. Intersection collapses back to
+        // Wi-Fi LAN.
+        val registry = MediumRegistry.DefaultWifiLan
+        val pick =
+            registry.selectBestUpgrade(
+                setOf(Medium.WIFI_LAN, Medium.WIFI_DIRECT, Medium.BLUETOOTH),
+            )
+        assertThat(pick).isEqualTo(Medium.WIFI_LAN)
+    }
+
+    @Test
+    fun `empty registry reports empty supported set`() {
+        val registry = MediumRegistry()
+        assertThat(registry.supportedMediums()).isEmpty()
+        assertThat(registry.isEmpty()).isTrue()
+        assertThat(registry.selectBestUpgrade(setOf(Medium.WIFI_LAN))).isNull()
+    }
+}

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/medium/MediumWireMappingTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/medium/MediumWireMappingTest.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.medium
+
+import com.google.common.truth.Truth.assertThat
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.BandwidthUpgradeNegotiationFrame.UpgradePathInfo
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.ConnectionRequestFrame
+import org.junit.jupiter.api.Test
+
+/**
+ * Round-trip guards for the domain [Medium] enum against the two proto
+ * enums it shadows.
+ *
+ * The proto's `LINT.IfChange` annotation pins the wire numbers across
+ * the two enums (ConnectionRequestFrame.Medium and
+ * UpgradePathInfo.Medium) so the same domain entry can map onto either
+ * one. These tests make that pinning explicit so a future proto vendor
+ * cannot drift the mapping silently.
+ */
+class MediumWireMappingTest {
+    @Test
+    fun `every domain Medium round-trips through ConnectionRequestFrame Medium`() {
+        for (m in Medium.entries) {
+            val proto = m.toConnectionRequestMedium()
+            val back = Medium.fromConnectionRequestMedium(proto)
+            assertThat(back).isEqualTo(m)
+        }
+    }
+
+    @Test
+    fun `every domain Medium with an UpgradePathInfo wire value round-trips`() {
+        for (m in Medium.entries) {
+            val proto = m.toUpgradePathMediumOrNull() ?: continue
+            val back = Medium.fromUpgradePathMedium(proto)
+            assertThat(back).isEqualTo(m)
+        }
+    }
+
+    @Test
+    fun `BLE_L2CAP has no UpgradePathInfo wire value (reserved)`() {
+        // Per the proto: `// 10 is reserved.` on
+        // UpgradePathInfo.Medium. BLE_L2CAP is its own bulk-transfer
+        // medium (BT 5+ data channel) rather than a bandwidth-upgrade
+        // target, which matches Quick Share's design.
+        assertThat(Medium.BLE_L2CAP.toUpgradePathMediumOrNull()).isNull()
+    }
+
+    @Test
+    fun `unsupported ConnectionRequestFrame Medium values decode to null`() {
+        // The ones we deliberately do not surface as domain entries
+        // (Apple-side or out-of-scope mediums) MUST decode to null —
+        // not throw — so a peer advertising one of them does not crash
+        // the receiver-side intersection.
+        val outOfScope =
+            listOf(
+                ConnectionRequestFrame.Medium.UNKNOWN_MEDIUM,
+                ConnectionRequestFrame.Medium.MDNS,
+                ConnectionRequestFrame.Medium.NFC,
+                ConnectionRequestFrame.Medium.USB,
+                ConnectionRequestFrame.Medium.WEB_RTC_NON_CELLULAR,
+                ConnectionRequestFrame.Medium.AWDL,
+            )
+        for (m in outOfScope) {
+            assertThat(Medium.fromConnectionRequestMedium(m)).isNull()
+        }
+    }
+
+    @Test
+    fun `unsupported UpgradePathInfo Medium values decode to null`() {
+        val outOfScope =
+            listOf(
+                UpgradePathInfo.Medium.UNKNOWN_MEDIUM,
+                UpgradePathInfo.Medium.MDNS,
+                UpgradePathInfo.Medium.NFC,
+                UpgradePathInfo.Medium.USB,
+                UpgradePathInfo.Medium.WEB_RTC_NON_CELLULAR,
+                UpgradePathInfo.Medium.AWDL,
+            )
+        for (m in outOfScope) {
+            assertThat(Medium.fromUpgradePathMedium(m)).isNull()
+        }
+    }
+
+    @Test
+    fun `wire numbers are pinned to the documented Quick Share assignments`() {
+        // Spot-check the values that show up in PROTOCOL.md so a
+        // vendoring drift is loud. These numbers are stable across
+        // every proto revision NearDrop has shipped against.
+        assertThat(Medium.WIFI_LAN.wireNumber).isEqualTo(5)
+        assertThat(Medium.BLUETOOTH.wireNumber).isEqualTo(2)
+        assertThat(Medium.BLE.wireNumber).isEqualTo(4)
+        assertThat(Medium.BLE_L2CAP.wireNumber).isEqualTo(10)
+        assertThat(Medium.WIFI_DIRECT.wireNumber).isEqualTo(8)
+        assertThat(Medium.WIFI_HOTSPOT.wireNumber).isEqualTo(3)
+        assertThat(Medium.WIFI_AWARE.wireNumber).isEqualTo(6)
+        assertThat(Medium.WEB_RTC.wireNumber).isEqualTo(9)
+    }
+}


### PR DESCRIPTION
## Summary
Lays the foundation for Phase 4 (#4). Adds the framework that issues
#49–#53 will plug their per-medium adapters into. Default behaviour is
unchanged (Wi-Fi LAN only) when no extra provider is registered.

Closes #48.

## Public API surface (for #49–#53 implementers)

All in `:core-protocol` — pure JVM, no `android.*`. Per-medium adapters
live in `:discovery-android` (or another Android-only module) and
implement the interface here.

### `io.github.kyujincho.wvmg.protocol.medium`

- `Medium` — domain enum mirroring the proto wire numbers shared by
  `ConnectionRequestFrame.Medium` and `UpgradePathInfo.Medium`. Use
  `Medium.WIFI_DIRECT` etc. as the sole identifier across the
  framework. `BLE_L2CAP` exists but cannot appear on `UpgradePathInfo`
  (proto reserves wire 10 there); use `toUpgradePathMediumOrNull()` if
  you need to defensively check.
- `MediumProvider` — the interface to implement. Three methods:
  - `isSupported(): Boolean` — synchronous, must be O(1) (cache OS
    state if needed).
  - `suspend prepareUpgrade(): UpgradePathCredentials?` — server side,
    returns the bring-up parameters or `null` to fall through.
  - `suspend adoptUpgrade(credentials): UpgradedTransport?` — client
    side, brings up the transport or returns `null` to abort.
- `UpgradePathCredentials` — sealed interface; today has `Generic`
  (medium-only) and `WifiLan(ipAddress, port)`. Each adapter PR adds
  its own subtype here AND a matching arm in
  `BandwidthUpgradeFrames.encodeCredentials` /
  `decodeCredentials`.
- `UpgradedTransport` — opaque marker for the post-upgrade transport;
  add your concrete subtype in your adapter module so the framework
  never imports your medium's socket type.
- `MediumRegistry` — built once per process; pass providers at
  construction. The orchestrator gets it via the new
  `mediumRegistry` parameter on `OutboundConnection` /
  `InboundConnection` (default = `MediumRegistry.DefaultWifiLan`).
- `MediumLadder` — selection ordering. Project default is
  `MediumLadder.Default` (Wi-Fi LAN > Hotspot > Direct > Aware >
  WebRTC > BLE_L2CAP > Bluetooth > BLE).
- `BandwidthUpgradeNegotiator` — pure FSM driving the six-event
  upgrade dance. Events in (`BandwidthUpgradeEvent`), effects out
  (`BandwidthUpgradeEffect`); same shape as the existing
  `OutboundSharingFsm` / `InboundSharingFsm`. **#54** is the issue
  that wires this into the connection drivers — your adapter does
  NOT need to know about the negotiator directly.

### `io.github.kyujincho.wvmg.protocol.connection`

- `BandwidthUpgradeFrames` — pure builder for every
  `BANDWIDTH_UPGRADE_NEGOTIATION` `OfflineFrame` shape
  (`upgradePathAvailable`, `clientIntroduction`,
  `clientIntroductionAck`, `lastWriteToPriorChannel`,
  `safeToClosePriorChannel`, `upgradeFailure`) plus
  `decodeCredentials(UpgradePathInfo)`.
- `OutboundFrames.connectionRequest(endpointId, endpointInfo,
  supportedMediums = setOf(WIFI_LAN))` now accepts a `Set<Medium>` and
  always implicitly includes Wi-Fi LAN (the discovery medium; absence
  breaks Android 14+).

### Default-off behaviour preserved

When no extra provider is registered:

- Sender advertises `[WIFI_LAN]` only on
  `ConnectionRequestFrame.mediums` — bit-for-bit identical to the
  pre-Phase-4 hard-coded shape and to NearDrop.
- Receiver decodes the peer's mediums but the chosen upgrade target
  resolves to `null` (Wi-Fi LAN ↔ Wi-Fi LAN intersection means "stay
  on the current transport"); the existing happy path runs unchanged.
- Inbound `BANDWIDTH_UPGRADE_NEGOTIATION` frames are observed and
  dropped (logged on the sender side); no FSM is wired in yet — that's
  #54's job.

### What an adapter PR (one of #49–#53) needs to do

1. Implement `MediumProvider` in `:discovery-android` (or its own
   module).
2. Add a credentials subtype to `UpgradePathCredentials` if your
   medium needs more than the medium type (Wi-Fi LAN already has one
   to copy from).
3. Add encoder + decoder arms in `BandwidthUpgradeFrames` for that
   subtype.
4. Add a concrete `UpgradedTransport` subtype carrying your real
   socket / channel.
5. Register the provider with the `MediumRegistry` the
   `:service-android` / `:app` layer passes into `InboundConnection` /
   `OutboundConnection`.

The framework code in `OutboundConnection` / `InboundConnection` /
their drivers does NOT change as new providers are added; the registry
dispatch keeps it constant.

## Test coverage

49 new JVM tests in `:core-protocol/src/test`:

- `MediumWireMappingTest` — pins every domain entry's wire number and
  round-trips through both proto enums.
- `MediumLadderTest` — selection semantics, default ordering, empty
  edge cases.
- `MediumRegistryTest` — supported set, intersection, ladder
  override, runtime support flips, duplicate-provider rejection.
- `BandwidthUpgradeNegotiatorTest` — every state transition on both
  roles, including the full happy path through to `Completed`.
- `BandwidthUpgradeFramesTest` — every builder, plus credentials
  round-trip.
- `ConnectionRequestMediumsTest` — wire shape on
  `ConnectionRequestFrame.mediums`, Wi-Fi LAN always implicit,
  deterministic ordering.

All pass under `./gradlew :core-protocol:test`. `staticAnalysis` and
`:app:assembleDebug` are also clean.