### PR TITLE
fix: sequence outbound discovery after receiver unpublish (#107)

### DIFF
--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendActivity.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendActivity.kt
@@ -32,6 +32,7 @@ import io.github.kyujincho.wvmg.protocol.connection.OutboundConnectionState
 import io.github.kyujincho.wvmg.protocol.endpoint.DeviceType
 import io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo
 import io.github.kyujincho.wvmg.service.receiver.OutboundSessionActiveHolder
+import io.github.kyujincho.wvmg.service.receiver.ReceiverAdvertisementStateHolder
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -80,6 +81,7 @@ public class SendActivity : AppCompatActivity() {
     private var files: List<FileSource> = emptyList()
     private val peers: MutableList<DiscoveredService> = mutableListOf()
     private val pendingPeerRemovalJobs: MutableMap<String, Job> = mutableMapOf()
+    private var outboundPresenceJob: Job? = null
     private var discoveryJob: Job? = null
     private var connectionJob: Job? = null
     private var activeConnection: OutboundConnection? = null
@@ -145,9 +147,7 @@ public class SendActivity : AppCompatActivity() {
 
         binding.sendPayloadSummary.text = PayloadSummary.forFiles(this, files)
         binding.sendSubtitle.setText(R.string.send_subtitle_discovering)
-        startDiscovery()
-        startEmptyPeerHintTimer()
-        startBleAdvertise()
+        startOutboundPresence()
     }
 
     /**
@@ -207,6 +207,7 @@ public class SendActivity : AppCompatActivity() {
         // OutboundConnection so a CancelFrame is sent on the wire when
         // possible (best-effort — already-terminal states are no-ops).
         activeConnection?.cancel()
+        outboundPresenceJob?.cancel()
         discoveryJob?.cancel()
         connectionJob?.cancel()
         emptyPeerHintJob?.cancel()
@@ -350,6 +351,33 @@ public class SendActivity : AppCompatActivity() {
     // -----------------------------------------------------------------
     // Discovery
     // -----------------------------------------------------------------
+
+    private fun startOutboundPresence() {
+        outboundPresenceJob?.cancel()
+        outboundPresenceJob =
+            lifecycleScope.launch {
+                val receiverWasAdvertising = ReceiverAdvertisementStateHolder.isAdvertising
+                if (receiverWasAdvertising) {
+                    logOutboundDiagnostic(
+                        "discovery: waiting for receiver mDNS unpublish before browse",
+                    )
+                }
+
+                val unpublishObserved = ReceiverAdvertisementStateHolder.awaitNotAdvertising()
+                if (!unpublishObserved) {
+                    logOutboundDiagnostic(
+                        "discovery: receiver mDNS unpublish wait timed out; starting browse",
+                    )
+                } else if (receiverWasAdvertising) {
+                    logOutboundDiagnostic("discovery: receiver mDNS unpublish observed")
+                }
+
+                if (!lifecycle.currentState.isAtLeast(Lifecycle.State.CREATED)) return@launch
+                startDiscovery()
+                startEmptyPeerHintTimer()
+                startBleAdvertise()
+            }
+    }
 
     private fun startDiscovery() {
         val discovery = Discovery(applicationContext)

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/AndroidNsdRegistrar.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/AndroidNsdRegistrar.kt
@@ -15,6 +15,8 @@ import java.io.IOException
 import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
 import java.net.InetAddress
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
@@ -111,6 +113,7 @@ internal class AndroidNsdRegistrar(
     ) : NsdManager.RegistrationListener {
         private val unregistered = AtomicBoolean(false)
         private val resumed = AtomicBoolean(false)
+        private val unregisterSignal = CountDownLatch(1)
 
         @Volatile
         private var handle: AndroidNsdRegistrationHandle? = null
@@ -149,6 +152,7 @@ internal class AndroidNsdRegistrar(
 
         override fun onServiceUnregistered(serviceInfo: NsdServiceInfo) {
             handle?.markInactive()
+            unregisterSignal.countDown()
         }
 
         override fun onUnregistrationFailed(
@@ -159,17 +163,27 @@ internal class AndroidNsdRegistrar(
             // (e.g. service already gone), the handle is dead from our
             // perspective.
             handle?.markInactive()
+            unregisterSignal.countDown()
             Log.w(TAG, "NsdManager unregister failed errorCode=$errorCode")
         }
 
         fun cancel() {
             if (unregistered.compareAndSet(false, true)) {
                 runCatching { nsdManager.unregisterService(this) }
+                    .onFailure {
+                        handle?.markInactive()
+                        unregisterSignal.countDown()
+                    }
             }
         }
 
         fun unregister() {
             cancel()
+            runCatching {
+                unregisterSignal.await(UNREGISTER_CALLBACK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
+            }.onFailure {
+                Log.w(TAG, "NsdManager unregister wait failed", it)
+            }
         }
 
         private fun readHostAddress(serviceInfo: NsdServiceInfo): InetAddress? =
@@ -218,6 +232,7 @@ internal class AndroidNsdRegistrar(
 
     internal companion object {
         private const val TAG = Discovery.TAG
+        private const val UNREGISTER_CALLBACK_TIMEOUT_MILLIS: Long = 1_000L
 
         /**
          * Cached reflective handle on `NsdServiceInfo.setAttribute(String, byte[])`.

--- a/docs/testing/interop-ble-trigger.md
+++ b/docs/testing/interop-ble-trigger.md
@@ -376,6 +376,26 @@ within 5 s of the BLE pulse landing on vivo hardware.
    service type:_FC9F5ED42C8A._tcp.local` line and `onServiceFound`
    entries for each visible Quick Share peer.
 
+### Same-service publish / browse sequencing
+
+Funtouch 16 can wedge a process-local `NsdManager.discoverServices`
+listener if WVMG starts browsing `_FC9F5ED42C8A._tcp` while its own
+receiver-side `registerService` for the same type is still active or
+tearing down. The sender flow therefore flips the outbound-session veto,
+waits briefly for the receiver mDNS advertisement to report stopped,
+then starts the peer-picker browse.
+
+When verifying issue #107 on a vivo device:
+
+1. Start the receiver service and enable Always Visible.
+2. Open a share intent while a Samsung / Pixel peer is visible.
+3. Confirm logcat or `wvmg-outbound.log` contains:
+   `discovery: waiting for receiver mDNS unpublish before browse`
+   followed by `discovery: receiver mDNS unpublish observed`.
+4. Confirm the peer picker re-acquires the Samsung / Pixel peer within
+   about 5 s. If it does not, collect `dumpsys servicediscovery` before
+   force-stopping WVMG so the platform listener/cache state is preserved.
+
 ### App freezing must be disabled
 
 Funtouch's "App Freezer" / "Background process management" suspends

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
@@ -45,8 +45,13 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import java.util.concurrent.atomic.AtomicReference
 
 /**
@@ -1076,6 +1081,46 @@ public object OutboundSessionActiveHolder {
     public fun setOutboundSessionActive(active: Boolean) {
         state.value = active
     }
+}
+
+/**
+ * Process-wide mirror of the receiver mDNS advertisement state.
+ *
+ * `SendActivity` uses this as a small synchronization point for vivo /
+ * Funtouch / OriginOS devices whose `NsdManager` can wedge a browse
+ * listener when the same process starts browsing the Quick Share service
+ * type before its own receiver-side publish has fully torn down.
+ */
+public object ReceiverAdvertisementStateHolder {
+    private val state: MutableStateFlow<Boolean> = MutableStateFlow(false)
+
+    /** Hot flow signalling whether the receiver mDNS record is active. */
+    public val advertisingFlow: StateFlow<Boolean> = state
+
+    /** Current snapshot of [advertisingFlow]. */
+    public val isAdvertising: Boolean
+        get() = state.value
+
+    /**
+     * Wait until receiver mDNS is no longer advertised, bounded so a
+     * stale state signal cannot block the sender picker indefinitely.
+     */
+    public suspend fun awaitNotAdvertising(
+        timeoutMillis: Long = DEFAULT_AWAIT_NOT_ADVERTISING_TIMEOUT_MILLIS,
+    ): Boolean {
+        if (!state.value) return true
+        return withTimeoutOrNull(timeoutMillis) {
+            advertisingFlow
+                .filter { advertising -> !advertising }
+                .first()
+        } != null
+    }
+
+    internal fun setAdvertising(active: Boolean) {
+        state.value = active
+    }
+
+    public const val DEFAULT_AWAIT_NOT_ADVERTISING_TIMEOUT_MILLIS: Long = 2_000L
 }
 
 /**

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverSession.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverSession.kt
@@ -268,6 +268,7 @@ public class ReceiverSession(
             runCatching { advertiseHandle?.close() }
             advertiseHandle = null
             stopInitialControlServersLocked()
+            ReceiverAdvertisementStateHolder.setAdvertising(false)
         }
 
         runCatching { server?.stopBlocking() }
@@ -329,6 +330,7 @@ public class ReceiverSession(
             runCatching { handle?.close() }
             advertiseHandle = null
             stopInitialControlServersLocked()
+            ReceiverAdvertisementStateHolder.setAdvertising(false)
         }
     }
 
@@ -339,6 +341,7 @@ public class ReceiverSession(
         port: Int,
     ) {
         advertiseHandle = advertiser.advertise(endpointInfo, port)
+        ReceiverAdvertisementStateHolder.setAdvertising(true)
         for (initialControlServer in initialControlServers) {
             if (initialControlServer.isActive) continue
             runCatching {

--- a/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/MdnsAdvertisementGateTest.kt
+++ b/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/MdnsAdvertisementGateTest.kt
@@ -16,11 +16,15 @@ import io.github.kyujincho.wvmg.protocol.payload.TempFileDestinationFactory
 import io.github.kyujincho.wvmg.protocol.server.TcpReceiverServer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.net.InetAddress
 import java.security.SecureRandom
@@ -42,6 +46,16 @@ import java.security.SecureRandom
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class MdnsAdvertisementGateTest {
+    @BeforeEach
+    fun setUp() {
+        ReceiverAdvertisementStateHolder.setAdvertising(false)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        ReceiverAdvertisementStateHolder.setAdvertising(false)
+    }
+
     @Test
     fun `idle activity at boot does not publish`() =
         runTest {
@@ -440,6 +454,7 @@ class MdnsAdvertisementGateTest {
             advanceUntilIdle()
             // Active pulse + no outbound: both channels advertising.
             assertThat(session.isAdvertising).isTrue()
+            assertThat(ReceiverAdvertisementStateHolder.isAdvertising).isTrue()
             assertThat(broadcaster.startCount).isAtLeast(1)
             val baselineStops = broadcaster.stopCount
 
@@ -448,10 +463,28 @@ class MdnsAdvertisementGateTest {
             outbound.value = true
             advanceUntilIdle()
             assertThat(session.isAdvertising).isFalse()
+            assertThat(ReceiverAdvertisementStateHolder.isAdvertising).isFalse()
             assertThat(broadcaster.stopCount).isGreaterThan(baselineStops)
 
             gate.stop()
             session.stop()
+        }
+
+    @Test
+    fun `receiver advertisement holder waits until unpublish is observed`() =
+        runTest {
+            ReceiverAdvertisementStateHolder.setAdvertising(true)
+
+            val observed =
+                async {
+                    ReceiverAdvertisementStateHolder.awaitNotAdvertising(timeoutMillis = 1_000L)
+                }
+            runCurrent()
+            assertThat(observed.isCompleted).isFalse()
+
+            ReceiverAdvertisementStateHolder.setAdvertising(false)
+
+            assertThat(observed.await()).isTrue()
         }
 
     @Test


### PR DESCRIPTION
## Summary
- gate SendActivity discovery startup on receiver mDNS unpublish so vivo/Funtouch does not browse while the same process still advertises the Quick Share service type
- mirror receiver advertisement state through a process-wide holder and wait for Android NSD unregister callbacks when closing registrations
- document the #107 vivo verification path and add JVM coverage for the new holder/gate behavior

## Verification
- ./gradlew :discovery-android:testDebugUnitTest :service-android:testDebugUnitTest :app:testDebugUnitTest
- ./gradlew staticAnalysis

Closes #107