### PR TITLE
feat: reorder dual-channel upgrade frames (#133)

### DIFF
--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeOrchestrator.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeOrchestrator.kt
@@ -9,6 +9,7 @@ import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.Band
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.V1Frame
 import io.github.kyujincho.wvmg.protocol.crypto.securemessage.SecureChannel
+import io.github.kyujincho.wvmg.protocol.crypto.securemessage.SequencedOfflineFrame
 import io.github.kyujincho.wvmg.protocol.medium.Medium
 import io.github.kyujincho.wvmg.protocol.medium.MediumRegistry
 import io.github.kyujincho.wvmg.protocol.medium.PreparedUpgradeSelection
@@ -17,6 +18,7 @@ import io.github.kyujincho.wvmg.protocol.medium.UpgradedTransport
 import io.github.kyujincho.wvmg.protocol.medium.asFramedConnection
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeoutOrNull
+import java.util.TreeMap
 
 /**
  * Blocking bandwidth-upgrade handshake runner.
@@ -93,23 +95,31 @@ internal object BandwidthUpgradeOrchestrator {
         logger: (String) -> Unit,
     ): ActiveTransportChannel {
         val bufferedFrames = mutableListOf<OfflineFrame>()
-        val oldUpgradeFrames = ArrayDeque<OfflineFrame>()
         val newChannel = oldChannel.withTransport(transport.asFramedConnection())
-        drainBufferedPriorChannelFrames(
-            channel = oldChannel,
-            applicationFrames = bufferedFrames,
-            upgradeFrames = oldUpgradeFrames,
-            logger = logger,
-            stage = "server pre-client-introduction",
+        val reader = DualChannelFrameReader(oldChannel, newChannel, logger)
+        val clientIntro =
+            receiveExpectedUpgradeFrame(
+                reader = reader,
+                expected = BandwidthUpgradeNegotiationFrame.EventType.CLIENT_INTRODUCTION,
+                stage = "server client introduction",
+                applicationFrames = bufferedFrames,
+                logger = logger,
+            )
+        validateServerClientIntroduction(
+            intro = clientIntro,
+            peerEndpointId = peerEndpointId,
         )
-        validateServerClientIntroduction(newChannel, peerEndpointId)
         newChannel.sendOfflineFrame(BandwidthUpgradeFrames.clientIntroductionAck())
         exchangePriorChannelClose(
             oldChannel = oldChannel,
+            reader = reader,
             bufferedFrames = bufferedFrames,
-            oldUpgradeFrames = oldUpgradeFrames,
             logger = logger,
             stagePrefix = "server",
+        )
+        reader.drainAvailableFrames(
+            stage = "server post-safe-to-close",
+            applicationFrames = bufferedFrames,
         )
         logger("medium-upgrade: server completed ${credentials.medium}")
         return ActiveTransportChannel(newChannel, credentials.medium, bufferedFrames)
@@ -148,48 +158,13 @@ internal object BandwidthUpgradeOrchestrator {
         }
 
         return runCatching {
-            val bufferedFrames = mutableListOf<OfflineFrame>()
-            val oldUpgradeFrames = ArrayDeque<OfflineFrame>()
-            val newChannel = oldChannel.withTransport(transport.asFramedConnection())
-            newChannel.sendOfflineFrame(BandwidthUpgradeFrames.clientIntroduction(endpointId))
-            val ack = receiveUpgradeFrame(newChannel, "CLIENT_INTRODUCTION_ACK on upgraded transport")
-            checkUpgradeEvent(
-                frame = ack,
-                expected = BandwidthUpgradeNegotiationFrame.EventType.CLIENT_INTRODUCTION_ACK,
-                stage = "client introduction ack",
+            completeClientUpgrade(
+                oldChannel = oldChannel,
+                transport = transport,
+                credentials = credentials,
+                endpointId = endpointId,
+                logger = logger,
             )
-            oldChannel.sendOfflineFrame(BandwidthUpgradeFrames.lastWriteToPriorChannel())
-            val peerLast =
-                receiveExpectedUpgradeFrame(
-                    channel = oldChannel,
-                    expected = BandwidthUpgradeNegotiationFrame.EventType.LAST_WRITE_TO_PRIOR_CHANNEL,
-                    stage = "client peer last-write",
-                    applicationFrames = bufferedFrames,
-                    upgradeFrames = oldUpgradeFrames,
-                    logger = logger,
-                )
-            checkUpgradeEvent(
-                frame = peerLast,
-                expected = BandwidthUpgradeNegotiationFrame.EventType.LAST_WRITE_TO_PRIOR_CHANNEL,
-                stage = "client peer last-write",
-            )
-            oldChannel.sendOfflineFrame(BandwidthUpgradeFrames.safeToClosePriorChannel())
-            val peerSafe =
-                receiveExpectedUpgradeFrame(
-                    channel = oldChannel,
-                    expected = BandwidthUpgradeNegotiationFrame.EventType.SAFE_TO_CLOSE_PRIOR_CHANNEL,
-                    stage = "client peer safe-to-close",
-                    applicationFrames = bufferedFrames,
-                    upgradeFrames = oldUpgradeFrames,
-                    logger = logger,
-                )
-            checkUpgradeEvent(
-                frame = peerSafe,
-                expected = BandwidthUpgradeNegotiationFrame.EventType.SAFE_TO_CLOSE_PRIOR_CHANNEL,
-                stage = "client peer safe-to-close",
-            )
-            logger("medium-upgrade: client completed ${credentials.medium}")
-            ActiveTransportChannel(newChannel, credentials.medium, bufferedFrames)
         }.getOrElse { failure ->
             logger(
                 "medium-upgrade: client failed ${credentials.medium}: " +
@@ -199,6 +174,62 @@ internal object BandwidthUpgradeOrchestrator {
             provider.cancelPendingUpgrade()
             ActiveTransportChannel(oldChannel, currentMedium)
         }
+    }
+
+    private suspend fun completeClientUpgrade(
+        oldChannel: SecureChannel,
+        transport: UpgradedTransport,
+        credentials: UpgradePathCredentials,
+        endpointId: String,
+        logger: (String) -> Unit,
+    ): ActiveTransportChannel {
+        val bufferedFrames = mutableListOf<OfflineFrame>()
+        val newChannel = oldChannel.withTransport(transport.asFramedConnection())
+        val reader = DualChannelFrameReader(oldChannel, newChannel, logger)
+        newChannel.sendOfflineFrame(BandwidthUpgradeFrames.clientIntroduction(endpointId))
+        receiveAndCheckUpgradeFrame(
+            reader = reader,
+            expected = BandwidthUpgradeNegotiationFrame.EventType.CLIENT_INTRODUCTION_ACK,
+            stage = "client introduction ack",
+            applicationFrames = bufferedFrames,
+            logger = logger,
+        )
+        exchangeClientPriorChannelClose(
+            oldChannel = oldChannel,
+            reader = reader,
+            bufferedFrames = bufferedFrames,
+            logger = logger,
+        )
+        reader.drainAvailableFrames(
+            stage = "client post-safe-to-close",
+            applicationFrames = bufferedFrames,
+        )
+        logger("medium-upgrade: client completed ${credentials.medium}")
+        return ActiveTransportChannel(newChannel, credentials.medium, bufferedFrames)
+    }
+
+    private suspend fun exchangeClientPriorChannelClose(
+        oldChannel: SecureChannel,
+        reader: DualChannelFrameReader,
+        bufferedFrames: MutableList<OfflineFrame>,
+        logger: (String) -> Unit,
+    ) {
+        oldChannel.sendOfflineFrame(BandwidthUpgradeFrames.lastWriteToPriorChannel())
+        receiveAndCheckUpgradeFrame(
+            reader = reader,
+            expected = BandwidthUpgradeNegotiationFrame.EventType.LAST_WRITE_TO_PRIOR_CHANNEL,
+            stage = "client peer last-write",
+            applicationFrames = bufferedFrames,
+            logger = logger,
+        )
+        oldChannel.sendOfflineFrame(BandwidthUpgradeFrames.safeToClosePriorChannel())
+        receiveAndCheckUpgradeFrame(
+            reader = reader,
+            expected = BandwidthUpgradeNegotiationFrame.EventType.SAFE_TO_CLOSE_PRIOR_CHANNEL,
+            stage = "client peer safe-to-close",
+            applicationFrames = bufferedFrames,
+            logger = logger,
+        )
     }
 
     suspend fun receiveOfferProbe(channel: SecureChannel): UpgradeOfferProbe =
@@ -211,11 +242,10 @@ internal object BandwidthUpgradeOrchestrator {
             }
         } ?: UpgradeOfferProbe.None
 
-    private suspend fun validateServerClientIntroduction(
-        newChannel: SecureChannel,
+    private fun validateServerClientIntroduction(
+        intro: OfflineFrame,
         peerEndpointId: String,
     ) {
-        val intro = receiveUpgradeFrame(newChannel, "CLIENT_INTRODUCTION on upgraded transport")
         val clientIntro = intro.v1.bandwidthUpgradeNegotiation.clientIntroduction
         checkUpgradeEvent(
             frame = intro,
@@ -232,19 +262,18 @@ internal object BandwidthUpgradeOrchestrator {
 
     private suspend fun exchangePriorChannelClose(
         oldChannel: SecureChannel,
+        reader: DualChannelFrameReader,
         bufferedFrames: MutableList<OfflineFrame>,
-        oldUpgradeFrames: ArrayDeque<OfflineFrame>,
         logger: (String) -> Unit,
         stagePrefix: String,
     ) {
         oldChannel.sendOfflineFrame(BandwidthUpgradeFrames.lastWriteToPriorChannel())
         val peerLast =
             receiveExpectedUpgradeFrame(
-                channel = oldChannel,
+                reader = reader,
                 expected = BandwidthUpgradeNegotiationFrame.EventType.LAST_WRITE_TO_PRIOR_CHANNEL,
                 stage = "$stagePrefix peer last-write",
                 applicationFrames = bufferedFrames,
-                upgradeFrames = oldUpgradeFrames,
                 logger = logger,
             )
         checkUpgradeEvent(
@@ -256,11 +285,10 @@ internal object BandwidthUpgradeOrchestrator {
         oldChannel.sendOfflineFrame(BandwidthUpgradeFrames.safeToClosePriorChannel())
         val peerSafe =
             receiveExpectedUpgradeFrame(
-                channel = oldChannel,
+                reader = reader,
                 expected = BandwidthUpgradeNegotiationFrame.EventType.SAFE_TO_CLOSE_PRIOR_CHANNEL,
                 stage = "$stagePrefix peer safe-to-close",
                 applicationFrames = bufferedFrames,
-                upgradeFrames = oldUpgradeFrames,
                 logger = logger,
             )
         checkUpgradeEvent(
@@ -277,29 +305,15 @@ internal object BandwidthUpgradeOrchestrator {
         return BandwidthUpgradeFrames.decodeCredentials(frame.v1.bandwidthUpgradeNegotiation.upgradePathInfo)
     }
 
-    private suspend fun receiveUpgradeFrame(
-        channel: SecureChannel,
-        stage: String,
-    ): OfflineFrame =
-        withTimeoutOrNull(UPGRADE_TIMEOUT_MILLIS) {
-            channel.receiveOfflineFrame()
-        } ?: error("Timed out waiting for $stage")
-
     private suspend fun receiveExpectedUpgradeFrame(
-        channel: SecureChannel,
+        reader: DualChannelFrameReader,
         expected: BandwidthUpgradeNegotiationFrame.EventType,
         stage: String,
         applicationFrames: MutableList<OfflineFrame>,
-        upgradeFrames: ArrayDeque<OfflineFrame>,
         logger: (String) -> Unit,
     ): OfflineFrame {
         while (true) {
-            val frame =
-                if (upgradeFrames.isNotEmpty()) {
-                    upgradeFrames.removeFirst()
-                } else {
-                    receiveUpgradeFrame(channel, stage)
-                }
+            val frame = reader.receiveNextFrame(stage)
             if (frame.isBandwidthUpgradeNegotiation()) {
                 return frame
             }
@@ -311,33 +325,26 @@ internal object BandwidthUpgradeOrchestrator {
         }
     }
 
-    private suspend fun drainBufferedPriorChannelFrames(
-        channel: SecureChannel,
-        applicationFrames: MutableList<OfflineFrame>,
-        upgradeFrames: ArrayDeque<OfflineFrame>,
-        logger: (String) -> Unit,
+    private suspend fun receiveAndCheckUpgradeFrame(
+        reader: DualChannelFrameReader,
+        expected: BandwidthUpgradeNegotiationFrame.EventType,
         stage: String,
-    ) {
-        var idleAttempts = 0
-        while (idleAttempts < PRIOR_CHANNEL_DRAIN_IDLE_ATTEMPTS) {
-            val hasInput = runCatching { channel.hasBufferedInput() }.getOrDefault(false)
-            if (!hasInput) {
-                idleAttempts += 1
-                delay(PRIOR_CHANNEL_DRAIN_IDLE_DELAY_MILLIS)
-                continue
-            }
-
-            idleAttempts = 0
-            val frame = channel.receiveOfflineFrame()
-            if (frame.isBandwidthUpgradeNegotiation()) {
-                logger("medium-upgrade: buffered prior-channel ${frame.describeUpgradeEvent()} during $stage")
-                upgradeFrames += frame
-            } else {
-                logger("medium-upgrade: buffered prior-channel ${frame.describeFrameType()} during $stage")
-                applicationFrames += frame
-            }
+        applicationFrames: MutableList<OfflineFrame>,
+        logger: (String) -> Unit,
+    ): OfflineFrame =
+        receiveExpectedUpgradeFrame(
+            reader = reader,
+            expected = expected,
+            stage = stage,
+            applicationFrames = applicationFrames,
+            logger = logger,
+        ).also { frame ->
+            checkUpgradeEvent(
+                frame = frame,
+                expected = expected,
+                stage = stage,
+            )
         }
-    }
 
     private fun checkUpgradeEvent(
         frame: OfflineFrame,
@@ -372,10 +379,123 @@ internal object BandwidthUpgradeOrchestrator {
             v1.type == V1Frame.FrameType.BANDWIDTH_UPGRADE_NEGOTIATION &&
             v1.bandwidthUpgradeNegotiation.eventType == expected
 
+    internal class DualChannelFrameReader(
+        oldChannel: SecureChannel,
+        newChannel: SecureChannel,
+        private val logger: (String) -> Unit,
+    ) {
+        private val sources =
+            listOf(
+                FrameSource("prior", oldChannel),
+                FrameSource("upgraded", newChannel),
+            )
+        private val pendingFrames: TreeMap<Int, SequencedRead> = TreeMap()
+        private var nextSequenceNumber: Int =
+            (oldChannel.nextReceiveSequenceNumber + 1)
+                .also { next ->
+                    check(next <= Int.MAX_VALUE.toLong()) {
+                        "Receive sequence number overflowed Int.MAX_VALUE; close the channel"
+                    }
+                }.toInt()
+
+        suspend fun receiveNextFrame(stage: String): OfflineFrame =
+            withTimeoutOrNull<OfflineFrame>(UPGRADE_TIMEOUT_MILLIS) {
+                while (true) {
+                    deliverNextPendingFrame()?.let { return@withTimeoutOrNull it }
+
+                    var readAny = false
+                    for (source in sources) {
+                        if (source.hasBufferedInput()) {
+                            readFrom(source)
+                            readAny = true
+                        }
+                    }
+                    if (!readAny) {
+                        delay(DUAL_CHANNEL_POLL_DELAY_MILLIS)
+                    }
+                }
+                error("unreachable")
+            } ?: error("Timed out waiting for $stage")
+
+        suspend fun drainAvailableFrames(
+            stage: String,
+            applicationFrames: MutableList<OfflineFrame>,
+        ) {
+            var idleAttempts = 0
+            while (idleAttempts < DUAL_CHANNEL_DRAIN_IDLE_ATTEMPTS) {
+                val delivered = deliverNextPendingFrame()
+                if (delivered != null) {
+                    logger("medium-upgrade: buffered ${delivered.describeFrameType()} during $stage")
+                    applicationFrames += delivered
+                    idleAttempts = 0
+                    continue
+                }
+
+                var readAny = false
+                for (source in sources) {
+                    if (source.hasBufferedInput()) {
+                        readFrom(source)
+                        readAny = true
+                    }
+                }
+                if (readAny) {
+                    idleAttempts = 0
+                } else {
+                    idleAttempts += 1
+                    delay(DUAL_CHANNEL_POLL_DELAY_MILLIS)
+                }
+            }
+        }
+
+        private suspend fun readFrom(source: FrameSource) {
+            val sequenced = source.channel.receiveSequencedOfflineFrame()
+            check(sequenced.sequenceNumber >= nextSequenceNumber) {
+                "Received stale SecureMessage sequence ${sequenced.sequenceNumber} from " +
+                    "${source.name}; next expected is $nextSequenceNumber"
+            }
+            val previous =
+                pendingFrames.putIfAbsent(
+                    sequenced.sequenceNumber,
+                    SequencedRead(source, sequenced),
+                )
+            check(previous == null) {
+                "Received duplicate SecureMessage sequence ${sequenced.sequenceNumber} " +
+                    "from ${source.name} and ${previous?.source?.name}"
+            }
+            logger(
+                "medium-upgrade: decoded ${sequenced.frame.describeFrameType()} " +
+                    "seq=${sequenced.sequenceNumber} from ${source.name}",
+            )
+        }
+
+        private suspend fun deliverNextPendingFrame(): OfflineFrame? {
+            val next = pendingFrames.remove(nextSequenceNumber) ?: return null
+            val frame = next.source.channel.acceptSequencedOfflineFrame(next.sequenced)
+            logger(
+                "medium-upgrade: delivered ${frame.describeFrameType()} " +
+                    "seq=$nextSequenceNumber from ${next.source.name}",
+            )
+            nextSequenceNumber += 1
+            return frame
+        }
+
+        private class FrameSource(
+            val name: String,
+            val channel: SecureChannel,
+        ) {
+            fun hasBufferedInput(): Boolean = runCatching { channel.hasBufferedInput() }.getOrDefault(false)
+        }
+
+        private data class SequencedRead(
+            val source: FrameSource,
+            val sequenced: SequencedOfflineFrame,
+        )
+    }
+
     private const val UPGRADE_TIMEOUT_MILLIS: Long = 30_000L
     private const val OFFER_WAIT_TIMEOUT_MILLIS: Long = 1_500L
-    private const val PRIOR_CHANNEL_DRAIN_IDLE_ATTEMPTS: Int = 25
-    private const val PRIOR_CHANNEL_DRAIN_IDLE_DELAY_MILLIS: Long = 10L
+    private const val DUAL_CHANNEL_DRAIN_IDLE_ATTEMPTS: Int = 25
+    private const val DUAL_CHANNEL_POLL_DELAY_MILLIS: Long = 10L
 }
 
 internal data class ActiveTransportChannel(

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/InboundConnection.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/InboundConnection.kt
@@ -124,15 +124,18 @@ public class InboundConnection(
      * transport swap into the dispatch loop.
      */
     private val mediumRegistry: MediumRegistry = MediumRegistry.DefaultWifiLan,
+    private val logger: (String) -> Unit = {},
 ) {
     public constructor(
         socket: Socket,
         secureRandom: SecureRandom = SecureRandom(),
         mediumRegistry: MediumRegistry = MediumRegistry.DefaultWifiLan,
+        logger: (String) -> Unit = {},
     ) : this(
         transport = socket.asConnectedTransport(),
         secureRandom = secureRandom,
         mediumRegistry = mediumRegistry,
+        logger = logger,
     )
 
     private val mutableState: MutableStateFlow<InboundConnectionState> =
@@ -250,6 +253,7 @@ public class InboundConnection(
                 factory = factory,
                 mediumRegistry = mediumRegistry,
                 onHandshakeComplete = ::markHandshakeComplete,
+                logger = logger,
             )
 
         return try {

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/InboundConnectionDriver.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/InboundConnectionDriver.kt
@@ -71,6 +71,7 @@ internal class InboundConnectionDriver(
     private val factory: FileDestinationFactory,
     private val mediumRegistry: MediumRegistry = MediumRegistry.DefaultWifiLan,
     private val onHandshakeComplete: () -> Unit = {},
+    private val logger: (String) -> Unit = {},
     /**
      * Wall-clock source for the rate estimator. Defaults to
      * [System.currentTimeMillis]; tests inject a deterministic
@@ -230,25 +231,19 @@ internal class InboundConnectionDriver(
         // Step 7: as the Nearby Connections server role, offer the best
         // prepared upgrade medium before the Nearby Share payload
         // negotiation starts. If the sender has already put a sharing
-        // payload on the original channel, stay on that channel: stock
-        // Samsung can continue sending Nearby Share frames while the old
-        // and upgraded channels are both draining, and our SecureChannel
-        // currently enforces one global receive order over one active
-        // transport at a time.
+        // payload on the original channel, keep it buffered while the
+        // upgrade orchestrator drains the old and upgraded channels in
+        // global SecureMessage sequence order.
         val activeTransport =
-            if (initialWireFrame == null) {
-                BandwidthUpgradeOrchestrator
-                    .runServerUpgradeIfAvailable(
-                        oldChannel = channel,
-                        currentMedium = transport.medium,
-                        mediumRegistry = mediumRegistry,
-                        peerSupportedMediums = peerSupportedMediums,
-                        peerEndpointId = initialFrame.v1.connectionRequest.endpointId,
-                        logger = {},
-                    )
-            } else {
-                ActiveTransportChannel(channel, transport.medium)
-            }
+            BandwidthUpgradeOrchestrator
+                .runServerUpgradeIfAvailable(
+                    oldChannel = channel,
+                    currentMedium = transport.medium,
+                    mediumRegistry = mediumRegistry,
+                    peerSupportedMediums = peerSupportedMediums,
+                    peerEndpointId = initialFrame.v1.connectionRequest.endpointId,
+                    logger = logger,
+                )
         val activeChannel = activeTransport.channel.also { secureChannel = it }
         mutableActiveMedium.value = activeTransport.medium
         val initialWireFrames =

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/crypto/securemessage/SecureChannel.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/crypto/securemessage/SecureChannel.kt
@@ -155,6 +155,12 @@ public class SecureChannel internal constructor(
      */
     public suspend fun receiveOfflineFrame(): OfflineFrame = session.receiveOfflineFrame(framedConnection)
 
+    internal suspend fun receiveSequencedOfflineFrame(): SequencedOfflineFrame =
+        session.receiveSequencedOfflineFrame(framedConnection)
+
+    internal suspend fun acceptSequencedOfflineFrame(frame: SequencedOfflineFrame): OfflineFrame =
+        session.acceptSequencedOfflineFrame(frame)
+
     /**
      * The next outgoing sequence number that [sendOfflineFrame] WOULD use,
      * exposed for diagnostics and tests. The value increases by exactly
@@ -258,21 +264,35 @@ internal class SecureMessageSession(
             }
             val expectedSeq = theirSeq.toInt()
 
-            val secureMessageBytes = framedConnection.receiveFrame()
-            val d2dBytes =
-                SecureMessageCodec.verifyAndDecrypt(
-                    secureMessageBytes = secureMessageBytes,
-                    decryptKey = keys.receiveEncryptKey,
-                    hmacKey = keys.receiveHmacKey,
-                )
-            val unwrapped = SecureMessageCodec.unwrapDeviceToDeviceMessage(d2dBytes)
-            if (unwrapped.sequenceNumber != expectedSeq) {
+            val sequenced = readSequencedOfflineFrame(framedConnection)
+            if (sequenced.sequenceNumber != expectedSeq) {
                 throw SequenceNumberMismatchException(
                     expected = expectedSeq,
-                    actual = unwrapped.sequenceNumber,
+                    actual = sequenced.sequenceNumber,
                 )
             }
-            return parseOfflineFrame(unwrapped.payload)
+            return sequenced.frame
+        }
+    }
+
+    suspend fun receiveSequencedOfflineFrame(framedConnection: FramedConnection): SequencedOfflineFrame =
+        readSequencedOfflineFrame(framedConnection)
+
+    suspend fun acceptSequencedOfflineFrame(sequenced: SequencedOfflineFrame): OfflineFrame {
+        receiveMutex.withLock {
+            val nextSeq = theirSeq + 1
+            check(nextSeq <= Int.MAX_VALUE.toLong()) {
+                "Receive sequence number overflowed Int.MAX_VALUE; close the channel"
+            }
+            val expectedSeq = nextSeq.toInt()
+            if (sequenced.sequenceNumber != expectedSeq) {
+                throw SequenceNumberMismatchException(
+                    expected = expectedSeq,
+                    actual = sequenced.sequenceNumber,
+                )
+            }
+            theirSeq = nextSeq
+            return sequenced.frame
         }
     }
 
@@ -293,7 +313,27 @@ internal class SecureMessageSession(
         } catch (e: com.google.protobuf.InvalidProtocolBufferException) {
             throw SecureMessageFormatException("OfflineFrame proto failed to parse", e)
         }
+
+    private suspend fun readSequencedOfflineFrame(framedConnection: FramedConnection): SequencedOfflineFrame {
+        val secureMessageBytes = framedConnection.receiveFrame()
+        val d2dBytes =
+            SecureMessageCodec.verifyAndDecrypt(
+                secureMessageBytes = secureMessageBytes,
+                decryptKey = keys.receiveEncryptKey,
+                hmacKey = keys.receiveHmacKey,
+            )
+        val unwrapped = SecureMessageCodec.unwrapDeviceToDeviceMessage(d2dBytes)
+        return SequencedOfflineFrame(
+            sequenceNumber = unwrapped.sequenceNumber,
+            frame = parseOfflineFrame(unwrapped.payload),
+        )
+    }
 }
+
+internal data class SequencedOfflineFrame(
+    val sequenceNumber: Int,
+    val frame: OfflineFrame,
+)
 
 /**
  * Thrown by [SecureChannel.receiveOfflineFrame] when the peer's reported

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/server/TcpReceiverServer.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/server/TcpReceiverServer.kt
@@ -116,6 +116,7 @@ import java.util.concurrent.atomic.AtomicLong
  *   (`InetAddress.getByName("0.0.0.0")` -- accept on every interface).
  *   Tests typically pass `InetAddress.getLoopbackAddress()` to avoid
  *   binding to the host's external NIC.
+ * @param logger diagnostic sink for per-connection protocol events.
  */
 public class TcpReceiverServer(
     private val parentScope: CoroutineScope,
@@ -123,6 +124,7 @@ public class TcpReceiverServer(
     private val secureRandomProvider: () -> SecureRandom = { SecureRandom() },
     private val mediumRegistry: MediumRegistry = MediumRegistry.DefaultWifiLan,
     private val bindAddress: InetAddress? = null,
+    private val logger: (String) -> Unit = {},
 ) {
     /**
      * Per-connection [Mutex] table. A single Quick Share connection is
@@ -453,6 +455,7 @@ public class TcpReceiverServer(
                 transport = transport,
                 secureRandom = secureRandomProvider(),
                 mediumRegistry = mediumRegistry,
+                logger = logger,
             )
 
         internalScope.launch {

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/DualChannelFrameReaderTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/DualChannelFrameReaderTest.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.connection
+
+import com.google.common.truth.Truth.assertThat
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.KeepAliveFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.V1Frame
+import io.github.kyujincho.wvmg.protocol.crypto.D2DKeyDerivation
+import io.github.kyujincho.wvmg.protocol.crypto.D2DRole
+import io.github.kyujincho.wvmg.protocol.crypto.D2DSessionKeys
+import io.github.kyujincho.wvmg.protocol.crypto.securemessage.SecureChannel
+import io.github.kyujincho.wvmg.protocol.crypto.securemessage.SecureMessageCodec
+import io.github.kyujincho.wvmg.protocol.transport.FramedConnection
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.Socket
+import java.security.SecureRandom
+import java.util.Collections
+
+class DualChannelFrameReaderTest {
+    private val serverSockets = mutableListOf<ServerSocket>()
+    private val openedSockets = mutableListOf<Socket>()
+
+    @AfterEach
+    fun tearDown() {
+        openedSockets.forEach { runCatching { it.close() } }
+        serverSockets.forEach { runCatching { it.close() } }
+    }
+
+    @Test
+    fun `reader buffers upgraded-channel frame until missing prior-channel sequence arrives`() =
+        runBlocking {
+            val (oldClientSocket, oldServerSocket) = connectedSocketPair()
+            val (newClientSocket, newServerSocket) = connectedSocketPair()
+            val oldClient = FramedConnection(oldClientSocket)
+            val newClient = FramedConnection(newClientSocket)
+            val oldServer =
+                SecureChannel(
+                    FramedConnection(oldServerSocket),
+                    freshSessionKeys(D2DRole.SERVER),
+                    SecureRandom(),
+                )
+            val newServer = oldServer.withTransport(FramedConnection(newServerSocket))
+            val logs = Collections.synchronizedList(mutableListOf<String>())
+            val reader =
+                BandwidthUpgradeOrchestrator.DualChannelFrameReader(
+                    oldChannel = oldServer,
+                    newChannel = newServer,
+                    logger = logs::add,
+                )
+            val firstFrame = keepAliveFrame(ack = false)
+            val secondFrame = keepAliveFrame(ack = true)
+
+            newClient.sendSequencedFrame(sequenceNumber = 2, frame = secondFrame)
+
+            coroutineScope {
+                val firstRead = async { reader.receiveNextFrame("first interleaved frame") }
+                waitForLog(logs, "seq=2 from upgraded")
+                assertThat(firstRead.isCompleted).isFalse()
+
+                oldClient.sendSequencedFrame(sequenceNumber = 1, frame = firstFrame)
+
+                assertThat(firstRead.await()).isEqualTo(firstFrame)
+                assertThat(reader.receiveNextFrame("second interleaved frame")).isEqualTo(secondFrame)
+            }
+
+            assertThat(oldServer.nextReceiveSequenceNumber).isEqualTo(2L)
+            assertThat(logs.joinToString("\n")).contains("delivered KEEP_ALIVE seq=1 from prior")
+            assertThat(logs.joinToString("\n")).contains("delivered KEEP_ALIVE seq=2 from upgraded")
+        }
+
+    private suspend fun waitForLog(
+        logs: List<String>,
+        needle: String,
+    ) {
+        repeat(LOG_WAIT_ATTEMPTS) {
+            if (logs.any { it.contains(needle) }) return
+            delay(LOG_WAIT_DELAY_MILLIS)
+        }
+        error("Timed out waiting for log containing '$needle'; logs=$logs")
+    }
+
+    private suspend fun FramedConnection.sendSequencedFrame(
+        sequenceNumber: Int,
+        frame: OfflineFrame,
+    ) {
+        val keys = freshSessionKeys(D2DRole.CLIENT).forRole()
+        val payload =
+            SecureMessageCodec.wrapDeviceToDeviceMessage(
+                offlineFrame = frame.toByteArray(),
+                sequenceNumber = sequenceNumber,
+            )
+        val sealed =
+            SecureMessageCodec.encryptAndSign(
+                payload = payload,
+                encryptKey = keys.sendEncryptKey,
+                hmacKey = keys.sendHmacKey,
+                iv = SecureMessageCodec.randomIv(SecureRandom()),
+            )
+        sendFrame(sealed)
+    }
+
+    private fun connectedSocketPair(): Pair<Socket, Socket> {
+        val serverSocket = ServerSocket(0, 0, InetAddress.getLoopbackAddress())
+        serverSockets += serverSocket
+        val client = Socket(InetAddress.getLoopbackAddress(), serverSocket.localPort)
+        val server = serverSocket.accept()
+        openedSockets += client
+        openedSockets += server
+        return client to server
+    }
+
+    private fun freshSessionKeys(role: D2DRole): D2DSessionKeys {
+        val dhs = ByteArray(D2DKeyDerivation.KEY_SIZE) { (it + 0x20).toByte() }
+        val clientInit = "dual-reader-client-init".toByteArray()
+        val serverInit = "dual-reader-server-init".toByteArray()
+        return D2DKeyDerivation.derive(dhs, clientInit, serverInit, role)
+    }
+
+    private fun keepAliveFrame(ack: Boolean): OfflineFrame =
+        OfflineFrame
+            .newBuilder()
+            .setVersion(OfflineFrame.Version.V1)
+            .setV1(
+                V1Frame
+                    .newBuilder()
+                    .setType(V1Frame.FrameType.KEEP_ALIVE)
+                    .setKeepAlive(KeepAliveFrame.newBuilder().setAck(ack)),
+            ).build()
+
+    private companion object {
+        const val LOG_WAIT_ATTEMPTS = 50
+        const val LOG_WAIT_DELAY_MILLIS = 10L
+    }
+}

--- a/docs/testing/medium-integration-suite.md
+++ b/docs/testing/medium-integration-suite.md
@@ -76,14 +76,32 @@ adb -s <device-b> install -r app/build/outputs/apk/debug/app-debug.apk
 6. Record the measured results in [`docs/medium-perf.md`](../medium-perf.md)
    when a device pair establishes a stable benchmark.
 
+## Upgraded-medium success vs fallback
+
+Issue #133 adds a dual-channel receive handoff: while a stock sender is
+switching to a direct medium, WVMG can keep draining the original Wi-Fi
+LAN channel and the upgraded channel, then deliver SecureMessage frames
+to the sharing FSM in sequence-number order.
+
+When validating Wi-Fi Direct or another upgraded medium, record the
+result as **upgraded-medium success** only if logs show both:
+
+- `medium-upgrade: delivered ... from prior`
+- `medium-upgrade: delivered ... from upgraded`
+
+If the transfer completes but `WvmgMedium` / `WvmgInbound` only reports
+Wi-Fi LAN as the active medium, record it as **Wi-Fi LAN fallback
+success**. That is still a pass for basic transfer stability, but it is
+not evidence that the direct-medium handoff worked.
+
 ## Failure handling
 
 - If Wi-Fi Direct group creation fails, the JVM fallback-selection test is
   the guard that the registry chooses Wi-Fi LAN instead.
-- This suite does not prove live transport replacement in the connection
-  drivers. A passing run means the per-medium support gates and selection
-  ladder are healthy; full upgrade-handshake validation still requires the
-  medium-specific two-device runbooks above.
+- The JVM dual-channel reorder test proves the connection layer can
+  accept interleaved prior/upgraded SecureMessage frames, but real-device
+  validation still requires the medium-specific two-device runbooks
+  above.
 - If an instrumentation test unexpectedly fails on supported hardware,
   capture `adb logcat` for the medium-specific tag before retrying.
 - If a device skips a medium that should be available, re-check runtime

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
@@ -818,7 +818,10 @@ public class ReceiverForegroundService : Service() {
                     )
                 ActiveDiscoveryHolder.set(discovery)
                 ReceiverSession(
-                    tcpServerFactory = TcpServerFactory.default(),
+                    tcpServerFactory =
+                        TcpServerFactory.default(
+                            logger = { line -> logInboundDiagnostic(context.applicationContext, line) },
+                        ),
                     advertiser =
                         DiscoveryAdvertiser { endpointInfo, port ->
                             discovery.advertise(endpointInfo, port)
@@ -918,6 +921,18 @@ public class ReceiverForegroundService : Service() {
                 deviceName = applicationLabel,
                 tlvRecords = emptyList(),
             )
+        }
+
+        private fun logInboundDiagnostic(
+            context: Context,
+            line: String,
+        ) {
+            Log.e(INBOUND_DIAG_TAG, line)
+            runCatching {
+                val dir = context.getExternalFilesDir(null) ?: return
+                val file = java.io.File(dir, "wvmg-inbound.log")
+                file.appendText("${System.currentTimeMillis()} $line\n")
+            }
         }
 
         private const val DEFAULT_DEVICE_NAME = "Quick Share"

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverSession.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverSession.kt
@@ -388,7 +388,7 @@ public interface TcpServerFactory {
          * on `0.0.0.0` (all interfaces) so any Wi-Fi peer can connect.
          */
         @JvmStatic
-        public fun default(): TcpServerFactory =
+        public fun default(logger: (String) -> Unit = {}): TcpServerFactory =
             object : TcpServerFactory {
                 override fun create(
                     scope: CoroutineScope,
@@ -401,6 +401,7 @@ public interface TcpServerFactory {
                         factoryProvider = factoryProvider,
                         secureRandomProvider = secureRandomProvider,
                         mediumRegistry = mediumRegistry,
+                        logger = logger,
                     )
             }
     }


### PR DESCRIPTION
## Summary
- add a dual-channel upgrade reader that drains prior and upgraded SecureMessage transports and delivers frames in global sequence order
- let inbound upgrade proceed even when a first application frame was already buffered on Wi-Fi LAN
- add inbound diagnostic logging and update medium integration docs to distinguish true upgraded-medium success from fallback

## Verification
- ./gradlew :core-protocol:test --tests '*DualChannelFrameReaderTest'
- ./gradlew :core-protocol:test
- ./gradlew staticAnalysis
- ./gradlew :service-android:testDebugUnitTest :app:testDebugUnitTest :app:assembleDebug
- ./gradlew check (fails in pre-existing discovery-android lint: WifiP2pConfig.Builder requires API 29 while minSdk is 24)

Closes #133