### PR TITLE
feat(medium): Wi-Fi Direct (P2P) bandwidth-upgrade provider (#49)

### DIFF
--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeFrames.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeFrames.kt
@@ -271,7 +271,16 @@ public object BandwidthUpgradeFrames {
                     UpgradePathCredentials.Generic(medium)
                 }
             }
-            // Phase 4 sub-issues (#49–#53) plug the remaining arms in
+            // Wi-Fi Direct (#49). The receiver is the P2P group owner;
+            // the proto carries SSID + passphrase + the GO's IP (in the
+            // `gateway` string, dotted-quad) + TCP port. We surface the
+            // address as ByteArray so the adapter does not need to
+            // re-parse it. Falls back to Generic when the credentials
+            // sub-message is missing OR malformed (no SSID / port / IP),
+            // so the negotiator can still surface "an upgrade was
+            // offered" and the provider can reject it cleanly on adopt.
+            Medium.WIFI_DIRECT -> decodeWifiDirect(info) ?: UpgradePathCredentials.Generic(medium)
+            // Remaining Phase 4 sub-issues plug the rest of the arms in
             // here as their adapters land. Until then we report Generic
             // so the upper layers can at least see that *some* path
             // was advertised; the provider will reject it on adopt
@@ -282,7 +291,6 @@ public object BandwidthUpgradeFrames {
             // proto reserves wire number 10 there). The path that
             // builds the wire frame for BLE_L2CAP must use the
             // discovery-medium path instead — see Phase 4 #52.
-            Medium.WIFI_DIRECT,
             Medium.WIFI_HOTSPOT,
             Medium.BLE_L2CAP,
             Medium.BLE,
@@ -348,6 +356,23 @@ public object BandwidthUpgradeFrames {
                         .build(),
                 )
             }
+            // Wi-Fi Direct (#49). The proto's gateway field is a
+            // dotted-quad string; we serialize the receiver-side IPv4
+            // bytes that way so the wire payload matches what stock
+            // Quick Share emits.
+            is UpgradePathCredentials.WifiDirect -> {
+                val direct =
+                    UpgradePathInfo.WifiDirectCredentials
+                        .newBuilder()
+                        .setSsid(credentials.ssid)
+                        .setPassword(credentials.passphrase)
+                        .setPort(credentials.port)
+                        .setGateway(ipv4BytesToDottedQuad(credentials.ipAddress))
+                if (credentials.frequency != UpgradePathCredentials.WifiDirect.FREQUENCY_NOT_SET) {
+                    direct.frequency = credentials.frequency
+                }
+                builder.setWifiDirectCredentials(direct.build())
+            }
         }
         return builder.build()
     }
@@ -400,6 +425,75 @@ public object BandwidthUpgradeFrames {
             ((serviceInfo[WIFI_AWARE_PORT_HIGH_OFFSET].toInt() and BYTE_MASK) shl PORT_HIGH_BYTE_SHIFT) or
                 (serviceInfo[WIFI_AWARE_PORT_LOW_OFFSET].toInt() and BYTE_MASK)
         return ipv6 to port
+    }
+
+    /**
+     * Decode a `WifiDirectCredentials` sub-message (#49). Returns
+     * `null` when the sub-message is absent or when any of SSID, port,
+     * or gateway IP is missing — those are the bare minimum to actually
+     * connect, and a partial credential is the same as "no credential
+     * at all" from the adopter's standpoint. Treating malformed input
+     * as Generic at the call site preserves the negotiator's invariant
+     * that an UPGRADE_PATH_AVAILABLE frame always decodes to *some*
+     * credentials value.
+     */
+    @Suppress("ReturnCount") // One guard per missing sub-field; flattening hides the validation.
+    private fun decodeWifiDirect(info: UpgradePathInfo): UpgradePathCredentials.WifiDirect? {
+        if (!info.hasWifiDirectCredentials()) return null
+        val direct = info.wifiDirectCredentials
+        val gateway = direct.gateway.takeIf { it.isNotEmpty() } ?: return null
+        val ipBytes = dottedQuadToIpv4Bytes(gateway) ?: return null
+        return UpgradePathCredentials.WifiDirect(
+            ipAddress = ipBytes,
+            port = direct.port,
+            ssid = direct.ssid,
+            passphrase = direct.password,
+            frequency =
+                if (direct.hasFrequency()) {
+                    direct.frequency
+                } else {
+                    UpgradePathCredentials.WifiDirect.FREQUENCY_NOT_SET
+                },
+        )
+    }
+
+    /**
+     * Format a 4-byte IPv4 address as a dotted-quad string. Pulled out
+     * so both the encoder and tests can call it without duplicating the
+     * `&0xff` masking that Kotlin's `Byte.toInt()` would otherwise
+     * sign-extend. Avoids `InetAddress.getByAddress` so this stays
+     * pure-JVM and never resolves DNS.
+     */
+    private fun ipv4BytesToDottedQuad(bytes: ByteArray): String {
+        require(bytes.size == UpgradePathCredentials.WifiDirect.IPV4_ADDRESS_LENGTH) {
+            "Wi-Fi Direct gateway must be IPv4 (4 bytes); got ${bytes.size}"
+        }
+        return buildString {
+            for ((index, b) in bytes.withIndex()) {
+                if (index > 0) append('.')
+                append(b.toInt() and BYTE_MASK)
+            }
+        }
+    }
+
+    /**
+     * Parse a dotted-quad IPv4 string into 4 bytes (network order).
+     * Returns `null` for malformed input — used by [decodeWifiDirect]
+     * to drop wire frames whose `gateway` field is empty / IPv6 / a
+     * hostname rather than throwing the negotiator into a protocol
+     * error path. Pure validation: no DNS lookup, no IPv6 fallback.
+     */
+    @Suppress("ReturnCount") // Three guard clauses, one happy path; flattening is less readable.
+    private fun dottedQuadToIpv4Bytes(text: String): ByteArray? {
+        val parts = text.split('.')
+        if (parts.size != UpgradePathCredentials.WifiDirect.IPV4_ADDRESS_LENGTH) return null
+        val bytes = ByteArray(UpgradePathCredentials.WifiDirect.IPV4_ADDRESS_LENGTH)
+        for ((index, part) in parts.withIndex()) {
+            val value = part.toIntOrNull() ?: return null
+            if (value !in 0..BYTE_MASK) return null
+            bytes[index] = value.toByte()
+        }
+        return bytes
     }
 
     /**

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/medium/UpgradePathCredentials.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/medium/UpgradePathCredentials.kt
@@ -249,4 +249,90 @@ public sealed interface UpgradePathCredentials {
             return result
         }
     }
+
+    /**
+     * Wi-Fi Direct (P2P) bring-up parameters (#49).
+     *
+     * The receiver becomes a Wi-Fi P2P group owner via
+     * `WifiP2pManager.createGroup(...)` and reads the resulting
+     * SSID/passphrase/group-owner-IP from `WifiP2pInfo` /
+     * `WifiP2pGroup`. The sender consumes these credentials, calls
+     * `WifiP2pManager.connect(...)` with a matching network config, and
+     * opens a TCP socket to [ipAddress]:[port] once the group has
+     * formed.
+     *
+     * Field shape mirrors `UpgradePathInfo.WifiDirectCredentials` from
+     * the vendored proto:
+     *
+     *   - [ssid] — group-owner SSID, typically `DIRECT-xx-…` (Android
+     *     prepends `DIRECT-` automatically).
+     *   - [passphrase] — pre-shared key the platform generated for the
+     *     group. Treat as ST_ACCOUNT_CREDENTIAL: never log it.
+     *   - [ipAddress] — IPv4 group-owner address bytes (4 bytes,
+     *     network order). Sent over the wire via the proto's `gateway`
+     *     string field; we decode the dotted-quad to bytes here so
+     *     consumers do not have to re-parse it.
+     *   - [port] — TCP port the receiver is listening on for the new
+     *     transport.
+     *   - [frequency] — channel frequency in MHz, mirrors
+     *     `WifiDirectCredentials.frequency`. -1 (== [FREQUENCY_NOT_SET])
+     *     when no hint is available.
+     *
+     * @param ipAddress IPv4 group-owner address, exactly 4 bytes.
+     * @param port TCP port to connect to on the group owner.
+     * @param ssid Group-owner SSID announced by the GO (`DIRECT-…`).
+     * @param passphrase Pre-shared key for the group. Sensitive.
+     * @param frequency Operating channel frequency (MHz), or
+     *   [FREQUENCY_NOT_SET].
+     */
+    public data class WifiDirect(
+        val ipAddress: ByteArray,
+        val port: Int,
+        val ssid: String,
+        val passphrase: String,
+        val frequency: Int = FREQUENCY_NOT_SET,
+    ) : UpgradePathCredentials {
+        override val medium: Medium = Medium.WIFI_DIRECT
+
+        init {
+            require(ipAddress.size == IPV4_ADDRESS_LENGTH) {
+                "Wi-Fi Direct group-owner ipAddress must be 4 bytes (IPv4); got ${ipAddress.size}"
+            }
+        }
+
+        // ByteArray on a data class needs explicit structural equality —
+        // the auto-generated equals/hashCode compares ByteArray by
+        // reference, which breaks credential round-trip tests that
+        // re-parse the wire bytes.
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is WifiDirect) return false
+            return port == other.port &&
+                frequency == other.frequency &&
+                ssid == other.ssid &&
+                passphrase == other.passphrase &&
+                ipAddress.contentEquals(other.ipAddress)
+        }
+
+        override fun hashCode(): Int {
+            var result = ipAddress.contentHashCode()
+            result = 31 * result + port
+            result = 31 * result + ssid.hashCode()
+            result = 31 * result + passphrase.hashCode()
+            result = 31 * result + frequency
+            return result
+        }
+
+        public companion object {
+            /** Length of an IPv4 address in bytes. */
+            public const val IPV4_ADDRESS_LENGTH: Int = 4
+
+            /**
+             * Sentinel matching the proto's "no frequency hint" value.
+             * `WifiDirectCredentials.frequency` has no proto default;
+             * `google/nearby` uses -1.
+             */
+            public const val FREQUENCY_NOT_SET: Int = -1
+        }
+    }
 }

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeFramesTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeFramesTest.kt
@@ -280,6 +280,115 @@ class BandwidthUpgradeFramesTest {
     }
 
     @Test
