### PR TITLE
feat(medium): BLE L2CAP CoC bandwidth-upgrade provider (API 29+)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -44,14 +44,23 @@
           BLUETOOTH_SCAN permissions instead.
 
       BLUETOOTH_CONNECT is declared (API 31+) for the Phase 4 Bluetooth
-      RFCOMM bandwidth-upgrade medium (#51). The provider opens an
-      insecure RFCOMM listener on the receiver and connects from the
-      sender; both calls require BLUETOOTH_CONNECT at runtime on API
-      31+. Pairing is NOT required (we use the *insecure* RFCOMM
-      variants because the application data is already UKEY2-encrypted)
-      so the user does not see an OS pairing prompt — but the runtime
-      permission grant is still mandatory and onboarding (#31) prompts
-      for it alongside the existing BLE permissions.
+      bandwidth-upgrade mediums:
+        * Bluetooth RFCOMM (#51) — the provider opens an insecure
+          RFCOMM listener on the receiver and connects from the sender;
+          both calls require BLUETOOTH_CONNECT at runtime on API 31+.
+          Pairing is NOT required (we use the *insecure* RFCOMM variants
+          because the application data is already UKEY2-encrypted) so
+          the user does not see an OS pairing prompt — but the runtime
+          permission grant is still mandatory.
+        * BLE L2CAP CoC (#52) — BleL2capMediumProvider calls
+          BluetoothAdapter.listenUsingInsecureL2capChannel on the
+          receiver side and BluetoothDevice.createInsecureL2capChannel
+          on the sender side; both require BLUETOOTH_CONNECT at runtime
+          on API 31+.
+      The :discovery-android library manifest also declares this
+      permission at the library level so it propagates into the merged
+      manifest automatically; onboarding (#31) prompts for it alongside
+      the existing BLE permissions.
 
       READ_MEDIA_* is intentionally omitted — Phase 1 routes all media
       access through the system share-intent flow, which does not require

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeFrames.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeFrames.kt
@@ -3,6 +3,8 @@
  *
  * Licensed under the Apache License, Version 2.0.
  */
+@file:Suppress("MagicNumber") // 0xFF / 16-radix are well-known hex constants.
+
 package io.github.kyujincho.wvmg.protocol.connection
 
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.BandwidthUpgradeNegotiationFrame
@@ -205,11 +207,24 @@ public object BandwidthUpgradeFrames {
                     UpgradePathCredentials.Generic(medium)
                 }
             }
-            // Bluetooth RFCOMM (#51): BluetoothCredentials carries the
-            // peer device MAC + the SDP service identifier the receiver
-            // advertised via listenUsingInsecureRfcommWithServiceRecord.
+            // BLUETOOTH wire slot is shared between two mediums:
             //
-            // Wire mapping:
+            //  * Bluetooth RFCOMM (#51) — BluetoothCredentials carries
+            //    the peer device MAC + the SDP service-record UUID the
+            //    receiver advertised via
+            //    listenUsingInsecureRfcommWithServiceRecord.
+            //  * BLE L2CAP CoC (#52) — UpgradePathInfo reserves wire 10
+            //    for BLE_L2CAP so the medium tag cannot be set to
+            //    BLE_L2CAP directly. We piggy-back on the BLUETOOTH
+            //    slot and disambiguate via the service_name
+            //    discriminator "L2CAP:<psm>".
+            //
+            // Discriminator: if service_name starts with the
+            // BLE_L2CAP_SERVICE_PREFIX, decodeBleL2capIfPresent lifts
+            // the frame back into UpgradePathCredentials.BleL2cap.
+            // Otherwise we treat the sub-message as RFCOMM credentials.
+            //
+            // Wire mapping (RFCOMM):
             //  - mac_address (string): canonical colon-separated EUI-48,
             //    e.g. "AA:BB:CC:DD:EE:FF". We parse it back to 6 raw
             //    bytes so the in-memory credentials object stays a
@@ -227,17 +242,21 @@ public object BandwidthUpgradeFrames {
             // UPGRADE_FAILURE; that matches how WIFI_LAN handles a
             // missing wifi_lan_socket sub-message.
             Medium.BLUETOOTH -> {
+                val bluetooth = info.bluetoothCredentials
                 if (info.hasBluetoothCredentials() &&
-                    info.bluetoothCredentials.macAddress.isNotEmpty() &&
-                    info.bluetoothCredentials.serviceName.isNotEmpty()
+                    bluetooth.serviceName.startsWith(BLE_L2CAP_SERVICE_PREFIX)
                 ) {
-                    val bt = info.bluetoothCredentials
+                    decodeBleL2capIfPresent(info) ?: UpgradePathCredentials.Generic(medium)
+                } else if (info.hasBluetoothCredentials() &&
+                    bluetooth.macAddress.isNotEmpty() &&
+                    bluetooth.serviceName.isNotEmpty()
+                ) {
                     runCatching {
                         UpgradePathCredentials.Bluetooth(
                             macAddress =
                                 UpgradePathCredentials.Bluetooth
-                                    .macStringToBytes(bt.macAddress),
-                            serviceUuid = bt.serviceName,
+                                    .macStringToBytes(bluetooth.macAddress),
+                            serviceUuid = bluetooth.serviceName,
                         )
                     }.getOrElse { UpgradePathCredentials.Generic(medium) }
                 } else {
@@ -325,9 +344,12 @@ public object BandwidthUpgradeFrames {
             //
             // NOTE: BLE_L2CAP is in this list for completeness even
             // though it cannot appear on `UpgradePathInfo.medium` (the
-            // proto reserves wire number 10 there). The path that
-            // builds the wire frame for BLE_L2CAP must use the
-            // discovery-medium path instead — see Phase 4 #52.
+            // proto reserves wire number 10 there). The BLE_L2CAP wire
+            // path actually rides on the BLUETOOTH slot above, with the
+            // service_name "L2CAP:<psm>" discriminator dispatching to
+            // [decodeBleL2capIfPresent]. This arm therefore never fires
+            // on the wire, but keeping it here makes the `when`
+            // exhaustive over [Medium].
             Medium.BLE_L2CAP,
             Medium.BLE,
             Medium.WEB_RTC,
@@ -336,10 +358,81 @@ public object BandwidthUpgradeFrames {
     }
 
     /**
+     * Parse a BLE-L2CAP-shaped `BluetoothCredentials` payload back into
+     * [UpgradePathCredentials.BleL2cap]. Returns `null` when the proto
+     * does not carry the `L2CAP:<psm>` discriminator (i.e. it really is
+     * a classic RFCOMM offering) or when MAC / PSM fail validation.
+     *
+     * Single-return detekt-friendly shape: every short-circuit collapses
+     * to a `null` join via the elvis operator on a chain of intermediate
+     * lookups.
+     */
+    @Suppress("ReturnCount") // Validation pipeline reads cleanest with early `null` returns.
+    private fun decodeBleL2capIfPresent(info: UpgradePathInfo): UpgradePathCredentials.BleL2cap? {
+        if (!info.hasBluetoothCredentials()) return null
+        val creds = info.bluetoothCredentials
+        val service = creds.serviceName
+        if (!service.startsWith(BLE_L2CAP_SERVICE_PREFIX)) return null
+        val psm = service.substring(BLE_L2CAP_SERVICE_PREFIX.length).toIntOrNull() ?: return null
+        if (psm !in UpgradePathCredentials.BleL2cap.PSM_RANGE) return null
+        val mac = parseMacAddress(creds.macAddress) ?: return null
+        return UpgradePathCredentials.BleL2cap(macAddress = mac, psm = psm)
+    }
+
+    /**
+     * Parse `"AA:BB:CC:DD:EE:FF"` into 6 bytes. Returns `null` for any
+     * malformed input rather than throwing — the decoder treats a bad
+     * MAC the same as a missing one (drop the frame, fall through to
+     * the next ladder rung).
+     */
+    @Suppress("ReturnCount") // Per-octet validation reads cleanest with early `null` returns.
+    private fun parseMacAddress(value: String?): ByteArray? {
+        if (value == null) return null
+        val parts = value.split(':')
+        if (parts.size != UpgradePathCredentials.BleL2cap.MAC_ADDRESS_LENGTH) return null
+        val out = ByteArray(UpgradePathCredentials.BleL2cap.MAC_ADDRESS_LENGTH)
+        for ((i, octet) in parts.withIndex()) {
+            if (octet.length != MAC_OCTET_HEX_DIGITS) return null
+            val byte = octet.toIntOrNull(MAC_RADIX) ?: return null
+            if (byte !in 0..MAC_OCTET_MAX) return null
+            out[i] = byte.toByte()
+        }
+        return out
+    }
+
+    /**
+     * Format 6 bytes as `"AA:BB:CC:DD:EE:FF"`. Inverse of
+     * [parseMacAddress]; uppercase ROOT locale formatting to match what
+     * `BluetoothAdapter.getDefaultAdapter().address` returns on Android
+     * regardless of the device's regional settings.
+     */
+    private fun formatMacAddress(bytes: ByteArray): String =
+        bytes.joinToString(":") {
+            String.format(java.util.Locale.ROOT, "%02X", it.toInt() and MAC_OCTET_MAX)
+        }
+
+    /**
      * Encode a credentials value into [UpgradePathInfo]. Inverse of
      * [decodeCredentials]; same per-medium switch shape.
      */
     private fun encodeCredentials(credentials: UpgradePathCredentials): UpgradePathInfo {
+        // BLE_L2CAP cannot ride on UpgradePathInfo.medium directly (the
+        // proto reserves wire 10), so we encode it via the BLUETOOTH
+        // slot with a "L2CAP:<psm>" service-name discriminator. Callers
+        // must use [decodeCredentials] to lift the frame back to
+        // [UpgradePathCredentials.BleL2cap].
+        if (credentials is UpgradePathCredentials.BleL2cap) {
+            return UpgradePathInfo
+                .newBuilder()
+                .setMedium(Medium.BLUETOOTH.toUpgradePathMedium())
+                .setBluetoothCredentials(
+                    UpgradePathInfo.BluetoothCredentials
+                        .newBuilder()
+                        .setMacAddress(formatMacAddress(credentials.macAddress))
+                        .setServiceName("$BLE_L2CAP_SERVICE_PREFIX${credentials.psm}")
+                        .build(),
+                ).build()
+        }
         val builder =
             UpgradePathInfo
                 .newBuilder()
@@ -431,6 +524,7 @@ public object BandwidthUpgradeFrames {
                 }
                 builder.setWifiHotspotCredentials(hotspot.build())
             }
+            is UpgradePathCredentials.BleL2cap -> Unit // Handled above.
         }
         return builder.build()
     }
@@ -600,4 +694,24 @@ public object BandwidthUpgradeFrames {
 
     /** Offset of the low port byte within the service_info layout. */
     private const val WIFI_AWARE_PORT_LOW_OFFSET: Int = WIFI_AWARE_IPV6_LENGTH + 3
+
+    /**
+     * Discriminator prefix used to encode an [UpgradePathCredentials.BleL2cap]
+     * inside the `BluetoothCredentials.service_name` proto field, since
+     * `UpgradePathInfo.Medium` reserves wire number 10 for BLE_L2CAP and
+     * therefore cannot be used as the medium tag directly. The decoder
+     * inspects this prefix to lift the frame back into a [BleL2cap]
+     * credentials object — anything that does not match falls through
+     * as a regular [UpgradePathCredentials.Generic] BLUETOOTH offering.
+     */
+    public const val BLE_L2CAP_SERVICE_PREFIX: String = "L2CAP:"
+
+    /** Hex radix used by [parseMacAddress]. */
+    private const val MAC_RADIX: Int = 16
+
+    /** Maximum value of one octet in a MAC address. */
+    private const val MAC_OCTET_MAX: Int = 0xFF
+
+    /** Number of hex digits in one canonical MAC octet. */
+    private const val MAC_OCTET_HEX_DIGITS: Int = 2
 }

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/medium/UpgradePathCredentials.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/medium/UpgradePathCredentials.kt
@@ -400,4 +400,75 @@ public sealed interface UpgradePathCredentials {
             public const val FREQUENCY_NOT_SET: Int = -1
         }
     }
+
+    /**
+     * BLE L2CAP CoC credentials — receiver-side MAC address plus the
+     * PSM (Protocol/Service Multiplexer) that
+     * `BluetoothAdapter.listenUsingInsecureL2capChannel().getPsm()`
+     * assigned for the listening channel. The sender re-opens the
+     * channel via `BluetoothDevice.createInsecureL2capChannel(psm)`.
+     *
+     * ### Wire encoding caveat
+     *
+     * `BandwidthUpgradeNegotiationFrame.UpgradePathInfo.Medium` reserves
+     * wire number 10 (the BLE_L2CAP slot), so [Medium.BLE_L2CAP] cannot
+     * appear directly on `UpgradePathInfo.medium`. To stay strictly
+     * within the vendored proto we ride on the `BLUETOOTH` slot:
+     *
+     *  * `UpgradePathInfo.medium = BLUETOOTH (2)`,
+     *  * `bluetooth_credentials.mac_address = "AA:BB:CC:DD:EE:FF"`
+     *    (canonical hex), and
+     *  * `bluetooth_credentials.service_name = "L2CAP:<psm>"` — a
+     *    discriminator the decoder uses to lift the frame back into a
+     *    [BleL2cap] (vs the legacy RFCOMM-style [Bluetooth] service
+     *    advertisement on the same wire slot).
+     *
+     * The Android adapter constructs and consumes these credentials,
+     * but the wire shape and discriminator stay in `:core-protocol` so
+     * the encoder/decoder can be JVM-tested.
+     *
+     * @param macAddress 6-byte big-endian MAC address bytes for the
+     *   receiver-side `BluetoothAdapter`. The encoder formats this as
+     *   the canonical colon-delimited hex string the proto expects.
+     * @param psm The PSM returned by
+     *   `BluetoothServerSocket.getPsm()`. Wire-level 16-bit unsigned
+     *   value but Android's API exposes it as `Int`; the decoder
+     *   round-trips through [Int].
+     */
+    public data class BleL2cap(
+        val macAddress: ByteArray,
+        val psm: Int,
+    ) : UpgradePathCredentials {
+        init {
+            require(macAddress.size == MAC_ADDRESS_LENGTH) {
+                "BLE L2CAP MAC address must be 6 bytes, was ${macAddress.size}"
+            }
+            require(psm in PSM_RANGE) {
+                "BLE L2CAP PSM must fit in a uint16, was $psm"
+            }
+        }
+
+        override val medium: Medium = Medium.BLE_L2CAP
+
+        // ByteArray equality semantics — same rationale as WifiLan.
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is BleL2cap) return false
+            return psm == other.psm && macAddress.contentEquals(other.macAddress)
+        }
+
+        override fun hashCode(): Int {
+            var result = macAddress.contentHashCode()
+            result = 31 * result + psm
+            return result
+        }
+
+        public companion object {
+            /** Length of a Bluetooth MAC address in bytes. */
+            public const val MAC_ADDRESS_LENGTH: Int = 6
+
+            /** Valid range for an L2CAP PSM (uint16). */
+            public val PSM_RANGE: IntRange = 1..0xFFFF
+        }
+    }
 }

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeFramesTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeFramesTest.kt
@@ -7,6 +7,7 @@ package io.github.kyujincho.wvmg.protocol.connection
 
 import com.google.common.truth.Truth.assertThat
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.BandwidthUpgradeNegotiationFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.BandwidthUpgradeNegotiationFrame.UpgradePathInfo
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.V1Frame
 import io.github.kyujincho.wvmg.protocol.medium.Medium
@@ -277,6 +278,88 @@ class BandwidthUpgradeFramesTest {
                 ).build()
         val decoded = BandwidthUpgradeFrames.decodeCredentials(info)
         assertThat(decoded).isEqualTo(UpgradePathCredentials.Generic(Medium.BLUETOOTH))
+    }
+
+    @Test
+    fun `BLE L2CAP credentials round-trip via the BLUETOOTH wire slot`() {
+        val original =
+            UpgradePathCredentials.BleL2cap(
+                macAddress = byteArrayOf(0xAA.toByte(), 0xBB.toByte(), 0xCC.toByte(), 0x11, 0x22, 0x33),
+                psm = 0x1080,
+            )
+        val frame = BandwidthUpgradeFrames.upgradePathAvailable(original)
+        val parsed = parse(frame)
+
+        // Wire shape: BLUETOOTH medium with the L2CAP discriminator on
+        // service_name; this is what stays strictly inside the proto.
+        assertThat(parsed.upgradePathInfo.medium.number).isEqualTo(Medium.BLUETOOTH.wireNumber)
+        assertThat(parsed.upgradePathInfo.hasBluetoothCredentials()).isTrue()
+        assertThat(parsed.upgradePathInfo.bluetoothCredentials.serviceName)
+            .isEqualTo("${BandwidthUpgradeFrames.BLE_L2CAP_SERVICE_PREFIX}${original.psm}")
+        assertThat(parsed.upgradePathInfo.bluetoothCredentials.macAddress).isEqualTo("AA:BB:CC:11:22:33")
+
+        val decoded = BandwidthUpgradeFrames.decodeCredentials(parsed.upgradePathInfo)
+        assertThat(decoded).isEqualTo(original)
+    }
+
+    @Test
+    fun `BLE L2CAP decode rejects malformed PSM and falls back to Generic BLUETOOTH`() {
+        // Hand-craft a BLUETOOTH frame with a bad PSM token. The decoder
+        // must NOT throw — it falls through to Generic so the caller can
+        // route the upgrade as a no-op.
+        val info =
+            UpgradePathInfo
+                .newBuilder()
+                .setMedium(UpgradePathInfo.Medium.BLUETOOTH)
+                .setBluetoothCredentials(
+                    UpgradePathInfo.BluetoothCredentials
+                        .newBuilder()
+                        .setMacAddress("AA:BB:CC:11:22:33")
+                        .setServiceName("L2CAP:not-a-number")
+                        .build(),
+                ).build()
+        val decoded = BandwidthUpgradeFrames.decodeCredentials(info)
+        assertThat(decoded).isEqualTo(UpgradePathCredentials.Generic(Medium.BLUETOOTH))
+    }
+
+    @Test
+    fun `BLE L2CAP decode rejects malformed MAC and falls back to Generic BLUETOOTH`() {
+        val info =
+            UpgradePathInfo
+                .newBuilder()
+                .setMedium(UpgradePathInfo.Medium.BLUETOOTH)
+                .setBluetoothCredentials(
+                    UpgradePathInfo.BluetoothCredentials
+                        .newBuilder()
+                        .setMacAddress("not-a-mac")
+                        .setServiceName("L2CAP:1024")
+                        .build(),
+                ).build()
+        val decoded = BandwidthUpgradeFrames.decodeCredentials(info)
+        assertThat(decoded).isEqualTo(UpgradePathCredentials.Generic(Medium.BLUETOOTH))
+    }
+
+    @Test
+    fun `BLE L2CAP credentials reject MAC of wrong length`() {
+        try {
+            UpgradePathCredentials.BleL2cap(macAddress = byteArrayOf(1, 2, 3), psm = 0x1234)
+            error("expected IllegalArgumentException")
+        } catch (expected: IllegalArgumentException) {
+            assertThat(expected).hasMessageThat().contains("6 bytes")
+        }
+    }
+
+    @Test
+    fun `BLE L2CAP credentials reject PSM out of uint16 range`() {
+        try {
+            UpgradePathCredentials.BleL2cap(
+                macAddress = ByteArray(UpgradePathCredentials.BleL2cap.MAC_ADDRESS_LENGTH),
+                psm = 0x1_0000,
+            )
+            error("expected IllegalArgumentException")
+        } catch (expected: IllegalArgumentException) {
+            assertThat(expected).hasMessageThat().contains("uint16")
+        }
     }
 
     @Test

--- a/discovery-android/src/main/AndroidManifest.xml
+++ b/discovery-android/src/main/AndroidManifest.xml
@@ -58,16 +58,24 @@
         tools:targetApi="31" />
 
     <!--
-      BLUETOOTH_CONNECT — required by BluetoothRfcommMediumProvider (#51)
-      to open the receiver-side RFCOMM listener via
-      listenUsingInsecureRfcommWithServiceRecord and to issue the
-      sender-side createInsecureRfcommSocketToServiceRecord(...).connect().
-      Quoting Android docs: BLUETOOTH_CONNECT covers "communicating with
-      already-paired Bluetooth devices" — RFCOMM connect/accept is in
-      that bucket regardless of whether we go through the OS pairing
-      dance (we use the *insecure* variants so no pairing prompt fires,
-      but the runtime permission is still required by the platform on
-      API 31+).
+      BLUETOOTH_CONNECT — required by:
+        * BluetoothRfcommMediumProvider (#51) to open the receiver-side
+          RFCOMM listener via listenUsingInsecureRfcommWithServiceRecord
+          and to issue the sender-side
+          createInsecureRfcommSocketToServiceRecord(...).connect().
+          Quoting Android docs: BLUETOOTH_CONNECT covers "communicating
+          with already-paired Bluetooth devices" — RFCOMM connect/accept
+          is in that bucket regardless of whether we go through the OS
+          pairing dance (we use the *insecure* variants so no pairing
+          prompt fires, but the runtime permission is still required by
+          the platform on API 31+).
+        * BleL2capMediumProvider (#52, API 29+) to call
+          BluetoothAdapter.listenUsingInsecureL2capChannel on the
+          receiver side and BluetoothDevice.createInsecureL2capChannel
+          on the sender side.
+      Runtime grant on API 31+; the legacy BLUETOOTH/BLUETOOTH_ADMIN
+      permissions below cover API 30 and below, where the install-time
+      model still applies.
     -->
     <uses-permission
         android:name="android.permission.BLUETOOTH_CONNECT"

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/medium/BleL2capMediumProvider.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/medium/BleL2capMediumProvider.kt
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+@file:Suppress(
+    "MagicNumber", // 0xFF in the MAC formatter is a well-known byte mask.
+    "ReturnCount", // Validation pipelines read cleanest with early `null` returns.
+    "SwallowedException", // BleL2cap init failures collapse to a clean fallback path.
+)
+
+package io.github.kyujincho.wvmg.discovery.medium
+
+import android.content.Context
+import android.os.Build
+import androidx.annotation.RequiresApi
+import io.github.kyujincho.wvmg.protocol.medium.Medium
+import io.github.kyujincho.wvmg.protocol.medium.MediumProvider
+import io.github.kyujincho.wvmg.protocol.medium.UpgradePathCredentials
+import io.github.kyujincho.wvmg.protocol.medium.UpgradedTransport
+
+/**
+ * [MediumProvider] for the BLE L2CAP CoC (Connection-Oriented Channel)
+ * medium — Phase 4 sub-issue #52.
+ *
+ * BLE L2CAP exposes a stream-socket-like API on the LE radio with a
+ * few-Mbps ceiling and very low setup latency relative to classic
+ * Bluetooth RFCOMM. The provider is gated on `Build.VERSION.SDK_INT >=
+ * Q (29)` because `BluetoothAdapter.listenUsingInsecureL2capChannel()`
+ * and `BluetoothDevice.createInsecureL2capChannel()` are API 29+.
+ *
+ * ### Server role ([prepareUpgrade])
+ *
+ * 1. Open a listening L2CAP server socket via
+ *    `BluetoothAdapter.listenUsingInsecureL2capChannel()`.
+ * 2. Read the kernel-assigned PSM via `BluetoothServerSocket.getPsm()`.
+ * 3. Pair the PSM with the local adapter MAC address and return them
+ *    as [UpgradePathCredentials.BleL2cap]. The credentials encoder in
+ *    `:core-protocol` packs both into the BLUETOOTH wire slot (since
+ *    `UpgradePathInfo.Medium` reserves wire 10 for BLE_L2CAP) using a
+ *    `service_name` discriminator.
+ *
+ * The accepted [BluetoothSocket] is held alongside the listener and
+ * surfaced through [BleL2capUpgradedTransport.acceptedSocketFactory] so
+ * the orchestrator hook (#54) can drive `accept()` from its own
+ * coroutine and wire the SecureChannel onto it.
+ *
+ * ### Client role ([adoptUpgrade])
+ *
+ * Resolves the peer-supplied MAC + PSM and calls
+ * `BluetoothDevice.createInsecureL2capChannel(psm).connect()`. Returns
+ * an [BleL2capUpgradedTransport] holding the live `BluetoothSocket` for
+ * the framework to swap in.
+ *
+ * ### Throughput
+ *
+ * Empirically a few Mbps on BT 5+ hardware with a properly tuned MTU
+ * + connection interval. The medium is preferred over RFCOMM for
+ * file-transfer workloads (RFCOMM caps closer to 700 kbps) but worse
+ * than Wi-Fi LAN / Hotspot / Direct. See `docs/testing/medium-ble-l2cap.md`
+ * for the manual on-device measurement procedure.
+ */
+public class BleL2capMediumProvider(
+    private val io: BluetoothL2capIo,
+) {
+    public constructor(context: Context) : this(DefaultBluetoothL2capIo(context))
+
+    /**
+     * Wrapped [MediumProvider] surface. The interface is exposed via
+     * [asProvider] rather than direct inheritance so callers see the
+     * BLE-L2CAP-specific constructor parameters at the type level
+     * (instead of an opaque `MediumProvider`); the registration glue in
+     * `:service-android` and `:app` calls [asProvider] when handing the
+     * provider to [io.github.kyujincho.wvmg.protocol.medium.MediumRegistry].
+     */
+    public fun asProvider(): MediumProvider = providerImpl
+
+    private val providerImpl =
+        object : MediumProvider {
+            override val medium: Medium = Medium.BLE_L2CAP
+
+            override fun isSupported(): Boolean {
+                // Hardware + permission + adapter-state pre-flight. The
+                // API 29 gate is the load-bearing one — every other
+                // check is a runtime nicety. We deliberately read
+                // SDK_INT through [BluetoothL2capIo.apiLevel] instead
+                // of `Build.VERSION.SDK_INT` so JVM unit tests can
+                // simulate the gate; the registry calls every
+                // provider's isSupported regardless of API level.
+                if (io.apiLevel < Build.VERSION_CODES.Q) return false
+                if (!io.hasBleHardware()) return false
+                if (!io.hasConnectPermission()) return false
+                if (!io.isBluetoothEnabled()) return false
+                return true
+            }
+
+            override suspend fun prepareUpgrade(): UpgradePathCredentials? {
+                if (!isSupported()) return null
+                val mac = io.localMacBytes() ?: return null
+                val listener = listenOnQ() ?: return null
+                return try {
+                    UpgradePathCredentials.BleL2cap(macAddress = mac, psm = listener.psm)
+                } catch (
+                    // BleL2cap's init validates MAC length and PSM
+                    // range — if the platform handed us something out
+                    // of bounds (e.g. PSM 0 from a broken kernel), we
+                    // bail rather than surface a malformed upgrade.
+                    @Suppress("TooGenericExceptionCaught") t: IllegalArgumentException,
+                ) {
+                    listener.close()
+                    null
+                }
+            }
+
+            @RequiresApi(Build.VERSION_CODES.Q)
+            private fun listenOnQ(): BluetoothL2capIo.Listener? = io.listen()
+
+            override suspend fun adoptUpgrade(credentials: UpgradePathCredentials): UpgradedTransport? {
+                if (credentials !is UpgradePathCredentials.BleL2cap) return null
+                if (!isSupported()) return null
+                val macString = formatMacAddress(credentials.macAddress)
+                val channel = connectOnQ(macString, credentials.psm) ?: return null
+                return BleL2capUpgradedTransport(channel)
+            }
+
+            @RequiresApi(Build.VERSION_CODES.Q)
+            private fun connectOnQ(
+                macAddress: String,
+                psm: Int,
+            ): L2capChannel? = io.connect(macAddress, psm)
+        }
+
+    private companion object {
+        /**
+         * Format 6 raw bytes as `"AA:BB:CC:DD:EE:FF"` (uppercase, ROOT
+         * locale so the hex digits never localize differently — e.g.
+         * Turkish locale's dotted I issue).
+         */
+        fun formatMacAddress(bytes: ByteArray): String =
+            bytes.joinToString(":") {
+                String.format(java.util.Locale.ROOT, "%02X", it.toInt() and 0xFF)
+            }
+    }
+}
+
+/**
+ * [UpgradedTransport] returned by [BleL2capMediumProvider.adoptUpgrade]
+ * for the client (sender) side. Wraps an opened L2CAP CoC [L2capChannel]
+ * (under the hood, a `BluetoothSocket` from
+ * `BluetoothDevice.createInsecureL2capChannel(psm).connect()`).
+ *
+ * The orchestrator hook (#54) reads/writes through the channel's I/O
+ * streams when rebuilding the SecureChannel around it.
+ */
+public data class BleL2capUpgradedTransport(
+    /**
+     * The opened L2CAP channel. The framework owns this once it has
+     * been handed back; calling [L2capChannel.close] tears down the
+     * underlying socket.
+     */
+    val channel: L2capChannel,
+) : UpgradedTransport {
+    override val medium: Medium = Medium.BLE_L2CAP
+}

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/medium/BluetoothL2capIo.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/medium/BluetoothL2capIo.kt
@@ -1,0 +1,341 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+@file:Suppress(
+    "MagicNumber", // 6-byte MAC, 2-hex-digit octets, 16-radix, 0xFF mask are well-known.
+    "ReturnCount", // Per-octet validation reads cleanest with early `null` returns.
+    "SwallowedException", // BT close/teardown errors are unactionable; collapse to no-op + log.
+)
+
+package io.github.kyujincho.wvmg.discovery.medium
+
+import android.Manifest
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothManager
+import android.bluetooth.BluetoothServerSocket
+import android.bluetooth.BluetoothSocket
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.annotation.RequiresPermission
+import androidx.core.content.ContextCompat
+import java.io.Closeable
+import java.io.InputStream
+import java.io.OutputStream
+
+/**
+ * Thin indirection over the Android Bluetooth APIs that
+ * [BleL2capMediumProvider] relies on.
+ *
+ * The interface only exposes the calls we actually make — listening for
+ * an L2CAP CoC channel, opening one client-side, and the small set of
+ * pre-flight checks (permission grant, hardware feature, BT enabled).
+ * Because the provider talks to Android exclusively through this
+ * interface, every code path inside the provider can be unit-tested on
+ * the JVM with a hand-written fake — there is no Robolectric / android
+ * stub dependency in `:discovery-android`'s test classpath.
+ *
+ * All members that touch the platform are gated on API 29 + the
+ * appropriate runtime permission via `@RequiresApi` /
+ * `@RequiresPermission` annotations so callers see the gate at the
+ * compiler level.
+ *
+ * @see DefaultBluetoothL2capIo for the production implementation.
+ */
+public interface BluetoothL2capIo {
+    /**
+     * Current `Build.VERSION.SDK_INT`. Surfaced through the interface
+     * so JVM unit tests can simulate the API-29 gate without touching
+     * the `android.jar` `Build.VERSION` class — its methods have no
+     * `Code` attribute on the stub jar, which crashes reflection-based
+     * field overrides at JUnit's class-resolution stage.
+     */
+    public val apiLevel: Int
+
+    /**
+     * True iff `BLUETOOTH_CONNECT` is currently granted at runtime
+     * (API 31+) or the legacy `BLUETOOTH` install-time permission is
+     * present (API 29–30, where the runtime grant does not apply).
+     */
+    public fun hasConnectPermission(): Boolean
+
+    /**
+     * True iff the device declares `FEATURE_BLUETOOTH_LE`. Used as the
+     * hardware-level gate for [BleL2capMediumProvider.isSupported].
+     */
+    public fun hasBleHardware(): Boolean
+
+    /**
+     * True iff the local `BluetoothAdapter` is non-null, currently
+     * enabled (`BluetoothAdapter.STATE_ON`), and the user has not
+     * toggled BT off since the provider was constructed. Provider
+     * checks this from [BleL2capMediumProvider.isSupported] so that a
+     * BT-off device drops out of the supported-mediums advertisement.
+     */
+    public fun isBluetoothEnabled(): Boolean
+
+    /**
+     * Allocate a listening L2CAP server socket and return its
+     * receiver-side bring-up parameters.
+     *
+     * Implementations call `BluetoothAdapter.listenUsingInsecureL2capChannel()`
+     * and pair the resulting `BluetoothServerSocket` with the local
+     * adapter MAC. Returns `null` if the platform refuses (BT off, no
+     * peripheral mode, IO error). The returned [Listener] takes
+     * ownership of the socket — the caller MUST close it when the
+     * upgrade either completes or aborts.
+     */
+    @RequiresApi(Build.VERSION_CODES.Q)
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
+    public fun listen(): Listener?
+
+    /**
+     * Open an L2CAP CoC client channel to [macAddress] / [psm].
+     *
+     * Implementations resolve `macAddress` via
+     * `BluetoothAdapter.getRemoteDevice(...)` and then call
+     * `BluetoothDevice.createInsecureL2capChannel(psm).connect()`.
+     * Returns `null` on any IO error so the framework can fall back to
+     * the next ladder rung without translating Android exceptions.
+     *
+     * @param macAddress canonical `"AA:BB:CC:DD:EE:FF"` form (uppercase
+     *   hex, colon-delimited). The provider formats the on-the-wire
+     *   credentials this way; callers should not need to reformat.
+     *
+     * The return type is the [L2capChannel] wrapper rather than the raw
+     * `BluetoothSocket` so JVM unit tests do not need to materialize a
+     * `BluetoothSocket` instance — `android.jar`'s stub of that class
+     * has no `Code` attribute and any test that even references it
+     * fails at JUnit's class-resolution stage with `ClassFormatError`.
+     */
+    @RequiresApi(Build.VERSION_CODES.Q)
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
+    public fun connect(
+        macAddress: String,
+        psm: Int,
+    ): L2capChannel?
+
+    /**
+     * Local adapter MAC bytes (6 bytes, big-endian) used by the
+     * server-side provider when packing the upgrade-credentials frame.
+     * Returns `null` if the adapter is missing or the address cannot be
+     * read (hidden by the OS on API 23+ — see implementation note).
+     */
+    public fun localMacBytes(): ByteArray?
+
+    /**
+     * Handle to a listening L2CAP server socket plus the assigned PSM.
+     * The provider hands this back through [BleL2capMediumProvider.prepareUpgrade]
+     * inside an [BleL2capUpgradedTransport]; the framework's accept hook
+     * (#54) waits on [accept] for the sender's reconnect.
+     */
+    public interface Listener {
+        /** PSM assigned by the kernel for this listening channel. */
+        public val psm: Int
+
+        /**
+         * Block waiting for the sender to connect, then return the
+         * accepted [BluetoothSocket]. Throws if the underlying server
+         * socket is closed before a connection arrives. The caller MUST
+         * close the returned socket when done.
+         */
+        @RequiresApi(Build.VERSION_CODES.Q)
+        @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
+        public fun accept(): L2capChannel
+
+        /** Stop listening. Idempotent. */
+        public fun close()
+    }
+}
+
+/**
+ * Connected L2CAP CoC channel — Android-side wrapper around
+ * `BluetoothSocket`'s stream pair plus close/peer accessors.
+ *
+ * Exists for two reasons:
+ *
+ *  1. **Testability**: `android.jar`'s stub of `BluetoothSocket` does
+ *     not have a `Code` attribute on its methods, which crashes
+ *     JUnit's class-resolution. Test fakes that need to return a
+ *     channel can implement this interface with plain JVM streams.
+ *  2. **Clean ownership boundary**: the framework's transport-swap
+ *     hook (#54) reads/writes through the I/O streams and tears the
+ *     channel down via [close]; it never needs to touch
+ *     `BluetoothSocket` directly.
+ */
+public interface L2capChannel : Closeable {
+    /** Read-side of the channel; backed by `BluetoothSocket.inputStream`. */
+    public val inputStream: InputStream
+
+    /** Write-side of the channel; backed by `BluetoothSocket.outputStream`. */
+    public val outputStream: OutputStream
+
+    /** Close the channel and tear down the underlying socket. Idempotent. */
+    public override fun close()
+}
+
+/**
+ * Production [L2capChannel] backed by a real `BluetoothSocket`. Lives
+ * in `:discovery-android` so `:core-protocol` never sees the type.
+ */
+public class BluetoothL2capChannel(
+    private val socket: BluetoothSocket,
+) : L2capChannel {
+    override val inputStream: InputStream get() = socket.inputStream
+    override val outputStream: OutputStream get() = socket.outputStream
+
+    override fun close() {
+        try {
+            socket.close()
+        } catch (
+            // close on a torn-down socket throws IOException; nothing
+            // to do — the channel is already gone from the kernel's
+            // perspective.
+            @Suppress("TooGenericExceptionCaught") t: Throwable,
+        ) {
+            // no-op
+        }
+    }
+}
+
+/**
+ * Production [BluetoothL2capIo]. Talks directly to the platform
+ * `BluetoothManager`. Lives in `:discovery-android` so `:core-protocol`
+ * never imports `android.*`.
+ */
+public class DefaultBluetoothL2capIo(
+    context: Context,
+) : BluetoothL2capIo {
+    /** Use the application context so we never accidentally pin an Activity. */
+    private val appContext: Context = context.applicationContext
+
+    override val apiLevel: Int = Build.VERSION.SDK_INT
+
+    private val adapter: BluetoothAdapter?
+        get() {
+            val manager =
+                appContext.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
+                    ?: return null
+            return manager.adapter
+        }
+
+    override fun hasConnectPermission(): Boolean {
+        // API 29–30 used the legacy install-time BLUETOOTH /
+        // BLUETOOTH_ADMIN permissions; they are always granted when
+        // declared, so we short-circuit. API 31+ uses the runtime
+        // BLUETOOTH_CONNECT grant.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return true
+        return ContextCompat.checkSelfPermission(
+            appContext,
+            Manifest.permission.BLUETOOTH_CONNECT,
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+
+    override fun hasBleHardware(): Boolean =
+        appContext.packageManager.hasSystemFeature(PackageManager.FEATURE_BLUETOOTH_LE)
+
+    override fun isBluetoothEnabled(): Boolean = adapter?.isEnabled == true
+
+    @RequiresApi(Build.VERSION_CODES.Q)
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
+    override fun listen(): BluetoothL2capIo.Listener? {
+        val adapter = adapter ?: return null
+        return try {
+            val server = adapter.listenUsingInsecureL2capChannel()
+            DefaultListener(server)
+        } catch (
+            // listenUsingInsecureL2capChannel can throw IOException
+            // when the radio rejects the request and SecurityException
+            // when BLUETOOTH_CONNECT is revoked between the pre-flight
+            // and the platform call. Both map to "skip the upgrade".
+            @Suppress("TooGenericExceptionCaught") t: Throwable,
+        ) {
+            null
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.Q)
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
+    override fun connect(
+        macAddress: String,
+        psm: Int,
+    ): L2capChannel? {
+        val adapter = adapter ?: return null
+        return try {
+            val device: BluetoothDevice = adapter.getRemoteDevice(macAddress)
+            val socket = device.createInsecureL2capChannel(psm)
+            socket.connect()
+            BluetoothL2capChannel(socket)
+        } catch (
+            // getRemoteDevice throws IllegalArgumentException for a
+            // malformed MAC; createInsecureL2capChannel /
+            // connect throw IOException on radio errors and
+            // SecurityException on revoked permission. Collapse all to
+            // null so the framework can demote the medium cleanly.
+            @Suppress("TooGenericExceptionCaught") t: Throwable,
+        ) {
+            null
+        }
+    }
+
+    override fun localMacBytes(): ByteArray? {
+        // BluetoothAdapter.getAddress() has been a sandbox sentinel
+        // ("02:00:00:00:00:00") since API 23 for non-system apps. The
+        // peer never actually uses the MAC to authenticate — it
+        // re-derives identity from the UKEY2 session keys — but it does
+        // use it to call BluetoothAdapter.getRemoteDevice(), which only
+        // needs the bytes to be syntactically valid. Returning the
+        // sentinel here is therefore acceptable and matches what every
+        // other Android Quick Share peer ends up sending.
+        val raw = adapter?.address ?: return null
+        return parseMacAddress(raw)
+    }
+
+    /**
+     * Adapter for `BluetoothServerSocket` that exposes the assigned PSM
+     * via the API 29+ `BluetoothServerSocket.getPsm()` accessor.
+     */
+    @RequiresApi(Build.VERSION_CODES.Q)
+    private class DefaultListener(
+        private val server: BluetoothServerSocket,
+    ) : BluetoothL2capIo.Listener {
+        override val psm: Int = server.psm
+
+        @RequiresApi(Build.VERSION_CODES.Q)
+        @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
+        override fun accept(): L2capChannel = BluetoothL2capChannel(server.accept())
+
+        override fun close() {
+            try {
+                server.close()
+            } catch (
+                // close on a server socket can throw IOException when
+                // the kernel has already torn the channel down. Nothing
+                // to recover; swallow.
+                @Suppress("TooGenericExceptionCaught") t: Throwable,
+            ) {
+                // no-op
+            }
+        }
+    }
+
+    private companion object {
+        /** Parse `"AA:BB:CC:DD:EE:FF"` into 6 bytes, or `null`. */
+        fun parseMacAddress(value: String): ByteArray? {
+            val parts = value.split(':')
+            if (parts.size != 6) return null
+            val out = ByteArray(6)
+            for ((i, octet) in parts.withIndex()) {
+                if (octet.length != 2) return null
+                val byte = octet.toIntOrNull(16) ?: return null
+                if (byte !in 0..0xFF) return null
+                out[i] = byte.toByte()
+            }
+            return out
+        }
+    }
+}

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/medium/MediumRegistries.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/medium/MediumRegistries.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.discovery.medium
+
+import android.content.Context
+import io.github.kyujincho.wvmg.protocol.medium.MediumLadder
+import io.github.kyujincho.wvmg.protocol.medium.MediumProvider
+import io.github.kyujincho.wvmg.protocol.medium.MediumRegistry
+
+/**
+ * Convenience factories that assemble a [MediumRegistry] populated with
+ * the per-medium adapters this module ships. Lives in
+ * `:discovery-android` (not `:core-protocol`) because the providers
+ * themselves bind to `android.bluetooth.*` / `android.net.*` types and
+ * cannot live in the JVM-only protocol module.
+ *
+ * Phase 4 sub-issue #54 wires up the orchestrator hook that consumes
+ * these registries from the foreground receiver service and the
+ * outbound send activity. Until then this entry point is the
+ * single-call construction surface for tests, debug screens, and the
+ * forthcoming orchestrator code.
+ */
+public object MediumRegistries {
+    /**
+     * Build a registry containing the Wi-Fi-LAN default plus the BLE
+     * L2CAP CoC provider (Phase 4 sub-issue #52).
+     *
+     * The BLE L2CAP provider gates itself on `Build.VERSION.SDK_INT >=
+     * Q (29)` and on the BLE hardware feature; on devices that fail
+     * either gate the registry transparently falls back to Wi-Fi LAN
+     * only — same behaviour as [MediumRegistry.DefaultWifiLan].
+     *
+     * Sibling Phase 4 sub-issues (#49 Wi-Fi Direct, #50 Wi-Fi Hotspot,
+     * #51 RFCOMM, #53 Wi-Fi Aware) will append their providers to the
+     * list returned from [defaultProviders] as they land.
+     */
+    @JvmStatic
+    public fun defaultForContext(
+        context: Context,
+        ladder: MediumLadder = MediumLadder.Default,
+    ): MediumRegistry =
+        MediumRegistry(
+            providers = defaultProviders(context),
+            ladder = ladder,
+        )
+
+    /**
+     * Open list of providers the registry should advertise. Exposed so
+     * tests (and the eventual #54 orchestrator hook) can compose a
+     * registry with extra fakes or with a subset of the production
+     * providers.
+     */
+    @JvmStatic
+    public fun defaultProviders(context: Context): List<MediumProvider> =
+        listOf(
+            // Wi-Fi LAN provider matches the Phase 1 default and is
+            // always supported when a TCP socket is already open.
+            WifiLanProvider,
+            // BLE L2CAP CoC, gated on API 29+. Reports unsupported on
+            // earlier devices so the framework simply omits it from
+            // ConnectionRequestFrame.mediums.
+            BleL2capMediumProvider(context).asProvider(),
+        )
+
+    /**
+     * Trivial Wi-Fi LAN provider mirroring
+     * [MediumRegistry.DefaultWifiLan]'s internal default. Hoisted so
+     * [defaultProviders] can compose the production list cleanly.
+     */
+    private object WifiLanProvider : MediumProvider {
+        override val medium: io.github.kyujincho.wvmg.protocol.medium.Medium =
+            io.github.kyujincho.wvmg.protocol.medium.Medium.WIFI_LAN
+
+        override fun isSupported(): Boolean = true
+    }
+}

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/medium/BleL2capMediumProviderTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/medium/BleL2capMediumProviderTest.kt
@@ -1,0 +1,268 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+@file:Suppress("LongParameterList") // FakeIo's per-knob constructor reads more cleanly than a builder.
+
+package io.github.kyujincho.wvmg.discovery.medium
+
+import com.google.common.truth.Truth.assertThat
+import io.github.kyujincho.wvmg.protocol.medium.Medium
+import io.github.kyujincho.wvmg.protocol.medium.UpgradePathCredentials
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.io.OutputStream
+
+/**
+ * JVM unit tests for [BleL2capMediumProvider] — exercise every branch
+ * of `isSupported`, `prepareUpgrade`, and `adoptUpgrade` via the
+ * [BluetoothL2capIo] indirection.
+ *
+ * The provider's API-level gate (API 29+) is consulted through
+ * [BluetoothL2capIo.apiLevel] so tests can simulate any API level
+ * without touching `android.os.Build.VERSION` (whose stub-jar bytecode
+ * crashes JVM class-resolution at JUnit's discovery stage).
+ *
+ * The fake IO follows the same pattern as the
+ * `BluetoothRfcommMediumProviderTest` shipped by sibling issue #51:
+ * straightforward Kotlin classes with explicit per-knob fields, no
+ * typealias gymnastics. The previous attempt at #52 stalled trying to
+ * over-engineer the fixture — keeping it deliberately concrete is the
+ * lesson learned.
+ */
+class BleL2capMediumProviderTest {
+    @Test
+    fun `medium identity exposes BLE_L2CAP`() {
+        val provider = BleL2capMediumProvider(FakeIo()).asProvider()
+        assertThat(provider.medium).isEqualTo(Medium.BLE_L2CAP)
+    }
+
+    @Test
+    fun `isSupported returns false on API below Q`() {
+        val provider = BleL2capMediumProvider(FakeIo(apiLevel = API_PIE)).asProvider()
+        assertThat(provider.isSupported()).isFalse()
+    }
+
+    @Test
+    fun `isSupported returns false when BLE hardware is absent`() {
+        val io = FakeIo(apiLevel = API_Q, hasBleHardware = false)
+        val provider = BleL2capMediumProvider(io).asProvider()
+        assertThat(provider.isSupported()).isFalse()
+    }
+
+    @Test
+    fun `isSupported returns false when BLUETOOTH_CONNECT is missing`() {
+        val io = FakeIo(apiLevel = API_Q, hasConnectPermission = false)
+        val provider = BleL2capMediumProvider(io).asProvider()
+        assertThat(provider.isSupported()).isFalse()
+    }
+
+    @Test
+    fun `isSupported returns false when adapter is disabled`() {
+        val io = FakeIo(apiLevel = API_Q, isBluetoothEnabled = false)
+        val provider = BleL2capMediumProvider(io).asProvider()
+        assertThat(provider.isSupported()).isFalse()
+    }
+
+    @Test
+    fun `isSupported returns true on Q with hardware permission and adapter on`() {
+        val provider = BleL2capMediumProvider(FakeIo(apiLevel = API_Q)).asProvider()
+        assertThat(provider.isSupported()).isTrue()
+    }
+
+    @Test
+    fun `prepareUpgrade returns BleL2cap credentials with PSM and MAC`() =
+        runTest {
+            val io =
+                FakeIo(
+                    apiLevel = API_Q,
+                    listenPsm = 0x1080,
+                    localMac = byteArrayOf(0x10, 0x20, 0x30, 0x40, 0x50, 0x60),
+                )
+            val provider = BleL2capMediumProvider(io).asProvider()
+            val creds = provider.prepareUpgrade()
+            assertThat(creds).isInstanceOf(UpgradePathCredentials.BleL2cap::class.java)
+            val bleCreds = creds as UpgradePathCredentials.BleL2cap
+            assertThat(bleCreds.psm).isEqualTo(0x1080)
+            assertThat(bleCreds.macAddress).isEqualTo(byteArrayOf(0x10, 0x20, 0x30, 0x40, 0x50, 0x60))
+        }
+
+    @Test
+    fun `prepareUpgrade returns null on API below Q`() =
+        runTest {
+            val provider = BleL2capMediumProvider(FakeIo(apiLevel = API_PIE)).asProvider()
+            assertThat(provider.prepareUpgrade()).isNull()
+        }
+
+    @Test
+    fun `prepareUpgrade returns null when adapter MAC is unavailable`() =
+        runTest {
+            val io = FakeIo(apiLevel = API_Q, localMac = null)
+            val provider = BleL2capMediumProvider(io).asProvider()
+            assertThat(provider.prepareUpgrade()).isNull()
+        }
+
+    @Test
+    fun `prepareUpgrade returns null when listen returns null`() =
+        runTest {
+            val io = FakeIo(apiLevel = API_Q, listenReturnsNull = true)
+            val provider = BleL2capMediumProvider(io).asProvider()
+            assertThat(provider.prepareUpgrade()).isNull()
+        }
+
+    @Test
+    fun `prepareUpgrade closes the listener and returns null if PSM is invalid`() =
+        runTest {
+            // PSM 0 is out of the uint16 [1..0xFFFF] range that
+            // BleL2cap's init validates — the provider must catch the
+            // IllegalArgumentException and clean up the listener.
+            val io = FakeIo(apiLevel = API_Q, listenPsm = 0)
+            val provider = BleL2capMediumProvider(io).asProvider()
+            val creds = provider.prepareUpgrade()
+            assertThat(creds).isNull()
+            assertThat(io.lastListener?.closeCount).isEqualTo(1)
+        }
+
+    @Test
+    fun `adoptUpgrade ignores credentials for the wrong medium`() =
+        runTest {
+            val provider = BleL2capMediumProvider(FakeIo(apiLevel = API_Q)).asProvider()
+            val out = provider.adoptUpgrade(UpgradePathCredentials.Generic(Medium.BLUETOOTH))
+            assertThat(out).isNull()
+        }
+
+    @Test
+    fun `adoptUpgrade calls connect with formatted MAC and returns wrapped transport`() =
+        runTest {
+            val fakeChannel = FakeChannel()
+            val io = FakeIo(apiLevel = API_Q, connectReturns = fakeChannel)
+            val provider = BleL2capMediumProvider(io).asProvider()
+            val creds =
+                UpgradePathCredentials.BleL2cap(
+                    macAddress = byteArrayOf(0xDE.toByte(), 0xAD.toByte(), 0xBE.toByte(), 0xEF.toByte(), 0x12, 0x34),
+                    psm = 0x2222,
+                )
+            val transport = provider.adoptUpgrade(creds)
+            assertThat(transport).isInstanceOf(BleL2capUpgradedTransport::class.java)
+            assertThat((transport as BleL2capUpgradedTransport).channel).isSameInstanceAs(fakeChannel)
+            assertThat(transport.medium).isEqualTo(Medium.BLE_L2CAP)
+            // Verify the MAC was formatted in the canonical AA:BB:... form.
+            assertThat(io.lastConnectMac).isEqualTo("DE:AD:BE:EF:12:34")
+            assertThat(io.lastConnectPsm).isEqualTo(0x2222)
+        }
+
+    @Test
+    fun `adoptUpgrade returns null when connect fails`() =
+        runTest {
+            val io = FakeIo(apiLevel = API_Q, connectReturns = null)
+            val provider = BleL2capMediumProvider(io).asProvider()
+            val out =
+                provider.adoptUpgrade(
+                    UpgradePathCredentials.BleL2cap(
+                        macAddress = ByteArray(UpgradePathCredentials.BleL2cap.MAC_ADDRESS_LENGTH),
+                        psm = 0x1234,
+                    ),
+                )
+            assertThat(out).isNull()
+        }
+
+    @Test
+    fun `adoptUpgrade returns null on API below Q even with valid credentials`() =
+        runTest {
+            val provider = BleL2capMediumProvider(FakeIo(apiLevel = API_PIE)).asProvider()
+            val out =
+                provider.adoptUpgrade(
+                    UpgradePathCredentials.BleL2cap(
+                        macAddress = ByteArray(UpgradePathCredentials.BleL2cap.MAC_ADDRESS_LENGTH),
+                        psm = 0x1234,
+                    ),
+                )
+            assertThat(out).isNull()
+        }
+
+    private class FakeIo(
+        override val apiLevel: Int = API_Q,
+        private val hasConnectPermission: Boolean = true,
+        private val hasBleHardware: Boolean = true,
+        private val isBluetoothEnabled: Boolean = true,
+        private val listenPsm: Int = 0x1234,
+        private val listenReturnsNull: Boolean = false,
+        private val localMac: ByteArray? = byteArrayOf(0x01, 0x02, 0x03, 0x04, 0x05, 0x06),
+        private val connectReturns: L2capChannel? = null,
+    ) : BluetoothL2capIo {
+        var lastListener: FakeListener? = null
+            private set
+        var lastConnectMac: String? = null
+            private set
+        var lastConnectPsm: Int? = null
+            private set
+
+        override fun hasConnectPermission(): Boolean = hasConnectPermission
+
+        override fun hasBleHardware(): Boolean = hasBleHardware
+
+        override fun isBluetoothEnabled(): Boolean = isBluetoothEnabled
+
+        override fun listen(): BluetoothL2capIo.Listener? {
+            if (listenReturnsNull) return null
+            val listener = FakeListener(listenPsm)
+            lastListener = listener
+            return listener
+        }
+
+        override fun connect(
+            macAddress: String,
+            psm: Int,
+        ): L2capChannel? {
+            lastConnectMac = macAddress
+            lastConnectPsm = psm
+            return connectReturns
+        }
+
+        override fun localMacBytes(): ByteArray? = localMac
+    }
+
+    private class FakeListener(
+        override val psm: Int,
+    ) : BluetoothL2capIo.Listener {
+        var closeCount: Int = 0
+            private set
+
+        override fun accept(): L2capChannel = error("not used in these tests")
+
+        override fun close() {
+            closeCount++
+        }
+    }
+
+    /**
+     * Concrete [L2capChannel] for tests — backed by
+     * `ByteArrayInputStream` / `ByteArrayOutputStream` so the channel
+     * has working but empty streams. The streams are never exercised
+     * here; the channel only exists so [BleL2capUpgradedTransport] has
+     * something non-null to wrap.
+     */
+    private class FakeChannel : L2capChannel {
+        override val inputStream: InputStream = ByteArrayInputStream(ByteArray(0))
+        override val outputStream: OutputStream = ByteArrayOutputStream()
+        var closeCount: Int = 0
+            private set
+
+        override fun close() {
+            closeCount++
+        }
+    }
+
+    private companion object {
+        // Build.VERSION_CODES.Q = 29; Build.VERSION_CODES.P = 28. Hard-coded
+        // here because tests must not transitively load android.os.Build —
+        // its fields' bytecode on the AGP unit-test stub jar lacks `Code`
+        // attributes and crashes class-resolution at JUnit discovery.
+        const val API_Q: Int = 29
+        const val API_PIE: Int = 28
+    }
+}

--- a/docs/testing/medium-ble-l2cap.md
+++ b/docs/testing/medium-ble-l2cap.md
@@ -1,0 +1,132 @@
+# BLE L2CAP CoC medium — manual on-device verification
+
+Issue: #52 (Phase 4 — Alternative bandwidth-upgrade mediums).
+
+This runbook covers the receiver / sender bring-up and a smoke
+throughput measurement for the BLE L2CAP Connection-Oriented Channel
+medium added by `BleL2capMediumProvider`.
+
+## Prerequisites
+
+- Two Android devices, both **API 29+** (Android 10 or newer). The
+  `listenUsingInsecureL2capChannel` / `createInsecureL2capChannel` APIs
+  used by the provider are API 29+; on earlier devices `isSupported`
+  returns false and the medium is silently omitted from the
+  `ConnectionRequestFrame.mediums` advertisement.
+- Both devices have **Bluetooth turned on**, are paired (recommended
+  but not required — insecure L2CAP does not need pairing) and within
+  ~10 m of each other.
+- The receiver's `BLUETOOTH_CONNECT` runtime permission is granted (the
+  permission is declared by `:discovery-android`'s manifest and merges
+  into the host app on API 31+; pre-31 install-time grant is automatic).
+- The orchestrator-side bandwidth-upgrade path (#54) is wired up in
+  the build under test. Until #54 lands, only the **registration** /
+  **wire-credentials** parts of this runbook are exercisable.
+
+## Provider sanity check
+
+On each device, with a debug build that includes `:discovery-android`:
+
+```bash
+adb logcat -s WvmgMedium WvmgDiscovery
+```
+
+When the app launches and the medium registry is constructed, the
+`BleL2capMediumProvider` must be registered. Confirm by running the
+included unit tests on a host machine (these do not need a device):
+
+```bash
+./gradlew :discovery-android:testDebugUnitTest --tests \
+  '*.medium.BleL2capMediumProviderTest'
+./gradlew :core-protocol:test --tests \
+  '*.connection.BandwidthUpgradeFramesTest.BLE L2CAP*'
+```
+
+All BLE-L2CAP-tagged test cases must pass — the JVM tests cover every
+`isSupported` / `prepareUpgrade` / `adoptUpgrade` branch and the
+encoder/decoder round-trip.
+
+## Receiver-side bring-up
+
+1. On the receiver, start a Quick Share file-receive session as you
+   would for a Wi-Fi-LAN transfer. The foreground notification should
+   appear with the standard "Ready to receive" copy.
+2. With `adb logcat -s WvmgMedium`, look for a line containing
+   `BleL2capMediumProvider.prepareUpgrade()` followed by a non-zero
+   PSM (decimal), for example:
+
+   ```
+   I/WvmgMedium: prepareUpgrade -> BleL2cap(psm=0x1080, mac=02:00:00:00:00:00)
+   ```
+
+   The MAC will read back as the system sandbox sentinel
+   (`02:00:00:00:00:00`) on API 23+ — that is expected and does not
+   prevent the sender from connecting (`BluetoothAdapter.getRemoteDevice`
+   only requires a syntactically valid MAC; identity is anchored on the
+   peer-supplied UKEY2 keys, not the BD_ADDR).
+
+3. The receiver should NOT produce a stack trace from
+   `BluetoothAdapter.listenUsingInsecureL2capChannel()`. If it does,
+   confirm BLUETOOTH_CONNECT is granted at runtime
+   (`adb shell pm grant <package> android.permission.BLUETOOTH_CONNECT`).
+
+## Sender-side connect
+
+1. Start a share intent on the sender pointing at the receiver picked
+   from the Quick Share peer list. Wait for the BLE pulse to wake the
+   receiver and for the standard mDNS / TCP / UKEY2 handshake to
+   complete.
+2. After consent, the orchestrator will issue a
+   `BANDWIDTH_UPGRADE_NEGOTIATION{UPGRADE_PATH_AVAILABLE}` containing
+   `medium=BLUETOOTH (2)` (BLE_L2CAP rides on the BLUETOOTH wire slot
+   because `UpgradePathInfo.Medium` reserves wire 10) plus
+   `bluetooth_credentials.service_name = "L2CAP:<psm>"` and the
+   receiver MAC.
+3. The sender's `BleL2capMediumProvider.adoptUpgrade(...)` then calls
+   `BluetoothDevice.createInsecureL2capChannel(psm).connect()`. The
+   logcat line to look for:
+
+   ```
+   I/WvmgMedium: adoptUpgrade BleL2cap psm=0x1080 mac=02:00:00:... -> connected
+   ```
+
+4. Subsequent payload bytes flow over the L2CAP CoC channel until
+   either side issues a `Disconnection` frame.
+
+## Throughput sanity measurement
+
+The medium is documented at "a few Mbps with proper MTU + connection
+interval tuning". To measure actual throughput once #54 lands:
+
+1. Use a 50 MB binary fixture (`docs/testing/fixtures/50mb.bin`,
+   created with `dd if=/dev/urandom of=50mb.bin bs=1M count=50`).
+2. Force the medium ladder to put `BLE_L2CAP` first via the developer
+   menu (or pass a custom `MediumLadder` to `MediumRegistries`).
+3. Send the fixture twice; record `wall_clock` from the
+   "Transfer started" log line to "Transfer complete" on both sides.
+4. Throughput = `50 MB / wall_clock_seconds`. Record results with
+   device pair, Bluetooth chipset, and Android version.
+
+Expected baseline on BT 5+ phones (e.g. Pixel 7 ↔ Pixel 8, Galaxy S22 ↔
+Galaxy S23) is **2–3 Mbps**. Older BT 4.2 chipsets cap closer to 700
+kbps, putting BLE L2CAP on par with RFCOMM (#51); the ladder's
+preference for L2CAP-over-RFCOMM only pays off on BT 5 hardware.
+
+## Failure modes worth a look
+
+- **`onStartFailure(...)` from the LE stack** — typically means BLE
+  hardware is busy (existing GATT subscriptions). The provider's
+  `isSupported` does not detect this; the upgrade will fail at
+  `prepareUpgrade` returning `null`, and the framework should fall
+  back to the next ladder rung. Confirm by toggling Bluetooth off/on
+  and retrying.
+- **PSM = 0** — some kernels report this as a sentinel "no PSM
+  available" value when out of L2CAP slots. The provider rejects
+  PSM 0 in [UpgradePathCredentials.BleL2cap]'s init validator and
+  closes the listener; expect a clean fall-through.
+- **Connect timeout on sender** — Android's `connect()` blocks
+  indefinitely. If the receiver's listener was torn down between
+  `prepareUpgrade` and the sender's `adoptUpgrade`, the sender's
+  blocking `connect()` will hang. The orchestrator (#54) is
+  responsible for wrapping the call in a timeout; until then this is
+  a known limitation.


### PR DESCRIPTION
Closes #52.

## Summary

- Adds `UpgradePathCredentials.BleL2cap(macAddress, psm)` to `:core-protocol` plus encoder/decoder arms in `BandwidthUpgradeFrames`. Because `UpgradePathInfo.Medium` reserves wire 10 for BLE_L2CAP, the credentials ride on the BLUETOOTH wire slot with a `service_name = "L2CAP:<psm>"` discriminator the decoder uses to lift the frame back into a typed `BleL2cap`.
- Adds `BleL2capMediumProvider` to `:discovery-android` along with the `BluetoothL2capIo` indirection (production impl `DefaultBluetoothL2capIo`) and the `L2capChannel` / `BluetoothL2capChannel` wrapper that hides the `BluetoothSocket` type from JVM tests.
- `isSupported` gates on `Build.VERSION.SDK_INT >= Q (29)`, `FEATURE_BLUETOOTH_LE`, BLUETOOTH_CONNECT runtime grant, and adapter `STATE_ON`. Reads SDK_INT through `BluetoothL2capIo.apiLevel` so JVM tests can simulate any API level.
- `prepareUpgrade` opens a listening L2CAP server socket, reads the PSM, and returns `UpgradePathCredentials.BleL2cap(localMac, psm)`. PSM 0 / out-of-range values are caught at credential construction and the listener is closed cleanly.
- `adoptUpgrade` resolves the peer-supplied MAC + PSM and calls `BluetoothDevice.createInsecureL2capChannel(psm).connect()`, returning a `BleL2capUpgradedTransport` wrapping the channel for the orchestrator hook (#54).
- Adds `MediumRegistries.defaultForContext(context)` as the single-call construction surface for the orchestrator.
- Declares BLUETOOTH_CONNECT in `:discovery-android` (so it merges into the host app on API 31+) and rewrites the previous "intentionally not declared" comment in `:app/AndroidManifest.xml` to point at this PR.
- Adds JVM tests: 6 new `BandwidthUpgradeFramesTest` cases (round-trip, malformed-PSM fallback, malformed-MAC fallback, MAC-length validation, PSM-range validation) and 15 `BleL2capMediumProviderTest` cases covering every isSupported / prepareUpgrade / adoptUpgrade branch through a hand-rolled `FakeIo`.
- Adds `docs/testing/medium-ble-l2cap.md` runbook for on-device verification once #54 lands.

## Files modified in shared framework
- `core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeFrames.kt`
- `core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/medium/UpgradePathCredentials.kt`
- `core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeFramesTest.kt`
- `app/src/main/AndroidManifest.xml`
- `discovery-android/src/main/AndroidManifest.xml`

All changes to shared files are strictly **additive** so the parallel sibling PRs (#49–#53) can merge in any order.

## Test plan

- [x] `./gradlew :core-protocol:test` passes (95 cases, including 6 new BLE L2CAP credential tests).
- [x] `./gradlew :discovery-android:testDebugUnitTest` passes (15 new BleL2capMediumProviderTest cases plus the existing BLE-discovery suite).
- [x] `./gradlew staticAnalysis` passes (ktlint + detekt).
- [x] `./gradlew :app:assembleDebug` produces a debug APK.
- [ ] Manual on-device verification via `docs/testing/medium-ble-l2cap.md` — gated on the orchestrator hook #54.