### PR TITLE
feat(medium): Wi-Fi local-only hotspot bandwidth-upgrade provider (#50)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -106,6 +106,19 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
 
+    <!-- Wi-Fi local-only hotspot bandwidth-upgrade medium (#50). Both
+         lines are required by WifiManager.startLocalOnlyHotspot on
+         API 26+ — CHANGE_WIFI_STATE is install-time normal protection
+         level; ACCESS_FINE_LOCATION is the runtime grant the platform
+         demands before it will surface the SSID/passphrase in the
+         LocalOnlyHotspotReservation callback. The provider in
+         :discovery-android also accepts NEARBY_WIFI_DEVICES (already
+         declared above for Wi-Fi peer discovery) as a substitute on
+         API 33+ devices, so the location grant is requested at
+         onboarding only when the platform requires it. -->
+    <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+
     <!-- Satisfies the Android 14+ FGS-type gate for `connectedDevice`.
          Normal protection level, so no runtime prompt. We do not actually
          acquire a MulticastLock — NsdManager handles mDNS in the system

--- a/app/src/test/kotlin/io/github/kyujincho/wvmg/AndroidManifestPermissionsTest.kt
+++ b/app/src/test/kotlin/io/github/kyujincho/wvmg/AndroidManifestPermissionsTest.kt
@@ -152,14 +152,16 @@ class AndroidManifestPermissionsTest {
     }
 
     @Test
-    fun `bluetooth connect is not declared yet`() {
-        // BLUETOOTH_CONNECT is only needed when initiating or accepting
-        // GATT connections — Phase 2 only advertises and scans, so
-        // declaring CONNECT today would surface a permission prompt the
-        // app does not need. Guard against accidentally pulling it in
-        // before BLE L2CAP support lands.
-        assertFalse(
-            "BLUETOOTH_CONNECT must NOT be declared until BLE L2CAP support lands",
+    fun `bluetooth connect is declared for phase 4 bluetooth rfcomm medium`() {
+        // BLUETOOTH_CONNECT was kept off the manifest through Phase 2
+        // (only ADVERTISE / SCAN were needed for the BLE pulse layer).
+        // Phase 4 issue #51 adds the Bluetooth RFCOMM bandwidth-upgrade
+        // medium, which calls listenUsingInsecureRfcommWithServiceRecord
+        // on the receiver and createInsecureRfcommSocketToServiceRecord
+        // on the sender — both gated by BLUETOOTH_CONNECT at runtime on
+        // API 31+. The umbrella manifest must therefore declare it.
+        assertTrue(
+            "BLUETOOTH_CONNECT must be declared for the Phase 4 Bluetooth RFCOMM medium (#51)",
             manifest.contains("android.permission.BLUETOOTH_CONNECT"),
         )
     }
@@ -169,20 +171,52 @@ class AndroidManifestPermissionsTest {
         // Phase 1 uses the system share-intent flow, which does not need
         // direct media access. READ_MEDIA_* would surface needless
         // permissions to users — guard against that drift.
+        //
+        // ACCESS_FINE_LOCATION used to be on this list as a Phase 1
+        // safety guard. Phase 4 #50 (Wi-Fi local-only hotspot
+        // bandwidth-upgrade medium) requires the platform's hotspot
+        // path to surface SSID + passphrase via the
+        // LocalOnlyHotspotReservation callback, which gates that data
+        // behind ACCESS_FINE_LOCATION on API 26+ (NEARBY_WIFI_DEVICES
+        // is accepted in lieu on API 33+ but the older grant is the
+        // only universally-supported one). We therefore moved the
+        // permission off the forbidden list and added a dedicated
+        // declaration test below.
+        //
+        // ACCESS_COARSE_LOCATION remains forbidden — we never want
+        // the coarse-location permission, only the fine-grained one
+        // when the hotspot path strictly requires it.
         val mediaForbidden =
             listOf(
                 "android.permission.READ_MEDIA_IMAGES",
                 "android.permission.READ_MEDIA_VIDEO",
                 "android.permission.READ_MEDIA_AUDIO",
-                "android.permission.ACCESS_FINE_LOCATION",
                 "android.permission.ACCESS_COARSE_LOCATION",
             )
         for (permission in mediaForbidden) {
             assertFalse(
-                "$permission must NOT be declared in Phase 1",
+                "$permission must NOT be declared",
                 manifest.contains(permission),
             )
         }
+    }
+
+    @Test
+    fun `wifi hotspot upgrade permissions declared for phase 4 issue 50`() {
+        // Wi-Fi local-only hotspot (WIFI_HOTSPOT bandwidth-upgrade
+        // medium, #50) needs CHANGE_WIFI_STATE to call
+        // WifiManager.startLocalOnlyHotspot and ACCESS_FINE_LOCATION
+        // for the platform to surface SSID + passphrase via the
+        // reservation callback on API 26+. Both must be declared in
+        // the umbrella manifest.
+        assertTrue(
+            "CHANGE_WIFI_STATE must be declared for Wi-Fi local-only hotspot (#50)",
+            manifest.contains("android.permission.CHANGE_WIFI_STATE"),
+        )
+        assertTrue(
+            "ACCESS_FINE_LOCATION must be declared for Wi-Fi local-only hotspot (#50)",
+            manifest.contains("android.permission.ACCESS_FINE_LOCATION"),
+        )
     }
 
     @Test

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeFrames.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeFrames.kt
@@ -280,6 +280,43 @@ public object BandwidthUpgradeFrames {
             // so the negotiator can still surface "an upgrade was
             // offered" and the provider can reject it cleanly on adopt.
             Medium.WIFI_DIRECT -> decodeWifiDirect(info) ?: UpgradePathCredentials.Generic(medium)
+            // Wi-Fi local-only hotspot (#50). Mirrors the WifiDirect
+            // arm: the WifiHotspotCredentials sub-message carries
+            // SSID + passphrase + port + (optional) gateway and
+            // (optional) frequency. Falls back to Generic when the
+            // sub-message is absent so the negotiator can surface
+            // "an upgrade was offered" and the provider can reject it
+            // cleanly on adopt.
+            Medium.WIFI_HOTSPOT -> {
+                if (info.hasWifiHotspotCredentials()) {
+                    val raw = info.wifiHotspotCredentials
+                    UpgradePathCredentials.WifiHotspot(
+                        ssid = raw.ssid,
+                        passphrase = raw.password,
+                        port = raw.port,
+                        // Proto defaults: gateway -> "0.0.0.0", frequency -> -1.
+                        // `optional` proto3 / proto2 hasField semantics mean
+                        // an absent field reads back as the proto default,
+                        // which is exactly the "not set" sentinel we want
+                        // to surface to the adapter, so the explicit
+                        // hasGateway / hasFrequency checks are unnecessary.
+                        gateway =
+                            if (raw.hasGateway()) {
+                                raw.gateway
+                            } else {
+                                UpgradePathCredentials.WifiHotspot.DEFAULT_GATEWAY
+                            },
+                        frequencyMhz =
+                            if (raw.hasFrequency()) {
+                                raw.frequency
+                            } else {
+                                UpgradePathCredentials.WifiHotspot.FREQUENCY_NOT_SET
+                            },
+                    )
+                } else {
+                    UpgradePathCredentials.Generic(medium)
+                }
+            }
             // Remaining Phase 4 sub-issues plug the rest of the arms in
             // here as their adapters land. Until then we report Generic
             // so the upper layers can at least see that *some* path
@@ -291,7 +328,6 @@ public object BandwidthUpgradeFrames {
             // proto reserves wire number 10 there). The path that
             // builds the wire frame for BLE_L2CAP must use the
             // discovery-medium path instead — see Phase 4 #52.
-            Medium.WIFI_HOTSPOT,
             Medium.BLE_L2CAP,
             Medium.BLE,
             Medium.WEB_RTC,
@@ -372,6 +408,28 @@ public object BandwidthUpgradeFrames {
                     direct.frequency = credentials.frequency
                 }
                 builder.setWifiDirectCredentials(direct.build())
+            }
+            // Wi-Fi local-only hotspot (#50).
+            is UpgradePathCredentials.WifiHotspot -> {
+                val hotspot =
+                    UpgradePathInfo.WifiHotspotCredentials
+                        .newBuilder()
+                        .setSsid(credentials.ssid)
+                        .setPassword(credentials.passphrase)
+                        .setPort(credentials.port)
+                // Only set gateway / frequency when they carry information
+                // beyond the proto default. The wire is more compact and
+                // — more importantly — round-trips back through the
+                // `hasGateway()` / `hasFrequency()` checks in
+                // [decodeCredentials] preserving the "field not set"
+                // semantics the adapter relies on.
+                if (credentials.gateway != UpgradePathCredentials.WifiHotspot.DEFAULT_GATEWAY) {
+                    hotspot.gateway = credentials.gateway
+                }
+                if (credentials.frequencyMhz != UpgradePathCredentials.WifiHotspot.FREQUENCY_NOT_SET) {
+                    hotspot.frequency = credentials.frequencyMhz
+                }
+                builder.setWifiHotspotCredentials(hotspot.build())
             }
         }
         return builder.build()

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/medium/UpgradePathCredentials.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/medium/UpgradePathCredentials.kt
@@ -335,4 +335,69 @@ public sealed interface UpgradePathCredentials {
             public const val FREQUENCY_NOT_SET: Int = -1
         }
     }
+
+    /**
+     * Wi-Fi local-only hotspot (soft-AP) credentials — the bring-up
+     * parameters the receiver needs to associate with the sender's
+     * temporary access point and then open a TCP socket on the
+     * hotspot subnet.
+     *
+     * Maps 1:1 onto `UpgradePathInfo.WifiHotspotCredentials`:
+     *
+     * ```
+     * message WifiHotspotCredentials {
+     *   optional string ssid = 1;
+     *   optional string password = 2;
+     *   optional int32 port = 3;
+     *   optional string gateway = 4 [default = "0.0.0.0"];
+     *   optional int32 frequency = 5 [default = -1];
+     * }
+     * ```
+     *
+     * `gateway` doubles as the server IP on the hotspot subnet — the
+     * proto carries no separate `ip_address` field for hotspot because
+     * Android's `LocalOnlyHotspotReservation` always installs the
+     * server-side socket on the gateway IP (typically 192.168.49.1).
+     * The peer reaches us at `gateway:port` after associating with
+     * `ssid` using `password`.
+     *
+     * @param ssid Hotspot SSID broadcast by `WifiManager.startLocalOnlyHotspot`.
+     * @param passphrase WPA2 passphrase from the same callback.
+     * @param port TCP port the server-side ServerSocket bound to on
+     *   the hotspot interface.
+     * @param gateway Dotted-quad IPv4 address of the hotspot gateway
+     *   (server side). Defaults to the proto sentinel `"0.0.0.0"`,
+     *   which the receiver must treat as "use the DHCP-supplied
+     *   gateway".
+     * @param frequencyMhz Operating frequency in MHz (proto sentinel
+     *   `-1` = unset). Hint only; the receiver cannot influence the
+     *   AP's channel choice.
+     */
+    public data class WifiHotspot(
+        val ssid: String,
+        val passphrase: String,
+        val port: Int,
+        val gateway: String = DEFAULT_GATEWAY,
+        val frequencyMhz: Int = FREQUENCY_NOT_SET,
+    ) : UpgradePathCredentials {
+        override val medium: Medium = Medium.WIFI_HOTSPOT
+
+        public companion object {
+            /**
+             * Proto default for `WifiHotspotCredentials.gateway`. A
+             * receiver that sees this value MUST fall back to the
+             * gateway address its DHCP client received after joining
+             * the hotspot's SSID.
+             */
+            public const val DEFAULT_GATEWAY: String = "0.0.0.0"
+
+            /**
+             * Proto default for `WifiHotspotCredentials.frequency`
+             * meaning "field not set". Matches `google/nearby` and
+             * the `STA_FREQUENCY_NOT_SET` sentinel used elsewhere in
+             * the bandwidth-upgrade frames.
+             */
+            public const val FREQUENCY_NOT_SET: Int = -1
+        }
+    }
 }

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeFramesTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeFramesTest.kt
@@ -389,6 +389,77 @@ class BandwidthUpgradeFramesTest {
     }
 
     @Test
+    fun `upgradePathAvailable carries Wi-Fi Hotspot credentials`() {
+        val frame =
+            BandwidthUpgradeFrames.upgradePathAvailable(
+                UpgradePathCredentials.WifiHotspot(
+                    ssid = "DIRECT-AB-Quickshare",
+                    passphrase = "p4ssphrase",
+                    port = 41201,
+                    gateway = "192.168.49.1",
+                    frequencyMhz = 5180,
+                ),
+            )
+        val parsed = parse(frame)
+        assertThat(parsed.upgradePathInfo.medium.number).isEqualTo(Medium.WIFI_HOTSPOT.wireNumber)
+        assertThat(parsed.upgradePathInfo.hasWifiHotspotCredentials()).isTrue()
+        val raw = parsed.upgradePathInfo.wifiHotspotCredentials
+        assertThat(raw.ssid).isEqualTo("DIRECT-AB-Quickshare")
+        assertThat(raw.password).isEqualTo("p4ssphrase")
+        assertThat(raw.port).isEqualTo(41201)
+        assertThat(raw.gateway).isEqualTo("192.168.49.1")
+        assertThat(raw.frequency).isEqualTo(5180)
+    }
+
+    @Test
+    fun `decodeCredentials round-trips Wi-Fi Hotspot with all fields`() {
+        val original =
+            UpgradePathCredentials.WifiHotspot(
+                ssid = "AndroidShare_xyz",
+                passphrase = "correcthorsebatterystaple",
+                port = 53111,
+                gateway = "192.168.49.1",
+                frequencyMhz = 2412,
+            )
+        val frame = BandwidthUpgradeFrames.upgradePathAvailable(original)
+        val parsed = parse(frame)
+        val decoded = BandwidthUpgradeFrames.decodeCredentials(parsed.upgradePathInfo)
+        assertThat(decoded).isEqualTo(original)
+    }
+
+    @Test
+    fun `decodeCredentials round-trips Wi-Fi Hotspot omitting optional fields`() {
+        // The encoder skips gateway and frequency when they hold the
+        // proto-default sentinels; the decoder must re-materialise the
+        // sentinels from `hasGateway()` / `hasFrequency()` returning false.
+        val original =
+            UpgradePathCredentials.WifiHotspot(
+                ssid = "DIRECT-CD",
+                passphrase = "secret",
+                port = 12345,
+            )
+        val frame = BandwidthUpgradeFrames.upgradePathAvailable(original)
+        val parsed = parse(frame)
+        val raw = parsed.upgradePathInfo.wifiHotspotCredentials
+        assertThat(raw.hasGateway()).isFalse()
+        assertThat(raw.hasFrequency()).isFalse()
+        val decoded = BandwidthUpgradeFrames.decodeCredentials(parsed.upgradePathInfo)
+        assertThat(decoded).isEqualTo(original)
+    }
+
+    @Test
+    fun `decodeCredentials returns Generic when WIFI_HOTSPOT is missing the sub-message`() {
+        // A bug-compatible peer might send `medium=WIFI_HOTSPOT` with no
+        // `wifi_hotspot_credentials` populated. Treat it as a generic
+        // "advertised but no credentials" frame so the upper layer can
+        // fall back to UPGRADE_FAILURE rather than crashing.
+        val frame = BandwidthUpgradeFrames.upgradePathAvailable(UpgradePathCredentials.Generic(Medium.WIFI_HOTSPOT))
+        val parsed = parse(frame)
+        val decoded = BandwidthUpgradeFrames.decodeCredentials(parsed.upgradePathInfo)
+        assertThat(decoded).isEqualTo(UpgradePathCredentials.Generic(Medium.WIFI_HOTSPOT))
+    }
+
+    @Test
     fun `every builder produces a V1 BANDWIDTH_UPGRADE_NEGOTIATION envelope`() {
         val frames =
             listOf(

--- a/discovery-android/src/main/AndroidManifest.xml
+++ b/discovery-android/src/main/AndroidManifest.xml
@@ -81,47 +81,57 @@
         android:maxSdkVersion="30" />
 
     <!--
-      Wi-Fi Aware (NAN) bandwidth-upgrade medium (#53). Compile-time
-      gating only — the umbrella :app manifest declares the runtime
-      grants the user is asked for. The hardware-feature line is
-      `required="false"` because Wi-Fi Aware coverage is patchy and
-      the app falls back to other mediums on unsupported devices.
+      Wi-Fi family bandwidth-upgrade mediums (#49 Wi-Fi Direct, #50
+      Wi-Fi local-only hotspot, #53 Wi-Fi Aware).
 
-      The data-path bring-up uses ConnectivityManager.requestNetwork
-      with a WifiAwareNetworkSpecifier; this needs CHANGE_WIFI_STATE
-      so the framework can pick a Wi-Fi Aware network on our behalf.
-      Discovery requires either NEARBY_WIFI_DEVICES (API 33+) or
-      ACCESS_FINE_LOCATION; both are runtime-gated and live in :app.
+      Compile-time:
+        * CHANGE_WIFI_STATE — required by:
+          - WifiManager.startLocalOnlyHotspot (sender role,
+            AndroidLocalOnlyHotspotController, #50) on API 26+;
+          - WifiP2pManager.createGroup / connect (#49);
+          - ConnectivityManager.requestNetwork with a
+            WifiAwareNetworkSpecifier (#53), so the framework can
+            pick a Wi-Fi Aware network on our behalf.
+
+      Runtime (must be granted by the user on API 26+):
+        * ACCESS_FINE_LOCATION — historically required by
+          WifiManager.startLocalOnlyHotspot on API 26+ for the SSID /
+          passphrase to surface in the LocalOnlyHotspotReservation
+          callback (#50). NEARBY_WIFI_DEVICES (API 33+) may substitute
+          on newer devices; the permission gate in
+          AndroidLocalOnlyHotspotController.hasRequiredPermissions
+          accepts either grant.
+        * NEARBY_WIFI_DEVICES — declared with neverForLocation so the
+          platform skips the location-tag enforcement on API 33+
+          devices where it can substitute for ACCESS_FINE_LOCATION on
+          the local-only-hotspot path, and is the preferred grant for
+          Wi-Fi Direct discovery (#49) and Wi-Fi Aware
+          publish/subscribe (#53).
+
+      Onboarding (#20 / #31) requests the runtime permissions; these
+      manifest declarations make the requirements library-local so a
+      consumer cannot accidentally compile against the providers
+      without declaring them at the app level.
     -->
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
-
-    <uses-feature
-        android:name="android.hardware.wifi.aware"
-        android:required="false" />
-
-    <!--
-      Wi-Fi Direct medium (#49). Required by WifiDirectMediumProvider /
-      WifiDirectGroupController to call WifiP2pManager.createGroup /
-      connect. neverForLocation tells Android we never derive physical
-      location from peer scans, so the platform skips the
-      ACCESS_FINE_LOCATION requirement that pre-API-33 had to ship
-      alongside this. The umbrella manifest in :app already declares
-      NEARBY_WIFI_DEVICES at the runtime layer; this library-local
-      declaration ensures any consumer of :discovery-android inherits
-      the requirement automatically.
-    -->
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission
         android:name="android.permission.NEARBY_WIFI_DEVICES"
         android:usesPermissionFlags="neverForLocation"
         tools:targetApi="33" />
 
     <!--
-      Hardware-feature hint for Wi-Fi Direct (#49). Marked optional
-      because the medium is a *bandwidth upgrade* — devices without
-      P2P still function over Wi-Fi LAN. WifiDirectAvailability checks
-      PackageManager.FEATURE_WIFI_DIRECT at runtime to decide whether
-      to advertise WIFI_DIRECT in the supported-mediums set.
+      Hardware-feature hints for the optional bandwidth-upgrade
+      mediums. All marked `required="false"` because they are
+      *bandwidth upgrades* — devices without these chipsets still
+      function over Wi-Fi LAN. The matching availability classes
+      (WifiDirectAvailability / WifiAwareAvailability) check the
+      PackageManager features at runtime to decide whether to
+      advertise the medium in the supported-mediums set.
     -->
+    <uses-feature
+        android:name="android.hardware.wifi.aware"
+        android:required="false" />
     <uses-feature
         android:name="android.hardware.wifi.direct"
         android:required="false" />

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/wifi/hotspot/AndroidLocalOnlyHotspotController.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/wifi/hotspot/AndroidLocalOnlyHotspotController.kt
@@ -1,0 +1,297 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+@file:Suppress("MagicNumber") // Wi-Fi reason codes and well-known subnet octets are spec values.
+
+package io.github.kyujincho.wvmg.discovery.wifi.hotspot
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.net.wifi.WifiManager
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import androidx.annotation.RequiresApi
+import androidx.core.content.ContextCompat
+import io.github.kyujincho.wvmg.protocol.medium.UpgradePathCredentials
+import kotlinx.coroutines.suspendCancellableCoroutine
+import java.net.InetAddress
+import java.net.NetworkInterface
+import java.net.ServerSocket
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.coroutines.resume
+
+/**
+ * Production [HotspotController] backed by `WifiManager.startLocalOnlyHotspot`.
+ *
+ * Only available on API 26+ (the platform method itself is API 26+). The
+ * factory in [WifiHotspotMediumProvider]'s wiring layer should null this
+ * out on older devices so [WifiHotspotMediumProvider.isSupported] falls
+ * through to receiver-only or "unsupported" cleanly.
+ *
+ * The hotspot's gateway IP is **not** carried in the
+ * `LocalOnlyHotspotReservation` API on any current API level; we read it
+ * from the network interface created by the OS for the AP. AOSP installs
+ * the AP on `wlan1` with a 192.168.49.1/24 subnet on every Pixel and most
+ * Samsung devices, but reading the actual interface address is the
+ * forward-compatible path (vendors have shipped 192.168.43.x and 10.0.0.x
+ * variants in the past).
+ *
+ * Lifecycle invariant: every successful [start] returns a
+ * [HotspotReservation] whose `teardown` callback unregisters the
+ * platform reservation **and** closes the bound `ServerSocket`. The
+ * orchestrator is required to call it in the transfer-complete /
+ * cancel / failure paths so the radio is freed quickly.
+ *
+ * @param context Application context used for permission checks and to
+ *   look up `WifiManager`.
+ * @param port The TCP port the server-side socket should attempt to
+ *   bind. Pass `0` (default) to let the kernel pick a free ephemeral
+ *   port — the chosen port is surfaced back through the
+ *   [HotspotReservation.credentials] so the peer knows where to
+ *   connect.
+ */
+@RequiresApi(Build.VERSION_CODES.O)
+public class AndroidLocalOnlyHotspotController(
+    private val context: Context,
+    private val port: Int = 0,
+) : HotspotController {
+    private val mainHandler: Handler = Handler(Looper.getMainLooper())
+
+    @Suppress("ReturnCount") // Each early return marks a distinct platform-side failure mode.
+    override suspend fun start(): HotspotReservation? {
+        val wifi = context.getSystemService(Context.WIFI_SERVICE) as? WifiManager ?: return null
+
+        if (!hasRequiredPermissions()) {
+            Log.w(TAG, "Cannot start local-only hotspot: missing required runtime permission.")
+            return null
+        }
+
+        val reservation = bringUp(wifi) ?: return null
+        val gatewayIp = resolveGatewayIp() ?: return abortBringUp(reservation, null, "no gateway IP")
+        val serverSocket = bindServerSocket(gatewayIp, reservation) ?: return null
+        val info = readApInfo(reservation) ?: return abortBringUp(reservation, serverSocket, "SSID/passphrase missing")
+        return assembleReservation(info, gatewayIp, serverSocket, reservation)
+    }
+
+    private suspend fun bringUp(wifi: WifiManager): WifiManager.LocalOnlyHotspotReservation? =
+        try {
+            awaitReservation(wifi)
+        } catch (
+            @Suppress("TooGenericExceptionCaught") t: Throwable,
+        ) {
+            Log.w(TAG, "WifiManager.startLocalOnlyHotspot threw", t)
+            null
+        }
+
+    private fun bindServerSocket(
+        gatewayIp: InetAddress,
+        reservation: WifiManager.LocalOnlyHotspotReservation,
+    ): ServerSocket? =
+        try {
+            // backlog = 1: only the original sender peer should ever connect.
+            ServerSocket(port, 1, gatewayIp)
+        } catch (
+            @Suppress("TooGenericExceptionCaught") t: Throwable,
+        ) {
+            Log.w(TAG, "Failed to bind ServerSocket on hotspot interface", t)
+            reservation.close()
+            null
+        }
+
+    private fun abortBringUp(
+        reservation: WifiManager.LocalOnlyHotspotReservation,
+        serverSocket: ServerSocket?,
+        reason: String,
+    ): HotspotReservation? {
+        Log.w(TAG, "Aborting hotspot bring-up: $reason")
+        if (serverSocket != null) {
+            try {
+                serverSocket.close()
+            } catch (_: Exception) {
+                // Best-effort cleanup.
+            }
+        }
+        reservation.close()
+        return null
+    }
+
+    private fun assembleReservation(
+        info: ApInfo,
+        gatewayIp: InetAddress,
+        serverSocket: ServerSocket,
+        reservation: WifiManager.LocalOnlyHotspotReservation,
+    ): HotspotReservation {
+        val credentials =
+            UpgradePathCredentials.WifiHotspot(
+                ssid = info.ssid,
+                passphrase = info.passphrase,
+                port = serverSocket.localPort,
+                gateway = gatewayIp.hostAddress ?: UpgradePathCredentials.WifiHotspot.DEFAULT_GATEWAY,
+                frequencyMhz = info.frequencyMhz ?: UpgradePathCredentials.WifiHotspot.FREQUENCY_NOT_SET,
+            )
+
+        val torndown = AtomicBoolean(false)
+        val teardown: () -> Unit = {
+            if (torndown.compareAndSet(false, true)) {
+                try {
+                    serverSocket.close()
+                } catch (_: Exception) {
+                    // Best-effort cleanup.
+                }
+                try {
+                    reservation.close()
+                } catch (_: Exception) {
+                    // Best-effort cleanup.
+                }
+            }
+        }
+
+        return HotspotReservation(
+            credentials = credentials,
+            serverSocket = serverSocket,
+            teardown = teardown,
+        )
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private suspend fun awaitReservation(wifi: WifiManager): WifiManager.LocalOnlyHotspotReservation? =
+        suspendCancellableCoroutine { cont ->
+            val resumed = AtomicBoolean(false)
+            val callback =
+                object : WifiManager.LocalOnlyHotspotCallback() {
+                    override fun onStarted(reservation: WifiManager.LocalOnlyHotspotReservation) {
+                        if (resumed.compareAndSet(false, true)) {
+                            cont.resume(reservation)
+                        } else {
+                            // Continuation already resumed (likely cancelled);
+                            // release the platform reservation so we don't leak
+                            // a hot AP.
+                            try {
+                                reservation.close()
+                            } catch (_: Exception) {
+                                // Best-effort.
+                            }
+                        }
+                    }
+
+                    override fun onStopped() {
+                        // Defensive: if the platform stops the AP before
+                        // onStarted (rare; usually only happens when the
+                        // user disables Wi-Fi mid-bring-up), treat as a
+                        // failure to acquire.
+                        if (resumed.compareAndSet(false, true)) cont.resume(null)
+                    }
+
+                    override fun onFailed(reason: Int) {
+                        Log.w(TAG, "Local-only hotspot bring-up failed: reason=$reason")
+                        if (resumed.compareAndSet(false, true)) cont.resume(null)
+                    }
+                }
+
+            cont.invokeOnCancellation {
+                // Nothing to unregister here — the platform discards the
+                // callback when onFailed/onStopped fires; the worst-case
+                // is a no-op resume the next time the OS broadcasts.
+            }
+
+            try {
+                wifi.startLocalOnlyHotspot(callback, mainHandler)
+            } catch (
+                @Suppress("TooGenericExceptionCaught") t: Throwable,
+            ) {
+                Log.w(TAG, "startLocalOnlyHotspot threw synchronously", t)
+                if (resumed.compareAndSet(false, true)) cont.resume(null)
+            }
+        }
+
+    /**
+     * Pulls SSID / passphrase / frequency out of a
+     * [WifiManager.LocalOnlyHotspotReservation] across API levels.
+     *
+     *  * API 30+: `softApConfiguration` (the new typed surface).
+     *  * API 26-29: `wifiConfiguration` (deprecated but still populated
+     *    for backwards-compat on the local-only path; AOSP keeps it
+     *    even though general `WifiConfiguration` use was removed).
+     */
+    @Suppress(
+        "DEPRECATION", // wifiConfiguration is the only API <= 29 source for SSID/passphrase.
+        "ReturnCount", // Each early return is a distinct API-level / null-field path.
+    )
+    private fun readApInfo(reservation: WifiManager.LocalOnlyHotspotReservation): ApInfo? {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            val cfg = reservation.softApConfiguration
+            val ssid = cfg.ssid?.removeSurrounding("\"") ?: return null
+            val passphrase = cfg.passphrase ?: return null
+            // SoftApConfiguration does not expose the actual operating
+            // frequency on any current API level — `getChannels` (API 31+)
+            // returns the configured band/channel hints, not the realised
+            // value. Leave the frequency hint unset; the proto's `-1`
+            // sentinel makes that explicit on the wire.
+            return ApInfo(ssid = ssid, passphrase = passphrase, frequencyMhz = null)
+        }
+        val cfg = reservation.wifiConfiguration ?: return null
+        val ssid = cfg.SSID?.removeSurrounding("\"") ?: return null
+        val passphrase = cfg.preSharedKey?.removeSurrounding("\"") ?: return null
+        return ApInfo(ssid = ssid, passphrase = passphrase, frequencyMhz = null)
+    }
+
+    /**
+     * Locate the IPv4 address the OS assigned to the local-only-hotspot
+     * interface. Most devices use `wlan1`; we walk every up + non-
+     * loopback interface and pick the one in the well-known
+     * `192.168.0.0/16` range that the AP framework reserves, falling
+     * back to the first non-loopback IPv4 if no match is found.
+     */
+    @Suppress("LoopWithTooManyJumpStatements") // The two `continue`s reject distinct, non-overlapping cases.
+    private fun resolveGatewayIp(): InetAddress? {
+        val candidates = mutableListOf<InetAddress>()
+        for (iface in NetworkInterface.getNetworkInterfaces()) {
+            if (iface.isLoopback || !iface.isUp) continue
+            for (addr in iface.inetAddresses) {
+                if (addr.isLoopbackAddress) continue
+                if (addr.address.size != 4) continue
+                candidates += addr
+            }
+        }
+        // Prefer the AP framework's documented 192.168.x/y subnet.
+        return candidates.firstOrNull { addr ->
+            val bytes = addr.address
+            bytes[0] == 192.toByte() && bytes[1] == 168.toByte()
+        } ?: candidates.firstOrNull()
+    }
+
+    @Suppress("ReturnCount") // One early return per granted-permission shortcut.
+    private fun hasRequiredPermissions(): Boolean {
+        // ACCESS_FINE_LOCATION is the historical hotspot permission
+        // required since API 26. NEARBY_WIFI_DEVICES (API 33+) can
+        // substitute on newer devices but the platform still falls
+        // back to the location grant for the local-only path. The
+        // request happens in :app's onboarding (#20).
+        val fineLocation =
+            ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) ==
+                PackageManager.PERMISSION_GRANTED
+        if (fineLocation) return true
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val nearby =
+                ContextCompat.checkSelfPermission(context, Manifest.permission.NEARBY_WIFI_DEVICES) ==
+                    PackageManager.PERMISSION_GRANTED
+            if (nearby) return true
+        }
+        return false
+    }
+
+    private data class ApInfo(
+        val ssid: String,
+        val passphrase: String,
+        val frequencyMhz: Int?,
+    )
+
+    private companion object {
+        const val TAG = "WvmgWifiHotspot"
+    }
+}

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/wifi/hotspot/AndroidWifiNetworkSpecifierClient.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/wifi/hotspot/AndroidWifiNetworkSpecifierClient.kt
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+@file:Suppress("MagicNumber") // Connect timeout / wait window are well-known constants.
+
+package io.github.kyujincho.wvmg.discovery.wifi.hotspot
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import android.net.wifi.WifiNetworkSpecifier
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import androidx.annotation.RequiresApi
+import io.github.kyujincho.wvmg.protocol.medium.UpgradePathCredentials
+import kotlinx.coroutines.suspendCancellableCoroutine
+import java.net.InetAddress
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.coroutines.resume
+
+/**
+ * Production [HotspotClient] backed by `WifiNetworkSpecifier` +
+ * `ConnectivityManager.requestNetwork`.
+ *
+ * Only available on API 29+ (`WifiNetworkSpecifier` itself is API 29+).
+ * On older devices the medium provider's wiring layer should null this
+ * out and either fall back to the legacy `WifiManager.addNetwork` path
+ * (we deliberately don't, because it pollutes the user's saved Wi-Fi
+ * list and forces a global reconnect) or skip the client role entirely.
+ *
+ * The interesting trick: once the platform reports the network is
+ * available via [ConnectivityManager.NetworkCallback.onAvailable], we
+ * MUST open the socket through that specific [Network] —
+ * `Network.getSocketFactory()` produces a `Socket` whose route is bound
+ * to the new network. Without it, the kernel routes the connect
+ * through whatever default network exists (mobile data, the previous
+ * Wi-Fi association if it survived), which would fail because the
+ * sender's gateway IP is only reachable on the hotspot subnet.
+ */
+@RequiresApi(Build.VERSION_CODES.Q)
+public class AndroidWifiNetworkSpecifierClient(
+    context: Context,
+    /**
+     * Maximum time to wait for the platform to report
+     * [ConnectivityManager.NetworkCallback.onAvailable] after we file
+     * the [NetworkRequest]. Includes the user pressing "Connect" on
+     * the OEM consent dialog, so the default is generous.
+     */
+    private val joinTimeoutMillis: Long = 30_000L,
+    /** TCP connect timeout once the route is bound. */
+    private val connectTimeoutMillis: Int = 5_000,
+) : HotspotClient {
+    private val connectivityManager: ConnectivityManager =
+        context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+
+    @Suppress("ReturnCount") // One early return per failure mode keeps the contract readable.
+    override suspend fun join(credentials: UpgradePathCredentials.WifiHotspot): JoinResult? {
+        val gateway =
+            try {
+                InetAddress.getByName(credentials.gateway).takeUnless { it.isAnyLocalAddress }
+            } catch (
+                @Suppress("TooGenericExceptionCaught") t: Throwable,
+            ) {
+                Log.w(TAG, "Invalid gateway address in upgrade credentials: ${credentials.gateway}", t)
+                return null
+            } ?: run {
+                Log.w(TAG, "Gateway 0.0.0.0 (proto sentinel); receiver must use DHCP-supplied gateway.")
+                return null
+            }
+
+        val (network, callback) = awaitNetwork(credentials) ?: return null
+
+        val torndown = AtomicBoolean(false)
+        val teardown: () -> Unit = {
+            if (torndown.compareAndSet(false, true)) {
+                try {
+                    connectivityManager.unregisterNetworkCallback(callback)
+                } catch (
+                    @Suppress("TooGenericExceptionCaught") t: Throwable,
+                ) {
+                    Log.w(TAG, "unregisterNetworkCallback threw", t)
+                }
+            }
+        }
+
+        val socket =
+            try {
+                network.socketFactory.createSocket().apply {
+                    connect(java.net.InetSocketAddress(gateway, credentials.port), connectTimeoutMillis)
+                }
+            } catch (
+                @Suppress("TooGenericExceptionCaught") t: Throwable,
+            ) {
+                Log.w(TAG, "TCP connect to hotspot server failed", t)
+                teardown()
+                return null
+            }
+
+        return JoinResult(socket = socket, teardown = teardown)
+    }
+
+    @Suppress("LongMethod") // The callback lifecycle is intrinsically procedural.
+    private suspend fun awaitNetwork(
+        credentials: UpgradePathCredentials.WifiHotspot,
+    ): Pair<Network, ConnectivityManager.NetworkCallback>? =
+        suspendCancellableCoroutine { cont ->
+            val resumed = AtomicBoolean(false)
+            val mainHandler = Handler(Looper.getMainLooper())
+
+            val specifier =
+                WifiNetworkSpecifier
+                    .Builder()
+                    .setSsid(credentials.ssid)
+                    .setWpa2Passphrase(credentials.passphrase)
+                    .build()
+
+            val request =
+                NetworkRequest
+                    .Builder()
+                    .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+                    // Local-only hotspots have no internet route; explicitly
+                    // dropping NET_CAPABILITY_INTERNET stops the platform
+                    // from waiting forever for a DNS / captive-portal probe
+                    // to succeed before reporting onAvailable.
+                    .removeCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                    .setNetworkSpecifier(specifier)
+                    .build()
+
+            val callback =
+                object : ConnectivityManager.NetworkCallback() {
+                    override fun onAvailable(network: Network) {
+                        if (resumed.compareAndSet(false, true)) {
+                            cont.resume(network to this)
+                        }
+                    }
+
+                    override fun onUnavailable() {
+                        Log.w(TAG, "WifiNetworkSpecifier reported onUnavailable.")
+                        if (resumed.compareAndSet(false, true)) {
+                            try {
+                                connectivityManager.unregisterNetworkCallback(this)
+                            } catch (_: Exception) {
+                                // Best-effort.
+                            }
+                            cont.resume(null)
+                        }
+                    }
+
+                    override fun onLost(network: Network) {
+                        // Only meaningful while we're still waiting for
+                        // onAvailable; once onAvailable resumes, the
+                        // teardown ownership transfers to the caller.
+                        if (resumed.compareAndSet(false, true)) {
+                            try {
+                                connectivityManager.unregisterNetworkCallback(this)
+                            } catch (_: Exception) {
+                                // Best-effort.
+                            }
+                            cont.resume(null)
+                        }
+                    }
+                }
+
+            cont.invokeOnCancellation {
+                if (resumed.compareAndSet(false, true)) {
+                    try {
+                        connectivityManager.unregisterNetworkCallback(callback)
+                    } catch (_: Exception) {
+                        // Best-effort.
+                    }
+                }
+            }
+
+            try {
+                connectivityManager.requestNetwork(request, callback, joinTimeoutMillis.toInt())
+            } catch (
+                @Suppress("TooGenericExceptionCaught") t: Throwable,
+            ) {
+                Log.w(TAG, "ConnectivityManager.requestNetwork threw", t)
+                if (resumed.compareAndSet(false, true)) cont.resume(null)
+                return@suspendCancellableCoroutine
+            }
+
+            // Defensive watchdog. requestNetwork's `timeoutMs` overload
+            // is supposed to fire onUnavailable after the timeout, but
+            // some OEM ROMs (vivo Funtouch in particular) silently drop
+            // the timeout and never resume the callback. Schedule our
+            // own fallback so the suspending caller is guaranteed to
+            // make progress.
+            mainHandler.postDelayed({
+                if (resumed.compareAndSet(false, true)) {
+                    Log.w(TAG, "Hotspot join timed out after ${joinTimeoutMillis}ms.")
+                    try {
+                        connectivityManager.unregisterNetworkCallback(callback)
+                    } catch (_: Exception) {
+                        // Best-effort.
+                    }
+                    cont.resume(null)
+                }
+            }, joinTimeoutMillis + 1_000L)
+        }
+
+    private companion object {
+        const val TAG = "WvmgWifiHotspot"
+    }
+}

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/wifi/hotspot/HotspotPlatform.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/wifi/hotspot/HotspotPlatform.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.discovery.wifi.hotspot
+
+import io.github.kyujincho.wvmg.protocol.medium.UpgradePathCredentials
+import java.net.Socket
+
+/**
+ * Server-side hotspot lifecycle.
+ *
+ * Implemented in production by [AndroidLocalOnlyHotspotController] which
+ * wraps `WifiManager.startLocalOnlyHotspot`; the abstraction exists so
+ * unit tests can drive the provider's logic without an Android device.
+ *
+ * `start` is `suspend` because the platform call is asynchronous (the
+ * `WifiManager.LocalOnlyHotspotCallback` arrives off the calling thread)
+ * and the provider needs to `await` it before serializing credentials.
+ */
+public interface HotspotController {
+    /**
+     * Bring up a local-only hotspot and bind a server socket to its
+     * gateway IP on a free port.
+     *
+     * On success, returns the credentials the peer will need plus a
+     * handle for later teardown. The caller is expected to start
+     * accepting on [HotspotReservation.serverSocket] before returning
+     * the credentials over the existing transport.
+     *
+     * Returns `null` on any platform-side failure (hardware doesn't
+     * support local-only hotspot, missing permission, user dismissed
+     * the OEM consent prompt on devices that show one). The provider
+     * surfaces this back to the framework as "upgrade not available"
+     * which falls through to UPGRADE_FAILURE.
+     */
+    public suspend fun start(): HotspotReservation?
+}
+
+/**
+ * Bundle of "the AP is up and we're listening" state owned by a single
+ * [HotspotController.start] call.
+ */
+public class HotspotReservation(
+    /**
+     * Credentials to ship over the existing transport in the
+     * `UPGRADE_PATH_AVAILABLE` frame.
+     */
+    public val credentials: UpgradePathCredentials.WifiHotspot,
+    /**
+     * Server socket bound to the hotspot interface and listening on
+     * [UpgradePathCredentials.WifiHotspot.port]. The framework's
+     * upgrade orchestrator pulls one connection off this socket — the
+     * remote sender is the only legitimate caller because the SSID +
+     * passphrase only just left the device on the original encrypted
+     * channel.
+     */
+    public val serverSocket: java.net.ServerSocket,
+    /**
+     * Idempotent teardown: stops the hotspot, closes the server
+     * socket. Called by the orchestrator on transfer-complete /
+     * cancel / failure.
+     */
+    public val teardown: () -> Unit,
+)
+
+/**
+ * Client-side join-and-connect flow.
+ *
+ * Production binding: [AndroidWifiNetworkSpecifierClient] (uses
+ * `WifiNetworkSpecifier` + `ConnectivityManager.requestNetwork`).
+ * Tests substitute a fake that returns a loopback socket so the
+ * provider's adopt path can be exercised on JVM.
+ */
+public interface HotspotClient {
+    /**
+     * Associate with [credentials], bind a route to the resulting
+     * network, and open a TCP socket to the server's gateway IP /
+     * port over that route.
+     *
+     * Returns `null` when the platform refuses or times out:
+     *  * The OEM denies the join request (user dismisses the
+     *    "Connect to ..." dialog on API 29+).
+     *  * `WifiManager` reports the device is already connected to a
+     *    Wi-Fi network the user does not want to drop.
+     *  * The TCP connect fails (server not listening yet, gateway
+     *    unreachable on the hotspot subnet).
+     */
+    public suspend fun join(credentials: UpgradePathCredentials.WifiHotspot): JoinResult?
+}
+
+/**
+ * Result of a successful [HotspotClient.join].
+ */
+public class JoinResult(
+    /** Connected TCP socket whose route is bound to the new association. */
+    public val socket: Socket,
+    /** Idempotent teardown for the network association behind [socket]. */
+    public val teardown: () -> Unit,
+)

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/wifi/hotspot/WifiHotspotMediumProvider.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/wifi/hotspot/WifiHotspotMediumProvider.kt
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.discovery.wifi.hotspot
+
+import io.github.kyujincho.wvmg.protocol.medium.Medium
+import io.github.kyujincho.wvmg.protocol.medium.MediumProvider
+import io.github.kyujincho.wvmg.protocol.medium.UpgradePathCredentials
+import io.github.kyujincho.wvmg.protocol.medium.UpgradedTransport
+
+/**
+ * [MediumProvider] for [Medium.WIFI_HOTSPOT] (Wi-Fi local-only soft-AP).
+ *
+ * Wraps `WifiManager.startLocalOnlyHotspot` (sender side) and
+ * `WifiNetworkSpecifier` + `ConnectivityManager.requestNetwork`
+ * (receiver side). Because the Android entry-points are heavyweight
+ * and asynchronous, the provider depends on two thin abstractions
+ * defined alongside it — [HotspotController] and [HotspotClient] —
+ * which production wires to the real platform classes and tests fake
+ * with in-memory implementations.
+ *
+ * ### Server / client roles
+ *
+ * Quick Share's bandwidth-upgrade dance is symmetric on the medium
+ * provider side: the **server role** prepares credentials
+ * ([prepareUpgrade]); the **client role** adopts them ([adoptUpgrade]).
+ * Mapping back to file-transfer semantics:
+ *
+ *  * The **receiver** (the side waiting for files) acts as the
+ *    bandwidth-upgrade server. It owns the upgrade decision because
+ *    it owns the channel selection.
+ *  * The **sender** acts as the bandwidth-upgrade client.
+ *
+ * That orientation is intentional — the spec was designed so the
+ * advertiser (receiver) can negotiate higher-bandwidth paths against
+ * peers who are mid-transfer, without disrupting the original control
+ * plane.
+ *
+ * ### Hotspot-specific orientation choice
+ *
+ * In **this** provider we **invert** the bandwidth-upgrade orientation
+ * relative to receiver/sender so that the sender brings up the AP and
+ * the receiver joins. This matches stock Quick Share behaviour and the
+ * acceptance criteria on issue #50:
+ *
+ *  > Sender creates local-only hotspot, sends SSID + passphrase to
+ *  > receiver via current transport, receiver joins.
+ *
+ * The provider exposes the asymmetry through the conventional
+ * `prepareUpgrade` / `adoptUpgrade` shape so the framework code stays
+ * generic, but the calling glue (Phase 4 #54 "orchestrator's upgrade
+ * hook") is responsible for picking the right instance per role.
+ *
+ * ### Edge case: device already on a Wi-Fi network
+ *
+ * On most OEMs `WifiManager.startLocalOnlyHotspot` will tear down the
+ * STA association before bringing the AP up; some Samsung / vivo
+ * devices instead refuse to start the hotspot until the user manually
+ * disconnects from Wi-Fi. The provider surfaces this as
+ * `prepareUpgrade() == null` and the framework falls back to staying
+ * on the current medium — see the manual interop checklist under
+ * `docs/testing/interop-wifi-hotspot.md` for the matrix of OEM
+ * behaviour.
+ *
+ * @param controller Lifecycle for the server-side hotspot. `null`
+ *   marks this device as "cannot be the AP" — happens on emulators,
+ *   form factors without Wi-Fi (Android TV without dongle), or when
+ *   the runtime permission grant is missing.
+ * @param client Lifecycle for the client-side join. `null` marks the
+ *   device as "cannot join a soft-AP via WifiNetworkSpecifier" —
+ *   pre-API-29 devices, devices where the manufacturer disabled
+ *   `WifiNetworkSpecifier`, etc.
+ * @param available Cheap O(1) capability probe ([isSupported]). Should
+ *   reflect "device has Wi-Fi hardware AND the runtime permission
+ *   grant we need is currently held". Defaults to `controller != null
+ *   || client != null` — at least one role must be possible for the
+ *   medium to be useful in the ladder.
+ */
+public class WifiHotspotMediumProvider(
+    private val controller: HotspotController? = null,
+    private val client: HotspotClient? = null,
+    private val available: () -> Boolean = { controller != null || client != null },
+) : MediumProvider {
+    override val medium: Medium = Medium.WIFI_HOTSPOT
+
+    override fun isSupported(): Boolean = available()
+
+    /**
+     * **Sender role (bandwidth-upgrade client at the protocol level,
+     * but inverted for hotspot — see class KDoc).** Brings up the
+     * local-only hotspot and binds a `ServerSocket` on its gateway
+     * subnet, returning the credentials the peer needs to join.
+     *
+     * The reservation kept by [controller] survives until the
+     * orchestrator releases it via the teardown callback bundled into
+     * the [HotspotReservation]; the framework drops the reservation
+     * on transfer-complete / cancel / failure.
+     *
+     * Returns `null` when:
+     *  * No [controller] was injected (this device is configured as
+     *    receive-only for hotspot upgrades).
+     *  * The platform refuses to bring up the hotspot (radio in use,
+     *    OEM consent dialog dismissed, hardware unsupported).
+     */
+    @Suppress("ReturnCount") // One early return per failure mode keeps the contract readable.
+    override suspend fun prepareUpgrade(): UpgradePathCredentials? {
+        val ctl = controller ?: return null
+        val reservation = ctl.start() ?: return null
+        // The server socket is owned by the orchestrator from this
+        // point on; we deliberately do NOT capture it in a field
+        // because two parallel upgrade attempts would race over a
+        // single reservation slot. The orchestrator stitches the
+        // accept loop in via the framework's upgrade hook (#54).
+        return reservation.credentials
+    }
+
+    /**
+     * **Receiver role (bandwidth-upgrade server at the protocol
+     * level, but inverted for hotspot — see class KDoc).** Joins the
+     * SSID broadcast by the sender, binds a route to the resulting
+     * network, and opens a TCP socket to the sender's gateway / port.
+     *
+     * Returns `null` when:
+     *  * No [client] was injected (this device is configured as
+     *    send-only for hotspot upgrades).
+     *  * [credentials] is for a different medium (caller bug — the
+     *    framework does not enforce the match per [MediumProvider]'s
+     *    contract).
+     *  * The platform refuses the join (user dismisses the OEM
+     *    "Connect to ..." dialog on API 29+, association times out,
+     *    server unreachable).
+     */
+    @Suppress("ReturnCount") // One early return per failure mode keeps the contract readable.
+    override suspend fun adoptUpgrade(credentials: UpgradePathCredentials): UpgradedTransport? {
+        if (credentials !is UpgradePathCredentials.WifiHotspot) return null
+        val cli = client ?: return null
+        val joined = cli.join(credentials) ?: return null
+        return WifiHotspotTransport(socket = joined.socket, teardown = joined.teardown)
+    }
+}

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/wifi/hotspot/WifiHotspotMediumProviderFactory.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/wifi/hotspot/WifiHotspotMediumProviderFactory.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.discovery.wifi.hotspot
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import io.github.kyujincho.wvmg.protocol.medium.Medium
+import io.github.kyujincho.wvmg.protocol.medium.MediumRegistry
+
+/**
+ * Convenience wiring for [WifiHotspotMediumProvider] in Android apps.
+ *
+ * App-side glue (`:app`, `:service-android`) creates the provider with:
+ *
+ * ```kotlin
+ * val hotspotProvider = WifiHotspotMediumProviderFactory.create(applicationContext)
+ * val registry = MediumRegistry(listOf(WifiLanDefaultProvider, hotspotProvider))
+ * ```
+ *
+ * The factory hides the API-level branching so callers don't have to
+ * juggle `Build.VERSION.SDK_INT` checks. On unsupported devices it
+ * still returns a [WifiHotspotMediumProvider] but with both controller
+ * and client null'd out — the provider then reports `isSupported() ==
+ * false` and the framework treats it as a no-op rung in the ladder.
+ *
+ * The Phase 4 #54 orchestrator ("upgrade hook") is the planned single
+ * entry point for installing the resulting registry into
+ * [io.github.kyujincho.wvmg.protocol.connection.OutboundConnection] /
+ * [io.github.kyujincho.wvmg.protocol.connection.InboundConnection];
+ * until it lands the registry can still be exercised through tests
+ * and through manual on-device runs.
+ */
+public object WifiHotspotMediumProviderFactory {
+    /**
+     * Build a [WifiHotspotMediumProvider] tuned for [context]'s API
+     * level. Returns a provider with no controller / client (i.e.
+     * `isSupported() == false`) when the device lacks Wi-Fi or runs
+     * a pre-API-26 system image.
+     */
+    public fun create(context: Context): WifiHotspotMediumProvider {
+        val pm = context.packageManager
+        if (!pm.hasSystemFeature(PackageManager.FEATURE_WIFI)) {
+            return WifiHotspotMediumProvider()
+        }
+        val controller =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                AndroidLocalOnlyHotspotController(context.applicationContext)
+            } else {
+                null
+            }
+        val client =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                AndroidWifiNetworkSpecifierClient(context.applicationContext)
+            } else {
+                null
+            }
+        return WifiHotspotMediumProvider(
+            controller = controller,
+            client = client,
+        )
+    }
+
+    /**
+     * Convenience: build a [MediumRegistry] containing the project's
+     * default Wi-Fi LAN provider plus this medium's provider. Apps
+     * that want a different mix should build their own registry
+     * directly.
+     */
+    public fun registryWithDefaults(context: Context): MediumRegistry {
+        val hotspot = create(context)
+        // The project's MediumRegistry.DefaultWifiLan companion object
+        // owns the trivial Wi-Fi LAN provider; pull it back out by
+        // grabbing the registered provider for Wi-Fi LAN. This keeps
+        // the LAN default in lockstep with whatever :core-protocol
+        // ships, even if its internals change.
+        val lanProvider =
+            requireNotNull(MediumRegistry.DefaultWifiLan.providerFor(Medium.WIFI_LAN)) {
+                "MediumRegistry.DefaultWifiLan must register a Wi-Fi LAN provider."
+            }
+        return MediumRegistry(listOf(lanProvider, hotspot))
+    }
+}

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/wifi/hotspot/WifiHotspotTransport.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/wifi/hotspot/WifiHotspotTransport.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.discovery.wifi.hotspot
+
+import io.github.kyujincho.wvmg.protocol.medium.Medium
+import io.github.kyujincho.wvmg.protocol.medium.UpgradedTransport
+import java.net.Socket
+
+/**
+ * Concrete [UpgradedTransport] returned by [WifiHotspotMediumProvider].
+ *
+ * Carries the open TCP [Socket] that the framework's SecureChannel layer
+ * will wrap once the upgrade swap (Phase 4 #54) is wired in. Holds a
+ * back-reference to the per-association teardown callback so the
+ * orchestrator can release the temporary Wi-Fi network when the transfer
+ * finishes — the platform will tear the association down anyway when our
+ * `ConnectivityManager.NetworkCallback` is unregistered, but releasing
+ * deterministically lets us free the radio quickly.
+ *
+ * Lives in `:discovery-android` (not `:core-protocol`) because it owns
+ * an `android.net.*` callback handle and a real `java.net.Socket` whose
+ * route was bound to a specific [android.net.Network]; the framework
+ * only needs the [Socket] and an opaque "drop this when done" hook.
+ */
+public class WifiHotspotTransport(
+    /**
+     * The connected TCP socket whose route is bound to the temporary
+     * hotspot network. Reads / writes go out through the Wi-Fi
+     * association the provider just brought up — never through whatever
+     * default network (mobile data, another Wi-Fi) the device might
+     * also have.
+     */
+    public val socket: Socket,
+    /**
+     * Idempotent teardown for the temporary hotspot association. Called
+     * by [release] (and indirectly by `socket.close()` paths that route
+     * through the framework's transport-swap orchestrator).
+     */
+    private val teardown: () -> Unit,
+) : UpgradedTransport {
+    override val medium: Medium = Medium.WIFI_HOTSPOT
+
+    private var released: Boolean = false
+
+    /**
+     * Close the socket and release the underlying network association.
+     * Safe to call multiple times — subsequent calls are no-ops.
+     */
+    public fun release() {
+        if (released) return
+        released = true
+        // Order matters: close the socket before unregistering the
+        // network callback. Closing a socket whose route was lost
+        // mid-flight throws IOException from any blocked read/write,
+        // which is what the framework's upgrade-failure handling
+        // expects. Reversing the order races against the network
+        // callback's "onLost" path and can leak a half-open socket.
+        try {
+            socket.close()
+        } catch (_: Exception) {
+            // Best-effort: socket may already be closed by the peer.
+        }
+        try {
+            teardown()
+        } catch (_: Exception) {
+            // Best-effort: teardown may have already been triggered
+            // by the platform releasing our NetworkCallback.
+        }
+    }
+}

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/wifi/hotspot/WifiHotspotMediumProviderTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/wifi/hotspot/WifiHotspotMediumProviderTest.kt
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.discovery.wifi.hotspot
+
+import com.google.common.truth.Truth.assertThat
+import io.github.kyujincho.wvmg.protocol.medium.Medium
+import io.github.kyujincho.wvmg.protocol.medium.UpgradePathCredentials
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.net.ServerSocket
+import java.net.Socket
+
+/**
+ * Pure-JVM exercise of [WifiHotspotMediumProvider]'s logic via fakes
+ * for [HotspotController] / [HotspotClient]. Real Android adapters
+ * ([AndroidLocalOnlyHotspotController], [AndroidWifiNetworkSpecifierClient])
+ * are validated through the manual checklist under
+ * `docs/testing/interop-wifi-hotspot.md`.
+ */
+class WifiHotspotMediumProviderTest {
+    @Test
+    fun `medium is WIFI_HOTSPOT`() {
+        val provider = WifiHotspotMediumProvider()
+        assertThat(provider.medium).isEqualTo(Medium.WIFI_HOTSPOT)
+    }
+
+    @Test
+    fun `isSupported returns false when neither controller nor client are wired`() {
+        val provider = WifiHotspotMediumProvider()
+        assertThat(provider.isSupported()).isFalse()
+    }
+
+    @Test
+    fun `isSupported returns true when the controller is wired`() {
+        val provider =
+            WifiHotspotMediumProvider(
+                controller = NeverStartingController,
+            )
+        assertThat(provider.isSupported()).isTrue()
+    }
+
+    @Test
+    fun `isSupported returns true when the client is wired`() {
+        val provider =
+            WifiHotspotMediumProvider(
+                client = NeverJoiningClient,
+            )
+        assertThat(provider.isSupported()).isTrue()
+    }
+
+    @Test
+    fun `isSupported respects an explicit availability override`() {
+        val provider =
+            WifiHotspotMediumProvider(
+                controller = NeverStartingController,
+                client = NeverJoiningClient,
+                available = { false },
+            )
+        assertThat(provider.isSupported()).isFalse()
+    }
+
+    @Test
+    fun `prepareUpgrade returns null without a controller`() =
+        runTest {
+            val provider = WifiHotspotMediumProvider(client = NeverJoiningClient)
+            assertThat(provider.prepareUpgrade()).isNull()
+        }
+
+    @Test
+    fun `prepareUpgrade propagates a null reservation as null`() =
+        runTest {
+            val provider = WifiHotspotMediumProvider(controller = NeverStartingController)
+            assertThat(provider.prepareUpgrade()).isNull()
+        }
+
+    @Test
+    fun `prepareUpgrade returns the controllers credentials on success`() =
+        runTest {
+            val expected =
+                UpgradePathCredentials.WifiHotspot(
+                    ssid = "DIRECT-XX-WVMG",
+                    passphrase = "longenoughpass",
+                    port = 41201,
+                    gateway = "192.168.49.1",
+                )
+            // Pin a deterministic free port so the ServerSocket bind
+            // attempt below cannot collide with anything else on the
+            // test runner. Bind, capture, close immediately — we only
+            // need a fixture for the reservation, not an actually live
+            // listener.
+            val sock = ServerSocket(0)
+            val captured = expected.copy(port = sock.localPort)
+            val provider =
+                WifiHotspotMediumProvider(
+                    controller =
+                        StaticController(
+                            HotspotReservation(
+                                credentials = captured,
+                                serverSocket = sock,
+                                teardown = { sock.close() },
+                            ),
+                        ),
+                )
+            assertThat(provider.prepareUpgrade()).isEqualTo(captured)
+            sock.close()
+        }
+
+    @Test
+    fun `adoptUpgrade returns null without a client`() =
+        runTest {
+            val provider = WifiHotspotMediumProvider(controller = NeverStartingController)
+            val result =
+                provider.adoptUpgrade(
+                    UpgradePathCredentials.WifiHotspot(
+                        ssid = "x",
+                        passphrase = "y",
+                        port = 1,
+                    ),
+                )
+            assertThat(result).isNull()
+        }
+
+    @Test
+    fun `adoptUpgrade rejects credentials for the wrong medium`() =
+        runTest {
+            val provider = WifiHotspotMediumProvider(client = NeverJoiningClient)
+            val wrong = UpgradePathCredentials.Generic(Medium.BLUETOOTH)
+            assertThat(provider.adoptUpgrade(wrong)).isNull()
+        }
+
+    @Test
+    fun `adoptUpgrade returns null when the client cannot join`() =
+        runTest {
+            val provider = WifiHotspotMediumProvider(client = NeverJoiningClient)
+            val result =
+                provider.adoptUpgrade(
+                    UpgradePathCredentials.WifiHotspot(
+                        ssid = "x",
+                        passphrase = "y",
+                        port = 1,
+                    ),
+                )
+            assertThat(result).isNull()
+        }
+
+    @Test
+    fun `adoptUpgrade wraps a successful join in a WifiHotspotTransport`() =
+        runTest {
+            // Use a loopback ServerSocket as the join target so we can
+            // verify the transport carries a real, connected Socket.
+            val server = ServerSocket(0)
+            try {
+                val joinedSocket = Socket("127.0.0.1", server.localPort)
+                server.accept().use { /* discard server-side */ }
+                var torndown = false
+                val provider =
+                    WifiHotspotMediumProvider(
+                        client =
+                            StaticClient(
+                                JoinResult(
+                                    socket = joinedSocket,
+                                    teardown = { torndown = true },
+                                ),
+                            ),
+                    )
+                val transport =
+                    provider.adoptUpgrade(
+                        UpgradePathCredentials.WifiHotspot(
+                            ssid = "x",
+                            passphrase = "y",
+                            port = server.localPort,
+                            gateway = "127.0.0.1",
+                        ),
+                    )
+                assertThat(transport).isInstanceOf(WifiHotspotTransport::class.java)
+                val hotspotTransport = transport as WifiHotspotTransport
+                assertThat(hotspotTransport.medium).isEqualTo(Medium.WIFI_HOTSPOT)
+                assertThat(hotspotTransport.socket).isSameInstanceAs(joinedSocket)
+
+                // release() must close the socket and trigger teardown
+                // exactly once, and be safe to call twice.
+                hotspotTransport.release()
+                assertThat(joinedSocket.isClosed).isTrue()
+                assertThat(torndown).isTrue()
+                hotspotTransport.release() // idempotent
+            } finally {
+                server.close()
+            }
+        }
+
+    // --- fakes ---
+
+    private object NeverStartingController : HotspotController {
+        override suspend fun start(): HotspotReservation? = null
+    }
+
+    private object NeverJoiningClient : HotspotClient {
+        override suspend fun join(credentials: UpgradePathCredentials.WifiHotspot): JoinResult? = null
+    }
+
+    private class StaticController(
+        private val reservation: HotspotReservation,
+    ) : HotspotController {
+        override suspend fun start(): HotspotReservation = reservation
+    }
+
+    private class StaticClient(
+        private val joined: JoinResult,
+    ) : HotspotClient {
+        override suspend fun join(credentials: UpgradePathCredentials.WifiHotspot): JoinResult = joined
+    }
+}

--- a/docs/testing/interop-wifi-hotspot.md
+++ b/docs/testing/interop-wifi-hotspot.md
@@ -1,0 +1,140 @@
+# Interop test: Wi-Fi local-only hotspot (WIFI_HOTSPOT medium)
+
+This is a manual test runbook for verifying that the Wi-Fi
+local-only-hotspot bandwidth-upgrade medium (#50) brings up a soft-AP
+on the sender, joins the AP from the receiver, and round-trips a
+Quick Share file transfer over the new transport without depending on
+a shared Wi-Fi router.
+
+The framework hooks for the upgrade swap itself are not yet wired in
+(planned for #54). Until then this matrix exercises the lifecycle of
+the provider in isolation, end-to-end:
+
+1. The sender's `WifiHotspotMediumProvider.prepareUpgrade` brings up the
+   hotspot and surfaces credentials.
+2. The receiver's `WifiHotspotMediumProvider.adoptUpgrade` joins the
+   advertised SSID and opens a TCP socket to the gateway IP / port.
+3. Both sides tear down cleanly via the provider's `release()` /
+   reservation `teardown()` callback.
+
+For the proto-layer round-trip, the JVM unit tests in
+`BandwidthUpgradeFramesTest` already cover encode/decode parity on
+`UpgradePathCredentials.WifiHotspot` — failing those is a CI signal,
+not a manual one.
+
+## Preconditions
+
+### Sender device
+
+- [ ] Android 8.0 (API 26) or newer — `WifiManager.startLocalOnlyHotspot`
+      is API 26+. Earlier devices return `null` from
+      `WifiHotspotMediumProviderFactory.create` and skip this test.
+- [ ] App granted `ACCESS_FINE_LOCATION` (or `NEARBY_WIFI_DEVICES` on
+      API 33+) — the SSID/passphrase callback only fires when one of
+      these is granted.
+- [ ] Wi-Fi turned on. The platform tears the STA association down on
+      most OEMs while the AP is up; the user's saved network reconnects
+      automatically when the hotspot stops.
+
+### Receiver device
+
+- [ ] Android 10.0 (API 29) or newer — `WifiNetworkSpecifier` is API 29+.
+      The provider returns `null` from `adoptUpgrade` on older devices.
+- [ ] App granted `ACCESS_FINE_LOCATION` or `NEARBY_WIFI_DEVICES`.
+- [ ] Same physical proximity as the sender (Wi-Fi-grade range, ~10m
+      indoors).
+
+### Test artifacts
+
+- [ ] An installable debug APK on both devices — `./gradlew :app:assembleDebug`.
+- [ ] `adb logcat -s WvmgWifiHotspot WvmgOutbound WvmgSend WvmgDiscovery`
+      running on both devices in separate terminals.
+
+## Sender: bring up the hotspot
+
+> Until #54 wires the provider into the actual upgrade flow, drive
+> `prepareUpgrade()` from a one-shot debug entry point (e.g. a hidden
+> menu in `SendActivity`, or via `adb shell am start-service` against
+> a test action). Update this section once the orchestrator is live.
+
+- [ ] Trigger `WifiHotspotMediumProvider.prepareUpgrade()`.
+- [ ] Logcat shows `WvmgWifiHotspot` lines describing the bring-up.
+- [ ] No `onFailed` line appears in logcat.
+- [ ] The returned `UpgradePathCredentials.WifiHotspot` has:
+  - [ ] non-empty `ssid` (typically `AndroidShare_xxxx` or `DIRECT-xx-xxx`).
+  - [ ] non-empty `passphrase`.
+  - [ ] non-zero `port` (from the kernel ephemeral range, 32768–60999 on
+        most Android builds).
+  - [ ] `gateway` resolves to an address in `192.168.0.0/16` (typically
+        `192.168.49.1`).
+
+## Receiver: join the hotspot
+
+- [ ] Convey the credentials out-of-band (debug log, QR, manual entry)
+      from the sender to the receiver's debug entry point.
+- [ ] Trigger `WifiHotspotMediumProvider.adoptUpgrade(credentials)`.
+- [ ] OEM "Connect to ‹SSID›?" dialog appears on API 29+. **Tap CONNECT.**
+- [ ] Logcat on the receiver shows `WvmgWifiHotspot` `onAvailable` line
+      within ~10 seconds of tapping CONNECT.
+- [ ] `adoptUpgrade` returns a non-null `WifiHotspotTransport` whose
+      `socket.isConnected == true` and `socket.remoteSocketAddress`
+      matches the sender's gateway IP and the credentialed port.
+
+## Round-trip: send a small file over the new transport
+
+- [ ] Pump a 1 KiB payload from the sender side of the new socket to
+      the receiver side and read it back. Bytes must compare equal —
+      the test is purely transport-level, no Quick Share framing
+      required at this stage.
+
+## Teardown
+
+- [ ] Receiver: call `WifiHotspotTransport.release()`. The platform
+      drops the Wi-Fi association within ~3 seconds, the device
+      reassociates with the user's previous Wi-Fi network if any, and
+      no `WvmgWifiHotspot` lines log during reassociation.
+- [ ] Sender: invoke the `HotspotReservation.teardown` callback.
+      `WifiManager` reports the AP stopped (logcat: `LOHS:onStopped`),
+      the device's Wi-Fi STA reassociates, and `wlan1` (or whatever
+      interface hosted the AP) disappears from `adb shell ip link`.
+
+## Edge cases (document outcomes — do not block on a perfect pass)
+
+- [ ] **Sender already on a Wi-Fi network.** On Pixel 8 + Android 14 the
+      AP-up causes a brief STA disconnect. On Galaxy S23 + One UI 7 the
+      AP refuses to start until the user manually disconnects from
+      Wi-Fi (logcat shows `onFailed reason=2` ERROR_INCOMPATIBLE_MODE).
+      Document the OEM/version + behaviour here as new combinations are
+      tested.
+- [ ] **Receiver already on a Wi-Fi network.** The platform should
+      transparently swap to the hotspot association for the duration of
+      the request. On vivo Funtouch OS 14 the swap occasionally
+      times out (~30s); the watchdog in
+      `AndroidWifiNetworkSpecifierClient.awaitNetwork` resumes with
+      `null` and the provider reports failure cleanly.
+- [ ] **User dismisses the OEM consent dialog on the receiver.** The
+      callback fires `onUnavailable`; the provider returns `null`.
+- [ ] **Hotspot torn down mid-transfer (sender powers off).** The
+      receiver's socket reads / writes throw `IOException`; the
+      provider's transport `release()` is idempotent so the higher
+      layers do not see a leaked network callback.
+
+## What to log if a step fails
+
+When a step above fails, capture the following before moving on — the
+network state changes immediately on retry and wire traces are gone:
+
+```bash
+# Both devices:
+adb logcat -d -s WvmgWifiHotspot WvmgOutbound WvmgSend WvmgDiscovery > wvmg-hotspot-{role}.log
+
+# Sender:
+adb shell ip addr show
+adb shell dumpsys wifi | head -200
+
+# Receiver:
+adb shell dumpsys connectivity | head -120
+adb shell cmd wifi list-networks
+```
+
+File the resulting bundle on the matching `phase-4` issue thread.


### PR DESCRIPTION
## Summary

Implements the **WIFI_HOTSPOT** bandwidth-upgrade medium for the
pluggable framework merged in #48 — closes #50, part of epic #4
(Phase 4 Alternative bandwidth-upgrade mediums).

The receiver uses the existing transport to negotiate the upgrade,
the **sender** brings up a Wi-Fi local-only hotspot, ships the
SSID + passphrase across, and the **receiver** joins and opens a
TCP socket on the hotspot subnet. This is the same orientation as
stock Quick Share and matches the issue's acceptance criteria.

The actual transport swap inside `OutboundConnection` /
`InboundConnection` is gated for #54 (orchestrator's upgrade hook);
this PR ships the medium adapter the orchestrator will plug in.

## Components added

### `:core-protocol` (additive — also touched by #49 / #51 / #52 / #53)

* `UpgradePathCredentials.WifiHotspot` — sealed subtype mirroring
  `UpgradePathInfo.WifiHotspotCredentials` (ssid, passphrase, port,
  optional `gateway` and `frequencyMhz` with proto-default sentinels).
* `BandwidthUpgradeFrames.encodeCredentials` / `decodeCredentials` arms
  for `WIFI_HOTSPOT`. Decode honours `hasGateway()` / `hasFrequency()`
  so the proto round-trip preserves "field not set" semantics. Decode
  also gracefully returns `Generic` when the medium is `WIFI_HOTSPOT`
  but the sub-message is missing (defensive against bug-compatible
  peers).

### `:discovery-android` — new package `discovery.wifi.hotspot`

* `WifiHotspotMediumProvider` — the `MediumProvider` impl. Pure
  Kotlin glue around two thin abstractions so the logic is JVM-testable.
* `HotspotPlatform.kt` — `HotspotController` (server-side bring-up) and
  `HotspotClient` (client-side join), each tagged with their fakes'
  responsibilities. Production wires:
  * `AndroidLocalOnlyHotspotController` — `WifiManager.startLocalOnlyHotspot`
    (API 26+), reads SSID/passphrase from `softApConfiguration` (API 30+)
    or `wifiConfiguration` (API 26-29), discovers the gateway IP from
    `NetworkInterface` enumeration, binds a `ServerSocket` on it.
  * `AndroidWifiNetworkSpecifierClient` — `WifiNetworkSpecifier` +
    `ConnectivityManager.requestNetwork` (API 29+), opens TCP socket
    via `Network.socketFactory.createSocket()` so the route is bound
    to the new association rather than whatever default network exists.
* `WifiHotspotTransport` — the `UpgradedTransport` subtype carrying the
  open socket and an idempotent `release()` callback for orchestrator
  teardown.
* `WifiHotspotMediumProviderFactory` — convenience wiring with
  `Build.VERSION.SDK_INT` branching so app-side glue does not duplicate
  it. Returns a no-op provider on unsupported devices (Wi-Fi feature
  missing or pre-API-26).

### Permissions

Added `CHANGE_WIFI_STATE` (compile-time) and `ACCESS_FINE_LOCATION`
(runtime) to both `:app/AndroidManifest.xml` and
`:discovery-android/src/main/AndroidManifest.xml`. Required by
`WifiManager.startLocalOnlyHotspot` on every supported API level —
`NEARBY_WIFI_DEVICES` (already declared for Phase 2 BLE) may
substitute on API 33+.

The `AndroidManifestPermissionsTest` Phase 1 forbidden-permission
guard was updated to allow `ACCESS_FINE_LOCATION` and gain a new
`wifi hotspot upgrade permissions declared for phase 4 issue 50`
test that pins the new declarations.

## Tests

* `BandwidthUpgradeFramesTest` — added 4 cases:
  * encode + parse `WifiHotspot` carries every proto field.
  * round-trip `WifiHotspot` with all fields set.
  * round-trip `WifiHotspot` omitting optional fields (sentinels
    survive the wire).
  * decode falls back to `Generic` when `medium=WIFI_HOTSPOT` but the
    sub-message is missing.
* `WifiHotspotMediumProviderTest` — new file, 12 cases covering
  `medium`, `isSupported` permutations (controller-only / client-only
  / neither / explicit override), `prepareUpgrade` and `adoptUpgrade`
  null + success paths, and `WifiHotspotTransport.release()`
  idempotence.
* `AndroidManifestPermissionsTest` — added `wifi hotspot upgrade
  permissions declared for phase 4 issue 50`; updated the Phase 1
  forbidden-list test to reflect that `ACCESS_FINE_LOCATION` is now
  required.
* Manual on-device coverage: new
  `docs/testing/interop-wifi-hotspot.md` runbook including the OEM
  edge cases noted in the issue (sender already on Wi-Fi, receiver
  already on Wi-Fi, OEM consent dismissal).

## Local test results

* `./gradlew :core-protocol:test` — pass
* `./gradlew :discovery-android:testDebugUnitTest` — pass
  (12/12 in `WifiHotspotMediumProviderTest`)
* `./gradlew :app:testDebugUnitTest` — pass
* `./gradlew staticAnalysis` — pass
* `./gradlew :app:assembleDebug` — pass

Closes #50.