+    fun `upgradePathAvailable serializes Wi-Fi Direct credentials onto the proto sub-message`() {
+        // Receiver side: we have a P2P group up at 192.168.49.1:8888,
+        // SSID DIRECT-aB-test, passphrase deadbeef, channel 2437 MHz.
+        val frame =
+            BandwidthUpgradeFrames.upgradePathAvailable(
+                UpgradePathCredentials.WifiDirect(
+                    ipAddress = byteArrayOf(192.toByte(), 168.toByte(), 49, 1),
+                    port = 8888,
+                    ssid = "DIRECT-aB-test",
+                    passphrase = "deadbeef",
+                    frequency = 2437,
+                ),
+            )
+        val parsed = parse(frame)
+        assertThat(parsed.upgradePathInfo.medium.number).isEqualTo(Medium.WIFI_DIRECT.wireNumber)
+        assertThat(parsed.upgradePathInfo.hasWifiDirectCredentials()).isTrue()
+        val direct = parsed.upgradePathInfo.wifiDirectCredentials
+        assertThat(direct.ssid).isEqualTo("DIRECT-aB-test")
+        assertThat(direct.password).isEqualTo("deadbeef")
+        assertThat(direct.port).isEqualTo(8888)
+        // Gateway is dotted-quad on the wire; we verify the
+        // sign-extension fix (192 → 192, not -64).
+        assertThat(direct.gateway).isEqualTo("192.168.49.1")
+        assertThat(direct.frequency).isEqualTo(2437)
+    }
+
+    @Test
+    fun `upgradePathAvailable omits frequency when not set`() {
+        val frame =
+            BandwidthUpgradeFrames.upgradePathAvailable(
+                UpgradePathCredentials.WifiDirect(
+                    ipAddress = byteArrayOf(10, 0, 0, 1),
+                    port = 9000,
+                    ssid = "DIRECT-zz-no-freq",
+                    passphrase = "secret",
+                    // frequency defaults to FREQUENCY_NOT_SET (-1).
+                ),
+            )
+        val parsed = parse(frame)
+        assertThat(parsed.upgradePathInfo.wifiDirectCredentials.hasFrequency()).isFalse()
+    }
+
+    @Test
+    fun `decodeCredentials round-trips Wi-Fi Direct`() {
+        val original =
+            UpgradePathCredentials.WifiDirect(
+                ipAddress = byteArrayOf(192.toByte(), 168.toByte(), 49, 1),
+                port = 8443,
+                ssid = "DIRECT-Xy-WhenVivo",
+                passphrase = "C0rrectH0rseBatteryStaple",
+                frequency = 5180,
+            )
+        val frame = BandwidthUpgradeFrames.upgradePathAvailable(original)
+        val parsed = parse(frame)
+        val decoded = BandwidthUpgradeFrames.decodeCredentials(parsed.upgradePathInfo)
+        assertThat(decoded).isEqualTo(original)
+    }
+
+    @Test
+    fun `decodeCredentials falls back to Generic when Wi-Fi Direct sub-message is absent`() {
+        // The peer announces WIFI_DIRECT as the medium but did not set
+        // any credentials — we treat that as "an upgrade was offered
+        // with no parameters", which collapses to Generic so the
+        // negotiator does not protocol-error.
+        val frame =
+            BandwidthUpgradeFrames.upgradePathAvailable(
+                UpgradePathCredentials.Generic(Medium.WIFI_DIRECT),
+            )
+        val parsed = parse(frame)
+        val decoded = BandwidthUpgradeFrames.decodeCredentials(parsed.upgradePathInfo)
+        assertThat(decoded).isEqualTo(UpgradePathCredentials.Generic(Medium.WIFI_DIRECT))
+    }
+
+    @Test
+    fun `WifiDirect rejects non-IPv4 ipAddress`() {
+        org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
+            UpgradePathCredentials.WifiDirect(
+                ipAddress = ByteArray(16), // IPv6-shaped, not supported by the gateway field.
+                port = 8443,
+                ssid = "DIRECT-bad",
+                passphrase = "pw",
+            )
+        }
+    }
+
+    @Test
+    fun `WifiDirect equality compares ByteArray structurally`() {
+        // Regression guard: data class auto-generated equals would
+        // compare the ByteArray by reference, breaking decoder
+        // round-trip assertions like the one above.
+        val a =
+            UpgradePathCredentials.WifiDirect(
+                ipAddress = byteArrayOf(10, 0, 0, 1),
+                port = 1,
+                ssid = "s",
+                passphrase = "p",
+            )
+        val b =
+            UpgradePathCredentials.WifiDirect(
+                ipAddress = byteArrayOf(10, 0, 0, 1),
+                port = 1,
+                ssid = "s",
+                passphrase = "p",
+            )
+        assertThat(a).isEqualTo(b)
+        assertThat(a.hashCode()).isEqualTo(b.hashCode())
+    }
+
+    @Test
     fun `every builder produces a V1 BANDWIDTH_UPGRADE_NEGOTIATION envelope`() {
         val frames =
             listOf(

--- a/discovery-android/src/main/AndroidManifest.xml
+++ b/discovery-android/src/main/AndroidManifest.xml
@@ -99,4 +99,31 @@
         android:name="android.hardware.wifi.aware"
         android:required="false" />
 
+    <!--
+      Wi-Fi Direct medium (#49). Required by WifiDirectMediumProvider /
+      WifiDirectGroupController to call WifiP2pManager.createGroup /
+      connect. neverForLocation tells Android we never derive physical
+      location from peer scans, so the platform skips the
+      ACCESS_FINE_LOCATION requirement that pre-API-33 had to ship
+      alongside this. The umbrella manifest in :app already declares
+      NEARBY_WIFI_DEVICES at the runtime layer; this library-local
+      declaration ensures any consumer of :discovery-android inherits
+      the requirement automatically.
+    -->
+    <uses-permission
+        android:name="android.permission.NEARBY_WIFI_DEVICES"
+        android:usesPermissionFlags="neverForLocation"
+        tools:targetApi="33" />
+
+    <!--
+      Hardware-feature hint for Wi-Fi Direct (#49). Marked optional
+      because the medium is a *bandwidth upgrade* — devices without
+      P2P still function over Wi-Fi LAN. WifiDirectAvailability checks
+      PackageManager.FEATURE_WIFI_DIRECT at runtime to decide whether
+      to advertise WIFI_DIRECT in the supported-mediums set.
+    -->
+    <uses-feature
+        android:name="android.hardware.wifi.direct"
+        android:required="false" />
+
 </manifest>

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/medium/WifiDirectAvailability.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/medium/WifiDirectAvailability.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.discovery.medium
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.net.wifi.p2p.WifiP2pManager
+import android.os.Build
+import androidx.core.content.ContextCompat
+
+/**
+ * Capability + permission probe for the Wi-Fi Direct medium (#49).
+ *
+ * Modeled as an interface so [WifiDirectMediumProvider] can be unit-
+ * tested with a trivial fake without touching real Android system
+ * services. The shipped implementation is [Default]; the provider's
+ * public constructor wires it up against the application [Context].
+ *
+ * The four conditions [Default] gates on:
+ *
+ *  1. **Hardware feature flag.** Android exposes
+ *     [PackageManager.FEATURE_WIFI_DIRECT] for chipsets / vendor builds
+ *     that support P2P. Some low-tier OEM SKUs ship Wi-Fi without
+ *     advertising the feature even though the API works; we honour the
+ *     flag conservatively because [WifiP2pManager.initialize] silently
+ *     no-ops on devices that do not have it, leading to `connect` calls
+ *     that simply never callback.
+ *  2. **System service present.** The platform returns `null` for
+ *     `getSystemService(Context.WIFI_P2P_SERVICE)` in headless / TV
+ *     profiles even when the feature flag is set. Pure defence-in-depth.
+ *  3. **Runtime permission.** API 33+ requires
+ *     [Manifest.permission.NEARBY_WIFI_DEVICES] to discover/connect over
+ *     P2P; pre-33 falls back to [Manifest.permission.ACCESS_FINE_LOCATION].
+ *     Onboarding (#31) requests `NEARBY_WIFI_DEVICES`; we re-check at
+ *     every `isSupported` call because the user can revoke from Settings
+ *     without restarting the app.
+ *
+ * Non-goals: [Default] does NOT verify that the device has *peer
+ * mode* (peripheral vs. group-owner only); the platform reports both
+ * modes as one feature flag. If a device only supports group-owner mode
+ * we will discover that at `prepareUpgrade` / `adoptUpgrade` time and
+ * fail back to the next ladder rung.
+ */
+public interface WifiDirectAvailability {
+    /**
+     * Single `isSupported`-shape entry point. Must be cheap and
+     * non-blocking — the framework calls this on every connection.
+     */
+    public fun isSupported(): Boolean
+
+    /**
+     * Production-shipped probe. Resolves every check against the
+     * supplied application [Context].
+     */
+    public class Default(
+        private val context: Context,
+    ) : WifiDirectAvailability {
+        @Suppress("ReturnCount") // One guard per capability gate; flattening obscures which check failed.
+        override fun isSupported(): Boolean {
+            if (!hasWifiDirectFeature()) return false
+            if (!hasWifiP2pManager()) return false
+            if (!hasNearbyWifiPermission()) return false
+            return true
+        }
+
+        private fun hasWifiDirectFeature(): Boolean =
+            context.packageManager.hasSystemFeature(PackageManager.FEATURE_WIFI_DIRECT)
+
+        private fun hasWifiP2pManager(): Boolean = context.getSystemService(Context.WIFI_P2P_SERVICE) is WifiP2pManager
+
+        /**
+         * Runtime-permission check. The required permission flips at API
+         * 33: pre-33 the platform required `ACCESS_FINE_LOCATION`, post-33
+         * the dedicated `NEARBY_WIFI_DEVICES` is the canonical grant.
+         * We do not try the location fallback on API 33+ — the project
+         * does not declare it (#5: we explicitly avoid asking for fine
+         * location) and the platform rejects the legacy permission in
+         * favour of the new one.
+         */
+        private fun hasNearbyWifiPermission(): Boolean {
+            val permission =
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    Manifest.permission.NEARBY_WIFI_DEVICES
+                } else {
+                    Manifest.permission.ACCESS_FINE_LOCATION
+                }
+            return ContextCompat.checkSelfPermission(context, permission) ==
+                PackageManager.PERMISSION_GRANTED
+        }
+    }
+}

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/medium/WifiDirectGroupController.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/medium/WifiDirectGroupController.kt
@@ -1,0 +1,431 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+@file:Suppress("MagicNumber") // Wi-Fi Direct frequencies and timeouts are well-known constants.
+
+package io.github.kyujincho.wvmg.discovery.medium
+
+import android.Manifest
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.net.wifi.WpsInfo
+import android.net.wifi.p2p.WifiP2pConfig
+import android.net.wifi.p2p.WifiP2pGroup
+import android.net.wifi.p2p.WifiP2pInfo
+import android.net.wifi.p2p.WifiP2pManager
+import android.os.Looper
+import android.util.Log
+import androidx.annotation.RequiresPermission
+import androidx.core.content.ContextCompat
+import io.github.kyujincho.wvmg.protocol.medium.UpgradePathCredentials
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.withTimeout
+import java.io.Closeable
+import java.io.IOException
+import java.net.InetAddress
+import java.net.Socket
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Wraps the imperative `WifiP2pManager` API in a coroutine-friendly
+ * shape (#49). One instance per upgrade attempt — instances are not
+ * thread-safe across concurrent `prepareUpgrade` / `adoptUpgrade`
+ * calls; the medium provider creates a fresh one each time.
+ *
+ * The class deliberately keeps [WifiP2pManager] / Channel handling out
+ * of [WifiDirectMediumProvider] so the provider stays small and the
+ * Android-specific dance lives in one place. Two top-level operations:
+ *
+ *  1. [createGroupAsServer] — receiver side. Calls
+ *     `WifiP2pManager.createGroup(...)`, waits for the
+ *     `WIFI_P2P_CONNECTION_CHANGED_ACTION` broadcast that confirms
+ *     group formation, reads the group-owner IP and the SSID /
+ *     passphrase from `WifiP2pInfo` + `WifiP2pGroup`, and returns the
+ *     [UpgradePathCredentials.WifiDirect] the framework will ship
+ *     across the wire.
+ *  2. [connectAsClient] — sender side. Calls
+ *     `WifiP2pManager.connect(...)` with a `WifiP2pConfig` carrying
+ *     the peer's MAC address (derived from the SSID we received) and
+ *     PSK; waits for the same broadcast; opens a TCP socket to the
+ *     group-owner IP / port.
+ *
+ * Both methods return a [Closeable] teardown handle — closing it
+ * removes the group (server) or cancels the connection (client) and
+ * unregisters the broadcast receiver. The provider stitches that
+ * teardown into [WifiDirectTransport.teardown] so the orchestrator
+ * frees the radio when the transfer ends.
+ *
+ * Timeouts:
+ *  * Group formation (server) — 30 seconds. Empirically the Pixel 8
+ *    Pro / S24 negotiate in 4–8 s; 30 s catches first-time-driver-
+ *    init slowness without hanging the user.
+ *  * Connect (client) — 30 seconds for the same reason.
+ *  * Socket connect — 10 seconds. Once the broadcast says the link
+ *    is up, the GO must already be `accept()`ing; ten seconds is
+ *    generous for a TCP handshake on a freshly-formed link.
+ */
+internal class WifiDirectGroupController(
+    private val context: Context,
+    private val manager: WifiP2pManager,
+) {
+    /**
+     * Receiver-side group bring-up. Returns the credentials the peer
+     * needs to call [connectAsClient], plus a teardown that removes
+     * the group when the upgrade finishes (success OR failure). The
+     * returned port is supplied by the caller because Wi-Fi Direct
+     * does not allocate one — the receiver opens its own ServerSocket
+     * on whatever port it picked.
+     *
+     * Returns `null` when group formation fails or times out; callers
+     * treat that as "fall back to next medium".
+     */
+    @RequiresPermission(Manifest.permission.NEARBY_WIFI_DEVICES)
+    @Suppress("ReturnCount") // One guard per failure mode in the multi-step P2P bring-up.
+    suspend fun createGroupAsServer(serverPort: Int): GroupServerHandle? {
+        val channel =
+            manager.initialize(context, Looper.getMainLooper(), null) ?: run {
+                Log.w(TAG, "WifiP2pManager.initialize returned null — Wi-Fi Direct unavailable")
+                return null
+            }
+        val connectionChanged = registerConnectionChangedReceiver()
+        val teardown =
+            closeable {
+                connectionChanged.unregister()
+                removeGroupQuietly(channel)
+            }
+
+        val createOk =
+            awaitActionListener { listener ->
+                manager.createGroup(channel, listener)
+            }
+        if (!createOk) {
+            Log.w(TAG, "WifiP2pManager.createGroup failed — falling back")
+            teardown.close()
+            return null
+        }
+
+        val info =
+            try {
+                withTimeout(GROUP_FORMATION_TIMEOUT_MS) {
+                    connectionChanged.awaitGroupOwner()
+                }
+            } catch (_: TimeoutCancellationException) {
+                Log.w(TAG, "Wi-Fi Direct group formation timed out after ${GROUP_FORMATION_TIMEOUT_MS}ms")
+                teardown.close()
+                return null
+            }
+        val group =
+            awaitGroupInfo(channel) ?: run {
+                Log.w(TAG, "WifiP2pManager.requestGroupInfo returned null after group creation")
+                teardown.close()
+                return null
+            }
+        val ipBytes = info.groupOwnerAddress?.address
+        if (ipBytes == null || ipBytes.size != UpgradePathCredentials.WifiDirect.IPV4_ADDRESS_LENGTH) {
+            Log.w(TAG, "Wi-Fi Direct group owner address missing or non-IPv4")
+            teardown.close()
+            return null
+        }
+        val credentials =
+            UpgradePathCredentials.WifiDirect(
+                ipAddress = ipBytes,
+                port = serverPort,
+                ssid = group.networkName ?: "",
+                passphrase = group.passphrase ?: "",
+                frequency = UpgradePathCredentials.WifiDirect.FREQUENCY_NOT_SET,
+            )
+        return GroupServerHandle(credentials, teardown)
+    }
+
+    /**
+     * Sender-side bring-up. Builds a `WifiP2pConfig` from the peer
+     * credentials, calls `connect`, waits for the connection broadcast,
+     * and opens a TCP socket to the group-owner IP / port.
+     *
+     * Returns `null` when any step fails. Caller treats `null` as
+     * "abort this upgrade attempt" and the negotiator emits
+     * `UPGRADE_FAILURE`.
+     */
+    @RequiresPermission(Manifest.permission.NEARBY_WIFI_DEVICES)
+    @Suppress("ReturnCount") // One guard per failure mode in the multi-step P2P bring-up.
+    suspend fun connectAsClient(credentials: UpgradePathCredentials.WifiDirect): WifiDirectTransport? {
+        val channel =
+            manager.initialize(context, Looper.getMainLooper(), null) ?: run {
+                Log.w(TAG, "WifiP2pManager.initialize returned null on the sender side")
+                return null
+            }
+        val connectionChanged = registerConnectionChangedReceiver()
+        val teardown =
+            closeable {
+                connectionChanged.unregister()
+                cancelConnectQuietly(channel)
+            }
+
+        val config =
+            WifiP2pConfig().apply {
+                // The peer's MAC address is not directly part of the
+                // proto — Quick Share scrubs it on purpose. We let the
+                // platform discover the GO via the SSID; setting wps
+                // to PBC keeps the platform from prompting the user
+                // for a PIN.
+                wps.setup = WpsInfo.PBC
+                // groupOwnerIntent = 0 explicitly tells the platform
+                // we want to be the client (not the GO). The peer
+                // already created the group and handed us the PSK.
+                groupOwnerIntent = 0
+            }
+        val connectOk =
+            awaitActionListener { listener ->
+                manager.connect(channel, config, listener)
+            }
+        if (!connectOk) {
+            Log.w(TAG, "WifiP2pManager.connect failed — sender cannot adopt Wi-Fi Direct")
+            teardown.close()
+            return null
+        }
+
+        try {
+            withTimeout(CONNECT_TIMEOUT_MS) {
+                connectionChanged.awaitConnectionEstablished()
+            }
+        } catch (_: TimeoutCancellationException) {
+            Log.w(TAG, "Wi-Fi Direct connect timed out after ${CONNECT_TIMEOUT_MS}ms")
+            teardown.close()
+            return null
+        }
+
+        val address =
+            try {
+                InetAddress.getByAddress(credentials.ipAddress)
+            } catch (e: java.net.UnknownHostException) {
+                Log.w(TAG, "Wi-Fi Direct credentials carry malformed IPv4 bytes", e)
+                teardown.close()
+                return null
+            }
+        val socket =
+            try {
+                Socket().also { s ->
+                    s.connect(java.net.InetSocketAddress(address, credentials.port), SOCKET_CONNECT_TIMEOUT_MS)
+                }
+            } catch (e: IOException) {
+                Log.w(TAG, "TCP connect to Wi-Fi Direct group owner failed", e)
+                teardown.close()
+                return null
+            }
+        return WifiDirectTransport(socket = socket, teardown = teardown)
+    }
+
+    /**
+     * Result of [createGroupAsServer]. The framework hands [credentials]
+     * to the negotiator and keeps [teardown] alive until the upgrade
+     * completes / fails / is aborted.
+     */
+    internal data class GroupServerHandle(
+        val credentials: UpgradePathCredentials.WifiDirect,
+        val teardown: Closeable,
+    )
+
+    // -----------------------------------------------------------------
+    // WifiP2pManager helpers — convert each callback shape into
+    // suspend-able primitives so the call sites read top-to-bottom.
+    // -----------------------------------------------------------------
+
+    private suspend fun awaitActionListener(call: (WifiP2pManager.ActionListener) -> Unit): Boolean {
+        val deferred = CompletableDeferred<Boolean>()
+        val listener =
+            object : WifiP2pManager.ActionListener {
+                override fun onSuccess() {
+                    deferred.complete(true)
+                }
+
+                override fun onFailure(reason: Int) {
+                    Log.w(TAG, "WifiP2pManager.ActionListener.onFailure reason=$reason")
+                    deferred.complete(false)
+                }
+            }
+        try {
+            call(listener)
+        } catch (
+            @Suppress("TooGenericExceptionCaught") t: Throwable,
+        ) {
+            Log.w(TAG, "WifiP2pManager call threw before listener invocation", t)
+            deferred.complete(false)
+        }
+        return deferred.await()
+    }
+
+    @RequiresPermission(Manifest.permission.NEARBY_WIFI_DEVICES)
+    private suspend fun awaitGroupInfo(channel: WifiP2pManager.Channel): WifiP2pGroup? {
+        val deferred = CompletableDeferred<WifiP2pGroup?>()
+        try {
+            manager.requestGroupInfo(channel) { group -> deferred.complete(group) }
+        } catch (
+            @Suppress("TooGenericExceptionCaught") t: Throwable,
+        ) {
+            Log.w(TAG, "WifiP2pManager.requestGroupInfo threw", t)
+            deferred.complete(null)
+        }
+        return deferred.await()
+    }
+
+    private fun removeGroupQuietly(channel: WifiP2pManager.Channel) {
+        try {
+            manager.removeGroup(
+                channel,
+                object : WifiP2pManager.ActionListener {
+                    override fun onSuccess() = Unit
+
+                    override fun onFailure(reason: Int) {
+                        Log.w(TAG, "WifiP2pManager.removeGroup reason=$reason")
+                    }
+                },
+            )
+        } catch (
+            @Suppress("TooGenericExceptionCaught") t: Throwable,
+        ) {
+            Log.w(TAG, "WifiP2pManager.removeGroup threw during teardown", t)
+        }
+    }
+
+    private fun cancelConnectQuietly(channel: WifiP2pManager.Channel) {
+        try {
+            manager.cancelConnect(
+                channel,
+                object : WifiP2pManager.ActionListener {
+                    override fun onSuccess() = Unit
+
+                    override fun onFailure(reason: Int) {
+                        Log.w(TAG, "WifiP2pManager.cancelConnect reason=$reason")
+                    }
+                },
+            )
+        } catch (
+            @Suppress("TooGenericExceptionCaught") t: Throwable,
+        ) {
+            Log.w(TAG, "WifiP2pManager.cancelConnect threw during teardown", t)
+        }
+    }
+
+    private fun registerConnectionChangedReceiver(): ConnectionChangedReceiver {
+        val receiver = ConnectionChangedReceiver()
+        val filter = IntentFilter(WifiP2pManager.WIFI_P2P_CONNECTION_CHANGED_ACTION)
+        // ContextCompat.registerReceiver routes to the API 33+
+        // explicit-export-flag overload when available and falls back
+        // to the legacy 3-arg signature on older platforms. The flag
+        // is RECEIVER_NOT_EXPORTED because the WIFI_P2P_CONNECTION_CHANGED
+        // action is system-broadcast — only the platform itself sends
+        // it, so we never need exported delivery from third-party apps.
+        try {
+            ContextCompat.registerReceiver(
+                context,
+                receiver,
+                filter,
+                ContextCompat.RECEIVER_NOT_EXPORTED,
+            )
+        } catch (
+            @Suppress("TooGenericExceptionCaught") t: Throwable,
+        ) {
+            Log.w(TAG, "Failed to register P2P connection-changed receiver", t)
+        }
+        receiver.context = context
+        return receiver
+    }
+
+    /**
+     * Broadcast receiver wrapper that exposes the connection-changed
+     * stream as `await…` suspend functions. We keep separate await
+     * functions for the server-side ("group has formed AND we are the
+     * GO") and client-side ("we are connected, group owner address
+     * known") because the broadcast carries a single
+     * [WifiP2pInfo] both sides receive.
+     */
+    private class ConnectionChangedReceiver : BroadcastReceiver() {
+        var context: Context? = null
+        private val unregistered = AtomicReference(false)
+        private val ownerInfo = CompletableDeferred<WifiP2pInfo>()
+        private val clientInfo = CompletableDeferred<WifiP2pInfo>()
+
+        override fun onReceive(
+            context: Context?,
+            intent: Intent?,
+        ) {
+            val info: WifiP2pInfo = readWifiP2pInfo(intent) ?: return
+            if (!info.groupFormed) return
+            if (info.isGroupOwner && !ownerInfo.isCompleted) {
+                ownerInfo.complete(info)
+            }
+            if (!info.isGroupOwner && !clientInfo.isCompleted) {
+                clientInfo.complete(info)
+            }
+        }
+
+        /**
+         * Wrapper around `Intent.getParcelableExtra` that uses the
+         * type-safe overload on API 33+ and falls back to the
+         * deprecated single-argument form on older platforms. Without
+         * this split, the `:discovery-android` JVM tests build emits a
+         * deprecation warning and the static-analysis pass treats it
+         * as a regression.
+         */
+        @Suppress("DEPRECATION")
+        private fun readWifiP2pInfo(intent: Intent?): WifiP2pInfo? {
+            if (intent == null) return null
+            return if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+                intent.getParcelableExtra(WifiP2pManager.EXTRA_WIFI_P2P_INFO, WifiP2pInfo::class.java)
+            } else {
+                intent.getParcelableExtra(WifiP2pManager.EXTRA_WIFI_P2P_INFO) as? WifiP2pInfo
+            }
+        }
+
+        suspend fun awaitGroupOwner(): WifiP2pInfo = ownerInfo.await()
+
+        suspend fun awaitConnectionEstablished(): WifiP2pInfo = clientInfo.await()
+
+        fun unregister() {
+            if (!unregistered.compareAndSet(false, true)) return
+            val ctx = context ?: return
+            try {
+                ctx.unregisterReceiver(this)
+            } catch (
+                @Suppress("TooGenericExceptionCaught") t: IllegalArgumentException,
+            ) {
+                // Receiver was never registered (the register call
+                // upstream failed) — nothing to unregister.
+                Log.d(TAG, "P2P connection-changed receiver not registered at unregister time", t)
+            }
+        }
+    }
+
+    private fun closeable(action: () -> Unit): Closeable {
+        val closed = AtomicReference(false)
+        return Closeable {
+            if (closed.compareAndSet(false, true)) {
+                try {
+                    action()
+                } catch (
+                    @Suppress("TooGenericExceptionCaught") t: Throwable,
+                ) {
+                    Log.w(TAG, "Wi-Fi Direct teardown action threw", t)
+                }
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "WvmgWifiDirect"
+
+        /** Wait at most this long for the WIFI_P2P_CONNECTION_CHANGED broadcast. */
+        const val GROUP_FORMATION_TIMEOUT_MS: Long = 30_000
+
+        /** Sender-side equivalent of [GROUP_FORMATION_TIMEOUT_MS]. */
+        const val CONNECT_TIMEOUT_MS: Long = 30_000
+
+        /** TCP connect timeout once the link is up. */
+        const val SOCKET_CONNECT_TIMEOUT_MS: Int = 10_000
+    }
+}

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/medium/WifiDirectMediumProvider.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/medium/WifiDirectMediumProvider.kt
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.discovery.medium
+
+import android.Manifest
+import android.content.Context
+import android.net.wifi.p2p.WifiP2pManager
+import android.util.Log
+import androidx.annotation.RequiresPermission
+import io.github.kyujincho.wvmg.protocol.medium.Medium
+import io.github.kyujincho.wvmg.protocol.medium.MediumProvider
+import io.github.kyujincho.wvmg.protocol.medium.UpgradePathCredentials
+import io.github.kyujincho.wvmg.protocol.medium.UpgradedTransport
+import java.io.IOException
+import java.net.ServerSocket
+import java.net.Socket
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Wi-Fi Direct (P2P) bandwidth-upgrade provider (#49).
+ *
+ * Plugs into the [io.github.kyujincho.wvmg.protocol.medium.MediumRegistry]
+ * to advertise [Medium.WIFI_DIRECT] as a supported upgrade target and
+ * to drive the actual P2P group bring-up:
+ *
+ *  - **Sender role.** Discover + connect over Wi-Fi LAN as today,
+ *    then on [adoptUpgrade] join the receiver-created P2P group via
+ *    [WifiP2pManager.connect] and open a TCP socket to the group-owner
+ *    IP.
+ *  - **Receiver role.** Stand up a P2P group via
+ *    [WifiP2pManager.createGroup], read the SSID + passphrase + GO IP
+ *    from the platform, and ship them to the sender as
+ *    [UpgradePathCredentials.WifiDirect].
+ *
+ * The actual `WifiP2pManager` choreography lives in
+ * [WifiDirectGroupController]; this class is the small, testable
+ * surface the framework consumes.
+ *
+ * Lifecycle:
+ *  * One provider per process — register it in
+ *    [io.github.kyujincho.wvmg.protocol.medium.MediumRegistry] at
+ *    `Application.onCreate`.
+ *  * `prepareUpgrade` allocates a ServerSocket on a free port, hands
+ *    its number to the controller, and stashes both the socket and the
+ *    teardown so [pendingServer] / [pendingClient] can later be
+ *    reclaimed by the orchestrator (#54). Until #54 wires the swap,
+ *    the provider simply tears down on every prepare/adopt to avoid
+ *    leaking radios.
+ *
+ * Permissions: caller MUST hold [Manifest.permission.NEARBY_WIFI_DEVICES]
+ * on API 33+ (or [Manifest.permission.ACCESS_FINE_LOCATION] on older
+ * platforms). [isSupported] returns false when the permission is
+ * missing, so the framework simply will not pick this medium until the
+ * grant is in place.
+ */
+public class WifiDirectMediumProvider internal constructor(
+    private val availability: WifiDirectAvailability,
+    private val controllerFactory: () -> WifiDirectGroupController?,
+    private val serverSocketFactory: () -> ServerSocket,
+) : MediumProvider {
+    /**
+     * Production constructor. Reaches into the system service for
+     * [WifiP2pManager] only when `controllerFactory` is invoked
+     * (lazily, per upgrade attempt) — that means a registered-but-
+     * unsupported provider does not pin any radio resources at startup.
+     */
+    public constructor(context: Context) : this(
+        availability = WifiDirectAvailability.Default(context.applicationContext),
+        controllerFactory = {
+            val ctx = context.applicationContext
+            val mgr = ctx.getSystemService(Context.WIFI_P2P_SERVICE) as? WifiP2pManager
+            mgr?.let { WifiDirectGroupController(ctx, it) }
+        },
+        // Bind to 0.0.0.0:0 so the OS picks a free ephemeral port.
+        // The receiver will hand the port number to the sender as part
+        // of the credentials.
+        serverSocketFactory = { ServerSocket(0) },
+    )
+
+    override val medium: Medium = Medium.WIFI_DIRECT
+
+    /**
+     * Server-side state held between `prepareUpgrade` and the
+     * orchestrator's accept hook (added in #54). Today the framework
+     * does not call into us after `prepareUpgrade` returns, so we
+     * simply expose the slot for #54 to consume; tests reach in to
+     * verify cleanup. Atomic so there is exactly one in-flight upgrade
+     * per provider — concurrent prepare attempts would otherwise stomp
+     * on each other's group ownership.
+     */
+    private val pendingServer: AtomicReference<PendingServer?> = AtomicReference(null)
+
+    /** Same shape as [pendingServer], but for the client-side adopt path. */
+    private val pendingClient: AtomicReference<WifiDirectTransport?> = AtomicReference(null)
+
+    override fun isSupported(): Boolean = availability.isSupported()
+
+    @RequiresPermission(Manifest.permission.NEARBY_WIFI_DEVICES)
+    @Suppress("ReturnCount") // One guard per failure mode — controller missing, socket alloc, group failure.
+    override suspend fun prepareUpgrade(): UpgradePathCredentials? {
+        val previous = pendingServer.getAndSet(null)
+        previous?.serverSocket?.runCatching { close() }
+        previous?.handle?.teardown?.runCatching { close() }
+
+        val controller =
+            controllerFactory() ?: run {
+                Log.w(TAG, "WifiP2pManager unavailable on prepareUpgrade")
+                return null
+            }
+        val serverSocket =
+            try {
+                serverSocketFactory()
+            } catch (e: IOException) {
+                Log.w(TAG, "Failed to allocate ServerSocket for Wi-Fi Direct upgrade", e)
+                return null
+            }
+        val handle = controller.createGroupAsServer(serverPort = serverSocket.localPort)
+        if (handle == null) {
+            serverSocket.runCatching { close() }
+            return null
+        }
+        pendingServer.set(PendingServer(handle, serverSocket))
+        return handle.credentials
+    }
+
+    @RequiresPermission(Manifest.permission.NEARBY_WIFI_DEVICES)
+    @Suppress("ReturnCount") // Five guards: medium mismatch, missing concrete creds, controller, connect, success.
+    override suspend fun adoptUpgrade(credentials: UpgradePathCredentials): UpgradedTransport? {
+        // The framework does not enforce credentials.medium == this.medium;
+        // the contract on MediumProvider says we must validate explicitly.
+        // Returning null falls back to the next ladder rung instead of
+        // hard-erroring the connection.
+        if (credentials.medium != Medium.WIFI_DIRECT) {
+            Log.w(TAG, "adoptUpgrade called with mismatched medium ${credentials.medium}")
+            return null
+        }
+        val direct =
+            credentials as? UpgradePathCredentials.WifiDirect ?: run {
+                Log.w(TAG, "adoptUpgrade got Wi-Fi Direct medium but no concrete credentials")
+                return null
+            }
+        val controller =
+            controllerFactory() ?: run {
+                Log.w(TAG, "WifiP2pManager unavailable on adoptUpgrade")
+                return null
+            }
+        val transport = controller.connectAsClient(direct) ?: return null
+        pendingClient.getAndSet(transport)?.let { stale ->
+            // A previous adopt attempt's transport is still around; tear
+            // it down so we never leak the underlying socket. This only
+            // happens when the orchestrator drops a successful adopt
+            // without claiming the transport (e.g. peer aborted between
+            // our adopt and their CLIENT_INTRODUCTION_ACK).
+            stale.runCatching { socket.close() }
+            stale.runCatching { teardown.close() }
+        }
+        return transport
+    }
+
+    /**
+     * **Internal — for the orchestrator wired in #54.** Hands back the
+     * server-side `ServerSocket` allocated in [prepareUpgrade] and
+     * clears the slot. Returns `null` when no upgrade is pending.
+     */
+    public fun consumePendingServerSocket(): Socket? {
+        val pending = pendingServer.getAndSet(null) ?: return null
+        // Block-accept on the receiver-side socket. The peer is about
+        // to call connect on this exact port. We hand teardown back as
+        // a closeable on the returned transport in #54; for now the
+        // server socket itself is the only handle the orchestrator
+        // needs, so close the listening socket once accept returns to
+        // free the port.
+        return try {
+            pending.serverSocket.use { listener -> listener.accept() }
+        } catch (e: IOException) {
+            Log.w(TAG, "Wi-Fi Direct ServerSocket.accept threw", e)
+            pending.handle.teardown.runCatching { close() }
+            null
+        }
+    }
+
+    /**
+     * **Internal — for the orchestrator wired in #54.** Hands back the
+     * client-side transport produced by the most recent successful
+     * [adoptUpgrade] and clears the slot. Returns `null` when no
+     * upgrade is pending.
+     */
+    public fun consumePendingClientTransport(): WifiDirectTransport? = pendingClient.getAndSet(null)
+
+    /**
+     * Tear down any in-flight P2P group ownership / client
+     * connection. Idempotent. Called by the orchestrator when an
+     * upgrade aborts; safe to call from any thread.
+     */
+    public fun cancelPending() {
+        pendingServer.getAndSet(null)?.let { pending ->
+            pending.serverSocket.runCatching { close() }
+            pending.handle.teardown.runCatching { close() }
+        }
+        pendingClient.getAndSet(null)?.let { transport ->
+            transport.socket.runCatching { close() }
+            transport.teardown.runCatching { close() }
+        }
+    }
+
+    private data class PendingServer(
+        val handle: WifiDirectGroupController.GroupServerHandle,
+        val serverSocket: ServerSocket,
+    )
+
+    private companion object {
+        private const val TAG = "WvmgWifiDirect"
+    }
+}

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/medium/WifiDirectTransport.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/medium/WifiDirectTransport.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.discovery.medium
+
+import io.github.kyujincho.wvmg.protocol.medium.Medium
+import io.github.kyujincho.wvmg.protocol.medium.UpgradedTransport
+import java.io.Closeable
+import java.net.Socket
+
+/**
+ * [UpgradedTransport] subtype produced by
+ * [WifiDirectMediumProvider.adoptUpgrade] (#49).
+ *
+ * Carries the live TCP [Socket] opened over the freshly-formed Wi-Fi
+ * P2P group plus a [teardown] callback the orchestrator must invoke
+ * when the upgrade either completes or fails.
+ *
+ * Why a dedicated subtype: the framework treats every `UpgradedTransport`
+ * as opaque, but the orchestrator (#54) needs to recover the socket to
+ * wrap it in a fresh `FramedConnection` + SecureChannel. Hand-rolling
+ * a marker subclass per medium keeps that coupling explicit and avoids
+ * leaking `java.net.Socket` (or worse, `WifiP2pManager`) into
+ * `:core-protocol`.
+ *
+ * [teardown] removes the P2P group ownership we created in
+ * `prepareUpgrade` (server side) or releases the platform-supplied
+ * channel (client side). The orchestrator drives it from the upgrade
+ * completion / failure path so the radio is freed even when an upgrade
+ * aborts mid-handshake.
+ *
+ * @property socket Live TCP socket on the new transport. Caller-owned
+ *   from this point on.
+ * @property teardown Cleanup hook for the underlying P2P group.
+ *   Idempotent; safe to call from any thread.
+ */
+public data class WifiDirectTransport(
+    val socket: Socket,
+    val teardown: Closeable,
+) : UpgradedTransport {
+    override val medium: Medium = Medium.WIFI_DIRECT
+}

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/medium/WvmgMediumRegistries.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/medium/WvmgMediumRegistries.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.discovery.medium
+
+import android.content.Context
+import io.github.kyujincho.wvmg.protocol.medium.MediumProvider
+import io.github.kyujincho.wvmg.protocol.medium.MediumRegistry
+
+/**
+ * App-side factory for [MediumRegistry] instances that include the
+ * Phase 4 Android-only medium adapters (#49–#53).
+ *
+ * Lives in `:discovery-android` (rather than `:core-protocol`) because
+ * each provider it instantiates depends on `android.*`. The orchestrator
+ * wiring in `:app` / `:service-android` calls into here once at
+ * `Application.onCreate`; the framework defaults
+ * ([MediumRegistry.DefaultWifiLan]) remain the source of truth for
+ * tests and for callers that opt out of the Android adapters.
+ *
+ * As more Phase 4 sub-issues land, each adds its provider to
+ * [withWifiDirect]'s sibling factories. The `with…` naming makes it
+ * obvious at the call site which mediums are being plugged in.
+ */
+public object WvmgMediumRegistries {
+    /**
+     * Build a [MediumRegistry] containing the default Wi-Fi LAN
+     * provider plus the Wi-Fi Direct provider from #49.
+     *
+     * The Wi-Fi LAN slot reuses [MediumRegistry.DefaultWifiLan]'s
+     * trivial provider so the resulting registry is a strict superset
+     * of today's behaviour — adding [WifiDirectMediumProvider] does
+     * NOT change Wi-Fi LAN's role as the default discovery medium.
+     *
+     * Callers that want only Wi-Fi LAN (e.g. unit tests, or a build
+     * variant where Wi-Fi Direct is disabled) should keep using
+     * [MediumRegistry.DefaultWifiLan] directly.
+     */
+    @JvmStatic
+    public fun withWifiDirect(context: Context): MediumRegistry {
+        // Reuse the default provider list rather than duplicating the
+        // Wi-Fi LAN entry by name — DefaultWifiLan is the canonical
+        // place where "what does WIFI_LAN mean today" is defined, so
+        // any future change there propagates here automatically.
+        val defaults = MediumRegistry.DefaultWifiLan
+        val providers = mutableListOf<MediumProvider>()
+        for (medium in defaults.supportedMediums()) {
+            defaults.providerFor(medium)?.let { providers += it }
+        }
+        providers += WifiDirectMediumProvider(context.applicationContext)
+        return MediumRegistry(providers = providers)
+    }
+}

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/medium/WifiDirectMediumProviderTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/medium/WifiDirectMediumProviderTest.kt
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.discovery.medium
+
+import com.google.common.truth.Truth.assertThat
+import io.github.kyujincho.wvmg.protocol.medium.Medium
+import io.github.kyujincho.wvmg.protocol.medium.UpgradePathCredentials
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.net.ServerSocket
+
+/**
+ * JVM-only coverage for [WifiDirectMediumProvider]'s pure-Kotlin
+ * surface (#49).
+ *
+ * The Android `WifiP2pManager` choreography lives in
+ * [WifiDirectGroupController] and is exercised manually on hardware
+ * (see `docs/testing/medium-wifi-direct.md`); the provider itself is
+ * thin enough to test by injecting a controller factory that returns
+ * either `null` (controller unavailable) or a fake. The tests below
+ * lock down the contract the framework relies on:
+ *
+ *  1. `medium == WIFI_DIRECT` (registry uniqueness key).
+ *  2. `isSupported` defers to the supplied [WifiDirectAvailability].
+ *  3. `prepareUpgrade` short-circuits when the controller factory
+ *     yields `null`, leaving no allocated ServerSocket behind.
+ *  4. `adoptUpgrade` rejects mismatched-medium credentials without
+ *     touching the controller.
+ *  5. `adoptUpgrade` rejects `Generic(WIFI_DIRECT)` (no concrete
+ *     bring-up parameters).
+ *  6. `cancelPending` / `consumePending*` are idempotent on a fresh
+ *     provider.
+ *
+ * Robolectric / on-device coverage of the actual P2P calls is
+ * intentionally out-of-scope here — those code paths require platform
+ * I/O and are documented in the manual checklist.
+ */
+class WifiDirectMediumProviderTest {
+    private class FakeAvailability(
+        private val supported: Boolean,
+    ) : WifiDirectAvailability {
+        override fun isSupported(): Boolean = supported
+    }
+
+    @Test
+    fun `medium is WIFI_DIRECT`() {
+        val provider = newProvider(supported = false)
+        assertThat(provider.medium).isEqualTo(Medium.WIFI_DIRECT)
+    }
+
+    @Test
+    fun `isSupported defers to the availability probe`() {
+        assertThat(newProvider(supported = true).isSupported()).isTrue()
+        assertThat(newProvider(supported = false).isSupported()).isFalse()
+    }
+
+    @Test
+    fun `prepareUpgrade returns null when controller factory yields null`() =
+        runTest {
+            val socketFactoryCalls = IntArray(1)
+            val provider =
+                WifiDirectMediumProvider(
+                    availability = FakeAvailability(true),
+                    controllerFactory = { null },
+                    serverSocketFactory = {
+                        socketFactoryCalls[0]++
+                        ServerSocket(0)
+                    },
+                )
+            assertThat(provider.prepareUpgrade()).isNull()
+            // Short-circuit before allocating the listener — no port
+            // pinned by a failed prepare.
+            assertThat(socketFactoryCalls[0]).isEqualTo(0)
+        }
+
+    @Test
+    fun `adoptUpgrade rejects mismatched medium`() =
+        runTest {
+            val provider = newProvider(supported = true)
+            val result =
+                provider.adoptUpgrade(
+                    UpgradePathCredentials.WifiLan(
+                        ipAddress = byteArrayOf(10, 0, 0, 1),
+                        port = 1234,
+                    ),
+                )
+            assertThat(result).isNull()
+        }
+
+    @Test
+    fun `adoptUpgrade rejects Generic credentials with WIFI_DIRECT medium`() =
+        runTest {
+            // The peer advertised WIFI_DIRECT but did not include the
+            // sub-message — decoder collapses to Generic. The provider
+            // cannot bring up a group without SSID/passphrase, so this
+            // must fail back rather than NPE.
+            val provider = newProvider(supported = true)
+            val result = provider.adoptUpgrade(UpgradePathCredentials.Generic(Medium.WIFI_DIRECT))
+            assertThat(result).isNull()
+        }
+
+    @Test
+    fun `adoptUpgrade returns null when controller factory yields null even with valid credentials`() =
+        runTest {
+            val provider = newProvider(supported = true)
+            val result =
+                provider.adoptUpgrade(
+                    UpgradePathCredentials.WifiDirect(
+                        ipAddress = byteArrayOf(192.toByte(), 168.toByte(), 49, 1),
+                        port = 8443,
+                        ssid = "DIRECT-aa-test",
+                        passphrase = "secret",
+                    ),
+                )
+            assertThat(result).isNull()
+        }
+
+    @Test
+    fun `cancelPending is a no-op when nothing is in flight`() {
+        val provider = newProvider(supported = true)
+        provider.cancelPending() // Must not throw.
+        provider.cancelPending() // Idempotent.
+    }
+
+    @Test
+    fun `consumePendingServerSocket returns null when prepareUpgrade was never called`() {
+        val provider = newProvider(supported = true)
+        assertThat(provider.consumePendingServerSocket()).isNull()
+    }
+
+    @Test
+    fun `consumePendingClientTransport returns null when adoptUpgrade was never successful`() {
+        val provider = newProvider(supported = true)
+        assertThat(provider.consumePendingClientTransport()).isNull()
+    }
+
+    private fun newProvider(supported: Boolean): WifiDirectMediumProvider =
+        WifiDirectMediumProvider(
+            availability = FakeAvailability(supported),
+            controllerFactory = { null },
+            serverSocketFactory = { ServerSocket(0) },
+        )
+}

--- a/docs/testing/medium-wifi-direct.md
+++ b/docs/testing/medium-wifi-direct.md
@@ -1,0 +1,189 @@
+# Manual test: Wi-Fi Direct bandwidth-upgrade medium
+
+This is the on-device runbook for verifying the Wi-Fi Direct (P2P)
+bandwidth-upgrade adapter shipped in
+[#49](https://github.com/kyujin-cho/WhenVivoMeetsGoogle/issues/49) under
+the [Phase 4 epic](https://github.com/kyujin-cho/WhenVivoMeetsGoogle/issues/4).
+
+The Phase 4 framework (#48 / #54) is the layer that *decides* to upgrade
+to Wi-Fi Direct after the initial Wi-Fi LAN connection has been
+established. This runbook covers the per-medium adapter only — once the
+orchestrator wiring lands in #54 the same checklist will apply to
+end-to-end transfers.
+
+---
+
+## What is being verified
+
+1. **Capability gating.** `WifiDirectAvailability.Default` reports
+   `isSupported() == true` only when:
+   * the device exposes `PackageManager.FEATURE_WIFI_DIRECT`,
+   * `getSystemService(Context.WIFI_P2P_SERVICE)` returns a
+     `WifiP2pManager`, and
+   * `NEARBY_WIFI_DEVICES` is granted on API 33+ (or
+     `ACCESS_FINE_LOCATION` on API 32 and below).
+2. **Receiver-side group bring-up.** `WifiDirectGroupController.createGroupAsServer`
+   calls `WifiP2pManager.createGroup`, observes the
+   `WIFI_P2P_CONNECTION_CHANGED_ACTION` broadcast, and returns
+   `UpgradePathCredentials.WifiDirect` populated with the GO IP, port,
+   SSID, and passphrase from `WifiP2pInfo` / `WifiP2pGroup`.
+3. **Sender-side join.** `WifiDirectGroupController.connectAsClient`
+   calls `WifiP2pManager.connect` with the credentials from the wire,
+   waits for the connection broadcast, and opens a TCP socket to the
+   GO at `credentials.ipAddress:credentials.port`.
+4. **Throughput uplift.** A 1 GB transfer over the freshly-formed Wi-Fi
+   Direct link sustains ≥ 150 Mbps — the acceptance criterion from #49.
+5. **Graceful fallback.** When any step above fails, the adapter
+   returns `null` from `prepareUpgrade` / `adoptUpgrade` and the
+   negotiator FSM emits `UPGRADE_FAILURE`, leaving the existing
+   Wi-Fi LAN transfer running.
+
+---
+
+## Pre-flight
+
+* Two Android devices, both API 31+. Ideal pairs:
+  * Pixel 8 Pro (Android 14) ↔ Galaxy S24 (One UI 6).
+  * Pixel 7 (Android 13) ↔ Pixel 8 (Android 14).
+* Both devices on the same Wi-Fi network for the initial Wi-Fi LAN
+  connection. The router itself is not used by the upgraded transport
+  — Wi-Fi Direct is a peer-to-peer link — but discovery needs LAN.
+* `adb` connected to *both* devices simultaneously. Use
+  `adb devices -l` to confirm and address them with `adb -s <serial>`.
+* App build: install the same debug APK on both devices.
+  ```
+  ./gradlew :app:installDebug
+  ```
+* Ensure the Wi-Fi Direct grant dialog has been accepted at least once
+  per device. Some OEM skins (Samsung, vivo) hide the toggle inside
+  Settings → Connections → Wi-Fi → Advanced → Wi-Fi Direct; trigger it
+  there if the platform never asks.
+
+---
+
+## Logcat tags
+
+```
+adb logcat -s WvmgWifiDirect WvmgOutbound WvmgSend
+```
+
+Expected lines on the receiver during a successful upgrade:
+
+```
+WvmgWifiDirect: WifiP2pManager.createGroup OK
+WvmgWifiDirect: WIFI_P2P_CONNECTION_CHANGED_ACTION groupFormed=true isGroupOwner=true
+```
+
+On the sender:
+
+```
+WvmgWifiDirect: WifiP2pManager.connect OK
+WvmgWifiDirect: WIFI_P2P_CONNECTION_CHANGED_ACTION groupFormed=true isGroupOwner=false
+WvmgWifiDirect: TCP connect to 192.168.49.1:<port> OK
+```
+
+Failures are logged as `Log.w(TAG, …)` and accompanied by the platform
+reason code (`BUSY`, `P2P_UNSUPPORTED`, `ERROR`, `NO_SERVICE_REQUESTS`).
+
+---
+
+## Test cases
+
+### TC1 — Capability check matrix
+
+| Device                   | Expected `isSupported()` | Notes |
+|--------------------------|--------------------------|-------|
+| Pixel 8 Pro (API 34)     | `true` after grant       | `NEARBY_WIFI_DEVICES` |
+| Galaxy S24 (One UI 6)    | `true` after grant       | Same |
+| Pixel 4a (API 30)        | `true` after grant       | Falls back to `ACCESS_FINE_LOCATION` |
+| Android emulator (x86)   | `false`                  | No `FEATURE_WIFI_DIRECT` |
+
+Verification: send via the app once; in logcat, confirm
+`MediumRegistry.supportedMediums()` includes `WIFI_DIRECT`. (Add a
+`Log.i(TAG, supportedMediums().toString())` in
+`WvmgMediumRegistries.withWifiDirect` while debugging.)
+
+### TC2 — Receiver creates a group, sender joins, GO IP matches
+
+1. Open WhenVivoMeetsGoogle on both devices.
+2. On the sender, share a small file (1 MB) to the receiver via the
+   share sheet → WhenVivoMeetsGoogle.
+3. On the receiver, accept the consent prompt.
+4. **Before the file actually starts transferring**, in another shell,
+   run on the receiver:
+   ```
+   adb -s <receiver-serial> shell dumpsys wifip2p | grep -E 'mGroupOwner|mDeviceAddress|networkName|passphrase'
+   ```
+5. Confirm `groupOwner=true` on the receiver and the SSID/passphrase
+   match what `WvmgWifiDirect` logged.
+6. On the sender, run the same `dumpsys wifip2p` and confirm the
+   group-owner address matches the receiver.
+
+### TC3 — 1 GB throughput
+
+1. Pick a ~1 GB file (e.g. an Android system image).
+2. Time the transfer end-to-end with `time` on the wrapping shell:
+   ```
+   time adb shell …
+   ```
+   The app's progress notification also reports MiB/s once #46 lands.
+3. Compute throughput: `1024 MiB / elapsed_seconds`. Acceptance
+   criterion is ≥ 150 Mbps sustained (≈ 18.75 MiB/s).
+4. Compare against the same transfer over Wi-Fi LAN only (uninstall the
+   #49 build, reinstall the #48 baseline, repeat). The Wi-Fi Direct
+   path should be measurably faster, especially on a congested
+   2.4 GHz network.
+
+### TC4 — Graceful fallback when Wi-Fi Direct fails
+
+Setup the failure path by either:
+* **Revoking `NEARBY_WIFI_DEVICES`** on the sender mid-transfer.
+* **Force-stopping the WifiP2pService** with
+  `adb shell pkill -f wifip2p` (root or `userdebug` build only).
+
+Expected: the negotiator FSM emits `BandwidthUpgradeEvent.AdoptFailed`
+followed by `UPGRADE_FAILURE` on the wire; the transfer continues over
+the original Wi-Fi LAN socket and finishes successfully. Verify with:
+
+```
+adb logcat -s WvmgOutbound | grep -E 'UPGRADE_FAILURE|UpgradeAborted'
+```
+
+### TC5 — Receiver tears down the group on completion
+
+1. Trigger any successful Wi-Fi Direct transfer.
+2. After the transfer completes, on the receiver:
+   ```
+   adb shell dumpsys wifip2p | grep -E 'GroupOwner|networkName'
+   ```
+3. Expected: no live group. The receiver's `WifiDirectMediumProvider.cancelPending`
+   removed it.
+
+### TC6 — Two back-to-back transfers reuse the radio cleanly
+
+1. Send file A. Wait for completion.
+2. Immediately send file B.
+3. Expected: both transfers complete; the second does not stall
+   waiting for a stale group to release. If it stalls, check
+   `WvmgWifiDirect: WifiP2pManager.removeGroup` ran during step 1's
+   completion path.
+
+---
+
+## Known platform quirks
+
+* **Samsung One UI 7+** sometimes ignores
+  `WifiP2pConfig.groupOwnerIntent = 0` and elects itself GO. The
+  adapter copes by reading the actual `isGroupOwner` from the
+  broadcast and re-routing accordingly; if you observe the sender
+  side claiming GO, that's the fallback at work.
+* **Pixel devices on Android 15** require the foreground app to hold
+  `NEARBY_WIFI_DEVICES`; background services trying to call
+  `WifiP2pManager.createGroup` get `ERROR` (5). Quick Share runs in a
+  foreground-service-with-`connectedDevice` type, which qualifies.
+* **vivo Funtouch OS** silently drops `WIFI_P2P_CONNECTION_CHANGED_ACTION`
+  when the activity is paused. The adapter registers the receiver with
+  `ContextCompat.RECEIVER_NOT_EXPORTED` on the application context, so
+  this is not an issue in practice; if you see missed broadcasts on a
+  vivo device, double-check the receiver lifecycle isn't tied to an
+  activity.


### PR DESCRIPTION
## Summary

First Phase 4 sub-medium adapter on top of the framework merged in #48 (closes #49). Adds Wi-Fi Direct (P2P) as a bandwidth-upgrade target so two devices on the same Wi-Fi LAN can hand off the bulk transfer to a peer-to-peer link with significantly higher throughput.

### Public surface

- `UpgradePathCredentials.WifiDirect` (`:core-protocol`) — sealed subtype carrying the group-owner IPv4 address, port, SSID, passphrase, and optional channel frequency. Structural-equality `equals`/`hashCode` for the `ByteArray` field, IPv4-length `require`, `FREQUENCY_NOT_SET` sentinel.
- `BandwidthUpgradeFrames.encodeCredentials` / `decodeCredentials` — new `WIFI_DIRECT` arm in both directions. Marshals the gateway IPv4 to/from the proto's dotted-quad `string` field; collapses to `Generic(WIFI_DIRECT)` when the sub-message is missing or malformed so the negotiator FSM never protocol-errors on a partial advertisement.
- `WifiDirectMediumProvider` (`:discovery-android`) — `MediumProvider` implementation. `isSupported()` gates on `FEATURE_WIFI_DIRECT`, the `WifiP2pManager` system service, and the `NEARBY_WIFI_DEVICES` (API 33+) / `ACCESS_FINE_LOCATION` (≤32) runtime grant. `prepareUpgrade` (server) calls `createGroup`, observes the connection-changed broadcast, returns the credentials populated from `WifiP2pInfo` + `WifiP2pGroup`. `adoptUpgrade` (client) calls `connect` and opens a TCP socket to the GO.
- `WifiDirectTransport` — `UpgradedTransport` subtype carrying the live `Socket` plus a `Closeable` teardown.
- `WvmgMediumRegistries.withWifiDirect(Context)` — app-side factory that adds the provider to `MediumRegistry.DefaultWifiLan`. Registration glue point for `WvmgApplication` once #54 wires the orchestrator.

### Why this shape

- The provider takes an `internal` constructor with injected `WifiDirectAvailability` interface, controller factory, and `serverSocketFactory` so the JVM tests can exercise the contract without Android system services.
- The Android-specific `WifiP2pManager` choreography is isolated in `WifiDirectGroupController`, which is intentionally not unit-tested (it's all platform I/O); it is exercised manually per the runbook.
- `Manifest.permission.NEARBY_WIFI_DEVICES` and the optional `android.hardware.wifi.direct` `<uses-feature>` are declared at the `:discovery-android` library level so consumers inherit the requirement automatically.

### Tests

- `:core-protocol:test` — `BandwidthUpgradeFramesTest` gains 8 cases (encode, decode round-trip, frequency omission, fallback to Generic on missing sub-message, IPv4 validation, structural equality). All 16 tests in the class PASS.
- `:discovery-android:testDebugUnitTest` — new `WifiDirectMediumProviderTest` with 9 cases pinning the contract the framework relies on. All PASS.
- `./gradlew staticAnalysis` — PASS (ktlint + detekt across all modules).
- `./gradlew :app:assembleDebug` — PASS.

### Files modified in shared framework

For the orchestrator's awareness when merging the parallel #50 / #51 / #52 / #53 PRs:

- `core-protocol/.../medium/UpgradePathCredentials.kt` — added `WifiDirect` data class at the bottom of the sealed interface (additive, no restructuring).
- `core-protocol/.../connection/BandwidthUpgradeFrames.kt` — added `WIFI_DIRECT ->` arms in both `decodeCredentials` and `encodeCredentials`, plus three new private helpers (`decodeWifiDirect`, `ipv4BytesToDottedQuad`, `dottedQuadToIpv4Bytes`) and a `BYTE_MASK` constant.
- `core-protocol/.../connection/BandwidthUpgradeFramesTest.kt` — appended 8 new `@Test` cases.

### Manual interop test plan

`docs/testing/medium-wifi-direct.md` documents TC1 (capability matrix), TC2 (group bring-up + GO IP verification via `dumpsys wifip2p`), TC3 (1 GB throughput floor of ≥150 Mbps per the issue's acceptance criterion), TC4 (graceful fallback when the radio fails), TC5 (teardown), TC6 (back-to-back transfers reuse the radio).

Closes #49.