### PR TITLE
test: add Robolectric NSD integration coverage (#100)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Run :core-protocol JVM tests
         run: ./gradlew :core-protocol:test --stacktrace
 
+      - name: Run :discovery-android JVM unit tests
+        run: ./gradlew :discovery-android:testDebugUnitTest --stacktrace
+
       - name: Run :app JVM unit tests
         run: ./gradlew :app:testDebugUnitTest --stacktrace
 

--- a/discovery-android/build.gradle.kts
+++ b/discovery-android/build.gradle.kts
@@ -40,6 +40,7 @@ android {
 
     testOptions {
         unitTests {
+            isIncludeAndroidResources = true
             // The discovery code calls `android.util.Log.i(...)` for the
             // structured diagnostics added in #83. Without
             // `returnDefaultValues = true` the AGP unit-test runtime
@@ -62,19 +63,59 @@ dependencies {
 
     // Junit Jupiter is the project-wide test runtime; align with
     // :core-protocol so all unit tests run under the same engine.
+    testImplementation(libs.junit4)
     testImplementation(libs.junit.jupiter.api)
     testImplementation(libs.junit.jupiter.params)
     testImplementation(libs.truth)
     testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.robolectric)
     testRuntimeOnly(libs.junit.jupiter.engine)
+    testRuntimeOnly(libs.junit.vintage.engine)
 
     androidTestImplementation(libs.androidx.test.junit)
     androidTestImplementation(libs.androidx.test.runner)
     androidTestImplementation(libs.truth)
 }
 
-// Run JVM unit tests with the Jupiter engine so test discovery works
-// without per-class @RunWith annotations.
+afterEvaluate {
+    val debugUnitTest = tasks.named<Test>("testDebugUnitTest")
+    val robolectricAndroidAllClasspath =
+        configurations.detachedConfiguration(
+            dependencies.create(
+                libs.robolectric.android.all
+                    .get(),
+            ),
+        )
+    val robolectricDebugUnitTest =
+        tasks.register<Test>("robolectricDebugUnitTest") {
+            val debugClasspath =
+                debugUnitTest
+                    .get()
+                    .classpath
+                    .filter { file -> !file.name.startsWith("mockable-android") }
+            description = "Runs Robolectric JUnit4 integration tests for discovery-android."
+            group = "verification"
+            testClassesDirs = debugUnitTest.get().testClassesDirs
+            classpath = files(robolectricAndroidAllClasspath) + debugClasspath
+            include("**/AndroidNsdRobolectricTest.class")
+            shouldRunAfter(debugUnitTest)
+        }
+
+    debugUnitTest.configure {
+        finalizedBy(robolectricDebugUnitTest)
+    }
+}
+
+// Run regular JVM unit tests with the Jupiter engine so test discovery
+// works without per-class @RunWith annotations. Robolectric tests use the
+// dedicated JUnit4 task above because Jupiter resolves Android platform
+// descriptors before Robolectric can install its sandbox classloader.
 tasks.withType<Test>().configureEach {
-    useJUnitPlatform()
+    if (name != "robolectricDebugUnitTest") {
+        useJUnitPlatform()
+        exclude("**/AndroidNsdRobolectricTest.class")
+        exclude("**/AndroidNsdRobolectricTest$*.class")
+        exclude("**/AndroidNsdRobolectricTestKt.class")
+        exclude("**/TestShadowNsdManager*.class")
+    }
 }

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/AndroidNsdBrowserTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/AndroidNsdBrowserTest.kt
@@ -20,11 +20,9 @@ import org.junit.jupiter.api.Test
  * Pure-JVM tests for [AndroidNsdBrowser]'s timeout-and-queue
  * primitives.
  *
- * The full integration that exercises [android.net.nsd.NsdManager.resolveService]
- * cannot run from a JVM unit test — the AGP unit-test stub jar throws
- * `ClassFormatError` when the test merely allocates an `NsdServiceInfo`.
- * That integration is verified end-to-end on real hardware via the
- * BLE-trigger interop runbook (`docs/testing/interop-ble-trigger.md`).
+ * Robolectric integration coverage for the actual [android.net.nsd.NsdManager]
+ * call path lives in [AndroidNsdRobolectricTest]. These tests stay as
+ * narrow regression guards for the queue constants and timeout helper.
  *
  * What we *can* and *do* exercise from JVM:
  *
@@ -154,19 +152,10 @@ class AndroidNsdBrowserTest {
     // silently no-ops, leaving the resolve worker hung at the 5 s
     // timeout and the picker empty.
     //
-    // Issue #100 originally proposed Robolectric integration coverage
-    // for `AndroidNsdBrowser.runResolve`. Robolectric+AGP+Jupiter
-    // integration in this project is non-trivial: Kotlin compiles
-    // captured-variable lambdas with synthetic methods on the outer
-    // class whose method descriptors reference platform-typed lambda
-    // parameters (NsdManager.DiscoveryListener), which then resolve to
-    // the AGP unit-test stub jar's NsdServiceInfo and trigger
-    // ClassFormatError during JUnit Platform discovery — before
-    // Robolectric's own classloader has a chance to substitute. The
-    // tests below are the JVM-friendly substitute: they pin the
-    // predicate's contract precisely. A regression that breaks the
-    // f1bdcb5 fix (e.g. switching `> 0` to `>= 0`, or removing the
-    // shortcut altogether) fails these tests immediately.
+    // The tests below pin the JVM-friendly predicate contract. A
+    // regression that breaks the f1bdcb5 fix (e.g. switching `> 0` to
+    // `>= 0`, or removing the shortcut altogether) fails here, while
+    // AndroidNsdRobolectricTest exercises the platform call path.
 
     @Test
     fun `shouldSkipResolve returns true for a positive port (modern MdnsDiscoveryManager pipeline)`() {

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/AndroidNsdRegistrarTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/AndroidNsdRegistrarTest.kt
@@ -13,14 +13,9 @@ import org.junit.jupiter.api.Test
  * Pure-JVM tests for [AndroidNsdRegistrar]'s `applyAttributes` helper
  * that pushes binary TXT attributes onto an `NsdServiceInfo`.
  *
- * The Android unit-tests-with-default-values harness can't load
- * `NsdServiceInfo` as-is (the platform stub jar lacks Code attributes
- * for non-abstract methods, throwing `ClassFormatError` even when a
- * test merely instantiates the class). To work around that, the
- * production code's `applyAttributes` helper is exposed in a form that
- * delegates the platform call through a caller-supplied lambda; the
- * tests below drive that lambda against recording stubs and assert the
- * raw [ByteArray] payload is passed through unmodified.
+ * Robolectric integration coverage for the actual [NsdServiceInfo]
+ * mutation path lives in [AndroidNsdRobolectricTest]. These tests keep
+ * the test-friendly helper pinned with plain recording lambdas.
  *
  * The lambda always receives raw bytes regardless of API level — both
  * the public byte[] overload (API 33+) and the reflective fallback
@@ -101,15 +96,9 @@ class AndroidNsdRegistrarTest {
         // TIRAMISU). Pin that the lookup target is at minimum visible
         // on whatever platform JAR the unit tests run against.
         //
-        // Best-effort: the AGP unit-test stub jar throws either
-        // `NoSuchMethodException` (when @hide methods are redacted) or
-        // `ClassFormatError` ("Absent Code attribute …") when the class
-        // can't even load. In both cases this test no-ops; the
-        // production reflection target is verified against AOSP
-        // `NsdServiceInfo.java` (API 35 + 36) in the kdoc on
-        // `applyAttributes`. A future runtime (Robolectric, or a stub
-        // jar that does include the @hide method bodies) lets this
-        // test actually fire its assertions.
+        // Best-effort: when the plain AGP unit-test stub cannot load
+        // the platform class, this test no-ops. The executable
+        // Robolectric coverage is in AndroidNsdRobolectricTest.
         val method =
             try {
                 NsdServiceInfo::class.java.getDeclaredMethod(

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/AndroidNsdRobolectricTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/AndroidNsdRobolectricTest.kt
@@ -1,0 +1,341 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.discovery
+
+import android.net.nsd.NsdManager
+import android.net.nsd.NsdServiceInfo
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
+import org.robolectric.shadow.api.Shadow
+import java.io.IOException
+import java.net.InetAddress
+import java.util.Collections
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+
+@RunWith(RobolectricTestRunner::class)
+class AndroidNsdRobolectricTest {
+    @Test
+    fun `browser resolve queue drains after a hanging resolve times out`() =
+        runBlocking(Dispatchers.Default) {
+            val manager = Shadow.newInstanceOf(NsdManager::class.java)
+            val shadowNsd = Shadow.extract<TestShadowNsdManager>(manager)
+            shadowNsd.reset()
+            val browser =
+                AndroidNsdBrowser(
+                    nsdManager = manager,
+                    resolveTimeoutMillis = 75L,
+                )
+            val events = Collections.synchronizedList(mutableListOf<NsdBrowserEvent>())
+            val job =
+                launch {
+                    browser
+                        .discover(QuickShareMdns.SERVICE_TYPE_NSD)
+                        .collect { event -> events += event }
+                }
+
+            try {
+                waitUntil("discovery listener registered") {
+                    shadowNsd.discoveryListenerCount == 1
+                }
+
+                shadowNsd.emitServiceFound(nsdServiceInfo(name = "peer-a", port = 0))
+                waitUntil("first resolve started") {
+                    shadowNsd.resolveCallCount == 1
+                }
+
+                shadowNsd.emitServiceFound(nsdServiceInfo(name = "peer-b", port = 0))
+                waitUntil("both found events emitted") {
+                    events.filterIsInstance<NsdBrowserEvent.Found>().map { it.instanceName } ==
+                        listOf("peer-a", "peer-b")
+                }
+                assertThat(shadowNsd.resolveCallCount).isEqualTo(1)
+
+                waitUntil("first resolve timed out") {
+                    events.any {
+                        it is NsdBrowserEvent.Error &&
+                            it.instanceName == "peer-a" &&
+                            it.message.contains("timed out")
+                    }
+                }
+                waitUntil("second resolve started after timeout") {
+                    shadowNsd.resolveCallCount == 2
+                }
+
+                shadowNsd.resolveByName(
+                    requestedName = "peer-b",
+                    resolved = nsdServiceInfo(name = "peer-b", port = 42_424),
+                )
+                waitUntil("second peer resolved") {
+                    events.any {
+                        it is NsdBrowserEvent.Resolved &&
+                            it.instanceName == "peer-b" &&
+                            it.port == 42_424
+                    }
+                }
+            } finally {
+                job.cancelAndJoin()
+            }
+        }
+
+    @Test
+    fun `registrar returns the platform registered name and unregisters on close`() =
+        runBlocking {
+            val manager = Shadow.newInstanceOf(NsdManager::class.java)
+            val shadowNsd = Shadow.extract<TestShadowNsdManager>(manager)
+            shadowNsd.reset()
+            shadowNsd.nextRegisteredName.set("WVMG (1)")
+            val payload = byteArrayOf(0x00, 0x7F, 0x80.toByte(), 0xFF.toByte())
+            val registrar = AndroidNsdRegistrar(manager)
+
+            val handle =
+                registrar.register(
+                    serviceType = QuickShareMdns.SERVICE_TYPE_NSD,
+                    instanceName = "WVMG",
+                    port = 53_601,
+                    attributes = mapOf(QuickShareMdns.TXT_KEY_ENDPOINT_INFO to payload),
+                )
+
+            assertThat(handle.instanceName).isEqualTo("WVMG (1)")
+            assertThat(handle.isActive).isTrue()
+            assertThat(shadowNsd.registrationRequests).hasSize(1)
+            val registeredInfo = shadowNsd.registrationRequests.single().serviceInfo
+            assertThat(registeredInfo.serviceName).isEqualTo("WVMG")
+            assertThat(registeredInfo.serviceType).isEqualTo(QuickShareMdns.SERVICE_TYPE_NSD)
+            assertThat(registeredInfo.port).isEqualTo(53_601)
+            assertThat(registeredInfo.attributes[QuickShareMdns.TXT_KEY_ENDPOINT_INFO])
+                .isEqualTo(payload)
+
+            handle.close()
+
+            assertThat(handle.isActive).isFalse()
+            assertThat(shadowNsd.unregisterCallCount.get()).isEqualTo(1)
+        }
+
+    @Test
+    fun `registrar surfaces platform registration failure as IOException`() =
+        runBlocking {
+            val manager = Shadow.newInstanceOf(NsdManager::class.java)
+            val shadowNsd = Shadow.extract<TestShadowNsdManager>(manager)
+            shadowNsd.reset()
+            shadowNsd.nextRegistrationFailure.set(NsdManager.FAILURE_ALREADY_ACTIVE)
+            val registrar = AndroidNsdRegistrar(manager)
+
+            val failure =
+                try {
+                    registrar.register(
+                        serviceType = QuickShareMdns.SERVICE_TYPE_NSD,
+                        instanceName = "WVMG",
+                        port = 12_345,
+                        attributes = emptyMap(),
+                    )
+                    null
+                } catch (e: IOException) {
+                    e
+                }
+
+            assertThat(failure).isNotNull()
+            assertThat(failure?.message).contains("errorCode=${NsdManager.FAILURE_ALREADY_ACTIVE}")
+        }
+
+    @Test
+    fun `pre API 33 reflective attribute setter unwraps platform validation failures`() =
+        runBlocking {
+            val manager = Shadow.newInstanceOf(NsdManager::class.java)
+            val shadowNsd = Shadow.extract<TestShadowNsdManager>(manager)
+            shadowNsd.reset()
+            val registrar = AndroidNsdRegistrar(manager)
+
+            val failure =
+                try {
+                    registrar.register(
+                        serviceType = QuickShareMdns.SERVICE_TYPE_NSD,
+                        instanceName = "WVMG",
+                        port = 12_345,
+                        attributes = mapOf("bad=key" to byteArrayOf(1)),
+                    )
+                    null
+                } catch (e: IllegalStateException) {
+                    e
+                }
+
+            assertThat(failure).isNotNull()
+            assertThat(failure?.message).contains("reflective invoke failed")
+            assertThat(failure?.message).contains("bad=key")
+        }
+
+    private suspend fun waitUntil(
+        description: String,
+        predicate: () -> Boolean,
+    ) {
+        try {
+            withTimeout(WAIT_TIMEOUT_MILLIS) {
+                while (!predicate()) {
+                    kotlinx.coroutines.delay(WAIT_POLL_MILLIS)
+                }
+            }
+        } catch (_: TimeoutCancellationException) {
+            error("Timed out waiting for $description")
+        }
+    }
+}
+
+private const val WAIT_TIMEOUT_MILLIS: Long = 2_000L
+private const val WAIT_POLL_MILLIS: Long = 10L
+
+private fun nsdServiceInfo(
+    name: String,
+    port: Int,
+    attributes: Map<String, ByteArray> = emptyMap(),
+): NsdServiceInfo =
+    NsdServiceInfo().apply {
+        serviceName = name
+        serviceType = QuickShareMdns.SERVICE_TYPE_NSD
+        this.port = port
+        @Suppress("DEPRECATION")
+        host = InetAddress.getByName("192.0.2.44")
+        for ((key, value) in attributes) {
+            setAttribute(key, value)
+        }
+    }
+
+@Implements(NsdManager::class)
+internal class TestShadowNsdManager {
+    private val discoveryListeners = CopyOnWriteArrayList<NsdManager.DiscoveryListener>()
+    private val pendingResolves = CopyOnWriteArrayList<ResolveRequest>()
+    private val resolveRequests = CopyOnWriteArrayList<ResolveRequest>()
+
+    val nextRegisteredName: AtomicReference<String?> = AtomicReference(null)
+    val nextRegistrationFailure: AtomicReference<Int?> = AtomicReference(null)
+    val registrationRequests: CopyOnWriteArrayList<RegistrationRequest> = CopyOnWriteArrayList()
+    val unregisterCallCount: AtomicInteger = AtomicInteger(0)
+
+    val discoveryListenerCount: Int
+        get() = discoveryListeners.size
+
+    val resolveCallCount: Int
+        get() = resolveRequests.size
+
+    fun reset() {
+        discoveryListeners.clear()
+        pendingResolves.clear()
+        resolveRequests.clear()
+        nextRegisteredName.set(null)
+        nextRegistrationFailure.set(null)
+        registrationRequests.clear()
+        unregisterCallCount.set(0)
+    }
+
+    fun emitServiceFound(serviceInfo: NsdServiceInfo) {
+        for (listener in discoveryListeners) {
+            listener.onServiceFound(serviceInfo)
+        }
+    }
+
+    fun resolveByName(
+        requestedName: String,
+        resolved: NsdServiceInfo,
+    ) {
+        val request =
+            pendingResolves
+                .firstOrNull { it.serviceInfo.serviceName == requestedName }
+                ?: error("No pending resolve for $requestedName")
+        pendingResolves.remove(request)
+        request.listener.onServiceResolved(resolved)
+    }
+
+    @Implementation
+    fun discoverServices(
+        serviceType: String,
+        protocolType: Int,
+        listener: NsdManager.DiscoveryListener,
+    ) {
+        check(protocolType == NsdManager.PROTOCOL_DNS_SD)
+        discoveryListeners += listener
+        listener.onDiscoveryStarted(serviceType)
+    }
+
+    @Implementation
+    fun stopServiceDiscovery(listener: NsdManager.DiscoveryListener) {
+        discoveryListeners.remove(listener)
+        listener.onDiscoveryStopped(QuickShareMdns.SERVICE_TYPE_NSD)
+    }
+
+    @Implementation
+    fun resolveService(
+        serviceInfo: NsdServiceInfo,
+        listener: NsdManager.ResolveListener,
+    ) {
+        val request = ResolveRequest(serviceInfo, listener)
+        resolveRequests += request
+        pendingResolves += request
+    }
+
+    @Implementation
+    fun registerService(
+        serviceInfo: NsdServiceInfo,
+        protocolType: Int,
+        listener: NsdManager.RegistrationListener,
+    ) {
+        check(protocolType == NsdManager.PROTOCOL_DNS_SD)
+        registrationRequests += RegistrationRequest(serviceInfo, protocolType, listener)
+        val failureCode = nextRegistrationFailure.getAndSet(null)
+        if (failureCode != null) {
+            listener.onRegistrationFailed(serviceInfo, failureCode)
+            return
+        }
+
+        val callbackInfo = serviceInfo.copyForCallback()
+        nextRegisteredName.getAndSet(null)?.let { callbackInfo.serviceName = it }
+        listener.onServiceRegistered(callbackInfo)
+    }
+
+    @Implementation
+    fun unregisterService(listener: NsdManager.RegistrationListener) {
+        unregisterCallCount.incrementAndGet()
+        val serviceInfo =
+            registrationRequests
+                .lastOrNull { it.listener === listener }
+                ?.serviceInfo
+                ?: NsdServiceInfo()
+        listener.onServiceUnregistered(serviceInfo)
+    }
+
+    data class ResolveRequest(
+        val serviceInfo: NsdServiceInfo,
+        val listener: NsdManager.ResolveListener,
+    )
+
+    data class RegistrationRequest(
+        val serviceInfo: NsdServiceInfo,
+        val protocolType: Int,
+        val listener: NsdManager.RegistrationListener,
+    )
+
+    private fun NsdServiceInfo.copyForCallback(): NsdServiceInfo =
+        NsdServiceInfo().also { copy ->
+            copy.serviceName = serviceName
+            copy.serviceType = serviceType
+            copy.port = port
+            @Suppress("DEPRECATION")
+            copy.host = host
+            for ((key, value) in attributes.orEmpty()) {
+                copy.setAttribute(key, value)
+            }
+        }
+}

--- a/discovery-android/src/test/resources/robolectric.properties
+++ b/discovery-android/src/test/resources/robolectric.properties
@@ -1,0 +1,2 @@
+sdk=28
+shadows=io.github.kyujincho.wvmg.discovery.TestShadowNsdManager

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,6 +41,8 @@ truth = "1.4.4"
 androidxJunit = "1.2.1"
 androidxEspresso = "3.6.1"
 androidxTestRunner = "1.6.2"
+robolectric = "4.16.1"
+robolectricAndroidAll = "15-robolectric-12650502"
 
 # Static analysis
 ktlintPlugin = "12.1.2"
@@ -83,10 +85,13 @@ junit4 = { module = "junit:junit", version.ref = "junit4" }
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junitJupiter" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junitJupiter" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junitJupiter" }
+junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "junitJupiter" }
 truth = { module = "com.google.truth:truth", version.ref = "truth" }
 androidx-test-junit = { module = "androidx.test.ext:junit", version.ref = "androidxJunit" }
 androidx-test-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "androidxEspresso" }
 androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidxTestRunner" }
+robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
+robolectric-android-all = { module = "org.robolectric:android-all", version.ref = "robolectricAndroidAll" }
 
 # Detekt formatting plugin (loadable into detekt's plugin classpath)
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }


### PR DESCRIPTION
## Summary
- add Robolectric and a custom NsdManager shadow for AndroidNsdBrowser / AndroidNsdRegistrar integration coverage
- isolate Robolectric under a JUnit4 task that runs from :discovery-android:testDebugUnitTest without leaking android-all into the normal Jupiter suite
- add discovery-android debug unit tests to CI so the new coverage is gated

## Verification
- ./gradlew :discovery-android:robolectricDebugUnitTest
- ./gradlew :discovery-android:testDebugUnitTest
- ./gradlew staticAnalysis
- ./gradlew staticAnalysis :core-protocol:test :discovery-android:testDebugUnitTest :app:testDebugUnitTest :app:assembleDebug

Closes #100