### PR TITLE
feat(medium): Wi-Fi Aware (WIFI_AWARE) bandwidth-upgrade provider (#53)

### DIFF
--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeFrames.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeFrames.kt
@@ -244,6 +244,33 @@ public object BandwidthUpgradeFrames {
                     UpgradePathCredentials.Generic(medium)
                 }
             }
+            // Wi-Fi Aware (#53): WifiAwareCredentials carries the
+            // publisher-side service_id, the IPv6 + port packed into
+            // service_info, and the data-path passphrase. See
+            // decodeWifiAwareServiceInfo for the byte layout.
+            Medium.WIFI_AWARE -> {
+                if (info.hasWifiAwareCredentials()) {
+                    val creds = info.wifiAwareCredentials
+                    val serviceInfo = creds.serviceInfo.toByteArray()
+                    val parsed = decodeWifiAwareServiceInfo(serviceInfo)
+                    if (parsed != null) {
+                        UpgradePathCredentials.WifiAware(
+                            serviceName = creds.serviceId,
+                            ipv6Address = parsed.first,
+                            port = parsed.second,
+                            passphrase = creds.password,
+                        )
+                    } else {
+                        // Wi-Fi Aware credentials present but service_info
+                        // is missing the IPv6+port packing we expect —
+                        // fall through to Generic so the orchestrator
+                        // can fail the upgrade cleanly.
+                        UpgradePathCredentials.Generic(medium)
+                    }
+                } else {
+                    UpgradePathCredentials.Generic(medium)
+                }
+            }
             // Phase 4 sub-issues (#49–#53) plug the remaining arms in
             // here as their adapters land. Until then we report Generic
             // so the upper layers can at least see that *some* path
@@ -257,7 +284,6 @@ public object BandwidthUpgradeFrames {
             // discovery-medium path instead — see Phase 4 #52.
             Medium.WIFI_DIRECT,
             Medium.WIFI_HOTSPOT,
-            Medium.WIFI_AWARE,
             Medium.BLE_L2CAP,
             Medium.BLE,
             Medium.WEB_RTC,
@@ -300,8 +326,80 @@ public object BandwidthUpgradeFrames {
                         .build(),
                 )
             }
+            is UpgradePathCredentials.WifiAware -> {
+                // The proto's WifiAwareCredentials oneof slot only has
+                // `service_id`, `service_info` (bytes), and `password`.
+                // Quick Share packs the publisher-side IPv6 link-local
+                // address (16 bytes, network order) and the TCP port
+                // (4 bytes, big-endian) into `service_info` so the
+                // subscriber can connect after the data-path callback
+                // resolves the per-network IPv6 routing. We mirror that
+                // shape here; the matching decoder lives next to the
+                // encoder for reviewability.
+                builder.setWifiAwareCredentials(
+                    UpgradePathInfo.WifiAwareCredentials
+                        .newBuilder()
+                        .setServiceId(credentials.serviceName)
+                        .setServiceInfo(
+                            ByteString.copyFrom(
+                                encodeWifiAwareServiceInfo(credentials.ipv6Address, credentials.port),
+                            ),
+                        ).setPassword(credentials.passphrase)
+                        .build(),
+                )
+            }
         }
         return builder.build()
+    }
+
+    /**
+     * Serialize the publisher-side IPv6 + port pair into the byte layout
+     * Quick Share uses for `WifiAwareCredentials.service_info`:
+     *
+     *   bytes 0..15  — IPv6 address, network order (16 bytes)
+     *   bytes 16..19 — TCP port, big-endian unsigned 16 stored in 4 bytes
+     *                  (high two bytes always zero; matches NearDrop's
+     *                  serialization of `ushort` into a 4-byte slot).
+     *
+     * Throws `IllegalArgumentException` for an address whose length is
+     * not exactly 16 bytes or a port outside `0..65535`. The caller
+     * (the per-medium provider) is responsible for handing in valid
+     * values; this function does not silently truncate.
+     */
+    internal fun encodeWifiAwareServiceInfo(
+        ipv6Address: ByteArray,
+        port: Int,
+    ): ByteArray {
+        require(ipv6Address.size == WIFI_AWARE_IPV6_LENGTH) {
+            "Wi-Fi Aware IPv6 address must be 16 bytes, got ${ipv6Address.size}"
+        }
+        require(port in 0..0xFFFF) { "Wi-Fi Aware port must fit in 16 bits, got $port" }
+        val out = ByteArray(WIFI_AWARE_SERVICE_INFO_LENGTH)
+        System.arraycopy(ipv6Address, 0, out, 0, WIFI_AWARE_IPV6_LENGTH)
+        // Big-endian, two high bytes zero — matches the Quick Share
+        // shape so a stock receiver decodes our advertisement and our
+        // decoder accepts a stock-emitted one.
+        out[WIFI_AWARE_IPV6_LENGTH] = 0
+        out[WIFI_AWARE_IPV6_LENGTH + 1] = 0
+        out[WIFI_AWARE_PORT_HIGH_OFFSET] = ((port ushr PORT_HIGH_BYTE_SHIFT) and BYTE_MASK).toByte()
+        out[WIFI_AWARE_PORT_LOW_OFFSET] = (port and BYTE_MASK).toByte()
+        return out
+    }
+
+    /**
+     * Inverse of [encodeWifiAwareServiceInfo]. Returns `null` for any
+     * `service_info` that is not exactly 20 bytes long — the wire layout
+     * is fixed-width, so a different length almost certainly means a
+     * peer encoded it differently and we should fail the upgrade rather
+     * than guess.
+     */
+    internal fun decodeWifiAwareServiceInfo(serviceInfo: ByteArray): Pair<ByteArray, Int>? {
+        if (serviceInfo.size != WIFI_AWARE_SERVICE_INFO_LENGTH) return null
+        val ipv6 = serviceInfo.copyOfRange(0, WIFI_AWARE_IPV6_LENGTH)
+        val port =
+            ((serviceInfo[WIFI_AWARE_PORT_HIGH_OFFSET].toInt() and BYTE_MASK) shl PORT_HIGH_BYTE_SHIFT) or
+                (serviceInfo[WIFI_AWARE_PORT_LOW_OFFSET].toInt() and BYTE_MASK)
+        return ipv6 to port
     }
 
     /**
@@ -328,4 +426,26 @@ public object BandwidthUpgradeFrames {
      * `google/nearby` uses.
      */
     public const val STA_FREQUENCY_NOT_SET: Int = -1
+
+    /** Length of a Wi-Fi Aware IPv6 link-local address in bytes. */
+    private const val WIFI_AWARE_IPV6_LENGTH: Int = 16
+
+    /**
+     * Length of the byte payload Quick Share packs into
+     * `WifiAwareCredentials.service_info`: 16 bytes IPv6 + 4-byte port
+     * slot (16-bit value zero-padded to 32 bits).
+     */
+    private const val WIFI_AWARE_SERVICE_INFO_LENGTH: Int = 20
+
+    /** Bit-shift for the high byte of a 16-bit big-endian port value. */
+    private const val PORT_HIGH_BYTE_SHIFT: Int = 8
+
+    /** Mask for extracting a single byte from an Int. */
+    private const val BYTE_MASK: Int = 0xFF
+
+    /** Offset of the high port byte within the service_info layout. */
+    private const val WIFI_AWARE_PORT_HIGH_OFFSET: Int = WIFI_AWARE_IPV6_LENGTH + 2
+
+    /** Offset of the low port byte within the service_info layout. */
+    private const val WIFI_AWARE_PORT_LOW_OFFSET: Int = WIFI_AWARE_IPV6_LENGTH + 3
 }

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/medium/UpgradePathCredentials.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/medium/UpgradePathCredentials.kt
@@ -193,4 +193,60 @@ public sealed interface UpgradePathCredentials {
             private const val HEX_DIGITS: String = "0123456789ABCDEF"
         }
     }
+
+    /**
+     * Wi-Fi Aware (NAN) credentials — the bring-up parameters that the
+     * subscriber (sender) needs in order to request a Wi-Fi Aware data
+     * path to the publisher (receiver) after the discovery match.
+     *
+     * Wi-Fi Aware is one of the higher-throughput Phase 4 mediums when
+     * supported by the chipset. Discovery uses a publish/subscribe
+     * service-name pairing; the data path is brought up out-of-band by
+     * exchanging a passphrase (or PMK) and an IPv6 link-local address +
+     * port over the framework's `BANDWIDTH_UPGRADE_NEGOTIATION` channel.
+     *
+     * @param serviceName ASCII service name the publisher used in
+     *   `PublishConfig.setServiceName(...)`. Subscriber must use the
+     *   same string when calling `subscribe(...)`.
+     * @param port Receiver-side TCP port bound to the Wi-Fi Aware
+     *   network interface. The sender connects to this on the IPv6
+     *   address obtained from the data-path callback.
+     * @param ipv6Address IPv6 address bytes (16 bytes, link-local
+     *   `fe80::/10`) of the publisher's Wi-Fi Aware interface. Sent
+     *   alongside the port so the subscriber doesn't have to derive it
+     *   from the peer handle. Senders typically need to combine this
+     *   with the network's scope id (interface index) when constructing
+     *   an `Inet6Address`.
+     * @param passphrase Out-of-band passphrase used to secure the
+     *   Wi-Fi Aware data path (8–63 ASCII chars per
+     *   `WifiAwareNetworkSpecifier.Builder.setPskPassphrase`). Must
+     *   match on both sides; the receiver generates a fresh one per
+     *   upgrade.
+     */
+    public data class WifiAware(
+        val serviceName: String,
+        val port: Int,
+        val ipv6Address: ByteArray,
+        val passphrase: String,
+    ) : UpgradePathCredentials {
+        override val medium: Medium = Medium.WIFI_AWARE
+
+        // ByteArray equality, same rationale as WifiLan above.
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is WifiAware) return false
+            return serviceName == other.serviceName &&
+                port == other.port &&
+                passphrase == other.passphrase &&
+                ipv6Address.contentEquals(other.ipv6Address)
+        }
+
+        override fun hashCode(): Int {
+            var result = serviceName.hashCode()
+            result = 31 * result + port
+            result = 31 * result + ipv6Address.contentHashCode()
+            result = 31 * result + passphrase.hashCode()
+            return result
+        }
+    }
 }

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeFramesTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeFramesTest.kt
@@ -101,6 +101,115 @@ class BandwidthUpgradeFramesTest {
     }
 
     @Test
+    fun `upgradePathAvailable carries Wi-Fi Aware credentials in WifiAwareCredentials slot`() {
+        val ipv6 =
+            byteArrayOf(
+                0xFE.toByte(),
+                0x80.toByte(),
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0x12,
+                0x34,
+                0xAB.toByte(),
+                0xCD.toByte(),
+                0xEF.toByte(),
+                0x01,
+                0x02,
+            )
+        val frame =
+            BandwidthUpgradeFrames.upgradePathAvailable(
+                UpgradePathCredentials.WifiAware(
+                    serviceName = "wvmg-quickshare-aware",
+                    ipv6Address = ipv6,
+                    port = 8443,
+                    passphrase = "abcdefghij0123456789",
+                ),
+            )
+        val parsed = parse(frame)
+        assertThat(parsed.upgradePathInfo.medium.number).isEqualTo(Medium.WIFI_AWARE.wireNumber)
+        assertThat(parsed.upgradePathInfo.hasWifiAwareCredentials()).isTrue()
+        assertThat(parsed.upgradePathInfo.wifiAwareCredentials.serviceId).isEqualTo("wvmg-quickshare-aware")
+        assertThat(parsed.upgradePathInfo.wifiAwareCredentials.password).isEqualTo("abcdefghij0123456789")
+
+        // service_info packs the IPv6 (16 bytes) and the port
+        // (zero-padded to 4 bytes, big-endian) into a 20-byte payload.
+        val serviceInfo =
+            parsed.upgradePathInfo.wifiAwareCredentials.serviceInfo
+                .toByteArray()
+        assertThat(serviceInfo).hasLength(20)
+        assertThat(serviceInfo.copyOfRange(0, 16)).isEqualTo(ipv6)
+        // Port 8443 = 0x20FB; high two bytes zero, then 0x20, 0xFB.
+        assertThat(serviceInfo[16]).isEqualTo(0.toByte())
+        assertThat(serviceInfo[17]).isEqualTo(0.toByte())
+        assertThat(serviceInfo[18]).isEqualTo(0x20.toByte())
+        assertThat(serviceInfo[19]).isEqualTo(0xFB.toByte())
+    }
+
+    @Test
+    fun `decodeCredentials round-trips Wi-Fi Aware credentials`() {
+        val ipv6 =
+            byteArrayOf(
+                0xFE.toByte(),
+                0x80.toByte(),
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0xAA.toByte(),
+                0xBB.toByte(),
+                0xCC.toByte(),
+                0xDD.toByte(),
+                0xEE.toByte(),
+                0xFF.toByte(),
+                0x01,
+                0x23,
+            )
+        val original =
+            UpgradePathCredentials.WifiAware(
+                serviceName = "wvmg-quickshare-aware",
+                ipv6Address = ipv6,
+                port = 4242,
+                passphrase = "very-secret-passphrase-32chars!!",
+            )
+        val frame = BandwidthUpgradeFrames.upgradePathAvailable(original)
+        val parsed = parse(frame)
+        val decoded = BandwidthUpgradeFrames.decodeCredentials(parsed.upgradePathInfo)
+        assertThat(decoded).isEqualTo(original)
+    }
+
+    @Test
+    fun `decodeCredentials returns Generic for Wi-Fi Aware with malformed service_info`() {
+        // Build an UpgradePathInfo manually with a too-short service_info
+        // so the decoder cannot extract IPv6 + port; it should fall back
+        // to Generic rather than producing garbage credentials.
+        val info =
+            com.google.location.nearby.connections.proto
+                .OfflineWireFormatsProto.BandwidthUpgradeNegotiationFrame.UpgradePathInfo
+                .newBuilder()
+                .setMedium(Medium.WIFI_AWARE.toUpgradePathMedium())
+                .setWifiAwareCredentials(
+                    com.google.location.nearby.connections.proto
+                        .OfflineWireFormatsProto.BandwidthUpgradeNegotiationFrame.UpgradePathInfo.WifiAwareCredentials
+                        .newBuilder()
+                        .setServiceId("svc")
+                        .setServiceInfo(
+                            com.google.protobuf.ByteString
+                                .copyFrom(ByteArray(8)),
+                        ).setPassword("pw")
+                        .build(),
+                ).build()
+        val decoded = BandwidthUpgradeFrames.decodeCredentials(info)
+        assertThat(decoded).isEqualTo(UpgradePathCredentials.Generic(Medium.WIFI_AWARE))
+    }
+
+    @Test
     fun `decodeCredentials returns Generic for not-yet-implemented mediums`() {
         val frame = BandwidthUpgradeFrames.upgradePathAvailable(UpgradePathCredentials.Generic(Medium.WIFI_DIRECT))
         val parsed = parse(frame)

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/medium/UpgradePathCredentialsTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/medium/UpgradePathCredentialsTest.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.medium
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Structural-equality coverage for the per-medium [UpgradePathCredentials]
+ * subtypes. Important because each subtype with a `ByteArray` field
+ * needs an explicit `equals`/`hashCode` override (Kotlin `data class`
+ * defaults to reference equality on arrays); a regression there breaks
+ * round-trip tests in `BandwidthUpgradeFramesTest` with confusing
+ * "expected X got X" failures.
+ */
+class UpgradePathCredentialsTest {
+    @Test
+    fun `WifiAware equals compares IPv6 bytes structurally`() {
+        val ipv6a = byteArrayOf(0xFE.toByte(), 0x80.toByte(), 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8)
+        val ipv6b = byteArrayOf(0xFE.toByte(), 0x80.toByte(), 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8)
+        val first =
+            UpgradePathCredentials.WifiAware(
+                serviceName = "wvmg-quickshare-aware",
+                ipv6Address = ipv6a,
+                port = 1234,
+                passphrase = "secret",
+            )
+        val second =
+            UpgradePathCredentials.WifiAware(
+                serviceName = "wvmg-quickshare-aware",
+                ipv6Address = ipv6b,
+                port = 1234,
+                passphrase = "secret",
+            )
+        assertThat(first).isEqualTo(second)
+        assertThat(first.hashCode()).isEqualTo(second.hashCode())
+    }
+
+    @Test
+    fun `WifiAware not-equal when port differs`() {
+        val ipv6 = ByteArray(16)
+        val first =
+            UpgradePathCredentials.WifiAware(
+                serviceName = "svc",
+                ipv6Address = ipv6,
+                port = 1,
+                passphrase = "p",
+            )
+        val second = first.copy(port = 2)
+        assertThat(first).isNotEqualTo(second)
+    }
+
+    @Test
+    fun `WifiAware not-equal when passphrase differs`() {
+        val ipv6 = ByteArray(16)
+        val first =
+            UpgradePathCredentials.WifiAware(
+                serviceName = "svc",
+                ipv6Address = ipv6,
+                port = 1,
+                passphrase = "alpha",
+            )
+        val second = first.copy(passphrase = "beta")
+        assertThat(first).isNotEqualTo(second)
+    }
+
+    @Test
+    fun `WifiAware medium is always WIFI_AWARE`() {
+        val creds =
+            UpgradePathCredentials.WifiAware(
+                serviceName = "svc",
+                ipv6Address = ByteArray(16),
+                port = 0,
+                passphrase = "passphrase",
+            )
+        assertThat(creds.medium).isEqualTo(Medium.WIFI_AWARE)
+    }
+}

--- a/discovery-android/src/main/AndroidManifest.xml
+++ b/discovery-android/src/main/AndroidManifest.xml
@@ -80,4 +80,23 @@
         android:name="android.permission.BLUETOOTH_ADMIN"
         android:maxSdkVersion="30" />
 
+    <!--
+      Wi-Fi Aware (NAN) bandwidth-upgrade medium (#53). Compile-time
+      gating only — the umbrella :app manifest declares the runtime
+      grants the user is asked for. The hardware-feature line is
+      `required="false"` because Wi-Fi Aware coverage is patchy and
+      the app falls back to other mediums on unsupported devices.
+
+      The data-path bring-up uses ConnectivityManager.requestNetwork
+      with a WifiAwareNetworkSpecifier; this needs CHANGE_WIFI_STATE
+      so the framework can pick a Wi-Fi Aware network on our behalf.
+      Discovery requires either NEARBY_WIFI_DEVICES (API 33+) or
+      ACCESS_FINE_LOCATION; both are runtime-gated and live in :app.
+    -->
+    <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
+
+    <uses-feature
+        android:name="android.hardware.wifi.aware"
+        android:required="false" />
+
 </manifest>

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/aware/WifiAwareMediumProvider.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/aware/WifiAwareMediumProvider.kt
@@ -1,0 +1,743 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+
+// Wi-Fi Aware passphrase length / IPv6 byte length are well-known.
+// The platform lifecycle is inherently multi-step async; suppressing
+// detekt's per-method ReturnCount / CyclomaticComplexity rules at the
+// file level keeps the bring-up code readable as a single linear flow
+// rather than fragmenting it into cross-cutting helpers that hide the
+// overall ordering.
+@file:Suppress(
+    "MagicNumber",
+    "ReturnCount",
+    "CyclomaticComplexMethod",
+    "FunctionOnlyReturningConstant",
+)
+
+package io.github.kyujincho.wvmg.discovery.aware
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.net.ConnectivityManager
+import android.net.LinkProperties
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import android.net.wifi.aware.AttachCallback
+import android.net.wifi.aware.DiscoverySession
+import android.net.wifi.aware.DiscoverySessionCallback
+import android.net.wifi.aware.PeerHandle
+import android.net.wifi.aware.PublishConfig
+import android.net.wifi.aware.PublishDiscoverySession
+import android.net.wifi.aware.SubscribeConfig
+import android.net.wifi.aware.SubscribeDiscoverySession
+import android.net.wifi.aware.WifiAwareManager
+import android.net.wifi.aware.WifiAwareNetworkInfo
+import android.net.wifi.aware.WifiAwareNetworkSpecifier
+import android.net.wifi.aware.WifiAwareSession
+import android.os.Build
+import android.os.Handler
+import android.os.HandlerThread
+import android.util.Log
+import androidx.annotation.RequiresApi
+import androidx.annotation.RequiresPermission
+import androidx.core.content.ContextCompat
+import io.github.kyujincho.wvmg.protocol.medium.Medium
+import io.github.kyujincho.wvmg.protocol.medium.MediumProvider
+import io.github.kyujincho.wvmg.protocol.medium.UpgradePathCredentials
+import io.github.kyujincho.wvmg.protocol.medium.UpgradedTransport
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.withTimeoutOrNull
+import java.net.Inet6Address
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.Socket
+import java.security.SecureRandom
+
+/**
+ * Wi-Fi Aware (NAN) [MediumProvider] for Android 8.0+ devices whose
+ * chipset advertises `PackageManager.FEATURE_WIFI_AWARE`. Hardware
+ * coverage is patchy (most flagships from 2020+, very few mid-range
+ * chipsets) — the provider is best-effort and falls back to other
+ * mediums via [isSupported] returning `false` when the platform path is
+ * unavailable.
+ *
+ * ### Topology
+ *
+ * Wi-Fi Aware uses publish/subscribe service discovery; the publisher
+ * (server / receiver) advertises a service name, the subscriber (client
+ * / sender) matches against it, then both sides bring up an IPv6
+ * link-local data path through `ConnectivityManager.requestNetwork(...)`
+ * with a [WifiAwareNetworkSpecifier]. Per the Quick Share wire format,
+ * the publisher embeds its bound TCP port and IPv6 address into the
+ * `WifiAwareCredentials.service_info` field of `UpgradePathInfo` (see
+ * [io.github.kyujincho.wvmg.protocol.connection.BandwidthUpgradeFrames]
+ * for the byte layout); the subscriber reads them back, requests a
+ * passphrase-secured network, and connects via
+ * `Network.getSocketFactory().createSocket(addr, port)`.
+ *
+ * ### Hardware/SDK gating
+ *
+ * [isSupported] returns true iff:
+ *   - `Build.VERSION.SDK_INT >= 26` (Wi-Fi Aware APIs landed in O).
+ *   - `PackageManager.hasSystemFeature(FEATURE_WIFI_AWARE)` is true
+ *     (chipset declares aware capability).
+ *   - `WifiAwareManager.isAvailable()` is true (Wi-Fi is on and the
+ *     framework hasn't temporarily disabled aware).
+ *   - The runtime location/nearby permission is granted (see
+ *     [hasDiscoveryPermission]). On API 33+ we accept either
+ *     `NEARBY_WIFI_DEVICES` or `ACCESS_FINE_LOCATION`; on older
+ *     releases only the legacy `ACCESS_FINE_LOCATION` is checked.
+ *
+ * Any of these failing returns `false` and the framework selects the
+ * next-best ladder rung. The check is O(1), as the [MediumRegistry]
+ * contract requires.
+ *
+ * ### Lifecycle
+ *
+ * The platform [WifiAwareSession] and any [DiscoverySession] /
+ * [Network] objects are released by the per-call helpers in
+ * [prepareUpgrade] / [adoptUpgrade] before they return. The provider
+ * itself holds no long-lived state. If the orchestrator decides to
+ * reuse the provider across multiple upgrades, each call brings up a
+ * fresh attach.
+ *
+ * ### Testability
+ *
+ * The platform surface is wrapped behind [WifiAwareSupport]. Tests on
+ * a plain JVM construct a fake support that drives the lifecycle
+ * without touching `android.*`. The production constructor builds the
+ * default Android-backed support from a [Context].
+ *
+ * @param support platform abstraction; tests inject a fake.
+ * @param logger leveled log sink. Defaults to a [Log.i] / [Log.w]
+ *   adapter under the [TAG]. Tests inject a recording sink.
+ */
+public class WifiAwareMediumProvider internal constructor(
+    private val support: WifiAwareSupport,
+    private val logger: AwareLogger = AndroidAwareLogger,
+) : MediumProvider {
+    /**
+     * Production constructor. Wraps a real [WifiAwareManager] and
+     * [ConnectivityManager] obtained from the application context.
+     */
+    public constructor(context: Context) : this(
+        support = AndroidWifiAwareSupport(context.applicationContext),
+    )
+
+    override val medium: Medium = Medium.WIFI_AWARE
+
+    /**
+     * Hardware + SDK + permission gate. See class KDoc for the full
+     * predicate list. Must remain O(1); cached state inside [support]
+     * makes this safe.
+     */
+    override fun isSupported(): Boolean = support.isAvailable()
+
+    /**
+     * **Server role.** Stand up a Wi-Fi Aware publisher, bind an IPv6
+     * `ServerSocket` on the data-path interface, and return the
+     * credentials needed by the subscriber to dial back in.
+     *
+     * Returns `null` when:
+     *   - The chipset stops advertising aware between [isSupported]
+     *     and this call (Wi-Fi turned off mid-session).
+     *   - Attach to [WifiAwareManager] times out.
+     *   - The publisher session never receives a subscriber match
+     *     within [PREPARE_TIMEOUT_MS].
+     *   - Any platform callback reports failure.
+     *
+     * On any failure path the provider releases the partially-acquired
+     * resources before returning `null` — the framework treats this as
+     * "fall back to the next rung" without leaking sessions.
+     */
+    override suspend fun prepareUpgrade(): UpgradePathCredentials? {
+        if (!support.isAvailable()) {
+            logger.warn("prepareUpgrade: Wi-Fi Aware not available; refusing upgrade")
+            return null
+        }
+        // Defer to support so a fake can short-circuit and a future
+        // production refactor can swap the real implementation without
+        // touching the call site.
+        return support.prepareUpgrade(generatePassphrase())
+    }
+
+    /**
+     * **Client role.** Subscribe to the publisher's service, request a
+     * passphrase-secured Wi-Fi Aware network, and return a
+     * [WifiAwareTransport] wrapping the connected [Socket].
+     *
+     * @param credentials Must be a [UpgradePathCredentials.WifiAware]
+     *   produced by the receiver; any other subtype is rejected with
+     *   `null` (defensive — the framework should never route a wrong
+     *   medium here, but the contract on [MediumProvider.adoptUpgrade]
+     *   requires the provider validate this).
+     */
+    override suspend fun adoptUpgrade(credentials: UpgradePathCredentials): UpgradedTransport? {
+        if (credentials !is UpgradePathCredentials.WifiAware) {
+            logger.warn("adoptUpgrade: refusing non-WifiAware credentials ($credentials)")
+            return null
+        }
+        if (!support.isAvailable()) {
+            logger.warn("adoptUpgrade: Wi-Fi Aware not available; refusing")
+            return null
+        }
+        val socket = support.adoptUpgrade(credentials) ?: return null
+        return WifiAwareTransport(socket)
+    }
+
+    /**
+     * Generate a fresh per-upgrade passphrase. Wi-Fi Aware requires
+     * 8..63 ASCII chars; we pick 32 chars from a URL-safe alphabet to
+     * stay well above any platform minimum without bumping into
+     * encoding corner cases on older Android releases.
+     */
+    private fun generatePassphrase(): String {
+        val bytes = ByteArray(PASSPHRASE_BYTES)
+        SECURE_RANDOM.nextBytes(bytes)
+        val out = StringBuilder(PASSPHRASE_BYTES)
+        for (b in bytes) {
+            out.append(PASSPHRASE_ALPHABET[(b.toInt() and 0xFF) % PASSPHRASE_ALPHABET.length])
+        }
+        return out.toString()
+    }
+
+    public companion object {
+        private const val TAG: String = "WvmgWifiAware"
+
+        /**
+         * Attach + publish/subscribe combined timeout. The platform
+         * sometimes takes a couple of seconds for the chipset to come
+         * up after a cold start; 10 s comfortably covers cold-start
+         * worst case while still bailing if the chipset is wedged.
+         */
+        public const val PREPARE_TIMEOUT_MS: Long = 10_000L
+
+        /** Same magnitude as [PREPARE_TIMEOUT_MS], matching upgrade adoption. */
+        public const val ADOPT_TIMEOUT_MS: Long = 10_000L
+
+        /**
+         * Quick Share service name used for the publish/subscribe
+         * pairing. Stable string so a stock peer that hard-codes the
+         * same name (none does today, but the protocol allows it) can
+         * interoperate.
+         */
+        public const val SERVICE_NAME: String = "wvmg-quickshare-aware"
+
+        /** Number of ASCII chars in a generated passphrase. */
+        private const val PASSPHRASE_BYTES: Int = 32
+
+        /**
+         * Alphabet for [generatePassphrase]. URL-safe base64 chars,
+         * biased only by the `% length` reduction (negligible on a 32-byte
+         * passphrase).
+         */
+        private const val PASSPHRASE_ALPHABET: String =
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+
+        private val SECURE_RANDOM: SecureRandom = SecureRandom()
+    }
+}
+
+/**
+ * Concrete [UpgradedTransport] for Wi-Fi Aware. Wraps the [Socket]
+ * connected over the bring-up data-path so the framework's
+ * SecureChannel rebuild step (#54) can read/write through it.
+ */
+public class WifiAwareTransport(
+    public val socket: Socket,
+) : UpgradedTransport {
+    override val medium: Medium = Medium.WIFI_AWARE
+}
+
+/**
+ * Platform-abstraction surface so the provider can be unit-tested
+ * without `android.*`. Production binding lives in
+ * [AndroidWifiAwareSupport]; tests inject a fake.
+ */
+public interface WifiAwareSupport {
+    /** Combined hardware + SDK + permission availability gate. */
+    public fun isAvailable(): Boolean
+
+    /**
+     * Run the publisher-side bring-up. Returns the credentials the
+     * subscriber needs, or `null` on any failure. Implementations
+     * MUST release any partial resources (sessions, sockets) before
+     * returning.
+     */
+    public suspend fun prepareUpgrade(passphrase: String): UpgradePathCredentials.WifiAware?
+
+    /**
+     * Run the subscriber-side bring-up against [credentials]. Returns
+     * a connected [Socket] on success, `null` on failure (after
+     * releasing any partial resources).
+     */
+    public suspend fun adoptUpgrade(credentials: UpgradePathCredentials.WifiAware): Socket?
+}
+
+/**
+ * Production [WifiAwareSupport] backed by the Android Wi-Fi Aware
+ * stack. Gated to API 26+ at runtime via [Build.VERSION.SDK_INT]
+ * checks; older devices return `false` from [isAvailable] without ever
+ * touching the API surface.
+ *
+ * The actual session lifecycle is verbose (attach, publish, match,
+ * network request, accept/connect). It lives here, behind the
+ * interface, so the lifecycle complexity does not bleed into the
+ * pure-Kotlin provider.
+ */
+public class AndroidWifiAwareSupport(
+    private val context: Context,
+) : WifiAwareSupport {
+    private val handlerThread: HandlerThread by lazy {
+        HandlerThread("WvmgWifiAwareCb").apply { start() }
+    }
+    private val handler: Handler by lazy { Handler(handlerThread.looper) }
+
+    override fun isAvailable(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return false
+        val pm = context.packageManager
+        if (!pm.hasSystemFeature(PackageManager.FEATURE_WIFI_AWARE)) return false
+        val mgr =
+            context.getSystemService(Context.WIFI_AWARE_SERVICE) as? WifiAwareManager
+                ?: return false
+        if (!mgr.isAvailable) return false
+        return hasDiscoveryPermission()
+    }
+
+    /**
+     * Returns true iff the runtime permission needed for Wi-Fi Aware
+     * discovery is granted. On API 33+ either `NEARBY_WIFI_DEVICES`
+     * (preferred — flagged `neverForLocation`) or the legacy
+     * `ACCESS_FINE_LOCATION` is acceptable; on older releases only
+     * `ACCESS_FINE_LOCATION` works.
+     */
+    private fun hasDiscoveryPermission(): Boolean {
+        val fine =
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.ACCESS_FINE_LOCATION,
+            ) == PackageManager.PERMISSION_GRANTED
+        if (fine) return true
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            return ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.NEARBY_WIFI_DEVICES,
+            ) == PackageManager.PERMISSION_GRANTED
+        }
+        return false
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    @RequiresPermission(
+        anyOf = [
+            Manifest.permission.ACCESS_FINE_LOCATION,
+            Manifest.permission.NEARBY_WIFI_DEVICES,
+        ],
+    )
+    @Suppress("LongMethod") // Wi-Fi Aware lifecycle is inherently long; splitting hides intent.
+    override suspend fun prepareUpgrade(passphrase: String): UpgradePathCredentials.WifiAware? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return null
+        val mgr =
+            context.getSystemService(Context.WIFI_AWARE_SERVICE) as? WifiAwareManager
+                ?: return null
+        val cm =
+            context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+                ?: return null
+
+        val attached =
+            attachSession(mgr) ?: run {
+                Log.w(TAG, "prepareUpgrade: Wi-Fi Aware attach failed or timed out")
+                return null
+            }
+
+        var publishSession: PublishDiscoverySession? = null
+        var serverSocket: ServerSocket? = null
+        var network: Network? = null
+        var networkCallback: ConnectivityManager.NetworkCallback? = null
+        try {
+            publishSession =
+                publish(attached, WifiAwareMediumProvider.SERVICE_NAME)
+                    ?: return null
+            // Bind a server socket on the IPv6 wildcard so any data-path
+            // interface (the platform picks one when the network is
+            // requested) can route the inbound connect.
+            serverSocket = ServerSocket(0, BACKLOG, InetAddress.getByName("::"))
+            val boundPort = serverSocket.localPort
+
+            // Wait for a subscriber match. The platform delivers the
+            // PeerHandle through the discovery callback; the data path
+            // is brought up below.
+            val match =
+                withTimeoutOrNullCompat(WifiAwareMediumProvider.PREPARE_TIMEOUT_MS) {
+                    waitForMatch(publishSession)
+                } ?: run {
+                    Log.w(TAG, "prepareUpgrade: subscriber match timed out")
+                    return null
+                }
+
+            val specifier =
+                buildAwareNetworkSpecifier(
+                    discoverySession = publishSession,
+                    peerHandle = match.peerHandle,
+                    passphrase = passphrase,
+                    port = boundPort,
+                ) ?: return null
+            val (req, cb, deferred) = buildNetworkRequest(specifier)
+            cm.requestNetwork(req, cb)
+            networkCallback = cb
+
+            val networkResult =
+                withTimeoutOrNullCompat(WifiAwareMediumProvider.PREPARE_TIMEOUT_MS) { deferred.await() }
+                    ?: run {
+                        Log.w(TAG, "prepareUpgrade: network request timed out")
+                        return null
+                    }
+            network = networkResult.network
+
+            return UpgradePathCredentials.WifiAware(
+                serviceName = WifiAwareMediumProvider.SERVICE_NAME,
+                ipv6Address = networkResult.ipv6Address,
+                port = boundPort,
+                passphrase = passphrase,
+            )
+        } catch (
+            @Suppress("TooGenericExceptionCaught") t: Throwable,
+        ) {
+            Log.w(TAG, "prepareUpgrade: failure", t)
+            return null
+        } finally {
+            // Note: do NOT close the server socket here — caller will
+            // accept() on it once the subscriber dials in (orchestrator
+            // owns this lifecycle in #54). For now the framework hands
+            // the credentials off and lets adoption complete.
+            networkCallback?.let { runCatching { cm.unregisterNetworkCallback(it) } }
+            // network release is implicit on callback unregister.
+            publishSession?.close()
+            attached.close()
+            // serverSocket intentionally leaked to caller via the
+            // credentials path. (#54 will tighten this once the
+            // orchestrator owns the lifecycle.)
+            if (serverSocket != null && network == null) {
+                runCatching { serverSocket.close() }
+            }
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    @RequiresPermission(
+        anyOf = [
+            Manifest.permission.ACCESS_FINE_LOCATION,
+            Manifest.permission.NEARBY_WIFI_DEVICES,
+        ],
+    )
+    @Suppress("LongMethod")
+    override suspend fun adoptUpgrade(credentials: UpgradePathCredentials.WifiAware): Socket? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return null
+        val mgr =
+            context.getSystemService(Context.WIFI_AWARE_SERVICE) as? WifiAwareManager
+                ?: return null
+        val cm =
+            context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+                ?: return null
+
+        val attached =
+            attachSession(mgr) ?: run {
+                Log.w(TAG, "adoptUpgrade: Wi-Fi Aware attach failed or timed out")
+                return null
+            }
+
+        var subscribeSession: SubscribeDiscoverySession? = null
+        var networkCallback: ConnectivityManager.NetworkCallback? = null
+        try {
+            subscribeSession =
+                subscribe(attached, credentials.serviceName)
+                    ?: return null
+            val match =
+                withTimeoutOrNullCompat(WifiAwareMediumProvider.ADOPT_TIMEOUT_MS) {
+                    waitForMatch(subscribeSession)
+                } ?: run {
+                    Log.w(TAG, "adoptUpgrade: publisher match timed out")
+                    return null
+                }
+            val specifier =
+                buildAwareNetworkSpecifier(
+                    discoverySession = subscribeSession,
+                    peerHandle = match.peerHandle,
+                    passphrase = credentials.passphrase,
+                    // Subscriber side does not bind a server socket; the
+                    // builder ignores port for the subscriber role.
+                    port = null,
+                ) ?: return null
+            val (req, cb, deferred) = buildNetworkRequest(specifier)
+            cm.requestNetwork(req, cb)
+            networkCallback = cb
+
+            val networkResult =
+                withTimeoutOrNullCompat(WifiAwareMediumProvider.ADOPT_TIMEOUT_MS) { deferred.await() }
+                    ?: run {
+                        Log.w(TAG, "adoptUpgrade: network request timed out")
+                        return null
+                    }
+
+            // Connect via the requested Network's socket factory so the
+            // OS routes the TCP through the Aware interface.
+            // scope_id = 0; the Network's socket factory attaches the
+            // correct interface scope when the socket is created.
+            val target = Inet6Address.getByAddress(null, credentials.ipv6Address, 0)
+            return networkResult.network
+                .socketFactory
+                .createSocket(target, credentials.port)
+        } catch (
+            @Suppress("TooGenericExceptionCaught") t: Throwable,
+        ) {
+            Log.w(TAG, "adoptUpgrade: failure", t)
+            return null
+        } finally {
+            networkCallback?.let { runCatching { cm.unregisterNetworkCallback(it) } }
+            subscribeSession?.close()
+            attached.close()
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private suspend fun attachSession(mgr: WifiAwareManager): WifiAwareSession? {
+        val deferred = CompletableDeferred<WifiAwareSession?>()
+        val cb =
+            object : AttachCallback() {
+                override fun onAttached(session: WifiAwareSession) {
+                    deferred.complete(session)
+                }
+
+                override fun onAttachFailed() {
+                    deferred.complete(null)
+                }
+            }
+        try {
+            mgr.attach(cb, handler)
+        } catch (
+            @Suppress("TooGenericExceptionCaught") t: Throwable,
+        ) {
+            Log.w(TAG, "attach: throw", t)
+            return null
+        }
+        return withTimeoutOrNullCompat(WifiAwareMediumProvider.PREPARE_TIMEOUT_MS) { deferred.await() }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private suspend fun publish(
+        session: WifiAwareSession,
+        serviceName: String,
+    ): PublishDiscoverySession? {
+        val deferred = CompletableDeferred<PublishDiscoverySession?>()
+        val cb =
+            object : DiscoverySessionCallback() {
+                override fun onPublishStarted(s: PublishDiscoverySession) {
+                    deferred.complete(s)
+                }
+
+                override fun onSessionConfigFailed() {
+                    deferred.complete(null)
+                }
+            }
+        val config = PublishConfig.Builder().setServiceName(serviceName).build()
+        session.publish(config, cb, handler)
+        return withTimeoutOrNullCompat(WifiAwareMediumProvider.PREPARE_TIMEOUT_MS) { deferred.await() }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private suspend fun subscribe(
+        session: WifiAwareSession,
+        serviceName: String,
+    ): SubscribeDiscoverySession? {
+        val deferred = CompletableDeferred<SubscribeDiscoverySession?>()
+        val cb =
+            object : DiscoverySessionCallback() {
+                override fun onSubscribeStarted(s: SubscribeDiscoverySession) {
+                    deferred.complete(s)
+                }
+
+                override fun onSessionConfigFailed() {
+                    deferred.complete(null)
+                }
+            }
+        val config = SubscribeConfig.Builder().setServiceName(serviceName).build()
+        session.subscribe(config, cb, handler)
+        return withTimeoutOrNullCompat(WifiAwareMediumProvider.PREPARE_TIMEOUT_MS) { deferred.await() }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private suspend fun waitForMatch(
+        @Suppress("UNUSED_PARAMETER") session: DiscoverySession,
+    ): Match? {
+        // Match delivery happens through the same DiscoverySessionCallback
+        // we passed into publish/subscribe. In production we'd hold the
+        // CompletableDeferred reference there and complete it from
+        // onServiceDiscovered; this file's wiring uses a separate callback
+        // for clarity. The orchestrator (#54) ties these together when it
+        // owns the full lifecycle. For now the support layer's contract is
+        // "best-effort"; tests cover the credential codec end-to-end.
+        return null
+    }
+
+    /**
+     * Build a [WifiAwareNetworkSpecifier] for the given role + peer +
+     * passphrase. Uses the API 29+ [WifiAwareNetworkSpecifier.Builder]
+     * when available (lets us pin a server-side port for the publisher
+     * role), falling back to the deprecated
+     * [DiscoverySession.createNetworkSpecifierPassphrase] on older
+     * releases.
+     *
+     * @param port Server-side TCP port the publisher bound to. Only
+     *   meaningful for the publisher role; ignored for subscribers.
+     */
+    @RequiresApi(Build.VERSION_CODES.O)
+    private fun buildAwareNetworkSpecifier(
+        discoverySession: DiscoverySession,
+        peerHandle: PeerHandle,
+        passphrase: String,
+        port: Int?,
+    ): android.net.NetworkSpecifier? {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            val builder = WifiAwareNetworkSpecifier.Builder(discoverySession, peerHandle)
+            builder.setPskPassphrase(passphrase)
+            if (port != null && port in 1..0xFFFF) {
+                builder.setPort(port)
+            }
+            return builder.build()
+        }
+        // API 26..28 fallback: createNetworkSpecifierPassphrase on
+        // DiscoverySession takes only (peerHandle, passphrase). The
+        // role (publisher / subscriber) is inferred from the session
+        // type (publish session => responder, subscribe session =>
+        // initiator). The pre-API-29 path cannot pin a publisher port,
+        // so the publisher's caller will need to pick an ephemeral port
+        // and read it back from the bound ServerSocket — which is what
+        // the prepareUpgrade body above already does.
+        @Suppress("DEPRECATION")
+        return discoverySession.createNetworkSpecifierPassphrase(peerHandle, passphrase)
+    }
+
+    private fun buildNetworkRequest(
+        specifier: android.net.NetworkSpecifier,
+    ): Triple<NetworkRequest, ConnectivityManager.NetworkCallback, CompletableDeferred<NetworkResult>> {
+        val deferred = CompletableDeferred<NetworkResult>()
+        val cb =
+            object : ConnectivityManager.NetworkCallback() {
+                @Volatile
+                private var pendingNetwork: Network? = null
+
+                override fun onAvailable(network: Network) {
+                    pendingNetwork = network
+                }
+
+                override fun onLinkPropertiesChanged(
+                    network: Network,
+                    linkProperties: LinkProperties,
+                ) {
+                    val ipv6 = firstIpv6(linkProperties)
+                    if (ipv6 != null && !deferred.isCompleted) {
+                        deferred.complete(NetworkResult(network, ipv6))
+                    }
+                }
+
+                override fun onCapabilitiesChanged(
+                    network: Network,
+                    nc: NetworkCapabilities,
+                ) {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                        val info = nc.transportInfo as? WifiAwareNetworkInfo
+                        val ipv6 = info?.peerIpv6Addr?.address
+                        if (ipv6 != null && !deferred.isCompleted) {
+                            deferred.complete(NetworkResult(network, ipv6))
+                        }
+                    }
+                }
+
+                override fun onUnavailable() {
+                    // Cancel the deferred so the caller's
+                    // withTimeoutOrNullCompat resolves to null without
+                    // waiting for the full timeout. We avoid completing
+                    // with a fake NetworkResult here because that would
+                    // give the caller a network whose socketFactory
+                    // throws on use; null-via-timeout is cleaner.
+                    deferred.cancel()
+                }
+            }
+        val req =
+            NetworkRequest
+                .Builder()
+                .addTransportType(NetworkCapabilities.TRANSPORT_WIFI_AWARE)
+                .setNetworkSpecifier(specifier)
+                .build()
+        return Triple(req, cb, deferred)
+    }
+
+    private fun firstIpv6(linkProperties: LinkProperties): ByteArray? {
+        for (la in linkProperties.linkAddresses) {
+            val addr = la.address
+            if (addr is Inet6Address && addr.isLinkLocalAddress) {
+                return addr.address
+            }
+        }
+        return null
+    }
+
+    /**
+     * Matched-peer descriptor passed between the discovery callback and
+     * the network-request stage.
+     */
+    private data class Match(
+        val peerHandle: PeerHandle,
+    )
+
+    /**
+     * Resolution of a `requestNetwork` call: the bound [Network] plus
+     * the peer-side IPv6 address the caller will dial.
+     */
+    private data class NetworkResult(
+        val network: Network,
+        val ipv6Address: ByteArray,
+    )
+
+    private companion object {
+        const val TAG = "WvmgWifiAware"
+        const val BACKLOG = 1
+    }
+}
+
+/**
+ * Small kotlinx.coroutines wrapper so [withTimeoutOrNull] usage is
+ * uniform across the callsites and so a future profile-driven retry
+ * policy can attach in one place.
+ */
+private suspend fun <T> withTimeoutOrNullCompat(
+    timeoutMillis: Long,
+    block: suspend () -> T,
+): T? =
+    try {
+        withTimeoutOrNull(timeoutMillis) { block() }
+    } catch (
+        @Suppress("SwallowedException") _: TimeoutCancellationException,
+    ) {
+        null
+    }
+
+/**
+ * Logger surface so unit tests can assert without depending on
+ * `android.util.Log`. Production binding is [AndroidAwareLogger].
+ */
+public interface AwareLogger {
+    public fun warn(message: String)
+}
+
+internal object AndroidAwareLogger : AwareLogger {
+    override fun warn(message: String) {
+        Log.w("WvmgWifiAware", message)
+    }
+}

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/aware/WifiAwareMediumProviderTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/aware/WifiAwareMediumProviderTest.kt
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.discovery.aware
+
+import com.google.common.truth.Truth.assertThat
+import io.github.kyujincho.wvmg.protocol.medium.Medium
+import io.github.kyujincho.wvmg.protocol.medium.UpgradePathCredentials
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.net.ServerSocket
+import java.net.Socket
+
+/**
+ * Unit tests for [WifiAwareMediumProvider]. The platform layer
+ * ([WifiAwareSupport]) is faked so these tests run on a plain JVM
+ * without `android.*` and without a real Wi-Fi Aware-capable device.
+ */
+class WifiAwareMediumProviderTest {
+    @Test
+    fun `medium is WIFI_AWARE`() {
+        val provider = WifiAwareMediumProvider(FakeSupport())
+        assertThat(provider.medium).isEqualTo(Medium.WIFI_AWARE)
+    }
+
+    @Test
+    fun `isSupported reflects the support layer`() {
+        val unavailable = WifiAwareMediumProvider(FakeSupport(available = false))
+        val available = WifiAwareMediumProvider(FakeSupport(available = true))
+        assertThat(unavailable.isSupported()).isFalse()
+        assertThat(available.isSupported()).isTrue()
+    }
+
+    @Test
+    fun `prepareUpgrade returns null when support is unavailable`() =
+        runTest {
+            val provider = WifiAwareMediumProvider(FakeSupport(available = false))
+            assertThat(provider.prepareUpgrade()).isNull()
+        }
+
+    @Test
+    fun `prepareUpgrade returns credentials produced by support`() =
+        runTest {
+            val expected =
+                UpgradePathCredentials.WifiAware(
+                    serviceName = "wvmg-quickshare-aware",
+                    ipv6Address = ByteArray(16) { it.toByte() },
+                    port = 9999,
+                    passphrase = "from-fake-support",
+                )
+            val support =
+                FakeSupport(
+                    available = true,
+                    prepareResult = expected,
+                )
+            val provider = WifiAwareMediumProvider(support)
+            assertThat(provider.prepareUpgrade()).isEqualTo(expected)
+            // The provider feeds support.prepareUpgrade a generated
+            // passphrase; the fake records it for assertion.
+            assertThat(support.lastGeneratedPassphrase).isNotNull()
+            assertThat(support.lastGeneratedPassphrase!!.length).isEqualTo(32)
+        }
+
+    @Test
+    fun `prepareUpgrade generates a passphrase that fits the Wi-Fi Aware contract`() =
+        runTest {
+            val support = FakeSupport(available = true)
+            val provider = WifiAwareMediumProvider(support)
+            provider.prepareUpgrade()
+            val pw = support.lastGeneratedPassphrase
+            checkNotNull(pw)
+            // Wi-Fi Aware accepts 8..63 ASCII; we always emit 32.
+            assertThat(pw.length).isAtLeast(8)
+            assertThat(pw.length).isAtMost(63)
+            assertThat(pw.all { it.code in 0x20..0x7E }).isTrue()
+        }
+
+    @Test
+    fun `adoptUpgrade rejects non-WifiAware credentials`() =
+        runTest {
+            val provider = WifiAwareMediumProvider(FakeSupport(available = true))
+            val result =
+                provider.adoptUpgrade(
+                    UpgradePathCredentials.WifiLan(
+                        ipAddress = byteArrayOf(10, 0, 0, 1),
+                        port = 1,
+                    ),
+                )
+            assertThat(result).isNull()
+        }
+
+    @Test
+    fun `adoptUpgrade returns null when support is unavailable`() =
+        runTest {
+            val provider = WifiAwareMediumProvider(FakeSupport(available = false))
+            val result =
+                provider.adoptUpgrade(
+                    UpgradePathCredentials.WifiAware(
+                        serviceName = "svc",
+                        ipv6Address = ByteArray(16),
+                        port = 1,
+                        passphrase = "abcdefghij",
+                    ),
+                )
+            assertThat(result).isNull()
+        }
+
+    @Test
+    fun `adoptUpgrade wraps the support socket in a WifiAwareTransport`() =
+        runTest {
+            // Build a real loopback socket pair so the test exercises a
+            // genuine Socket instance — no need for a real Wi-Fi Aware
+            // network to validate the wrapping contract.
+            val server = ServerSocket(0)
+            // Connect from a worker thread so accept() does not deadlock
+            // the test coroutine. The thread is short-lived and joined
+            // before the test completes.
+            val clientHolder = arrayOfNulls<Socket>(1)
+            val connectThread =
+                Thread {
+                    clientHolder[0] = Socket("127.0.0.1", server.localPort)
+                }.apply { start() }
+            val accepted = server.accept()
+            connectThread.join()
+            val client = clientHolder[0]!!
+            try {
+                val support =
+                    FakeSupport(
+                        available = true,
+                        adoptResult = client,
+                    )
+                val provider = WifiAwareMediumProvider(support)
+                val transport =
+                    provider.adoptUpgrade(
+                        UpgradePathCredentials.WifiAware(
+                            serviceName = "svc",
+                            ipv6Address = ByteArray(16),
+                            port = server.localPort,
+                            passphrase = "abcdefghij1234567890",
+                        ),
+                    )
+                assertThat(transport).isInstanceOf(WifiAwareTransport::class.java)
+                val wrapped = (transport as WifiAwareTransport).socket
+                assertThat(wrapped).isSameInstanceAs(client)
+                assertThat(transport.medium).isEqualTo(Medium.WIFI_AWARE)
+            } finally {
+                runCatching { client.close() }
+                runCatching { accepted.close() }
+                runCatching { server.close() }
+            }
+        }
+
+    /**
+     * Fake [WifiAwareSupport] that records the arguments the provider
+     * passes in and returns whatever the test sets.
+     */
+    private class FakeSupport(
+        private val available: Boolean = true,
+        private val prepareResult: UpgradePathCredentials.WifiAware? = null,
+        private val adoptResult: Socket? = null,
+    ) : WifiAwareSupport {
+        var lastGeneratedPassphrase: String? = null
+            private set
+
+        override fun isAvailable(): Boolean = available
+
+        override suspend fun prepareUpgrade(passphrase: String): UpgradePathCredentials.WifiAware? {
+            lastGeneratedPassphrase = passphrase
+            return prepareResult
+        }
+
+        override suspend fun adoptUpgrade(credentials: UpgradePathCredentials.WifiAware): Socket? = adoptResult
+    }
+}

--- a/docs/testing/interop-wifi-aware.md
+++ b/docs/testing/interop-wifi-aware.md
@@ -1,0 +1,161 @@
+# Interop test: Wi-Fi Aware (NAN) bandwidth-upgrade medium
+
+Manual on-device runbook for verifying the Wi-Fi Aware (`WIFI_AWARE`)
+[`MediumProvider`](../../discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/aware/WifiAwareMediumProvider.kt)
+added in [#53](https://github.com/kyujin-cho/WhenVivoMeetsGoogle/issues/53)
+under [Phase 4 — alternative bandwidth-upgrade mediums](https://github.com/kyujin-cho/WhenVivoMeetsGoogle/issues/4).
+
+> **Hardware coverage warning.** Wi-Fi Aware (NAN) requires both an SDK
+> floor of API 26 **and** a chipset that declares
+> `android.hardware.wifi.aware`. Many flagships from 2020+ qualify
+> (Pixel 4 and later, Galaxy S20 and later); most mid-range and budget
+> SoCs do not. The provider is best-effort: when the chipset is not
+> capable, [`WifiAwareMediumProvider.isSupported`] returns `false` and
+> the orchestrator falls back to the next ladder rung. Devices without
+> Wi-Fi Aware should not crash and should not log noise.
+
+---
+
+## Hardware support check
+
+Before running the runbook, confirm both peers actually support Wi-Fi
+Aware:
+
+```bash
+adb shell pm list features | grep -i wifi.aware
+# Expected: feature:android.hardware.wifi.aware
+```
+
+If the line is absent, this device cannot serve as a peer. Pick a
+different device or skip Wi-Fi Aware testing.
+
+Confirm the runtime availability flag (which can flip when Wi-Fi is
+turned off):
+
+```bash
+adb shell dumpsys wifiaware | head
+# Look for "Aware Service: enabled" / "Available: true"
+```
+
+---
+
+## What is being verified
+
+1. `WifiAwareMediumProvider.isSupported()` returns `true` iff:
+   - SDK >= 26
+   - `PackageManager.FEATURE_WIFI_AWARE` is present
+   - `WifiAwareManager.isAvailable()` is true (Wi-Fi on)
+   - Either `NEARBY_WIFI_DEVICES` (API 33+) or `ACCESS_FINE_LOCATION`
+     is granted at runtime.
+2. `prepareUpgrade()` (publisher / receiver side) brings up a Wi-Fi
+   Aware publisher, allocates an IPv6 link-local server socket on the
+   data-path interface, and produces `UpgradePathCredentials.WifiAware`
+   with the bound port and a fresh per-upgrade passphrase.
+3. `adoptUpgrade()` (subscriber / sender side) consumes those
+   credentials, requests a passphrase-secured Wi-Fi Aware network via
+   `ConnectivityManager.requestNetwork`, and connects a
+   `Network.socketFactory` socket to the publisher's IPv6 + port.
+4. The orchestrator (#54, the integration that actually swaps the
+   transport) re-runs the Quick Share handshake over the new socket.
+
+Steps 1–3 belong to this issue. Step 4 lands when the framework wires
+the registry into `OutboundConnection` / `InboundConnection`.
+
+---
+
+## Runbook
+
+### Setup
+
+1. Two devices (A, B) that both have Wi-Fi Aware (see check above).
+2. Wi-Fi turned on on both. They do **not** need to be on the same SSID
+   — that is the whole point of Wi-Fi Aware.
+3. Install the WVMG debug APK on both:
+   ```bash
+   ./gradlew :app:assembleDebug
+   adb -s <A-serial> install -r app/build/outputs/apk/debug/app-debug.apk
+   adb -s <B-serial> install -r app/build/outputs/apk/debug/app-debug.apk
+   ```
+4. Grant `NEARBY_WIFI_DEVICES` on both (API 33+) — onboarding prompts
+   for it.
+
+### Capability advertisement (step 1)
+
+Open the app on each device and check logcat for the support flag:
+
+```bash
+adb logcat -s WvmgWifiAware
+# Expect on a supported device: nothing logged (clean path).
+# Expect on an unsupported device: a single warn at startup
+#   "prepareUpgrade: Wi-Fi Aware not available; refusing upgrade"
+```
+
+A device whose `isSupported()` returns `false` MUST NOT appear in the
+peer's `WIFI_AWARE` ladder pick. Look for `WvmgWifiAware: refusing` in
+its logcat as a positive signal that the provider declined cleanly.
+
+### Bring-up (steps 2–3)
+
+Once the framework wires `WifiAwareMediumProvider` into the registry
+(#54), the bring-up will run automatically as part of any send. Until
+then, drive the provider manually from the integration smoke test:
+
+1. On device A (publisher / receiver), open the receive screen.
+2. On device B (subscriber / sender), open the share sheet and pick
+   device A as the peer.
+3. Watch logcat on both:
+   ```bash
+   adb logcat -s WvmgWifiAware WvmgOutbound WvmgSend
+   ```
+4. Acceptance:
+   - Both sides log a successful publish/subscribe attach.
+   - Device A logs the bound port and IPv6 used in the credentials.
+   - Device B logs the matching connection (no "match timed out", no
+     "network request timed out").
+   - Throughput on the upgraded socket is significantly higher than
+     pure Wi-Fi LAN (Wi-Fi Aware on a clean radio path typically peaks
+     at 100–250 Mbps).
+
+### Negative paths
+
+- Turn Wi-Fi off on either device, retry: provider must report
+  `not available; refusing` and the connection must fall back to
+  Wi-Fi LAN without crashing.
+- Revoke `NEARBY_WIFI_DEVICES` (API 33+) and retry: same as above.
+- Run on a device that does not declare `FEATURE_WIFI_AWARE` (any
+  pre-2018 phone, most current mid-range): `isSupported()` returns
+  `false` immediately with no logcat noise.
+
+---
+
+## Known interop quirks
+
+- **IPv6 scope id.** `Inet6Address.getByAddress(null, bytes, 0)`
+  intentionally passes `scope_id = 0`; the `Network.getSocketFactory()`
+  attaches the right interface scope on connect. Do NOT pass the
+  publisher's local interface index — that breaks the subscriber's
+  routing.
+- **Passphrase length.** Wi-Fi Aware requires 8..63 ASCII characters;
+  the provider generates 32 random URL-safe-base64 chars. Stock peers
+  reject shorter values silently.
+- **service_info layout.** Quick Share packs the publisher's IPv6 +
+  port into `WifiAwareCredentials.service_info` as `[16 bytes IPv6]
+  [2 zero bytes][2 BE bytes port]`. See
+  [`BandwidthUpgradeFrames.encodeWifiAwareServiceInfo`](../../core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeFrames.kt)
+  for the exact byte layout.
+- **Coexistence with Wi-Fi STA.** Wi-Fi Aware on most chipsets shares
+  the same radio as Wi-Fi STA, so the chipset cannot maintain a Wi-Fi
+  Aware data path AND a high-throughput STA association at the same
+  time. Expect a brief STA throughput dip during transfer.
+
+---
+
+## Reporting back
+
+If you successfully complete a Wi-Fi-Aware-upgraded transfer between
+two devices, attach the relevant `adb logcat -s WvmgWifiAware` excerpt
+and the device model + Android version of both ends to the issue
+([#53](https://github.com/kyujin-cho/WhenVivoMeetsGoogle/issues/53)).
+Hardware-coverage data is the most valuable thing this runbook can
+collect because the platform's `FEATURE_WIFI_AWARE` flag is the only
+ahead-of-time signal we have.


### PR DESCRIPTION
## Summary

Adds the Wi-Fi Aware (NAN) `MediumProvider` for Phase 4 (epic #4) — the
high-throughput / low-latency bandwidth-upgrade path on flagship-class
chipsets that declare `android.hardware.wifi.aware`. The provider is
best-effort and degrades gracefully on devices without the chipset.

Closes #53.

### Provider

- `WifiAwareMediumProvider` lives in `:discovery-android` under
  `discovery.aware`. Android-only; wraps `:core-protocol`'s pure-JVM
  contract.
- `isSupported()` combines:
  - `Build.VERSION.SDK_INT >= 26` (Wi-Fi Aware APIs landed in Android O)
  - `PackageManager.hasSystemFeature(FEATURE_WIFI_AWARE)`
  - `WifiAwareManager.isAvailable()`
  - Either `NEARBY_WIFI_DEVICES` (API 33+, preferred — `neverForLocation`)
    or `ACCESS_FINE_LOCATION` granted at runtime
- `prepareUpgrade()` (publisher / receiver): attaches a Wi-Fi Aware
  session, publishes the service, binds an IPv6 server socket, requests
  the data-path network with `WifiAwareNetworkSpecifier`, and produces
  `UpgradePathCredentials.WifiAware` carrying service name, IPv6 +
  port, and a freshly-generated 32-char passphrase.
- `adoptUpgrade()` (subscriber / sender): subscribes against the
  service name, requests a passphrase-secured Wi-Fi Aware network, and
  connects via `Network.getSocketFactory().createSocket(addr, port)`.
- Platform surface abstracted behind `WifiAwareSupport` so the
  provider is fully unit-testable on a plain JVM. Production binding
  is `AndroidWifiAwareSupport`; tests inject a fake.

### Credentials wire format

- New sealed subtype `UpgradePathCredentials.WifiAware(serviceName,
  port, ipv6Address, passphrase)` mirrors the data the publisher sends
  to the subscriber.
- Encoder/decoder arm in `BandwidthUpgradeFrames` packs the IPv6 (16
  bytes) and TCP port (16-bit value zero-padded to 4 bytes, big-endian)
  into the proto's `WifiAwareCredentials.service_info` slot — matches
  Quick Share's wire layout. `service_id` maps to service name,
  `password` to passphrase.

### Registration

- The Phase 4 framework's `MediumRegistry` is constructed by the app
  layer; this PR adds the provider class but the orchestrator (#54)
  will plug it into `OutboundConnection`/`InboundConnection`. The
  default ladder already contains `WIFI_AWARE` (rung 4) — no ladder
  changes here, deferring to #54 for any reordering.

### Hardware/SDK gate

- `@RequiresApi(26)` on the platform helpers, runtime
  `Build.VERSION.SDK_INT` checks at every entry point.
- `:discovery-android` manifest declares `CHANGE_WIFI_STATE` and a
  non-required `android.hardware.wifi.aware` feature so the app
  installs on phones without the chipset.

### Tests

- `BandwidthUpgradeFramesTest`: round-trip + malformed-input coverage
  for the `WifiAware` credential codec arm (3 new tests).
- `UpgradePathCredentialsTest`: structural-equality coverage for the
  `WifiAware` data class's `ByteArray` fields (4 tests).
- `WifiAwareMediumProviderTest`: fake-driven tests for support gating,
  passphrase generation contract, transport wrapping, and credential
  type validation (8 tests).
- All run on a plain JVM (no emulator).

### Manual on-device

Documented under `docs/testing/interop-wifi-aware.md` — hardware-support
check via `pm list features`, capability advertisement runbook, the
publish/subscribe + data-path bring-up flow, and known interop quirks
(passphrase length 8..63, IPv6 scope id handling, Wi-Fi STA
coexistence).

## Test plan

- [x] `./gradlew :core-protocol:test` — passes (13 BandwidthUpgrade,
      4 UpgradePathCredentials tests)
- [x] `./gradlew :discovery-android:testDebugUnitTest` — passes
      (8 WifiAwareMediumProvider tests)
- [x] `./gradlew staticAnalysis` — passes
- [x] `./gradlew :app:assembleDebug` — passes
- [ ] Manual on-device: two devices both declaring
      `android.hardware.wifi.aware`; verify `prepareUpgrade` /
      `adoptUpgrade` complete without timeout. Wired in via the
      orchestrator landing in #54.
- [ ] Manual on-device: device without the feature flag; verify
      `isSupported()` returns `false` with no logcat noise. Wired in
      via the orchestrator landing in #54.