### PR TITLE
feat: support non-LAN Quick Share discovery and initial connection on sender side

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ logic.
 ```
 :app                  UI, share intents, settings (Android application)
 :service-android      ForegroundService, notifications, MediaStore writes
-:discovery-android    JmDNS / NsdManager wrappers, BLE advertise/scan
+:discovery-android    NsdManager wrappers, BLE advertise/scan, Bluetooth Classic bootstrap
 :core-protocol        Pure-Kotlin protocol implementation (no Android deps)
 :core-protocol-test   KAT vectors, fixtures
 ```
@@ -132,18 +132,25 @@ for the full sub-issue list and merged PRs.
 
 ## Networking requirements
 
-Phase 1 uses Wi-Fi LAN discovery (mDNS) to find nearby devices:
+Shared Wi-Fi remains the baseline Quick Share path, but sender-side
+bootstrap is no longer limited to pure LAN discovery:
 
-- **Both the sender and the receiver must be on the same Wi-Fi network**
-  — and on the same VLAN. mDNS multicasts (`_FC9F5ED42C8A._tcp.local.`)
-  do not cross routed subnets, so a typical "Guest" SSID will silently
-  break discovery.
+- **WVMG sender -> stock Quick Share receiver** can start either from the
+  shared-LAN mDNS path or from a nearby Bluetooth-assisted bootstrap path
+  when the devices are off-LAN. For the off-LAN path, keep Bluetooth on
+  at both ends and use the stock peer's visible-to-everyone mode.
+- **Stock Quick Share sender -> WVMG receiver** still depends on the
+  shared-LAN receiver discovery path today, so keep the devices on the
+  same Wi-Fi network for that direction.
+- For the shared-LAN regression path, both devices must be on the same
+  Wi-Fi network and on the same VLAN. mDNS multicasts
+  (`_FC9F5ED42C8A._tcp.local.`) do not cross routed subnets, so a
+  typical "Guest" SSID will silently break discovery.
 - The Wi-Fi network must permit IPv4 multicast / mDNS traffic. Some
   enterprise APs drop multicast frames by default.
 - AP isolation / "client isolation" must be off on the access point.
-- BLE auto-discovery (the "ping nearby devices" pulse that lights up a
-  stock receiver's "Sharing nearby" sheet automatically) is **out of
-  scope for Phase 1** and tracked under Phase 2.
+- The stock-device interop matrix and current manual validation checklist
+  live in [docs/testing/interop-stock-quick-share-android.md](docs/testing/interop-stock-quick-share-android.md).
 
 The receiver's persistent notification surfaces the current Wi-Fi SSID
 (`Receiving on "<SSID>"`) so you can verify both ends match without

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <activity
+            android:name=".debug.BleFastScanProbeActivity"
+            android:exported="true"
+            android:label="BLE Fast Scan Probe">
+            <intent-filter>
+                <action android:name="io.github.kyujincho.wvmg.debug.BLE_FAST_SCAN_PROBE" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/app/src/debug/kotlin/io/github/kyujincho/wvmg/debug/BleFastScanProbeActivity.kt
+++ b/app/src/debug/kotlin/io/github/kyujincho/wvmg/debug/BleFastScanProbeActivity.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.debug
+
+import android.os.Bundle
+import android.util.Log
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import io.github.kyujincho.wvmg.discovery.ble.BleFastAdvertisementScanner
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
+
+class BleFastScanProbeActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        lifecycleScope.launch {
+            Log.w(TAG, "probe start durationMs=$PROBE_DURATION_MILLIS")
+            try {
+                withTimeout(PROBE_DURATION_MILLIS) {
+                    BleFastAdvertisementScanner(applicationContext)
+                        .scan()
+                        .collect { observation ->
+                            Log.w(
+                                TAG,
+                                "probe observed endpointId=${observation.endpointId} " +
+                                    "address=${observation.advertiserAddress} rssi=${observation.rssi}",
+                            )
+                        }
+                }
+            } catch (_: TimeoutCancellationException) {
+                Log.w(TAG, "probe timeout")
+            } finally {
+                finish()
+            }
+        }
+    }
+
+    private companion object {
+        private const val TAG: String = "WvmgBleFastProbe"
+        private const val PROBE_DURATION_MILLIS: Long = 30_000L
+    }
+}

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/onboarding/PermissionRequirements.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/onboarding/PermissionRequirements.kt
@@ -25,20 +25,23 @@ import io.github.kyujincho.wvmg.R
  * layer migrated to NsdManager.
  *
  * Runtime permissions are gated by API level:
+ *   * `ACCESS_FINE_LOCATION` is required on Android 11 and lower for
+ *     Bluetooth discovery / BLE scans; older platform releases route
+ *     nearby-device discovery through the location runtime permission.
  *   * `NEARBY_WIFI_DEVICES` and `POST_NOTIFICATIONS` only exist on API 33+.
  *   * `BLUETOOTH_ADVERTISE`, `BLUETOOTH_SCAN`, and `BLUETOOTH_CONNECT` only
  *     exist on API 31+ — on API ≤ 30 the legacy install-time
  *     `BLUETOOTH` / `BLUETOOTH_ADMIN`
  *     permissions cover the same capabilities, so we skip the runtime
- *     prompt entirely on those devices.
+ *     nearby-devices dialog on those devices.
  *
  * Each requirement is classified as **mandatory** or **optional**:
  *   * Mandatory denials gate the app's primary discovery path.
  *     Currently `NEARBY_WIFI_DEVICES` is the only mandatory permission —
  *     without it Phase 1 cannot run mDNS discovery at all.
  *   * Optional denials let the app run in a degraded mode. Today that
- *     means missing notifications (silent transfers) or missing BLE
- *     auto-discovery (mDNS-only fallback per #31's acceptance criteria).
+ *     means missing notifications (silent transfers) or missing nearby
+ *     Bluetooth / off-LAN discovery.
  *
  * Onboarding is allowed to complete with optional-only denials; the
  * service-start gate re-checks at runtime so the user can grant later
@@ -67,12 +70,15 @@ internal object PermissionRequirements {
 
     /**
      * The set of runtime permissions that need to be requested on the
-     * **current** device. Empty on devices with API < 31 that don't run
-     * any runtime-permissioned features (currently impossible because
-     * minSdk is 24 and we have no runtime permissions for API 24–30).
+     * **current** device. Empty only on API levels below the modern
+     * Android runtime-permission model (our minSdk is 24, so production
+     * builds always request at least one permission).
      */
     internal fun requirementsFor(): List<Requirement> {
         val result = mutableListOf<Requirement>()
+        if (Build.VERSION.SDK_INT in Build.VERSION_CODES.M until Build.VERSION_CODES.S) {
+            result += legacyNearbyDiscoveryPermission()
+        }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             result += blePermissions()
         }
@@ -81,6 +87,17 @@ internal object PermissionRequirements {
         }
         return result
     }
+
+    @RequiresApi(Build.VERSION_CODES.M)
+    private fun legacyNearbyDiscoveryPermission(): Requirement =
+        Requirement(
+            permission = Manifest.permission.ACCESS_FINE_LOCATION,
+            titleRes = R.string.permission_legacy_nearby_location_title,
+            rationaleRes = R.string.permission_legacy_nearby_location_rationale,
+            grantedRes = R.string.permission_status_granted,
+            deniedRes = R.string.permission_status_optional_denied,
+            optional = true,
+        )
 
     @RequiresApi(Build.VERSION_CODES.S)
     private fun blePermissions(): List<Requirement> =
@@ -154,10 +171,11 @@ internal object PermissionRequirements {
 
     /**
      * True when the only outstanding permissions are non-blocking ones
-     * (`POST_NOTIFICATIONS` and the BLE permissions). The service can
-     * run in degraded mode in that case — see issue #26 / #31 acceptance
-     * criteria. Returns false when no permissions are missing (use
-     * [allGranted] to detect that case).
+     * (`POST_NOTIFICATIONS`, nearby Bluetooth/off-LAN discovery, and
+     * the BLE permissions). The service can run in degraded mode in
+     * that case — see issue #26 / #31 acceptance criteria. Returns
+     * false when no permissions are missing (use [allGranted] to detect
+     * that case).
      */
     internal fun onlyOptionalMissing(context: Context): Boolean {
         val missing = missingPermissions(context).toSet()

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/onboarding/PermissionRequirements.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/onboarding/PermissionRequirements.kt
@@ -74,15 +74,15 @@ internal object PermissionRequirements {
      * Android runtime-permission model (our minSdk is 24, so production
      * builds always request at least one permission).
      */
-    internal fun requirementsFor(): List<Requirement> {
+    internal fun requirementsFor(sdkInt: Int = Build.VERSION.SDK_INT): List<Requirement> {
         val result = mutableListOf<Requirement>()
-        if (Build.VERSION.SDK_INT in Build.VERSION_CODES.M until Build.VERSION_CODES.S) {
+        if (sdkInt in Build.VERSION_CODES.M until Build.VERSION_CODES.S) {
             result += legacyNearbyDiscoveryPermission()
         }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        if (sdkInt >= Build.VERSION_CODES.S) {
             result += blePermissions()
         }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        if (sdkInt >= Build.VERSION_CODES.TIRAMISU) {
             result += tiramisuPermissions()
         }
         return result

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/onboarding/PermissionRequirements.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/onboarding/PermissionRequirements.kt
@@ -6,6 +6,7 @@
 package io.github.kyujincho.wvmg.onboarding
 
 import android.Manifest
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
@@ -74,6 +75,7 @@ internal object PermissionRequirements {
      * Android runtime-permission model (our minSdk is 24, so production
      * builds always request at least one permission).
      */
+    @SuppressLint("NewApi") // Callers may pass sdkInt in tests; each API-specific list is gated here.
     internal fun requirementsFor(sdkInt: Int = Build.VERSION.SDK_INT): List<Requirement> {
         val result = mutableListOf<Requirement>()
         if (sdkInt in Build.VERSION_CODES.M until Build.VERSION_CODES.S) {

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendActivity.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendActivity.kt
@@ -6,37 +6,28 @@
 package io.github.kyujincho.wvmg.send
 
 import android.content.Intent
-import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
-import android.view.LayoutInflater
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import io.github.kyujincho.wvmg.R
 import io.github.kyujincho.wvmg.databinding.ActivitySendBinding
-import io.github.kyujincho.wvmg.databinding.ItemPeerRowBinding
-import io.github.kyujincho.wvmg.discovery.DiscoveredService
-import io.github.kyujincho.wvmg.discovery.Discovery
-import io.github.kyujincho.wvmg.discovery.DiscoveryEvent
-import io.github.kyujincho.wvmg.discovery.ble.BleAdvertiseHandle
-import io.github.kyujincho.wvmg.discovery.ble.BleAdvertiser
+import io.github.kyujincho.wvmg.discovery.NearbyPeer
+import io.github.kyujincho.wvmg.discovery.NearbyPeerRoute
+import io.github.kyujincho.wvmg.discovery.bootstrap.BluetoothClassicBootstrapClient
 import io.github.kyujincho.wvmg.discovery.medium.MediumRegistries
+import io.github.kyujincho.wvmg.protocol.connection.CancelCause
 import io.github.kyujincho.wvmg.protocol.connection.FileSource
 import io.github.kyujincho.wvmg.protocol.connection.OutboundConnection
 import io.github.kyujincho.wvmg.protocol.connection.OutboundConnectionState
 import io.github.kyujincho.wvmg.protocol.endpoint.DeviceType
 import io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo
 import io.github.kyujincho.wvmg.service.receiver.OutboundSessionActiveHolder
-import io.github.kyujincho.wvmg.service.receiver.ReceiverAdvertisementStateHolder
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import java.net.InetAddress
 import java.security.SecureRandom
 
 /**
@@ -48,10 +39,10 @@ import java.security.SecureRandom
  *     `ACTION_SEND_MULTIPLE` intent here. [ShareIntentRouter] parses
  *     the extras into a [ShareIntentInput], and [UriFileSourceFactory]
  *     turns each URI into a protocol-level [FileSource].
- *  2. Discovery starts via [Discovery.browse]; the user picks a peer
+ *  2. Discovery starts via [NearbyPeerDiscovery]; the user picks a peer
  *     from the live-updating list.
- *  3. The selected peer's first non-loopback address + advertised port
- *     becomes the target of an [OutboundConnection]. The connection's
+ *  3. The selected peer's preferred initial route becomes the target of
+ *     an [OutboundConnection]. The connection's
  *     [OutboundConnectionState] flow drives the status panel: the PIN
  *     is rendered when [OutboundConnectionState.AwaitingRemoteAcceptance]
  *     fires, and terminal states ([OutboundConnectionState.Completed],
@@ -77,41 +68,13 @@ public class SendActivity : AppCompatActivity() {
     private lateinit var binding: ActivitySendBinding
     private lateinit var fileSourceFactory: UriFileSourceFactory
     private lateinit var documentTreeFactory: DocumentTreeFileSourceFactory
+    private lateinit var payloadResolver: SendPayloadResolver
+    private lateinit var peerPickerController: SendPeerPickerController
 
     private var files: List<FileSource> = emptyList()
-    private val peers: MutableList<DiscoveredService> = mutableListOf()
-    private val pendingPeerRemovalJobs: MutableMap<String, Job> = mutableMapOf()
-    private var outboundPresenceJob: Job? = null
-    private var discoveryJob: Job? = null
     private var connectionJob: Job? = null
     private var activeConnection: OutboundConnection? = null
-
-    /**
-     * Tracks whether the same-Wi-Fi-network hint card (#85) has been
-     * shown long enough to count as user-visible. The timer starts on
-     * `onCreate` once we know we have files to share; the card is
-     * surfaced after [EmptyPeerHintTimer.DEFAULT_DELAY_MILLIS] of
-     * continuous empty-peer-list state.
-     */
-    private val emptyPeerHintTimer: EmptyPeerHintTimer = EmptyPeerHintTimer()
-    private var emptyPeerHintJob: Job? = null
-
-    /**
-     * BLE service-data advertiser (#32). Started alongside mDNS
-     * discovery so receivers' BLE scan loops wake up their mDNS
-     * responders before the user has finished picking a peer. Stopped
-     * when the outbound TCP connection enters [OutboundConnectionState.Handshaking]
-     * (no point continuing to broadcast once the wire link is up) or
-     * on `onDestroy` / cancel.
-     *
-     * Held as a nullable handle because [BleAdvertiser.start] returns
-     * `null` on devices without a peripheral-mode BLE radio, with the
-     * `BLUETOOTH_ADVERTISE` permission revoked, or with Bluetooth
-     * turned off — all of which fall through to the mDNS-only path
-     * per the issue's fallback acceptance criterion.
-     */
-    private var bleAdvertiser: BleAdvertiser? = null
-    private var bleAdvertiseHandle: BleAdvertiseHandle? = null
+    private var bluetoothBootstrapClient: BluetoothClassicBootstrapClient? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -130,74 +93,48 @@ public class SendActivity : AppCompatActivity() {
 
         fileSourceFactory = UriFileSourceFactory(contentResolver)
         documentTreeFactory = DocumentTreeFileSourceFactory(contentResolver)
+        payloadResolver = SendPayloadResolver(fileSourceFactory, documentTreeFactory)
+        peerPickerController =
+            SendPeerPickerController(
+                context = this,
+                binding = binding,
+                lifecycle = lifecycle,
+                scope = lifecycleScope,
+                onPeerSelected = ::onPeerSelected,
+                logDiagnostic = ::logOutboundDiagnostic,
+            )
 
         binding.sendCancelButton.setOnClickListener { onCancelClicked() }
         binding.sendDoneButton.setOnClickListener { finish() }
         binding.sendShowQrButton.setOnClickListener { onShowQrClicked() }
-        binding.sendNetworkHintDismiss.setOnClickListener { onHintDismissed() }
+        binding.sendNetworkHintDismiss.setOnClickListener { peerPickerController.onHintDismissed() }
 
         // Resolve the intent's file list. May render a terminal UI
         // state (unsupported / folder empty / folder walk failed) and
         // return null; in that case we leave `files` as the default
         // empty list and bail without starting discovery. The terminal
         // states already display "Done" / explanatory text.
-        val resolved = resolveIntentFiles()
-        if (resolved == null) return
-        files = resolved
+        val resolvedFiles =
+            when (val resolved = payloadResolver.resolve(intent)) {
+                is SendPayloadResolution.Files -> resolved.files
+                SendPayloadResolution.Unsupported -> {
+                    renderUnsupportedPayload()
+                    null
+                }
+                SendPayloadResolution.FolderEmpty -> {
+                    renderFolderEmpty()
+                    null
+                }
+                SendPayloadResolution.FolderWalkFailed -> {
+                    renderFolderWalkFailed()
+                    null
+                }
+            } ?: return
+        files = resolvedFiles
 
         binding.sendPayloadSummary.text = PayloadSummary.forFiles(this, files)
         binding.sendSubtitle.setText(R.string.send_subtitle_discovering)
-        startOutboundPresence()
-    }
-
-    /**
-     * Walk [intent] into the canonical [FileSource] list the rest of
-     * the activity expects, or render a terminal UI state and return
-     * null. Centralised here so `onCreate` carries a single early-
-     * return rather than threading the share-sheet vs. folder-send
-     * branching across multiple bail-out paths.
-     *
-     * Two distinct entry points:
-     *
-     *  1. `ACTION_SEND_FOLDER` (#38). The folder-picker on
-     *     [io.github.kyujincho.wvmg.MainActivity] forwards a `tree://`
-     *     URI here. We walk it via [DocumentTreeFileSourceFactory],
-     *     surface a folder-specific empty / failure message if needed,
-     *     and otherwise hand the list back.
-     *  2. `ACTION_SEND` / `ACTION_SEND_MULTIPLE` (#24). The system
-     *     share sheet routes individual file URIs here, which
-     *     [ShareIntentRouter] parses into the canonical input shapes.
-     */
-    @Suppress("ReturnCount") // The branching is inherent — each terminal-state path is its own bail.
-    private fun resolveIntentFiles(): List<FileSource>? {
-        if (intent.action == ACTION_SEND_FOLDER) {
-            val treeUri = intent.data
-            if (treeUri == null) {
-                renderUnsupportedPayload()
-                return null
-            }
-            val walked = materializeFolder(treeUri) ?: return null
-            if (walked.isEmpty()) {
-                // `materializeFolder` already swapped in the folder-
-                // specific empty-state UI before returning.
-                return null
-            }
-            return walked
-        }
-        val parsed = ShareIntentRouter.route(toShareIntent(intent))
-        if (parsed == null) {
-            renderUnsupportedPayload()
-            return null
-        }
-        val files = materializeFiles(parsed)
-        if (files.isEmpty()) {
-            // Currently true for plain-text shares (sender-side text
-            // payload support is a follow-up). Surface the same
-            // unsupported message so the user gets clear feedback.
-            renderUnsupportedPayload()
-            return null
-        }
-        return files
+        peerPickerController.start()
     }
 
     override fun onDestroy() {
@@ -207,462 +144,58 @@ public class SendActivity : AppCompatActivity() {
         // OutboundConnection so a CancelFrame is sent on the wire when
         // possible (best-effort — already-terminal states are no-ops).
         activeConnection?.cancel()
-        outboundPresenceJob?.cancel()
-        discoveryJob?.cancel()
+        bluetoothBootstrapClient?.cancelPendingConnect()
+        peerPickerController.stop()
         connectionJob?.cancel()
-        emptyPeerHintJob?.cancel()
-        cancelPendingPeerRemovals()
-        stopBleAdvertise()
         // Lift the gate veto so the receiver-side mDNS record can come
         // back up if any of the gate's existing publish signals
         // (BLE pulse, always-visible override, QR session) call for it.
         OutboundSessionActiveHolder.setOutboundSessionActive(false)
     }
 
-    // -----------------------------------------------------------------
-    // Intent parsing
-    // -----------------------------------------------------------------
-
-    /**
-     * Convert the live Android [Intent] into the
-     * platform-agnostic [ShareIntent] the router consumes.
-     *
-     * The Intent extras-extraction APIs are deprecated on API 33+ and
-     * replaced with type-safe variants; we route through both shapes
-     * so a single source compiles cleanly on every supported SDK.
-     */
-    private fun toShareIntent(source: Intent): ShareIntent {
-        val streamUri: Uri? =
-            when (source.action) {
-                Intent.ACTION_SEND -> getParcelableExtraCompat(source, Intent.EXTRA_STREAM)
-                else -> null
-            }
-        val streamUris: List<Uri>? =
-            when (source.action) {
-                Intent.ACTION_SEND_MULTIPLE -> getParcelableArrayListExtraCompat(source, Intent.EXTRA_STREAM)
-                else -> null
-            }
-        val text: CharSequence? = source.getCharSequenceExtra(Intent.EXTRA_TEXT)
-        return ShareIntent(
-            action = source.action,
-            streamUri = streamUri,
-            streamUris = streamUris,
-            textExtra = text,
-        )
-    }
-
-    @Suppress("DEPRECATION")
-    private fun getParcelableExtraCompat(
-        source: Intent,
-        key: String,
-    ): Uri? =
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            source.getParcelableExtra(key, Uri::class.java)
-        } else {
-            source.getParcelableExtra(key) as? Uri
-        }
-
-    @Suppress("DEPRECATION")
-    private fun getParcelableArrayListExtraCompat(
-        source: Intent,
-        key: String,
-    ): List<Uri>? =
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            source.getParcelableArrayListExtra(key, Uri::class.java)
-        } else {
-            source.getParcelableArrayListExtra(key)
-        }
-
-    /**
-     * Materialize the parsed input into a list of [FileSource]s. Plain
-     * text returns an empty list (sender-side text support is a
-     * follow-up); URI shapes return one FileSource per URI.
-     */
-    private fun materializeFiles(input: ShareIntentInput): List<FileSource> =
-        when (input) {
-            is ShareIntentInput.SingleUri ->
-                listOf(fileSourceFactory.fromUri(input.uri as Uri))
-            is ShareIntentInput.MultipleUris ->
-                input.uris.map { fileSourceFactory.fromUri(it as Uri) }
-            is ShareIntentInput.Text ->
-                emptyList()
-        }
-
-    /**
-     * Walk the SAF tree under [treeUri] and return one [FileSource] per
-     * descendant file (#38). Returns:
-     *
-     * - A non-empty list on success — the regular discovery / send
-     *   flow takes over from the caller.
-     * - An empty list when the picked folder contains no files (the
-     *   walker recurses into subdirectories but Quick Share has no
-     *   "create empty directory" frame, so we have nothing to ship).
-     *   In this case [renderFolderEmpty] swaps the UI into a
-     *   "no files" state and the caller bails out.
-     * - `null` when the walk threw (e.g. the SAF provider revoked the
-     *   read grant before we got here). [renderFolderWalkFailed] swaps
-     *   the UI into a "couldn't read folder" state and the caller bails
-     *   out.
-     *
-     * The walker runs synchronously on the UI thread because:
-     *
-     * 1. The `OpenDocumentTree` contract just returned, so the system
-     *    picker has already displayed and dismissed — the user is
-     *    actively waiting for our response.
-     * 2. Real-world folder sizes that fit Quick Share's transfer model
-     *    (ten-ish files, low-MB to ~tens-of-MB total) walk in single
-     *    digit milliseconds. Larger trees would block the UI thread,
-     *    but Quick Share's per-transfer payload cap (no formal limit,
-     *    but practical sender memory and timeout pressure) bounds the
-     *    walk's worst case.
-     *
-     * If real devices show jank on huge trees, this is the right place
-     * to move onto a background dispatcher — the rest of the activity
-     * already drives discovery / connection from `lifecycleScope`.
-     */
-    private fun materializeFolder(treeUri: Uri): List<FileSource>? {
-        binding.sendSubtitle.setText(R.string.send_folder_subtitle_walking)
-        // Both SecurityException and IllegalArgumentException land on
-        // the "couldn't read folder" UI:
-        //   - SecurityException: the SAF provider revoked the read
-        //     grant before we got here.
-        //   - IllegalArgumentException: getTreeDocumentId rejected a
-        //     non-tree URI. The OpenDocumentTree contract guarantees a
-        //     tree URI on success, so reaching here means a malformed
-        //     intent extra (e.g. a third-party app started us via a
-        //     future-exported variant of this activity with the wrong
-        //     shape). Surface as a user-visible error rather than
-        //     crashing.
-        val walked =
-            runCatching { documentTreeFactory.walk(treeUri) }
-                .onFailure { e ->
-                    if (e is SecurityException || e is IllegalArgumentException) {
-                        Log.e(OUTBOUND_TAG, "ACTION_SEND_FOLDER walk failed for $treeUri", e)
-                        renderFolderWalkFailed()
-                    } else {
-                        // Unknown throwable: let the framework see it.
-                        throw e
-                    }
-                }.getOrNull() ?: return null
-        if (walked.isEmpty()) renderFolderEmpty()
-        return walked
-    }
-
-    // -----------------------------------------------------------------
-    // Discovery
-    // -----------------------------------------------------------------
-
-    private fun startOutboundPresence() {
-        outboundPresenceJob?.cancel()
-        outboundPresenceJob =
-            lifecycleScope.launch {
-                val receiverWasAdvertising = ReceiverAdvertisementStateHolder.isAdvertising
-                if (receiverWasAdvertising) {
-                    logOutboundDiagnostic(
-                        "discovery: waiting for receiver mDNS unpublish before browse",
-                    )
-                }
-
-                val unpublishObserved = ReceiverAdvertisementStateHolder.awaitNotAdvertising()
-                if (!unpublishObserved) {
-                    logOutboundDiagnostic(
-                        "discovery: receiver mDNS unpublish wait timed out; starting browse",
-                    )
-                } else if (receiverWasAdvertising) {
-                    logOutboundDiagnostic("discovery: receiver mDNS unpublish observed")
-                }
-
-                if (!lifecycle.currentState.isAtLeast(Lifecycle.State.CREATED)) return@launch
-                startDiscovery()
-                startEmptyPeerHintTimer()
-                startBleAdvertise()
-            }
-    }
-
-    private fun startDiscovery() {
-        val discovery = Discovery(applicationContext)
-        logOutboundDiagnostic("discovery: start")
-        discoveryJob =
-            lifecycleScope.launch {
-                repeatOnLifecycle(Lifecycle.State.STARTED) {
-                    logOutboundDiagnostic("discovery: browse collector start")
+    private suspend fun buildOutboundConnection(
+        route: NearbyPeerRoute,
+        endpointInfo: ByteArray,
+    ): OutboundConnection? {
+        val mediumRegistry = MediumRegistries.defaultForContext(applicationContext)
+        return when (route) {
+            is NearbyPeerRoute.Lan ->
+                OutboundConnection(
+                    targetAddress = route.address,
+                    port = route.port,
+                    endpointInfo = endpointInfo,
+                    mediumRegistry = mediumRegistry,
+                    logger = ::logOutboundWireMessage,
+                )
+            is NearbyPeerRoute.BluetoothClassic -> {
+                val client = BluetoothClassicBootstrapClient(applicationContext)
+                bluetoothBootstrapClient = client
+                val transport =
                     try {
-                        discovery.browse().collect { event -> onDiscoveryEvent(event) }
+                        client.connect(route.macAddress)
                     } finally {
-                        logOutboundDiagnostic("discovery: browse collector stop")
-                    }
-                }
-            }
-    }
-
-    private fun onDiscoveryEvent(event: DiscoveryEvent) {
-        val before = peers.size
-        when (event) {
-            is DiscoveryEvent.Resolved -> {
-                cancelPendingPeerRemoval(event.service.instanceName)
-                upsertResolvedPeer(event.service)
-                logOutboundDiagnostic(
-                    "discovery: resolved ${formatPeerSnapshot(event.service)} " +
-                        "before=$before after=${peers.size} rows=${formatPeerRows()}",
-                )
-            }
-            is DiscoveryEvent.Lost -> {
-                // Lost events fire per-instance-name. Because Resolved
-                // events may have replaced an older instance under the
-                // same addr+port row, the lost name may not match any
-                // current peer's `instanceName` — that's fine, we
-                // silently skip. The next mDNS query will re-resolve a
-                // still-valid record if Samsung is just rotating ids.
-                schedulePeerRemoval(event.instanceName)
-                logOutboundDiagnostic(
-                    "discovery: lost instance=${event.instanceName} scheduledRemovalMillis=$PEER_LOST_GRACE_MILLIS " +
-                        "before=$before after=${peers.size} rows=${formatPeerRows()}",
+                        bluetoothBootstrapClient = null
+                    } ?: return null
+                OutboundConnection(
+                    transport = transport,
+                    endpointInfo = endpointInfo,
+                    mediumRegistry = mediumRegistry,
+                    logger = ::logOutboundWireMessage,
                 )
             }
         }
-        renderPeerList()
-    }
-
-    /**
-     * Insert or replace [incoming] in the picker's [peers] list.
-     *
-     * Dedup by primary address + port, NOT by mDNS instance name. Stock
-     * Quick Share rotates instance names rapidly for privacy and
-     * frequently publishes multiple records simultaneously (e.g., one
-     * with the friendly name and one without) — captured on a Galaxy
-     * S24 Ultra, all pointing at the same TCP listener. Keying on
-     * instance name leaves the picker with several rows for the same
-     * device, some of them stale, and tapping a stale row intermittently
-     * triggers a silent UKEY2 FIN on the peer (its current internal
-     * state no longer matches the older instance ID baked into the row).
-     *
-     * We deliberately do NOT filter by EndpointInfo's `hidden` bit.
-     * Stock peers publish every device — even "Everyone" mode — with
-     * visibility=1 and no plaintext name; the Everyone-vs-Contacts-only
-     * decision happens during the connection negotiation, not at the
-     * mDNS layer. Filtering here would hide the very peers the user is
-     * trying to send to.
-     */
-    private fun upsertResolvedPeer(incoming: DiscoveredService) {
-        val key = peerDedupKey(incoming)
-        if (key == null) {
-            // Defensive: if the resolved record has no usable address
-            // (rare; the discovery layer normally drops these earlier),
-            // fall back to instance-name dedup so the row at least
-            // appears.
-            val ix = peers.indexOfFirst { it.instanceName == incoming.instanceName }
-            if (ix >= 0) peers[ix] = incoming else peers.add(incoming)
-            return
-        }
-        val existingIndex = peers.indexOfFirst { peerDedupKey(it) == key }
-        if (existingIndex < 0) {
-            peers.add(incoming)
-            return
-        }
-        cancelPendingPeerRemoval(peers[existingIndex].instanceName)
-        // Keep whichever record carries a friendly device name. Stock
-        // Samsung alternates anonymous and named instances on the wire;
-        // the picker should settle on the named one once seen rather
-        // than flicker back to "Quick Share Device".
-        val existing = peers[existingIndex]
-        val existingNamed = existing.endpointInfo?.deviceName != null
-        val incomingNamed = incoming.endpointInfo?.deviceName != null
-        if (incomingNamed || !existingNamed) {
-            peers[existingIndex] = incoming
-        }
-    }
-
-    /**
-     * Returns the (primaryAddress, port) tuple used to dedup the picker's
-     * peer list, or `null` if [peer] has no usable connect target. Two
-     * mDNS records that resolve to the same TCP listener share this key
-     * regardless of mDNS instance name; that lets us collapse stock
-     * Quick Share's rotating-instance-id record stream into one stable
-     * row.
-     */
-    private fun peerDedupKey(peer: DiscoveredService): Pair<String, Int>? {
-        val addr = peer.primaryAddress()?.hostAddress ?: return null
-        return addr to peer.port
-    }
-
-    /**
-     * Samsung Quick Share frequently rotates mDNS instance names and may
-     * emit a short `Lost` gap before the replacement record is resolved.
-     * Removing rows immediately makes the picker appear empty even though
-     * the same TCP listener is still available. Delay the removal so
-     * routine rotation does not flicker the UI, while still eventually
-     * clearing truly-gone peers.
-     */
-    private fun schedulePeerRemoval(instanceName: String) {
-        pendingPeerRemovalJobs.remove(instanceName)?.cancel()
-        pendingPeerRemovalJobs[instanceName] =
-            lifecycleScope.launch {
-                delay(PEER_LOST_GRACE_MILLIS)
-                pendingPeerRemovalJobs.remove(instanceName)
-                val before = peers.size
-                val removed = peers.removeAll { it.instanceName == instanceName }
-                logOutboundDiagnostic(
-                    "discovery: lost removal instance=$instanceName removed=$removed " +
-                        "before=$before after=${peers.size} rows=${formatPeerRows()}",
-                )
-                if (removed) renderPeerList()
-            }
-    }
-
-    private fun cancelPendingPeerRemoval(instanceName: String) {
-        pendingPeerRemovalJobs.remove(instanceName)?.cancel()
-    }
-
-    private fun cancelPendingPeerRemovals() {
-        pendingPeerRemovalJobs.values.forEach { it.cancel() }
-        pendingPeerRemovalJobs.clear()
-    }
-
-    private fun renderPeerList() {
-        val container = binding.sendPeerList
-        container.removeAllViews()
-        val inflater = LayoutInflater.from(this)
-        for (peer in peers) {
-            val row = ItemPeerRowBinding.inflate(inflater, container, false)
-            row.peerRowTitle.text = peerLabel(peer)
-            row.peerRowSubtitle.text = peerSubtitle(peer)
-            row.root.setOnClickListener { onPeerSelected(peer) }
-            container.addView(row.root)
-        }
-        binding.sendEmptyState.visibility = if (peers.isEmpty()) View.VISIBLE else View.GONE
-        binding.sendSubtitle.setText(
-            if (peers.isEmpty()) R.string.send_subtitle_discovering else R.string.send_subtitle_pick_peer,
-        )
-        updateEmptyPeerHintVisibility()
-    }
-
-    /**
-     * Start the same-Wi-Fi-network hint timer (#85). After
-     * [EmptyPeerHintTimer.DEFAULT_DELAY_MILLIS] of continuous empty
-     * peer list, re-evaluate visibility — by then either a peer has
-     * shown up (in which case the hint stays hidden) or the timeout
-     * fires and the card surfaces.
-     */
-    private fun startEmptyPeerHintTimer() {
-        emptyPeerHintTimer.start(System.currentTimeMillis())
-        emptyPeerHintJob =
-            lifecycleScope.launch {
-                delay(EmptyPeerHintTimer.DEFAULT_DELAY_MILLIS)
-                updateEmptyPeerHintVisibility()
-            }
-    }
-
-    /**
-     * Re-evaluate the hint card's visibility against the timer + the
-     * current peer list. Called from `renderPeerList` (so a newly
-     * arrived peer hides the card) and from the delayed coroutine
-     * launched in [startEmptyPeerHintTimer] (so the timeout actually
-     * surfaces the card).
-     */
-    private fun updateEmptyPeerHintVisibility() {
-        val show =
-            emptyPeerHintTimer.shouldShowHint(
-                nowMillis = System.currentTimeMillis(),
-                peerListEmpty = peers.isEmpty(),
-            )
-        binding.sendNetworkHint.visibility = if (show) View.VISIBLE else View.GONE
-    }
-
-    private fun onHintDismissed() {
-        emptyPeerHintTimer.markDismissed()
-        binding.sendNetworkHint.visibility = View.GONE
-    }
-
-    /**
-     * Build a single-line diagnostic string capturing everything we know
-     * about [peer] at the moment the user picks it. Logged via
-     * [onPeerSelected] before any TCP work so a subsequent failure can
-     * be correlated against the exact target shape.
-     */
-    private fun formatPeerSnapshot(
-        peer: DiscoveredService,
-        chosenTarget: InetAddress? = null,
-    ): String {
-        val instanceName = peer.instanceName
-        val endpointIdHex =
-            peer.endpointId
-                ?.joinToString("") { "%02x".format(it) }
-                ?: "<none>"
-        val addressList =
-            if (peer.addresses.isEmpty()) {
-                "<none>"
-            } else {
-                peer.addresses.joinToString(",") { it.hostAddress ?: "<unresolved>" }
-            }
-        val info = peer.endpointInfo
-        val infoSummary =
-            if (info == null) {
-                "<none>"
-            } else {
-                buildString {
-                    append("v=").append(info.version)
-                    append(" hidden=").append(info.hidden)
-                    append(" type=").append(info.deviceType.name)
-                    append(" name=")
-                    append(info.deviceName?.let { "\"$it\"" } ?: "<null>")
-                    if (info.tlvRecords.isNotEmpty()) {
-                        append(" tlv=").append(
-                            info.tlvRecords.joinToString(",") { tlv ->
-                                val valueHex = tlv.value.joinToString("") { "%02x".format(it) }
-                                "${tlv.type}:$valueHex"
-                            },
-                        )
-                    }
-                }
-            }
-        return "instance=$instanceName endpointId=$endpointIdHex " +
-            "addrs=[$addressList] picked=${chosenTarget?.hostAddress ?: "<none>"} " +
-            "port=${peer.port} endpointInfo={$infoSummary}"
-    }
-
-    private fun formatPeerRows(): String =
-        if (peers.isEmpty()) {
-            "<empty>"
-        } else {
-            peers.joinToString(";") { peer ->
-                val name = peer.endpointInfo?.deviceName ?: "<anon>"
-                val endpointId =
-                    peer.endpointId
-                        ?.joinToString("") { "%02x".format(it) }
-                        ?: "<none>"
-                "${peer.instanceName}/$endpointId/${peer.primaryAddress()?.hostAddress ?: "?"}:${peer.port}/$name"
-            }
-        }
-
-    @Suppress("ReturnCount")
-    private fun peerLabel(peer: DiscoveredService): String {
-        val name = peer.endpointInfo?.deviceName
-        if (!name.isNullOrBlank()) return name
-        // Stock Quick Share publishes mDNS without a plaintext name —
-        // fall back to the 4-character endpoint id (e.g., "RINE") which
-        // is at least short and stable, then to the full instance name
-        // as a last resort.
-        peer.endpointId
-            ?.takeIf { it.isNotEmpty() }
-            ?.let { return "Quick Share device (${String(it, Charsets.US_ASCII)})" }
-        return peer.instanceName
-    }
-
-    private fun peerSubtitle(peer: DiscoveredService): String {
-        val addr = peer.primaryAddress()?.hostAddress ?: "?"
-        return "$addr:${peer.port}"
     }
 
     // -----------------------------------------------------------------
     // Outbound connection
     // -----------------------------------------------------------------
 
-    private fun onPeerSelected(peer: DiscoveredService) {
-        val target: InetAddress =
-            peer.primaryAddress() ?: run {
+    private fun onPeerSelected(peer: NearbyPeer) {
+        val route =
+            peer.preferredRoute() ?: run {
                 renderTerminal(
                     getString(R.string.send_phase_failed),
-                    getString(R.string.send_status_failure_reason, "no usable address"),
+                    getString(R.string.send_status_failure_reason, peerPickerController.peerFailureReason(peer)),
                 )
                 return
             }
@@ -671,28 +204,25 @@ public class SendActivity : AppCompatActivity() {
         // Log.i for non-system apps — without this a Galaxy "peer
         // closed" report leaves us guessing whether we even dialed the
         // right address. Includes everything we know about the peer:
-        // mDNS instance name, the 4-byte endpoint id slice, the full
-        // address list (so we can spot IPv6 vs IPv4 selection bugs) plus
-        // the chosen primary, the TCP port, and the parsed EndpointInfo
-        // header byte (visBit / version / deviceType) and device name.
-        val targetSnapshot = formatPeerSnapshot(peer, target)
+        // aggregated mediums, the chosen initial route, the full LAN
+        // address list (so we can spot IPv6 vs IPv4 selection bugs),
+        // and the parsed EndpointInfo header byte / device name.
+        val targetSnapshot = peerPickerController.formatPeerSnapshot(peer, route)
         Log.e(OUTBOUND_TAG, "picked target: $targetSnapshot")
         appendOutboundLog("picked target: $targetSnapshot")
-        // Stop discovery — we've made our pick and don't want the JmDNS
-        // browser holding the multicast lock during the actual transfer.
-        discoveryJob?.cancel()
-        discoveryJob = null
-        cancelPendingPeerRemovals()
+        // Stop discovery once we've made our pick.
+        peerPickerController.suspendPicker()
 
         // Hide the picker chrome.
-        binding.sendPeerList.visibility = View.GONE
-        binding.sendEmptyState.visibility = View.GONE
-        binding.sendNetworkHint.visibility = View.GONE
-        binding.sendShowQrButton.visibility = View.GONE
-        binding.sendStatusPanel.visibility = View.VISIBLE
-        emptyPeerHintJob?.cancel()
+        binding.sendPeerList.isVisible = false
+        binding.sendEmptyState.isVisible = false
+        binding.sendNetworkHint.isVisible = false
+        binding.sendShowQrButton.isVisible = false
+        binding.sendStatusPanel.isVisible = true
 
-        binding.sendStatusTarget.text = getString(R.string.send_status_target, peerLabel(peer))
+        binding.sendStatusTarget.text = getString(R.string.send_status_target, peerPickerController.peerLabel(peer))
+        binding.sendStatusPhase.setText(R.string.send_phase_connecting)
+        binding.sendStatusMessage.text = peerPickerController.peerSubtitle(peer)
 
         // Build a valid sender EndpointInfo. Stock Quick Share rejects a
         // ConnectionRequestFrame with an empty `endpoint_info` field by
@@ -710,29 +240,17 @@ public class SendActivity : AppCompatActivity() {
                 deviceName = senderDeviceLabel(),
             ).serialize()
 
-        val connection =
-            OutboundConnection(
-                targetAddress = target,
-                port = peer.port,
-                endpointInfo = senderEndpointInfoBytes,
-                mediumRegistry = MediumRegistries.defaultForContext(applicationContext),
-                logger = { msg ->
-                    // vivo Funtouch OS filters Log.i for non-system apps —
-                    // use Log.e to bypass the filter, and also append to a
-                    // file under getExternalFilesDir so `adb pull` can
-                    // recover the log if logcat is empty.
-                    Log.e(OUTBOUND_TAG, msg)
-                    appendOutboundLog(msg)
-                },
-            )
-        activeConnection = connection
-
         connectionJob =
             lifecycleScope.launch {
-                // Collect the state flow inside a child job so we can
-                // cancel it once `run` returns. StateFlow.collect never
-                // completes on its own, and leaving it hot past the
-                // terminal state would leak the activity scope.
+                val connection = buildOutboundConnection(route, senderEndpointInfoBytes)
+                if (connection == null) {
+                    renderTerminal(
+                        getString(R.string.send_phase_failed),
+                        getString(R.string.send_status_failure_reason, "initial bootstrap connect failed"),
+                    )
+                    return@launch
+                }
+                activeConnection = connection
                 val collector =
                     launch {
                         connection.state.collect { state ->
@@ -743,13 +261,15 @@ public class SendActivity : AppCompatActivity() {
                     connection.run(files)
                 } finally {
                     collector.cancel()
+                    activeConnection = null
+                    bluetoothBootstrapClient = null
                 }
             }
     }
 
     private fun renderConnectionState(
         state: OutboundConnectionState,
-        peer: DiscoveredService,
+        peer: NearbyPeer,
     ) {
         when (state) {
             OutboundConnectionState.Idle -> {
@@ -759,13 +279,13 @@ public class SendActivity : AppCompatActivity() {
             OutboundConnectionState.Connecting -> {
                 binding.sendStatusPhase.setText(R.string.send_phase_connecting)
                 binding.sendPin.visibility = View.GONE
-                binding.sendStatusMessage.text = getString(R.string.send_status_target, peerLabel(peer))
+                binding.sendStatusMessage.text = peerPickerController.peerSubtitle(peer)
             }
             OutboundConnectionState.Handshaking -> {
                 // TCP socket is up — the BLE wake-up pulse has done its
                 // job, stop broadcasting (#32 acceptance: stops as soon
                 // as the TCP connection to a recipient is established).
-                stopBleAdvertise()
+                peerPickerController.stopBleAdvertise()
                 binding.sendStatusPhase.setText(R.string.send_phase_handshaking)
                 binding.sendPin.visibility = View.GONE
             }
@@ -791,7 +311,7 @@ public class SendActivity : AppCompatActivity() {
             OutboundConnectionState.Completed ->
                 renderTerminal(
                     getString(R.string.send_phase_completed),
-                    getString(R.string.send_status_target, peerLabel(peer)),
+                    getString(R.string.send_status_target, peerPickerController.peerLabel(peer)),
                 )
             is OutboundConnectionState.Rejected ->
                 renderTerminal(
@@ -861,7 +381,7 @@ public class SendActivity : AppCompatActivity() {
      * collect any FileSources. Most likely cause is a provider that
      * revoked the read grant, but a malformed tree URI (someone
      * exported this activity later and a third-party app starts us
-     * with the wrong shape) lands here too — see `materializeFolder`.
+     * with the wrong shape) lands here too — see [SendPayloadResolver].
      */
     private fun renderFolderWalkFailed() {
         binding.sendPayloadSummary.text = getString(R.string.main_send_folder_button)
@@ -882,59 +402,26 @@ public class SendActivity : AppCompatActivity() {
             connection.cancel()
             return
         }
+        val bootstrapClient = bluetoothBootstrapClient
+        if (bootstrapClient != null && binding.sendStatusPanel.isVisible) {
+            bootstrapClient.cancelPendingConnect()
+            connectionJob?.cancel()
+            renderTerminal(
+                getString(R.string.send_phase_cancelled),
+                getString(R.string.send_status_failure_reason, CancelCause.LOCAL.toString()),
+            )
+            return
+        }
         // Cancel before any peer was selected: stop the BLE pulse now
         // so we don't waste the radio while finish() tears the activity
         // down. onDestroy would also catch this, but stopping here keeps
         // the timing tight for the "stops on user cancel" criterion (#32).
-        stopBleAdvertise()
+        peerPickerController.stopBleAdvertise()
         finish()
     }
 
     private fun onShowQrClicked() {
         startActivity(Intent(this, ShowQrActivity::class.java))
-    }
-
-    // -----------------------------------------------------------------
-    // BLE service-data pulse (#32)
-    // -----------------------------------------------------------------
-
-    /**
-     * Start the Quick Share BLE service-data advertisement (#32). The
-     * advertisement wakes nearby Quick Share receivers' BLE scan loops,
-     * which in turn enable their mDNS responder so our own discovery can
-     * find them.
-     *
-     * Best-effort: devices without peripheral-mode BLE, devices with
-     * Bluetooth turned off, and devices where the user revoked
-     * `BLUETOOTH_ADVERTISE` after onboarding all flow through the
-     * `null` return path of [BleAdvertiser.start] and are silently
-     * skipped — the mDNS-only discovery path still works for them.
-     */
-    @Suppress("MissingPermission") // Permission re-checked inside BleAdvertiser.start.
-    private fun startBleAdvertise() {
-        val advertiser = BleAdvertiser(applicationContext)
-        bleAdvertiser = advertiser
-        bleAdvertiseHandle = advertiser.start()
-        if (bleAdvertiseHandle == null) {
-            logOutboundDiagnostic("ble: pulse not started; falling back to mDNS-only discovery")
-            Log.i(BLE_TAG, "BLE pulse not started — falling back to mDNS-only discovery")
-        } else {
-            logOutboundDiagnostic("ble: pulse started")
-            Log.i(BLE_TAG, "BLE pulse started")
-        }
-    }
-
-    /**
-     * Stop the BLE service-data advertisement if one is active. Called
-     * when the outbound TCP connection lands ([OutboundConnectionState.Handshaking]
-     * onward), when the user cancels, and from `onDestroy` as a final
-     * safety net. Safe to call repeatedly — both the local handle and
-     * the underlying [BleAdvertiseHandle.close] are idempotent.
-     */
-    private fun stopBleAdvertise() {
-        bleAdvertiseHandle?.close()
-        bleAdvertiseHandle = null
-        bleAdvertiser = null
     }
 
     /**
@@ -970,6 +457,11 @@ public class SendActivity : AppCompatActivity() {
         appendOutboundLog(line)
     }
 
+    private fun logOutboundWireMessage(line: String) {
+        Log.e(OUTBOUND_TAG, line)
+        appendOutboundLog(line)
+    }
+
     public companion object {
         /**
          * Custom intent action used by [io.github.kyujincho.wvmg.MainActivity]
@@ -983,11 +475,5 @@ public class SendActivity : AppCompatActivity() {
         public const val ACTION_SEND_FOLDER: String = "io.github.kyujincho.wvmg.action.SEND_FOLDER"
 
         private const val OUTBOUND_TAG: String = "WvmgOutbound"
-        private const val PEER_LOST_GRACE_MILLIS: Long = 15_000L
-
-        // BLE advertise diagnostics share the discovery tag so a single
-        // `adb logcat -s WvmgDiscovery` line surfaces both mDNS and BLE
-        // events on real devices.
-        private const val BLE_TAG: String = "WvmgDiscovery"
     }
 }

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendActivity.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendActivity.kt
@@ -135,6 +135,7 @@ public class SendActivity : AppCompatActivity() {
                 }
             } ?: return
         files = resolvedFiles
+        logResolvedFiles(files)
 
         binding.sendPayloadSummary.text = PayloadSummary.forFiles(this, files)
         binding.sendSubtitle.setText(R.string.send_subtitle_discovering)
@@ -481,6 +482,15 @@ public class SendActivity : AppCompatActivity() {
      * when [Build.MODEL] is empty (rare but happens on some emulators).
      */
     private fun senderDeviceLabel(): String = Build.MODEL?.takeIf { it.isNotBlank() } ?: "WhenVivoMeetsGoogle"
+
+    private fun logResolvedFiles(files: List<FileSource>) {
+        files.forEachIndexed { index, file ->
+            logOutboundDiagnostic(
+                "resolved file[$index]: name=${file.name} size=${file.size} " +
+                    "mime=${file.mimeType} payloadId=${file.payloadId} parent=${file.parentFolder}",
+            )
+        }
+    }
 
     /**
      * Append a line to a per-run log file under

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendActivity.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendActivity.kt
@@ -17,6 +17,7 @@ import io.github.kyujincho.wvmg.R
 import io.github.kyujincho.wvmg.databinding.ActivitySendBinding
 import io.github.kyujincho.wvmg.discovery.NearbyPeer
 import io.github.kyujincho.wvmg.discovery.NearbyPeerRoute
+import io.github.kyujincho.wvmg.discovery.bootstrap.BleGattInitialControlClient
 import io.github.kyujincho.wvmg.discovery.bootstrap.BleL2capInitialControlClient
 import io.github.kyujincho.wvmg.discovery.bootstrap.BluetoothClassicBootstrapClient
 import io.github.kyujincho.wvmg.discovery.medium.MediumRegistries
@@ -77,6 +78,7 @@ public class SendActivity : AppCompatActivity() {
     private var activeConnection: OutboundConnection? = null
     private var bluetoothBootstrapClient: BluetoothClassicBootstrapClient? = null
     private var bleL2capBootstrapClient: BleL2capInitialControlClient? = null
+    private var bleGattBootstrapClient: BleGattInitialControlClient? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -148,6 +150,7 @@ public class SendActivity : AppCompatActivity() {
         activeConnection?.cancel()
         bluetoothBootstrapClient?.cancelPendingConnect()
         bleL2capBootstrapClient?.cancelPendingConnect()
+        bleGattBootstrapClient?.cancelPendingConnect()
         peerPickerController.stop()
         connectionJob?.cancel()
         // Lift the gate veto so the receiver-side mDNS record can come
@@ -195,6 +198,22 @@ public class SendActivity : AppCompatActivity() {
                         client.connect(route.macAddress, route.psm)
                     } finally {
                         bleL2capBootstrapClient = null
+                    } ?: return null
+                OutboundConnection(
+                    transport = transport,
+                    endpointInfo = endpointInfo,
+                    mediumRegistry = mediumRegistry,
+                    logger = ::logOutboundWireMessage,
+                )
+            }
+            is NearbyPeerRoute.BleGatt -> {
+                val client = BleGattInitialControlClient(applicationContext)
+                bleGattBootstrapClient = client
+                val transport =
+                    try {
+                        client.connect(route.macAddress)
+                    } finally {
+                        bleGattBootstrapClient = null
                     } ?: return null
                 OutboundConnection(
                     transport = transport,

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendActivity.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendActivity.kt
@@ -17,6 +17,7 @@ import io.github.kyujincho.wvmg.R
 import io.github.kyujincho.wvmg.databinding.ActivitySendBinding
 import io.github.kyujincho.wvmg.discovery.NearbyPeer
 import io.github.kyujincho.wvmg.discovery.NearbyPeerRoute
+import io.github.kyujincho.wvmg.discovery.bootstrap.BleL2capInitialControlClient
 import io.github.kyujincho.wvmg.discovery.bootstrap.BluetoothClassicBootstrapClient
 import io.github.kyujincho.wvmg.discovery.medium.MediumRegistries
 import io.github.kyujincho.wvmg.protocol.connection.CancelCause
@@ -75,6 +76,7 @@ public class SendActivity : AppCompatActivity() {
     private var connectionJob: Job? = null
     private var activeConnection: OutboundConnection? = null
     private var bluetoothBootstrapClient: BluetoothClassicBootstrapClient? = null
+    private var bleL2capBootstrapClient: BleL2capInitialControlClient? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -145,6 +147,7 @@ public class SendActivity : AppCompatActivity() {
         // possible (best-effort — already-terminal states are no-ops).
         activeConnection?.cancel()
         bluetoothBootstrapClient?.cancelPendingConnect()
+        bleL2capBootstrapClient?.cancelPendingConnect()
         peerPickerController.stop()
         connectionJob?.cancel()
         // Lift the gate veto so the receiver-side mDNS record can come
@@ -153,6 +156,7 @@ public class SendActivity : AppCompatActivity() {
         OutboundSessionActiveHolder.setOutboundSessionActive(false)
     }
 
+    @Suppress("ReturnCount")
     private suspend fun buildOutboundConnection(
         route: NearbyPeerRoute,
         endpointInfo: ByteArray,
@@ -175,6 +179,22 @@ public class SendActivity : AppCompatActivity() {
                         client.connect(route.macAddress)
                     } finally {
                         bluetoothBootstrapClient = null
+                    } ?: return null
+                OutboundConnection(
+                    transport = transport,
+                    endpointInfo = endpointInfo,
+                    mediumRegistry = mediumRegistry,
+                    logger = ::logOutboundWireMessage,
+                )
+            }
+            is NearbyPeerRoute.BleL2cap -> {
+                val client = BleL2capInitialControlClient(applicationContext)
+                bleL2capBootstrapClient = client
+                val transport =
+                    try {
+                        client.connect(route.macAddress, route.psm)
+                    } finally {
+                        bleL2capBootstrapClient = null
                     } ?: return null
                 OutboundConnection(
                     transport = transport,
@@ -263,6 +283,7 @@ public class SendActivity : AppCompatActivity() {
                     collector.cancel()
                     activeConnection = null
                     bluetoothBootstrapClient = null
+                    bleL2capBootstrapClient = null
                 }
             }
     }
@@ -393,6 +414,7 @@ public class SendActivity : AppCompatActivity() {
         binding.sendCancelButton.text = getString(R.string.send_done)
     }
 
+    @Suppress("ReturnCount")
     private fun onCancelClicked() {
         // If a connection is mid-flight, ask it to cancel cleanly so a
         // CancelFrame goes out on the wire. The terminal state will
@@ -405,6 +427,16 @@ public class SendActivity : AppCompatActivity() {
         val bootstrapClient = bluetoothBootstrapClient
         if (bootstrapClient != null && binding.sendStatusPanel.isVisible) {
             bootstrapClient.cancelPendingConnect()
+            connectionJob?.cancel()
+            renderTerminal(
+                getString(R.string.send_phase_cancelled),
+                getString(R.string.send_status_failure_reason, CancelCause.LOCAL.toString()),
+            )
+            return
+        }
+        val bleBootstrapClient = bleL2capBootstrapClient
+        if (bleBootstrapClient != null && binding.sendStatusPanel.isVisible) {
+            bleBootstrapClient.cancelPendingConnect()
             connectionJob?.cancel()
             renderTerminal(
                 getString(R.string.send_phase_cancelled),

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendPayloadResolver.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendPayloadResolver.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.send
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import io.github.kyujincho.wvmg.protocol.connection.FileSource
+
+internal sealed interface SendPayloadResolution {
+    data class Files(
+        val files: List<FileSource>,
+    ) : SendPayloadResolution
+
+    data object Unsupported : SendPayloadResolution
+
+    data object FolderEmpty : SendPayloadResolution
+
+    data object FolderWalkFailed : SendPayloadResolution
+}
+
+internal class SendPayloadResolver(
+    private val fileSourceFactory: UriFileSourceFactory,
+    private val documentTreeFactory: DocumentTreeFileSourceFactory,
+) {
+    fun resolve(intent: Intent): SendPayloadResolution =
+        if (intent.action == SendActivity.ACTION_SEND_FOLDER) {
+            intent.data?.let(::materializeFolder) ?: SendPayloadResolution.Unsupported
+        } else {
+            val parsed = ShareIntentRouter.route(toShareIntent(intent))
+            if (parsed == null) {
+                SendPayloadResolution.Unsupported
+            } else {
+                materializeFiles(parsed)
+                    .takeIf { it.isNotEmpty() }
+                    ?.let(SendPayloadResolution::Files)
+                    ?: SendPayloadResolution.Unsupported
+            }
+        }
+
+    private fun toShareIntent(source: Intent): ShareIntent {
+        val streamUri: Uri? =
+            when (source.action) {
+                Intent.ACTION_SEND -> getParcelableExtraCompat(source, Intent.EXTRA_STREAM)
+                else -> null
+            }
+        val streamUris: List<Uri>? =
+            when (source.action) {
+                Intent.ACTION_SEND_MULTIPLE -> getParcelableArrayListExtraCompat(source, Intent.EXTRA_STREAM)
+                else -> null
+            }
+        val text: CharSequence? = source.getCharSequenceExtra(Intent.EXTRA_TEXT)
+        return ShareIntent(
+            action = source.action,
+            streamUri = streamUri,
+            streamUris = streamUris,
+            textExtra = text,
+        )
+    }
+
+    @Suppress("DEPRECATION")
+    private fun getParcelableExtraCompat(
+        source: Intent,
+        key: String,
+    ): Uri? =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            source.getParcelableExtra(key, Uri::class.java)
+        } else {
+            source.getParcelableExtra(key) as? Uri
+        }
+
+    @Suppress("DEPRECATION")
+    private fun getParcelableArrayListExtraCompat(
+        source: Intent,
+        key: String,
+    ): List<Uri>? =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            source.getParcelableArrayListExtra(key, Uri::class.java)
+        } else {
+            source.getParcelableArrayListExtra(key)
+        }
+
+    private fun materializeFiles(input: ShareIntentInput): List<FileSource> =
+        when (input) {
+            is ShareIntentInput.SingleUri ->
+                listOf(fileSourceFactory.fromUri(input.uri as Uri))
+            is ShareIntentInput.MultipleUris ->
+                input.uris.map { fileSourceFactory.fromUri(it as Uri) }
+            is ShareIntentInput.Text ->
+                emptyList()
+        }
+
+    @Suppress("ReturnCount")
+    private fun materializeFolder(treeUri: Uri): SendPayloadResolution {
+        val walked =
+            try {
+                documentTreeFactory.walk(treeUri)
+            } catch (_: SecurityException) {
+                return SendPayloadResolution.FolderWalkFailed
+            } catch (_: IllegalArgumentException) {
+                return SendPayloadResolution.FolderWalkFailed
+            }
+
+        return if (walked.isEmpty()) {
+            SendPayloadResolution.FolderEmpty
+        } else {
+            SendPayloadResolution.Files(walked)
+        }
+    }
+}

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendPeerPickerController.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendPeerPickerController.kt
@@ -60,7 +60,7 @@ internal class SendPeerPickerController(
                     logDiagnostic("discovery: receiver mDNS unpublish observed")
                 }
 
-                if (!lifecycle.currentState.isAtLeast(Lifecycle.State.CREATED)) return@launch
+                if (lifecycle.currentState == Lifecycle.State.DESTROYED) return@launch
                 startDiscovery()
                 startEmptyPeerHintTimer()
                 startBleAdvertise()

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendPeerPickerController.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendPeerPickerController.kt
@@ -99,6 +99,7 @@ internal class SendPeerPickerController(
         when (val route = peer.preferredRoute()) {
             is NearbyPeerRoute.Lan -> "Wi-Fi LAN ${route.address.hostAddress}:${route.port}"
             is NearbyPeerRoute.BluetoothClassic -> "Bluetooth Classic ${route.macAddress}"
+            is NearbyPeerRoute.BleL2cap -> "BLE L2CAP ${route.macAddress} psm=${route.psm}"
             null -> "Nearby via BLE advertisement"
         }
 
@@ -145,6 +146,7 @@ internal class SendPeerPickerController(
             when (chosenRoute) {
                 is NearbyPeerRoute.Lan -> "lan=${chosenRoute.address.hostAddress}:${chosenRoute.port}"
                 is NearbyPeerRoute.BluetoothClassic -> "bluetooth=${chosenRoute.macAddress}"
+                is NearbyPeerRoute.BleL2cap -> "ble-l2cap=${chosenRoute.macAddress}:${chosenRoute.psm}"
                 null -> "<none>"
             }
         return "peer=${peer.stableId} endpointId=$endpointId mediums=${peer.candidateMediums} " +
@@ -264,6 +266,7 @@ internal class SendPeerPickerController(
                     when (val preferredRoute = peer.preferredRoute()) {
                         is NearbyPeerRoute.Lan -> "${preferredRoute.address.hostAddress}:${preferredRoute.port}"
                         is NearbyPeerRoute.BluetoothClassic -> preferredRoute.macAddress
+                        is NearbyPeerRoute.BleL2cap -> "${preferredRoute.macAddress}:${preferredRoute.psm}"
                         null -> "<none>"
                     }
                 "${peer.stableId}/${peer.endpointId ?: "<none>"}/$route/${peer.displayName()}"

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendPeerPickerController.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendPeerPickerController.kt
@@ -100,6 +100,7 @@ internal class SendPeerPickerController(
             is NearbyPeerRoute.Lan -> "Wi-Fi LAN ${route.address.hostAddress}:${route.port}"
             is NearbyPeerRoute.BluetoothClassic -> "Bluetooth Classic ${route.macAddress}"
             is NearbyPeerRoute.BleL2cap -> "BLE L2CAP ${route.macAddress} psm=${route.psm}"
+            is NearbyPeerRoute.BleGatt -> "BLE GATT ${route.macAddress}"
             null -> "Nearby via BLE advertisement"
         }
 
@@ -147,6 +148,7 @@ internal class SendPeerPickerController(
                 is NearbyPeerRoute.Lan -> "lan=${chosenRoute.address.hostAddress}:${chosenRoute.port}"
                 is NearbyPeerRoute.BluetoothClassic -> "bluetooth=${chosenRoute.macAddress}"
                 is NearbyPeerRoute.BleL2cap -> "ble-l2cap=${chosenRoute.macAddress}:${chosenRoute.psm}"
+                is NearbyPeerRoute.BleGatt -> "ble-gatt=${chosenRoute.macAddress}"
                 null -> "<none>"
             }
         return "peer=${peer.stableId} endpointId=$endpointId mediums=${peer.candidateMediums} " +
@@ -267,6 +269,7 @@ internal class SendPeerPickerController(
                         is NearbyPeerRoute.Lan -> "${preferredRoute.address.hostAddress}:${preferredRoute.port}"
                         is NearbyPeerRoute.BluetoothClassic -> preferredRoute.macAddress
                         is NearbyPeerRoute.BleL2cap -> "${preferredRoute.macAddress}:${preferredRoute.psm}"
+                        is NearbyPeerRoute.BleGatt -> preferredRoute.macAddress
                         null -> "<none>"
                     }
                 "${peer.stableId}/${peer.endpointId ?: "<none>"}/$route/${peer.displayName()}"

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendPeerPickerController.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendPeerPickerController.kt
@@ -1,0 +1,277 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.send
+
+import android.content.Context
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.repeatOnLifecycle
+import io.github.kyujincho.wvmg.R
+import io.github.kyujincho.wvmg.databinding.ActivitySendBinding
+import io.github.kyujincho.wvmg.databinding.ItemPeerRowBinding
+import io.github.kyujincho.wvmg.discovery.NearbyPeer
+import io.github.kyujincho.wvmg.discovery.NearbyPeerDiscovery
+import io.github.kyujincho.wvmg.discovery.NearbyPeerEvent
+import io.github.kyujincho.wvmg.discovery.NearbyPeerRoute
+import io.github.kyujincho.wvmg.discovery.ble.BleAdvertiseHandle
+import io.github.kyujincho.wvmg.discovery.ble.BleAdvertiser
+import io.github.kyujincho.wvmg.service.receiver.ReceiverAdvertisementStateHolder
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+internal class SendPeerPickerController(
+    private val context: Context,
+    private val binding: ActivitySendBinding,
+    private val lifecycle: Lifecycle,
+    private val scope: CoroutineScope,
+    private val onPeerSelected: (NearbyPeer) -> Unit,
+    private val logDiagnostic: (String) -> Unit,
+) {
+    private val peers: MutableList<NearbyPeer> = mutableListOf()
+
+    private var outboundPresenceJob: Job? = null
+    private var discoveryJob: Job? = null
+    private var emptyPeerHintJob: Job? = null
+
+    private val emptyPeerHintTimer: EmptyPeerHintTimer = EmptyPeerHintTimer()
+    private var bleAdvertiser: BleAdvertiser? = null
+    private var bleAdvertiseHandle: BleAdvertiseHandle? = null
+
+    fun start() {
+        outboundPresenceJob?.cancel()
+        outboundPresenceJob =
+            scope.launch {
+                val receiverWasAdvertising = ReceiverAdvertisementStateHolder.isAdvertising
+                if (receiverWasAdvertising) {
+                    logDiagnostic("discovery: waiting for receiver mDNS unpublish before browse")
+                }
+
+                val unpublishObserved = ReceiverAdvertisementStateHolder.awaitNotAdvertising()
+                if (!unpublishObserved) {
+                    logDiagnostic("discovery: receiver mDNS unpublish wait timed out; starting browse")
+                } else if (receiverWasAdvertising) {
+                    logDiagnostic("discovery: receiver mDNS unpublish observed")
+                }
+
+                if (!lifecycle.currentState.isAtLeast(Lifecycle.State.CREATED)) return@launch
+                startDiscovery()
+                startEmptyPeerHintTimer()
+                startBleAdvertise()
+            }
+    }
+
+    fun stop() {
+        outboundPresenceJob?.cancel()
+        discoveryJob?.cancel()
+        emptyPeerHintJob?.cancel()
+        stopBleAdvertise()
+    }
+
+    fun suspendPicker() {
+        discoveryJob?.cancel()
+        discoveryJob = null
+        emptyPeerHintJob?.cancel()
+        emptyPeerHintJob = null
+        binding.sendNetworkHint.visibility = View.GONE
+    }
+
+    fun stopBleAdvertise() {
+        bleAdvertiseHandle?.close()
+        bleAdvertiseHandle = null
+        bleAdvertiser = null
+    }
+
+    fun onHintDismissed() {
+        emptyPeerHintTimer.markDismissed()
+        binding.sendNetworkHint.visibility = View.GONE
+    }
+
+    fun peerLabel(peer: NearbyPeer): String = peer.displayName()
+
+    fun peerSubtitle(peer: NearbyPeer): String =
+        when (val route = peer.preferredRoute()) {
+            is NearbyPeerRoute.Lan -> "Wi-Fi LAN ${route.address.hostAddress}:${route.port}"
+            is NearbyPeerRoute.BluetoothClassic -> "Bluetooth Classic ${route.macAddress}"
+            null -> "Nearby via BLE advertisement"
+        }
+
+    fun peerFailureReason(peer: NearbyPeer): String =
+        when {
+            peer.bluetoothEndpoint == null && peer.bleAdvertisement != null ->
+                "BLE advertisement observed but no initial bootstrap route is available yet"
+            else -> "no usable initial route"
+        }
+
+    fun formatPeerSnapshot(
+        peer: NearbyPeer,
+        chosenRoute: NearbyPeerRoute? = null,
+    ): String {
+        val endpointId = peer.endpointId ?: "<none>"
+        val addressList =
+            peer.lanEndpoint
+                ?.addresses
+                ?.takeIf { it.isNotEmpty() }
+                ?.joinToString(",") { it.hostAddress ?: "<unresolved>" }
+                ?: "<none>"
+        val info = peer.endpointInfo
+        val infoSummary =
+            if (info == null) {
+                "<none>"
+            } else {
+                buildString {
+                    append("v=").append(info.version)
+                    append(" hidden=").append(info.hidden)
+                    append(" type=").append(info.deviceType.name)
+                    append(" name=")
+                    append(info.deviceName?.let { "\"$it\"" } ?: "<null>")
+                    if (info.tlvRecords.isNotEmpty()) {
+                        append(" tlv=").append(
+                            info.tlvRecords.joinToString(",") { tlv ->
+                                val valueHex = tlv.value.joinToString("") { "%02x".format(it) }
+                                "${tlv.type}:$valueHex"
+                            },
+                        )
+                    }
+                }
+            }
+        val routeSummary =
+            when (chosenRoute) {
+                is NearbyPeerRoute.Lan -> "lan=${chosenRoute.address.hostAddress}:${chosenRoute.port}"
+                is NearbyPeerRoute.BluetoothClassic -> "bluetooth=${chosenRoute.macAddress}"
+                null -> "<none>"
+            }
+        return "peer=${peer.stableId} endpointId=$endpointId mediums=${peer.candidateMediums} " +
+            "addrs=[$addressList] route=$routeSummary endpointInfo={$infoSummary}"
+    }
+
+    private fun startDiscovery() {
+        val discovery = NearbyPeerDiscovery(context.applicationContext)
+        logDiagnostic("discovery: start")
+        discoveryJob =
+            scope.launch {
+                lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                    logDiagnostic("discovery: browse collector start")
+                    try {
+                        discovery.browse().collect { event -> onDiscoveryEvent(event) }
+                    } finally {
+                        logDiagnostic("discovery: browse collector stop")
+                    }
+                }
+            }
+    }
+
+    private fun onDiscoveryEvent(event: NearbyPeerEvent) {
+        val before = peers.size
+        when (event) {
+            is NearbyPeerEvent.Resolved -> {
+                upsertResolvedPeer(event.peer)
+                logDiagnostic(
+                    "discovery: resolved ${formatPeerSnapshot(event.peer)} " +
+                        "before=$before after=${peers.size} rows=${formatPeerRows()}",
+                )
+            }
+            is NearbyPeerEvent.Lost -> {
+                val removed = peers.removeAll { it.stableId == event.stableId }
+                logDiagnostic(
+                    "discovery: lost peer=${event.stableId} removed=$removed " +
+                        "before=$before after=${peers.size} rows=${formatPeerRows()}",
+                )
+            }
+        }
+        renderPeerList()
+    }
+
+    private fun upsertResolvedPeer(incoming: NearbyPeer) {
+        val existingIndex = peers.indexOfFirst { it.stableId == incoming.stableId }
+        if (existingIndex >= 0) {
+            peers[existingIndex] = incoming
+        } else {
+            peers.add(incoming)
+        }
+        peers.sortWith(
+            compareByDescending<NearbyPeer> { it.isConnectable }
+                .thenBy { it.displayName().lowercase() },
+        )
+    }
+
+    private fun renderPeerList() {
+        val container = binding.sendPeerList
+        container.removeAllViews()
+        val inflater = LayoutInflater.from(context)
+        for (peer in peers) {
+            val row = ItemPeerRowBinding.inflate(inflater, container, false)
+            row.peerRowTitle.text = peerLabel(peer)
+            row.peerRowSubtitle.text = peerSubtitle(peer)
+            row.root.isEnabled = peer.isConnectable
+            row.root.alpha = if (peer.isConnectable) 1f else DISABLED_PEER_ALPHA
+            row.root.setOnClickListener {
+                if (peer.isConnectable) onPeerSelected(peer)
+            }
+            container.addView(row.root)
+        }
+        binding.sendEmptyState.visibility = if (peers.isEmpty()) View.VISIBLE else View.GONE
+        binding.sendSubtitle.setText(
+            if (peers.isEmpty()) R.string.send_subtitle_discovering else R.string.send_subtitle_pick_peer,
+        )
+        updateEmptyPeerHintVisibility()
+    }
+
+    private fun startEmptyPeerHintTimer() {
+        emptyPeerHintTimer.start(System.currentTimeMillis())
+        emptyPeerHintJob =
+            scope.launch {
+                delay(EmptyPeerHintTimer.DEFAULT_DELAY_MILLIS)
+                updateEmptyPeerHintVisibility()
+            }
+    }
+
+    private fun updateEmptyPeerHintVisibility() {
+        val show =
+            emptyPeerHintTimer.shouldShowHint(
+                nowMillis = System.currentTimeMillis(),
+                peerListEmpty = peers.isEmpty(),
+            )
+        binding.sendNetworkHint.visibility = if (show) View.VISIBLE else View.GONE
+    }
+
+    @Suppress("MissingPermission")
+    private fun startBleAdvertise() {
+        val advertiser = BleAdvertiser(context.applicationContext)
+        bleAdvertiser = advertiser
+        bleAdvertiseHandle = advertiser.start()
+        if (bleAdvertiseHandle == null) {
+            logDiagnostic("ble: pulse not started; falling back to mDNS-only discovery")
+            Log.i(BLE_TAG, "BLE pulse not started - falling back to mDNS-only discovery")
+        } else {
+            logDiagnostic("ble: pulse started")
+            Log.i(BLE_TAG, "BLE pulse started")
+        }
+    }
+
+    private fun formatPeerRows(): String =
+        if (peers.isEmpty()) {
+            "<empty>"
+        } else {
+            peers.joinToString(";") { peer ->
+                val route =
+                    when (val preferredRoute = peer.preferredRoute()) {
+                        is NearbyPeerRoute.Lan -> "${preferredRoute.address.hostAddress}:${preferredRoute.port}"
+                        is NearbyPeerRoute.BluetoothClassic -> preferredRoute.macAddress
+                        null -> "<none>"
+                    }
+                "${peer.stableId}/${peer.endpointId ?: "<none>"}/$route/${peer.displayName()}"
+            }
+        }
+
+    private companion object {
+        private const val BLE_TAG: String = "WvmgDiscovery"
+        private const val DISABLED_PEER_ALPHA: Float = 0.6f
+    }
+}

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/send/UriFileSourceFactory.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/send/UriFileSourceFactory.kt
@@ -6,10 +6,12 @@
 package io.github.kyujincho.wvmg.send
 
 import android.content.ContentResolver
+import android.content.res.AssetFileDescriptor
 import android.database.Cursor
 import android.net.Uri
 import android.provider.MediaStore
 import android.provider.OpenableColumns
+import android.util.Log
 import io.github.kyujincho.wvmg.protocol.connection.FileSource
 import java.nio.channels.Channels
 import java.nio.channels.ReadableByteChannel
@@ -29,13 +31,14 @@ import kotlin.math.absoluteValue
  *    falling back to the URI's last path segment, falling back to a
  *    generic placeholder. The Quick Share spec does not mandate a
  *    particular name shape, but receivers display this string verbatim.
- *  - **Size** — read from `OpenableColumns.SIZE`. If unknown
- *    (`-1`, missing column, or a `null` cursor), we report `0`. The
- *    receiver will then either trust the announced size or simply
+ *  - **Size** — read from `OpenableColumns.SIZE`, with an
+ *    `AssetFileDescriptor` length/stat fallback for providers that can
+ *    stream the URI but omit a usable cursor size. If all paths are
+ *    unknown (`-1`, missing column, or a `null` cursor), we report `0`.
+ *    The receiver will then either trust the announced size or simply
  *    receive bytes until the channel runs out (current orchestrator
  *    behaviour: streams up to `size` bytes — so an unknown size yields
- *    a zero-byte transfer; this is documented as a known limitation
- *    and is acceptable for #24's MVP).
+ *    a zero-byte transfer).
  *  - **MIME type** — `ContentResolver.getType(uri)`. May be `null`
  *    (e.g. for plain `file://` URIs without a registered mapping); we
  *    surface an empty string in that case so the receiver renders the
@@ -233,10 +236,11 @@ internal class ContentResolverMetadataReader(
 ) : UriMetadataReader {
     override fun read(uri: Uri): UriMetadata {
         val cursorMetadata = readCursorColumns(uri)
+        val size = resolveSize(uri, cursorMetadata.size)
         val mime = contentResolver.getType(uri)
         return UriMetadata(
             displayName = cursorMetadata.displayName,
-            size = cursorMetadata.size,
+            size = size,
             mimeType = mime,
             lastModifiedSeconds = cursorMetadata.lastModifiedSeconds,
         )
@@ -289,6 +293,46 @@ internal class ContentResolverMetadataReader(
         return cursor.getLong(index)
     }
 
+    private fun resolveSize(
+        uri: Uri,
+        cursorSize: Long,
+    ): Long {
+        if (cursorSize > 0L) return cursorSize
+
+        val descriptorSize = readDescriptorSize(uri)
+        val resolvedSize =
+            when {
+                descriptorSize > 0L -> descriptorSize
+                cursorSize >= 0L -> cursorSize
+                else -> -1L
+            }
+        Log.e(
+            TAG,
+            "URI size resolved uri=$uri cursorSize=$cursorSize " +
+                "descriptorSize=$descriptorSize resolvedSize=$resolvedSize",
+        )
+        return resolvedSize
+    }
+
+    private fun readDescriptorSize(uri: Uri): Long =
+        runCatching {
+            contentResolver
+                .openAssetFileDescriptor(uri, READ_MODE)
+                ?.use(::sizeFromDescriptor)
+                ?: -1L
+        }.getOrElse { e ->
+            Log.e(TAG, "URI descriptor size fallback failed uri=$uri: ${e.message}", e)
+            -1L
+        }
+
+    private fun sizeFromDescriptor(descriptor: AssetFileDescriptor): Long {
+        val length = descriptor.length
+        if (length >= 0L) return length
+
+        val statSize = descriptor.parcelFileDescriptor.statSize
+        return if (statSize >= 0L) statSize else -1L
+    }
+
     private fun readLastModifiedSeconds(cursor: Cursor): Long {
         val index = cursor.getColumnIndex(MediaStore.MediaColumns.DATE_MODIFIED)
         if (index < 0 || cursor.isNull(index)) return 0L
@@ -310,6 +354,9 @@ internal class ContentResolverMetadataReader(
     )
 
     private companion object {
+        const val TAG: String = "WvmgOutbound"
+        const val READ_MODE: String = "r"
+
         val PROJECTION =
             arrayOf(
                 OpenableColumns.DISPLAY_NAME,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,8 +55,8 @@
     <!-- Same-Wi-Fi-network onboarding card (#85). Displayed below the
          permission rows so the user understands the Phase 1 networking
          requirement before they land in the share flow. -->
-    <string name="onboarding_network_card_title">Same Wi-Fi network required</string>
-    <string name="onboarding_network_card_body">Phase 1 uses Wi-Fi LAN discovery (mDNS) to find nearby devices. Both the sender and the receiver must be on the same Wi-Fi network. BLE auto-discovery is coming in Phase 2.</string>
+    <string name="onboarding_network_card_title">Nearby discovery requirements</string>
+    <string name="onboarding_network_card_body">Shared Wi-Fi is still the baseline Quick Share path, especially when receiving. When sending to a nearby stock Quick Share peer, WVMG can also use Bluetooth-assisted bootstrap if the devices are off-LAN. Keep Bluetooth on for that path.</string>
     <string name="onboarding_network_card_dismiss">OK</string>
 
     <!-- NEARBY_WIFI_DEVICES (API 33+). -->
@@ -93,14 +93,14 @@
     <string name="send_activity_label">Send via Quick Share</string>
     <string name="send_subtitle_discovering">Looking for nearby devices…</string>
     <string name="send_subtitle_pick_peer">Tap a device to send.</string>
-    <string name="send_empty_state">No devices nearby yet. Make sure the receiver has Quick Share open and is on the same Wi-Fi network.</string>
+    <string name="send_empty_state">No devices nearby yet. Make sure the receiver has Quick Share open. Shared Wi-Fi is still the baseline path; if the devices are off-LAN, keep Bluetooth on for nearby bootstrap.</string>
 
     <!-- Same-Wi-Fi-network hint card (#85). Surfaced after a few seconds
          of empty peer list so the user understands why nothing has
          appeared. Condensed wording — the full explanation lives in
          the onboarding card. -->
-    <string name="send_network_hint_title">Same Wi-Fi network required</string>
-    <string name="send_network_hint_body">Phase 1 uses Wi-Fi LAN discovery (mDNS). Both devices must be on the same Wi-Fi network. BLE auto-discovery is coming in Phase 2.</string>
+    <string name="send_network_hint_title">Nearby discovery requirements</string>
+    <string name="send_network_hint_body">Shared Wi-Fi is still the baseline path. If the receiver is off-LAN, keep Bluetooth on so WVMG can try the nearby bootstrap path.</string>
     <string name="send_network_hint_dismiss">Got it</string>
     <string name="send_show_qr">Show QR</string>
     <string name="send_cancel">Cancel</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,7 +50,7 @@
     <string name="onboarding_open_settings">Open app settings</string>
     <string name="onboarding_continue">Continue</string>
     <string name="onboarding_continue_partial">Continue without all permissions</string>
-    <string name="onboarding_continue_degraded">Continue without notifications</string>
+    <string name="onboarding_continue_degraded">Continue in degraded mode</string>
 
     <!-- Same-Wi-Fi-network onboarding card (#85). Displayed below the
          permission rows so the user understands the Phase 1 networking
@@ -78,6 +78,10 @@
     <!-- BLUETOOTH_CONNECT (API 31+, Phase 4 Bluetooth transports). -->
     <string name="permission_bluetooth_connect_title">Bluetooth connections</string>
     <string name="permission_bluetooth_connect_rationale">Used to accept and open Bluetooth peer-to-peer links when the two devices cannot reach each other over the current Wi-Fi network. Transfers still use Quick Share encryption.</string>
+
+    <!-- ACCESS_FINE_LOCATION (API 24-30, legacy nearby-device discovery). -->
+    <string name="permission_legacy_nearby_location_title">Nearby device location access</string>
+    <string name="permission_legacy_nearby_location_rationale">Android 11 and lower route Bluetooth device discovery and BLE scan results through the location permission. WVMG uses it only to discover nearby Quick Share devices; it does not use your physical location.</string>
 
     <!-- Permission status labels. -->
     <string name="permission_status_granted">Granted</string>

--- a/app/src/test/kotlin/io/github/kyujincho/wvmg/onboarding/PermissionRequirementsTest.kt
+++ b/app/src/test/kotlin/io/github/kyujincho/wvmg/onboarding/PermissionRequirementsTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.onboarding
+
+import android.Manifest
+import android.os.Build
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PermissionRequirementsTest {
+    @Test
+    fun `api 30 requests only legacy nearby discovery location`() {
+        val requirements = PermissionRequirements.requirementsFor(sdkInt = Build.VERSION_CODES.R)
+
+        assertEquals(
+            listOf(Manifest.permission.ACCESS_FINE_LOCATION),
+            requirements.map(PermissionRequirements.Requirement::permission),
+        )
+        assertTrue(requirements.single().optional)
+    }
+
+    @Test
+    fun `api 31 switches to bluetooth runtime permissions`() {
+        val requirements = PermissionRequirements.requirementsFor(sdkInt = Build.VERSION_CODES.S)
+
+        assertEquals(
+            listOf(
+                Manifest.permission.BLUETOOTH_ADVERTISE,
+                Manifest.permission.BLUETOOTH_SCAN,
+                Manifest.permission.BLUETOOTH_CONNECT,
+            ),
+            requirements.map(PermissionRequirements.Requirement::permission),
+        )
+        assertTrue(requirements.all(PermissionRequirements.Requirement::optional))
+    }
+
+    @Test
+    fun `api 33 adds nearby wifi and notifications on top of bluetooth`() {
+        val requirements =
+            PermissionRequirements.requirementsFor(
+                sdkInt = Build.VERSION_CODES.TIRAMISU,
+            )
+
+        assertEquals(
+            listOf(
+                Manifest.permission.BLUETOOTH_ADVERTISE,
+                Manifest.permission.BLUETOOTH_SCAN,
+                Manifest.permission.BLUETOOTH_CONNECT,
+                Manifest.permission.NEARBY_WIFI_DEVICES,
+                Manifest.permission.POST_NOTIFICATIONS,
+            ),
+            requirements.map(PermissionRequirements.Requirement::permission),
+        )
+        val nearbyWifi =
+            requirements.first { it.permission == Manifest.permission.NEARBY_WIFI_DEVICES }
+        assertFalse(nearbyWifi.optional)
+        assertTrue(
+            requirements
+                .filterNot { it.permission == Manifest.permission.NEARBY_WIFI_DEVICES }
+                .all(PermissionRequirements.Requirement::optional),
+        )
+    }
+}

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeFrames.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeFrames.kt
@@ -26,16 +26,21 @@ import io.github.kyujincho.wvmg.protocol.medium.UpgradePathCredentials
  *      [UpgradePathInfo] describing which medium and the per-medium
  *      bring-up parameters.
  *   2. **`CLIENT_INTRODUCTION`** — client side. After the client has
- *      reconnected on the new medium, it sends its endpoint id over
- *      the new socket so the server can map the new connection back
- *      to the original one.
+ *      reconnected on the new medium, it sends its endpoint id as a raw
+ *      length-prefixed `OfflineFrame` over the new socket so the server
+ *      can map the new connection back to the original one.
  *   3. **`CLIENT_INTRODUCTION_ACK`** — server side. ACKs the
- *      introduction.
+ *      introduction as a raw length-prefixed `OfflineFrame` on the new
+ *      socket before that socket joins the SecureMessage session.
  *   4. **`LAST_WRITE_TO_PRIOR_CHANNEL`** — either side, on the OLD
  *      transport. "I am about to stop writing on the old socket." The
  *      sender flushes pending writes, then sends this and stops.
  *   5. **`SAFE_TO_CLOSE_PRIOR_CHANNEL`** — either side, on the OLD
  *      transport. "I have observed your LAST_WRITE; you can FIN now."
+ *      Some stock Quick Share senders move on after receiving the
+ *      receiver's safe-to-close and never send their own final safe
+ *      frame, so the receiver treats the peer's LAST_WRITE plus our
+ *      SAFE_TO_CLOSE as sufficient after a short drain window.
  *   6. **`UPGRADE_FAILURE`** — either side. Aborts the upgrade and
  *      tells the peer we are staying on the current transport.
  *
@@ -427,6 +432,7 @@ public object BandwidthUpgradeFrames {
             return UpgradePathInfo
                 .newBuilder()
                 .setMedium(Medium.BLUETOOTH.toUpgradePathMedium())
+                .setSupportsClientIntroductionAck(true)
                 .setBluetoothCredentials(
                     UpgradePathInfo.BluetoothCredentials
                         .newBuilder()
@@ -439,6 +445,7 @@ public object BandwidthUpgradeFrames {
             UpgradePathInfo
                 .newBuilder()
                 .setMedium(credentials.medium.toUpgradePathMedium())
+                .setSupportsClientIntroductionAck(true)
         when (credentials) {
             is UpgradePathCredentials.Generic -> Unit // Medium-only; nothing extra to set.
             is UpgradePathCredentials.WifiLan -> {

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeOrchestrator.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeOrchestrator.kt
@@ -41,7 +41,11 @@ internal object BandwidthUpgradeOrchestrator {
         peerEndpointId: String,
         logger: (String) -> Unit,
     ): ActiveTransportChannel {
-        val selection = mediumRegistry.prepareBestUpgrade(peerSupportedMediums)
+        val selection =
+            mediumRegistry.prepareBestUpgradeForCurrentTransport(
+                peerSupported = peerSupportedMediums,
+                currentMedium = currentMedium,
+            )
         if (selection !is PreparedUpgradeSelection.Upgrade) {
             logger("medium-upgrade: server staying on current transport selection=$selection")
             return ActiveTransportChannel(oldChannel, currentMedium)

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeOrchestrator.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeOrchestrator.kt
@@ -16,6 +16,7 @@ import io.github.kyujincho.wvmg.protocol.medium.PreparedUpgradeSelection
 import io.github.kyujincho.wvmg.protocol.medium.UpgradePathCredentials
 import io.github.kyujincho.wvmg.protocol.medium.UpgradedTransport
 import io.github.kyujincho.wvmg.protocol.medium.asFramedConnection
+import io.github.kyujincho.wvmg.protocol.transport.FramedConnection
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeoutOrNull
 import java.util.TreeMap
@@ -99,32 +100,36 @@ internal object BandwidthUpgradeOrchestrator {
         logger: (String) -> Unit,
     ): ActiveTransportChannel {
         val bufferedFrames = mutableListOf<OfflineFrame>()
-        val newChannel = oldChannel.withTransport(transport.asFramedConnection())
-        val reader = DualChannelFrameReader(oldChannel, newChannel, logger)
+        val newFramedConnection = transport.asFramedConnection()
         val clientIntro =
-            receiveExpectedUpgradeFrame(
-                reader = reader,
+            receiveRawUpgradeFrame(
+                framedConnection = newFramedConnection,
                 expected = BandwidthUpgradeNegotiationFrame.EventType.CLIENT_INTRODUCTION,
-                stage = "server client introduction",
-                applicationFrames = bufferedFrames,
-                logger = logger,
+                stage = "server raw client introduction",
             )
         validateServerClientIntroduction(
             intro = clientIntro,
             peerEndpointId = peerEndpointId,
         )
-        newChannel.sendOfflineFrame(BandwidthUpgradeFrames.clientIntroductionAck())
-        exchangePriorChannelClose(
-            oldChannel = oldChannel,
+        newFramedConnection.sendFrame(BandwidthUpgradeFrames.clientIntroductionAck().toByteArray())
+        logger("medium-upgrade: server sent raw CLIENT_INTRODUCTION_ACK")
+        val newChannel = oldChannel.withTransport(newFramedConnection)
+        oldChannel.sendOfflineFrame(BandwidthUpgradeFrames.lastWriteToPriorChannel())
+        val reader = DualChannelFrameReader(oldChannel, newChannel, logger)
+        receiveServerPeerLastWrite(
             reader = reader,
             bufferedFrames = bufferedFrames,
             logger = logger,
-            stagePrefix = "server",
         )
-        reader.drainAvailableFrames(
-            stage = "server post-safe-to-close",
-            applicationFrames = bufferedFrames,
-        )
+        oldChannel.sendOfflineFrame(BandwidthUpgradeFrames.safeToClosePriorChannel())
+        logger("medium-upgrade: server sent SAFE_TO_CLOSE_PRIOR_CHANNEL on prior channel")
+        val consumedPeerSafe =
+            drainServerPostSafeFrames(
+                reader = reader,
+                bufferedFrames = bufferedFrames,
+                logger = logger,
+            )
+        closePriorChannelAfterUpgrade(oldChannel, consumedPeerSafe, logger)
         logger("medium-upgrade: server completed ${credentials.medium}")
         return ActiveTransportChannel(newChannel, credentials.medium, bufferedFrames)
     }
@@ -143,6 +148,8 @@ internal object BandwidthUpgradeOrchestrator {
                 logger("medium-upgrade: client received malformed upgrade offer")
                 return ActiveTransportChannel(oldChannel, currentMedium)
             }
+        val expectsClientIntroductionAck =
+            offer.v1.bandwidthUpgradeNegotiation.upgradePathInfo.supportsClientIntroductionAck
         val provider = mediumRegistry.providerFor(credentials.medium)
         if (provider == null) {
             logger("medium-upgrade: client has no provider for ${credentials.medium}")
@@ -167,6 +174,7 @@ internal object BandwidthUpgradeOrchestrator {
                 transport = transport,
                 credentials = credentials,
                 endpointId = endpointId,
+                expectsClientIntroductionAck = expectsClientIntroductionAck,
                 logger = logger,
             )
         }.getOrElse { failure ->
@@ -185,19 +193,22 @@ internal object BandwidthUpgradeOrchestrator {
         transport: UpgradedTransport,
         credentials: UpgradePathCredentials,
         endpointId: String,
+        expectsClientIntroductionAck: Boolean,
         logger: (String) -> Unit,
     ): ActiveTransportChannel {
         val bufferedFrames = mutableListOf<OfflineFrame>()
-        val newChannel = oldChannel.withTransport(transport.asFramedConnection())
+        val newFramedConnection = transport.asFramedConnection()
+        newFramedConnection.sendFrame(BandwidthUpgradeFrames.clientIntroduction(endpointId).toByteArray())
+        if (expectsClientIntroductionAck) {
+            receiveRawUpgradeFrame(
+                framedConnection = newFramedConnection,
+                expected = BandwidthUpgradeNegotiationFrame.EventType.CLIENT_INTRODUCTION_ACK,
+                stage = "client raw introduction ack",
+            )
+            logger("medium-upgrade: client received raw CLIENT_INTRODUCTION_ACK")
+        }
+        val newChannel = oldChannel.withTransport(newFramedConnection)
         val reader = DualChannelFrameReader(oldChannel, newChannel, logger)
-        newChannel.sendOfflineFrame(BandwidthUpgradeFrames.clientIntroduction(endpointId))
-        receiveAndCheckUpgradeFrame(
-            reader = reader,
-            expected = BandwidthUpgradeNegotiationFrame.EventType.CLIENT_INTRODUCTION_ACK,
-            stage = "client introduction ack",
-            applicationFrames = bufferedFrames,
-            logger = logger,
-        )
         exchangeClientPriorChannelClose(
             oldChannel = oldChannel,
             reader = reader,
@@ -234,6 +245,7 @@ internal object BandwidthUpgradeOrchestrator {
             applicationFrames = bufferedFrames,
             logger = logger,
         )
+        closePriorChannelAfterUpgrade(oldChannel, consumedPeerSafe = true, logger = logger)
     }
 
     suspend fun receiveOfferProbe(channel: SecureChannel): UpgradeOfferProbe =
@@ -264,42 +276,81 @@ internal object BandwidthUpgradeOrchestrator {
         }
     }
 
-    private suspend fun exchangePriorChannelClose(
-        oldChannel: SecureChannel,
+    private suspend fun receiveServerPeerLastWrite(
         reader: DualChannelFrameReader,
         bufferedFrames: MutableList<OfflineFrame>,
         logger: (String) -> Unit,
-        stagePrefix: String,
     ) {
-        oldChannel.sendOfflineFrame(BandwidthUpgradeFrames.lastWriteToPriorChannel())
         val peerLast =
             receiveExpectedUpgradeFrame(
                 reader = reader,
                 expected = BandwidthUpgradeNegotiationFrame.EventType.LAST_WRITE_TO_PRIOR_CHANNEL,
-                stage = "$stagePrefix peer last-write",
+                stage = "server peer last-write",
                 applicationFrames = bufferedFrames,
                 logger = logger,
             )
         checkUpgradeEvent(
             frame = peerLast,
             expected = BandwidthUpgradeNegotiationFrame.EventType.LAST_WRITE_TO_PRIOR_CHANNEL,
-            stage = "$stagePrefix peer last-write",
+            stage = "server peer last-write",
         )
+    }
 
-        oldChannel.sendOfflineFrame(BandwidthUpgradeFrames.safeToClosePriorChannel())
-        val peerSafe =
-            receiveExpectedUpgradeFrame(
-                reader = reader,
-                expected = BandwidthUpgradeNegotiationFrame.EventType.SAFE_TO_CLOSE_PRIOR_CHANNEL,
-                stage = "$stagePrefix peer safe-to-close",
-                applicationFrames = bufferedFrames,
-                logger = logger,
-            )
-        checkUpgradeEvent(
-            frame = peerSafe,
-            expected = BandwidthUpgradeNegotiationFrame.EventType.SAFE_TO_CLOSE_PRIOR_CHANNEL,
-            stage = "$stagePrefix peer safe-to-close",
+    private suspend fun drainServerPostSafeFrames(
+        reader: DualChannelFrameReader,
+        bufferedFrames: MutableList<OfflineFrame>,
+        logger: (String) -> Unit,
+    ): Boolean {
+        val consumedPeerSafe =
+            withTimeoutOrNull(SERVER_PEER_SAFE_DRAIN_MILLIS) {
+                receiveOptionalPeerSafeToClose(
+                    reader = reader,
+                    bufferedFrames = bufferedFrames,
+                    logger = logger,
+                )
+            } == true
+        logger(
+            if (consumedPeerSafe) {
+                "medium-upgrade: server consumed peer SAFE_TO_CLOSE on prior channel"
+            } else {
+                "medium-upgrade: server treating peer LAST_WRITE as sufficient; peer SAFE_TO_CLOSE omitted"
+            },
         )
+        if (!consumedPeerSafe) {
+            reader.drainAvailableFrames(
+                stage = "server post-safe-to-close",
+                applicationFrames = bufferedFrames,
+            )
+        }
+        return consumedPeerSafe
+    }
+
+    private suspend fun receiveOptionalPeerSafeToClose(
+        reader: DualChannelFrameReader,
+        bufferedFrames: MutableList<OfflineFrame>,
+        logger: (String) -> Unit,
+    ): Boolean {
+        while (true) {
+            val frame = reader.receiveNextFrame("server optional peer safe-to-close")
+            when {
+                frame.isBandwidthUpgradeEvent(
+                    BandwidthUpgradeNegotiationFrame.EventType.SAFE_TO_CLOSE_PRIOR_CHANNEL,
+                ) -> return true
+                frame.isBandwidthUpgradeNegotiation() -> {
+                    logger(
+                        "medium-upgrade: ignored ${frame.describeUpgradeEvent()} " +
+                            "while draining optional peer SAFE_TO_CLOSE",
+                    )
+                }
+                else -> {
+                    logger(
+                        "medium-upgrade: buffered ${frame.describeFrameType()} " +
+                            "while draining optional peer SAFE_TO_CLOSE",
+                    )
+                    bufferedFrames += frame
+                }
+            }
+        }
     }
 
     private fun decodeOfferCredentials(frame: OfflineFrame): UpgradePathCredentials? {
@@ -308,6 +359,35 @@ internal object BandwidthUpgradeOrchestrator {
         }
         return BandwidthUpgradeFrames.decodeCredentials(frame.v1.bandwidthUpgradeNegotiation.upgradePathInfo)
     }
+
+    private suspend fun receiveRawUpgradeFrame(
+        framedConnection: FramedConnection,
+        expected: BandwidthUpgradeNegotiationFrame.EventType,
+        stage: String,
+    ): OfflineFrame {
+        val frame =
+            withTimeoutOrNull(UPGRADE_TIMEOUT_MILLIS) {
+                while (true) {
+                    if (framedConnection.hasBufferedInput()) {
+                        return@withTimeoutOrNull parseRawOfflineFrame(framedConnection, stage)
+                    }
+                    delay(DUAL_CHANNEL_POLL_DELAY_MILLIS)
+                }
+                error("unreachable")
+            } ?: error("Timed out waiting for $stage")
+        checkUpgradeEvent(frame = frame, expected = expected, stage = stage)
+        return frame
+    }
+
+    private suspend fun parseRawOfflineFrame(
+        framedConnection: FramedConnection,
+        stage: String,
+    ): OfflineFrame =
+        try {
+            OfflineFrame.parseFrom(framedConnection.receiveFrame())
+        } catch (e: com.google.protobuf.InvalidProtocolBufferException) {
+            error("Malformed raw OfflineFrame during $stage: ${e.message}")
+        }
 
     private suspend fun receiveExpectedUpgradeFrame(
         reader: DualChannelFrameReader,
@@ -350,6 +430,48 @@ internal object BandwidthUpgradeOrchestrator {
             )
         }
 
+    private suspend fun closePriorChannelAfterUpgrade(
+        oldChannel: SecureChannel,
+        consumedPeerSafe: Boolean,
+        logger: (String) -> Unit,
+    ) {
+        if (consumedPeerSafe) {
+            runCatching { oldChannel.sendRawOfflineFrame(OfflineFrames.disconnection()) }
+                .onSuccess { logger("medium-upgrade: sent raw prior-channel Disconnection") }
+                .onFailure {
+                    logger(
+                        "medium-upgrade: failed raw prior-channel Disconnection: " +
+                            (it.message ?: it::class.simpleName),
+                    )
+                }
+            drainRawPriorChannelDisconnect(oldChannel, logger)
+        }
+        runCatching { oldChannel.close() }
+    }
+
+    private suspend fun drainRawPriorChannelDisconnect(
+        oldChannel: SecureChannel,
+        logger: (String) -> Unit,
+    ) {
+        withTimeoutOrNull(PRIOR_CHANNEL_DISCONNECT_DRAIN_MILLIS) {
+            while (true) {
+                if (oldChannel.hasBufferedInput()) {
+                    runCatching { oldChannel.receiveRawOfflineFrame() }
+                        .onSuccess {
+                            logger("medium-upgrade: drained raw prior-channel frame after safe-to-close")
+                        }.onFailure {
+                            logger(
+                                "medium-upgrade: ignored prior-channel close drain failure: " +
+                                    (it.message ?: it::class.simpleName),
+                            )
+                        }
+                    return@withTimeoutOrNull
+                }
+                delay(DUAL_CHANNEL_POLL_DELAY_MILLIS)
+            }
+        }
+    }
+
     private fun checkUpgradeEvent(
         frame: OfflineFrame,
         expected: BandwidthUpgradeNegotiationFrame.EventType,
@@ -370,7 +492,13 @@ internal object BandwidthUpgradeOrchestrator {
 
     private fun OfflineFrame.describeFrameType(): String =
         if (hasV1()) {
-            v1.type.toString()
+            if (v1.type == V1Frame.FrameType.BANDWIDTH_UPGRADE_NEGOTIATION) {
+                "${v1.type}(${v1.bandwidthUpgradeNegotiation.eventType})"
+            } else if (v1.type == V1Frame.FrameType.BANDWIDTH_UPGRADE_RETRY) {
+                "${v1.type}(request=${v1.bandwidthUpgradeRetry.isRequest})"
+            } else {
+                v1.type.toString()
+            }
         } else {
             "NO_V1"
         }
@@ -498,6 +626,8 @@ internal object BandwidthUpgradeOrchestrator {
 
     private const val UPGRADE_TIMEOUT_MILLIS: Long = 30_000L
     private const val OFFER_WAIT_TIMEOUT_MILLIS: Long = 1_500L
+    private const val SERVER_PEER_SAFE_DRAIN_MILLIS: Long = 500L
+    private const val PRIOR_CHANNEL_DISCONNECT_DRAIN_MILLIS: Long = 200L
     private const val DUAL_CHANNEL_DRAIN_IDLE_ATTEMPTS: Int = 25
     private const val DUAL_CHANNEL_POLL_DELAY_MILLIS: Long = 10L
 }

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/InboundConnectionDriver.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/InboundConnectionDriver.kt
@@ -180,16 +180,25 @@ internal class InboundConnectionDriver(
                 ?.let { EndpointInfo.parse(it)?.deviceName }
 
         // Decode the peer's advertised mediums (Phase 4 framework). The
-        // intersection with our local registry's supportedMediums(),
-        // resolved by the registry's ladder, picks the upgrade target.
-        // The current driver records the choice for observability; the
-        // full BANDWIDTH_UPGRADE_NEGOTIATION transport swap is wired by
-        // a later orchestrator integration.
+        // intersection with our local registry's current-medium-aware
+        // supported set, resolved by the registry's ladder, picks the
+        // upgrade target. WIFI_LAN is only meaningful when the existing
+        // control channel is already LAN-backed; on a Bluetooth/BLE
+        // bootstrap we must ignore it or we would suppress real upgrade
+        // candidates by treating "stay on current socket" as if the
+        // current socket were LAN. The current driver records the
+        // choice for observability; the full
+        // BANDWIDTH_UPGRADE_NEGOTIATION transport swap is wired by a
+        // later orchestrator integration.
         peerSupportedMediums =
             initialFrame.v1.connectionRequest.mediumsList
                 .mapNotNull { Medium.fromConnectionRequestMedium(it) }
                 .toSet()
-        val chosen = mediumRegistry.selectBestUpgrade(peerSupportedMediums)
+        val chosen =
+            mediumRegistry.selectBestUpgradeForCurrentTransport(
+                peerSupported = peerSupportedMediums,
+                currentMedium = transport.medium,
+            )
         // WIFI_LAN is the discovery medium; selecting it means "stay on
         // the current transport". Treat that as `null` so callers do
         // not interpret it as an upgrade trigger.

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/InboundConnectionDriver.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/InboundConnectionDriver.kt
@@ -264,6 +264,13 @@ internal class InboundConnectionDriver(
         // Step 8-10: drive the negotiation FSM through to consent.
         mutableState.value = InboundConnectionState.Negotiating
         val negotiationFsm = InboundSharingFsm(secureRandom = secureRandom).also { fsm = it }
+        if (activeTransport.medium != transport.medium) {
+            logger(
+                "medium-upgrade: delaying sharing negotiation " +
+                    "${POST_UPGRADE_SHARING_DELAY_MILLIS}ms after ${activeTransport.medium}",
+            )
+            delay(POST_UPGRADE_SHARING_DELAY_MILLIS)
+        }
         applyEffects(activeChannel, negotiationFsm.start())
 
         // Mark the handshake as complete so a racing UI-side cancel()
@@ -544,6 +551,10 @@ internal class InboundConnectionDriver(
         }
         // Otherwise it's a negotiation frame. Parse and feed the FSM.
         val sharingFrame = SharingFrames.parse(event.data)
+        logger(
+            "sharing: received ${sharingFrame.v1.type} payloadId=${event.payloadId} " +
+                "bytes=${event.data.size} state=${fsm.state}",
+        )
         // Disambiguate peer-cancel from local-cancel before applyEffects
         // sees the Cancelled effect — both code paths emit the same FSM
         // effect, so the driver has to set the cause itself based on the
@@ -708,6 +719,10 @@ internal class InboundConnectionDriver(
     ) {
         val payloadId = secureRandom.nextLong()
         val frames = PayloadTransferEncoder.encodeBytesPayload(payloadId, send.frame.toByteArray())
+        logger(
+            "sharing: sending ${send.frame.v1.type} payloadId=$payloadId " +
+                "frames=${frames.size} state=${fsm?.state}",
+        )
         for (frame in frames) {
             channel.sendOfflineFrame(frame)
         }
@@ -819,5 +834,6 @@ internal class InboundConnectionDriver(
     private companion object {
         private const val INITIAL_FRAME_PROBE_ATTEMPTS = 20
         private const val INITIAL_FRAME_PROBE_DELAY_MILLIS = 10L
+        private const val POST_UPGRADE_SHARING_DELAY_MILLIS = 750L
     }
 }

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnection.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnection.kt
@@ -7,7 +7,9 @@ package io.github.kyujincho.wvmg.protocol.connection
 
 import io.github.kyujincho.wvmg.protocol.medium.MediumRegistry
 import io.github.kyujincho.wvmg.protocol.payload.PayloadProtocolException
+import io.github.kyujincho.wvmg.protocol.transport.ConnectedTransport
 import io.github.kyujincho.wvmg.protocol.transport.EndOfFrameStream
+import io.github.kyujincho.wvmg.protocol.transport.asConnectedTransport
 import io.github.kyujincho.wvmg.protocol.ukey2.Ukey2HandshakeException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
@@ -22,21 +24,24 @@ import java.net.Socket
 import java.security.SecureRandom
 
 /**
- * The sender-side glue tying together TCP, framing, UKEY2,
+ * The sender-side glue tying together an initial connected transport,
+ * framing, UKEY2,
  * SecureMessage, the negotiation state machine, and outbound payload
  * streaming into a single in-flight transfer attempt.
  *
- * Owns exactly one TCP [Socket]. One [OutboundConnection] handles one
- * connection to one peer; opening more (Quick Share permits parallel
- * sends to multiple peers) is the caller's responsibility.
+ * Owns exactly one initial [ConnectedTransport]. One [OutboundConnection]
+ * handles one connection to one peer; opening more (Quick Share permits
+ * parallel sends to multiple peers) is the caller's responsibility.
  *
  * ### Lifecycle
  *
  * The complete sequence the orchestrator drives, mirroring NearDrop's
  * `OutboundNearbyConnection.swift`:
  *
- *  1. Open a TCP socket to `(targetAddress, port)`.
- *  2. Wrap the socket in a
+ *  1. Obtain the initial connected transport (either by opening the
+ *     legacy LAN TCP socket or by consuming a caller-supplied
+ *     preconnected transport).
+ *  2. Wrap the transport in a
  *     [io.github.kyujincho.wvmg.protocol.transport.FramedConnection].
  *  3. Send the unencrypted
  *     [com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame]
@@ -105,10 +110,13 @@ import java.security.SecureRandom
  * driver's dispatch loop drains. This avoids racing the FSM with the
  * wire.
  *
- * @param targetAddress IP address (or hostname) of the receiver. The
- *   discovery layer (`:discovery-android`) translates an mDNS service
- *   record into this concrete value.
- * @param port TCP port the receiver advertised in its endpoint record.
+ * @param targetAddress IP address (or hostname) of the receiver for the
+ *   legacy LAN TCP path.
+ * @param port TCP port the receiver advertised in its endpoint record
+ *   for the legacy LAN TCP path.
+ * @param transport Optional already-connected initial-control transport.
+ *   Used by sender-side non-LAN bootstrap paths such as Bluetooth
+ *   Classic RFCOMM.
  * @param endpointId 4-char ASCII identifier the sender uses for itself
  *   in the opening `ConnectionRequest`. Default: a freshly generated
  *   alphanumeric id via [generateEndpointId]. Quick Share peers (Samsung
@@ -141,9 +149,10 @@ import java.security.SecureRandom
  *   actual upgrade swap.
  */
 @Suppress("LongParameterList") // The public constructor has many knobs but every one is needed by the spec.
-public class OutboundConnection(
-    private val targetAddress: InetAddress,
-    private val port: Int,
+public class OutboundConnection private constructor(
+    private val targetAddress: InetAddress?,
+    private val port: Int?,
+    private val transport: ConnectedTransport?,
     private val endpointId: String = generateEndpointId(),
     private val endpointInfo: ByteArray = ByteArray(0),
     private val qrCodeHandshakeData: ByteArray? = null,
@@ -160,6 +169,51 @@ public class OutboundConnection(
      */
     private val logger: (String) -> Unit = {},
 ) {
+    public constructor(
+        targetAddress: InetAddress,
+        port: Int,
+        endpointId: String = generateEndpointId(),
+        endpointInfo: ByteArray = ByteArray(0),
+        qrCodeHandshakeData: ByteArray? = null,
+        connectTimeoutMillis: Int = DEFAULT_CONNECT_TIMEOUT_MILLIS,
+        secureRandom: SecureRandom = SecureRandom(),
+        mediumRegistry: MediumRegistry = MediumRegistry.DefaultWifiLan,
+        logger: (String) -> Unit = {},
+    ) : this(
+        targetAddress = targetAddress,
+        port = port,
+        transport = null,
+        endpointId = endpointId,
+        endpointInfo = endpointInfo,
+        qrCodeHandshakeData = qrCodeHandshakeData,
+        connectTimeoutMillis = connectTimeoutMillis,
+        secureRandom = secureRandom,
+        mediumRegistry = mediumRegistry,
+        logger = logger,
+    )
+
+    public constructor(
+        transport: ConnectedTransport,
+        endpointId: String = generateEndpointId(),
+        endpointInfo: ByteArray = ByteArray(0),
+        qrCodeHandshakeData: ByteArray? = null,
+        connectTimeoutMillis: Int = DEFAULT_CONNECT_TIMEOUT_MILLIS,
+        secureRandom: SecureRandom = SecureRandom(),
+        mediumRegistry: MediumRegistry = MediumRegistry.DefaultWifiLan,
+        logger: (String) -> Unit = {},
+    ) : this(
+        targetAddress = null,
+        port = null,
+        transport = transport,
+        endpointId = endpointId,
+        endpointInfo = endpointInfo,
+        qrCodeHandshakeData = qrCodeHandshakeData,
+        connectTimeoutMillis = connectTimeoutMillis,
+        secureRandom = secureRandom,
+        mediumRegistry = mediumRegistry,
+        logger = logger,
+    )
+
     private val mutableState: MutableStateFlow<OutboundConnectionState> =
         MutableStateFlow(OutboundConnectionState.Idle)
 
@@ -209,7 +263,7 @@ public class OutboundConnection(
      * socket itself.
      */
     @Volatile
-    private var socketRef: Socket? = null
+    private var transportRef: ConnectedTransport? = null
 
     /**
      * Whether the lifecycle has progressed past the unencrypted
@@ -223,6 +277,14 @@ public class OutboundConnection(
 
     internal fun markHandshakeComplete() {
         handshakeComplete = true
+    }
+
+    init {
+        val usingLanSocket = targetAddress != null && port != null
+        val usingPreconnectedTransport = transport != null
+        require(usingLanSocket.xor(usingPreconnectedTransport)) {
+            "OutboundConnection requires either targetAddress+port or transport"
+        }
     }
 
     /**
@@ -257,29 +319,29 @@ public class OutboundConnection(
         validateFiles(files)
 
         mutableState.value = OutboundConnectionState.Connecting
-        val socket: Socket =
+        val initialTransport: ConnectedTransport =
             try {
-                openSocket()
+                openTransport()
             } catch (e: java.io.IOException) {
-                val reason = "TCP connect failed: ${e.message ?: e::class.simpleName}"
+                val reason = "Initial connect failed: ${e.message ?: e::class.simpleName}"
                 mutableState.value = OutboundConnectionState.Failed(reason)
                 return OutboundResult.Failed(reason)
             }
-        socketRef = socket
+        transportRef = initialTransport
         // A cancel() that arrived while we were blocked in
-        // openSocket() couldn't close the socket then (it didn't exist
-        // yet), but the connect just succeeded. Honour the latched
-        // cancellation by closing the new socket eagerly so the
+        // openTransport() couldn't close the transport then (it didn't
+        // exist yet), but the connect just succeeded. Honour the latched
+        // cancellation by closing the new transport eagerly so the
         // dispatch loop's first read fails fast. Without this, a
-        // pre-handshake cancel that lost the race against a fast TCP
+        // pre-handshake cancel that lost the race against a fast initial
         // connect would have to wait for a peer-side timeout.
         if (cancelled) {
-            runCatching { socket.close() }
+            runCatching { initialTransport.close() }
         }
 
         val driver =
             OutboundConnectionDriver(
-                socket = socket,
+                initialTransport = initialTransport,
                 secureRandom = secureRandom,
                 externalEvents = externalEvents,
                 mutableState = mutableState,
@@ -305,7 +367,7 @@ public class OutboundConnection(
             handleFailure(driver, e)
         } finally {
             externalEvents.close()
-            runCatching { socket.close() }
+            runCatching { initialTransport.close() }
         }
     }
 
@@ -339,21 +401,25 @@ public class OutboundConnection(
             // fail / succeed naturally; the post-connect block in
             // [run] re-checks [cancelled] and closes the new socket
             // immediately.
-            socketRef?.let { runCatching { it.close() } }
+            transportRef?.let { runCatching { it.close() } }
         }
     }
 
     /**
-     * Open the TCP socket. Hoisted so the failure path is a clean
+     * Open or adopt the initial transport. Hoisted so the failure path is a clean
      * try/catch in [run]. Dispatched onto [Dispatchers.IO] because
      * `Socket.connect` is blocking and must not pin the calling
      * coroutine's dispatcher (which on the JVM-test side is the
      * `runTest` scheduler — pinning it would deadlock the test).
      */
-    private suspend fun openSocket(): Socket =
-        withContext(Dispatchers.IO) {
+    private suspend fun openTransport(): ConnectedTransport {
+        val preconnected = transport
+        if (preconnected != null) return preconnected
+        val address = requireNotNull(targetAddress)
+        val targetPort = requireNotNull(port)
+        return withContext(Dispatchers.IO) {
             val socket = Socket()
-            socket.connect(InetSocketAddress(targetAddress, port), connectTimeoutMillis)
+            socket.connect(InetSocketAddress(address, targetPort), connectTimeoutMillis)
             // TCP_NODELAY mirrors the receiver-side accept loop
             // (`TcpReceiverServer` line ~414). Without it, Nagle batches
             // our small UKEY2 frames (~50 B) and the unencrypted
@@ -363,8 +429,9 @@ public class OutboundConnection(
             // Samsung's UKEY2 server alarm. Best-effort: a misbehaving
             // SocketImpl that rejects this option is non-fatal.
             runCatching { socket.tcpNoDelay = true }
-            socket
+            socket.asConnectedTransport()
         }
+    }
 
     /**
      * Sanity-check the [files] list before starting any I/O.

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionDriver.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionDriver.kt
@@ -117,13 +117,15 @@ internal class OutboundConnectionDriver(
         val transport = FramedConnection(initialTransport).also { framedConnection = it }
 
         // Step 1: send unencrypted ConnectionRequest. The mediums set
-        // is sourced from the registry's supportedMediums(); the encoder
-        // ensures WIFI_LAN is always present (it IS the discovery
-        // medium today). Phase 4's per-medium adapters extend the set
-        // by registering against the registry; absent any extra
+        // is sourced from the registry's current-medium-aware view:
+        // WIFI_LAN only means "stay on the already-open LAN socket", so
+        // a Bluetooth/BLE bootstrap must not advertise it as an
+        // off-LAN upgrade option. Phase 4's per-medium adapters extend
+        // the set by registering against the registry; absent any extra
         // provider this is functionally identical to the previous
-        // hard-coded `[WIFI_LAN]`.
-        val advertisedMediums = mediumRegistry.supportedMediums()
+        // hard-coded `[WIFI_LAN]` on the legacy LAN path.
+        val advertisedMediums =
+            mediumRegistry.supportedMediumsForCurrentTransport(initialTransport.medium)
         logger("step 1: advertising mediums=$advertisedMediums")
         transport.sendFrame(
             OutboundFrames

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionDriver.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionDriver.kt
@@ -12,7 +12,6 @@ import io.github.kyujincho.wvmg.protocol.crypto.D2DKeyDerivation
 import io.github.kyujincho.wvmg.protocol.crypto.D2DRole
 import io.github.kyujincho.wvmg.protocol.crypto.pin.PinDerivation
 import io.github.kyujincho.wvmg.protocol.crypto.securemessage.SecureChannel
-import io.github.kyujincho.wvmg.protocol.medium.Medium
 import io.github.kyujincho.wvmg.protocol.medium.MediumRegistry
 import io.github.kyujincho.wvmg.protocol.payload.PayloadAssembler
 import io.github.kyujincho.wvmg.protocol.payload.PayloadEvent
@@ -27,6 +26,7 @@ import io.github.kyujincho.wvmg.protocol.sharing.SharingFrames
 import io.github.kyujincho.wvmg.protocol.sharing.SharingFsmEffect
 import io.github.kyujincho.wvmg.protocol.sharing.SharingFsmEvent
 import io.github.kyujincho.wvmg.protocol.sharing.SharingV1Frame
+import io.github.kyujincho.wvmg.protocol.transport.ConnectedTransport
 import io.github.kyujincho.wvmg.protocol.transport.EndOfFrameStream
 import io.github.kyujincho.wvmg.protocol.transport.FramedConnection
 import io.github.kyujincho.wvmg.protocol.ukey2.Ukey2Client
@@ -39,7 +39,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.withTimeoutOrNull
-import java.net.Socket
 import java.security.SecureRandom
 
 /**
@@ -63,7 +62,7 @@ import java.security.SecureRandom
     "LongParameterList", // Constructor takes the connection's collaborators verbatim.
 )
 internal class OutboundConnectionDriver(
-    private val socket: Socket,
+    private val initialTransport: ConnectedTransport,
     private val secureRandom: SecureRandom,
     private val externalEvents: Channel<OutboundExternalEvent>,
     private val mutableState: MutableStateFlow<OutboundConnectionState>,
@@ -112,10 +111,10 @@ internal class OutboundConnectionDriver(
     suspend fun runLifecycle(): OutboundResult {
         mutableState.value = OutboundConnectionState.Handshaking
         logger(
-            "step 1: TCP socket open (${socket.inetAddress?.hostAddress}:${socket.port}) " +
+            "step 1: initial transport open medium=${initialTransport.medium} " +
                 "endpointId=$endpointId endpointInfo.size=${endpointInfo.size}",
         )
-        val transport = FramedConnection(socket).also { framedConnection = it }
+        val transport = FramedConnection(initialTransport).also { framedConnection = it }
 
         // Step 1: send unencrypted ConnectionRequest. The mediums set
         // is sourced from the registry's supportedMediums(); the encoder
@@ -236,7 +235,7 @@ internal class OutboundConnectionDriver(
                         BandwidthUpgradeOrchestrator
                             .runClientUpgradeFromOffer(
                                 oldChannel = channel,
-                                currentMedium = Medium.WIFI_LAN,
+                                currentMedium = initialTransport.medium,
                                 offer = probe.frame,
                                 mediumRegistry = mediumRegistry,
                                 endpointId = endpointId,
@@ -257,7 +256,7 @@ internal class OutboundConnectionDriver(
     fun tearDown() {
         runCatching { secureChannel?.close() }
         runCatching { framedConnection?.close() }
-        runCatching { socket.close() }
+        runCatching { initialTransport.close() }
     }
 
     /**
@@ -396,7 +395,7 @@ internal class OutboundConnectionDriver(
                 // Close the original socket as well because the upgraded
                 // channel no longer owns it.
                 runCatching { channel.close() }
-                runCatching { socket.close() }
+                runCatching { initialTransport.close() }
                 pumpJob.cancelAndJoin()
             }
         }

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/crypto/securemessage/SecureChannel.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/crypto/securemessage/SecureChannel.kt
@@ -161,6 +161,13 @@ public class SecureChannel internal constructor(
     internal suspend fun acceptSequencedOfflineFrame(frame: SequencedOfflineFrame): OfflineFrame =
         session.acceptSequencedOfflineFrame(frame)
 
+    internal suspend fun sendRawOfflineFrame(frame: OfflineFrame) {
+        framedConnection.sendFrame(frame.toByteArray())
+    }
+
+    internal suspend fun receiveRawOfflineFrame(): OfflineFrame =
+        OfflineFrame.parseFrom(framedConnection.receiveFrame())
+
     /**
      * The next outgoing sequence number that [sendOfflineFrame] WOULD use,
      * exposed for diagnostics and tests. The value increases by exactly

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/BleAdvertisement.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/BleAdvertisement.kt
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+@file:Suppress("CyclomaticComplexMethod", "MagicNumber", "ReturnCount")
+
+package io.github.kyujincho.wvmg.protocol.endpoint
+
+import java.security.MessageDigest
+
+/**
+ * Nearby Mediums BLE advertisement wrapper.
+ *
+ * `0xFEF3` legacy fast advertisements use the compact fast form
+ * `[version/socket/fast][data_len][data][device_token]`. GATT advertisement
+ * slots use the non-fast form
+ * `[version/socket][service_id_hash][data_len_u32][data][device_token]`.
+ * The inner [data] is the same endpoint advertisement body parsed by
+ * [BleServiceData].
+ */
+public object BleAdvertisement {
+    public const val SERVICE_ID_HASH_LEN: Int = 3
+    public const val DEVICE_TOKEN_LEN: Int = 2
+    public const val VERSION: Int = 2
+    public const val SOCKET_VERSION: Int = 2
+
+    private const val VERSION_MASK: Int = 0xE0
+    private const val VERSION_SHIFT: Int = 5
+    private const val SOCKET_VERSION_MASK: Int = 0x1C
+    private const val SOCKET_VERSION_SHIFT: Int = 2
+    private const val FAST_ADVERTISEMENT_MASK: Int = 0x02
+    private const val SECOND_PROFILE_MASK: Int = 0x01
+    private const val FAST_DATA_SIZE_LEN: Int = 1
+    private const val DATA_SIZE_LEN: Int = 4
+    private const val EXTRA_FIELDS_MASK_LEN: Int = 1
+    private const val EXTRA_FIELD_PSM_MASK: Int = 0x01
+    private const val EXTRA_FIELD_RX_INSTANT_CONNECTION_MASK: Int = 0x02
+    private const val PSM_LEN: Int = 2
+    private const val RX_INSTANT_CONNECTION_LEN_BYTES: Int = 1
+    private const val MAX_UINT16: Int = 0xFFFF
+    private const val UNSIGNED_BYTE_MASK: Int = 0xFF
+
+    @JvmStatic
+    public fun encodeGattAdvertisement(
+        endpointId: ByteArray,
+        endpointInfo: EndpointInfo,
+        serviceIdHash: ByteArray = NearbyServiceId.hashPrefix,
+        psm: Int = 0,
+    ): ByteArray {
+        require(serviceIdHash.size == SERVICE_ID_HASH_LEN) {
+            "serviceIdHash must be $SERVICE_ID_HASH_LEN bytes"
+        }
+        require(psm in 0..MAX_UINT16) { "psm must fit in uint16, got $psm" }
+        val data = BleServiceData.encode(endpointId, endpointInfo)
+        val fixed = ByteArray(1 + SERVICE_ID_HASH_LEN + DATA_SIZE_LEN + data.size + DEVICE_TOKEN_LEN)
+        var offset = 0
+        fixed[offset++] = packHeader(fastAdvertisement = false)
+        serviceIdHash.copyInto(fixed, destinationOffset = offset)
+        offset += SERVICE_ID_HASH_LEN
+        writeUInt32(data.size, fixed, offset)
+        offset += DATA_SIZE_LEN
+        data.copyInto(fixed, destinationOffset = offset)
+        offset += data.size
+        sha256FirstTwo(data).copyInto(fixed, destinationOffset = offset)
+        if (psm == 0) return fixed
+
+        val out = ByteArray(fixed.size + EXTRA_FIELDS_MASK_LEN + PSM_LEN)
+        fixed.copyInto(out)
+        out[fixed.size] = EXTRA_FIELD_PSM_MASK.toByte()
+        out[fixed.size + 1] = ((psm ushr Byte.SIZE_BITS) and UNSIGNED_BYTE_MASK).toByte()
+        out[fixed.size + 2] = (psm and UNSIGNED_BYTE_MASK).toByte()
+        return out
+    }
+
+    @Suppress("LongMethod")
+    @JvmStatic
+    public fun parse(bytes: ByteArray): Parsed? {
+        if (bytes.size < 1) return null
+        val header = bytes[0].toInt() and UNSIGNED_BYTE_MASK
+        val version = (header and VERSION_MASK) ushr VERSION_SHIFT
+        val socketVersion = (header and SOCKET_VERSION_MASK) ushr SOCKET_VERSION_SHIFT
+        val fastAdvertisement = (header and FAST_ADVERTISEMENT_MASK) != 0
+        val secondProfile = (header and SECOND_PROFILE_MASK) != 0
+        if (version !in 1..VERSION || socketVersion !in 1..SOCKET_VERSION) return null
+
+        var offset = 1
+        val serviceIdHash: ByteArray?
+        val dataLength: Int
+        if (fastAdvertisement) {
+            if (offset + FAST_DATA_SIZE_LEN > bytes.size) return null
+            serviceIdHash = null
+            dataLength = bytes[offset++].toInt() and UNSIGNED_BYTE_MASK
+        } else {
+            if (offset + SERVICE_ID_HASH_LEN + DATA_SIZE_LEN > bytes.size) return null
+            serviceIdHash = bytes.copyOfRange(offset, offset + SERVICE_ID_HASH_LEN)
+            offset += SERVICE_ID_HASH_LEN
+            dataLength = readUInt32(bytes, offset) ?: return null
+            offset += DATA_SIZE_LEN
+        }
+        if (dataLength < 0 || offset + dataLength > bytes.size) return null
+        val data = bytes.copyOfRange(offset, offset + dataLength)
+        offset += dataLength
+
+        val deviceToken =
+            if (offset + DEVICE_TOKEN_LEN <= bytes.size) {
+                bytes.copyOfRange(offset, offset + DEVICE_TOKEN_LEN).also { offset += DEVICE_TOKEN_LEN }
+            } else {
+                ByteArray(0)
+            }
+
+        var psm = 0
+        var rxInstantConnectionAdvertisement = ByteArray(0)
+        if (offset + EXTRA_FIELDS_MASK_LEN <= bytes.size) {
+            val mask = bytes[offset++].toInt() and UNSIGNED_BYTE_MASK
+            if ((mask and EXTRA_FIELD_PSM_MASK) != 0) {
+                if (offset + PSM_LEN > bytes.size) return null
+                psm =
+                    ((bytes[offset].toInt() and UNSIGNED_BYTE_MASK) shl Byte.SIZE_BITS) or
+                    (bytes[offset + 1].toInt() and UNSIGNED_BYTE_MASK)
+                offset += PSM_LEN
+            }
+            if ((mask and EXTRA_FIELD_RX_INSTANT_CONNECTION_MASK) != 0) {
+                if (offset + RX_INSTANT_CONNECTION_LEN_BYTES > bytes.size) return null
+                val len = bytes[offset++].toInt() and UNSIGNED_BYTE_MASK
+                if (offset + len > bytes.size) return null
+                rxInstantConnectionAdvertisement = bytes.copyOfRange(offset, offset + len)
+                offset += len
+            }
+        }
+        if (offset != bytes.size) return null
+
+        return Parsed(
+            version = version,
+            socketVersion = socketVersion,
+            fastAdvertisement = fastAdvertisement,
+            secondProfile = secondProfile,
+            serviceIdHash = serviceIdHash,
+            data = data,
+            deviceToken = deviceToken,
+            psm = psm,
+            rxInstantConnectionAdvertisement = rxInstantConnectionAdvertisement,
+        )
+    }
+
+    private fun packHeader(fastAdvertisement: Boolean): Byte {
+        var header = (VERSION shl VERSION_SHIFT) or (SOCKET_VERSION shl SOCKET_VERSION_SHIFT)
+        if (fastAdvertisement) header = header or FAST_ADVERTISEMENT_MASK
+        return header.toByte()
+    }
+
+    private fun writeUInt32(
+        value: Int,
+        out: ByteArray,
+        offset: Int,
+    ) {
+        out[offset] = (value ushr 24).toByte()
+        out[offset + 1] = (value ushr 16).toByte()
+        out[offset + 2] = (value ushr 8).toByte()
+        out[offset + 3] = value.toByte()
+    }
+
+    private fun readUInt32(
+        bytes: ByteArray,
+        offset: Int,
+    ): Int? {
+        if (offset + DATA_SIZE_LEN > bytes.size) return null
+        val value =
+            ((bytes[offset].toInt() and UNSIGNED_BYTE_MASK) shl 24) or
+                ((bytes[offset + 1].toInt() and UNSIGNED_BYTE_MASK) shl 16) or
+                ((bytes[offset + 2].toInt() and UNSIGNED_BYTE_MASK) shl 8) or
+                (bytes[offset + 3].toInt() and UNSIGNED_BYTE_MASK)
+        return value.takeIf { it >= 0 }
+    }
+
+    private fun sha256FirstTwo(bytes: ByteArray): ByteArray =
+        MessageDigest.getInstance("SHA-256").digest(bytes).copyOf(DEVICE_TOKEN_LEN)
+
+    public data class Parsed(
+        public val version: Int,
+        public val socketVersion: Int,
+        public val fastAdvertisement: Boolean,
+        public val secondProfile: Boolean,
+        public val serviceIdHash: ByteArray?,
+        public val data: ByteArray,
+        public val deviceToken: ByteArray,
+        public val psm: Int,
+        public val rxInstantConnectionAdvertisement: ByteArray,
+    ) {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is Parsed) return false
+            return version == other.version &&
+                socketVersion == other.socketVersion &&
+                fastAdvertisement == other.fastAdvertisement &&
+                secondProfile == other.secondProfile &&
+                serviceIdHash.contentEqualsNullable(other.serviceIdHash) &&
+                data.contentEquals(other.data) &&
+                deviceToken.contentEquals(other.deviceToken) &&
+                psm == other.psm &&
+                rxInstantConnectionAdvertisement.contentEquals(other.rxInstantConnectionAdvertisement)
+        }
+
+        override fun hashCode(): Int {
+            var result = version
+            result = 31 * result + socketVersion
+            result = 31 * result + fastAdvertisement.hashCode()
+            result = 31 * result + secondProfile.hashCode()
+            result = 31 * result + (serviceIdHash?.contentHashCode() ?: 0)
+            result = 31 * result + data.contentHashCode()
+            result = 31 * result + deviceToken.contentHashCode()
+            result = 31 * result + psm
+            result = 31 * result + rxInstantConnectionAdvertisement.contentHashCode()
+            return result
+        }
+    }
+}
+
+private fun ByteArray?.contentEqualsNullable(other: ByteArray?): Boolean =
+    when {
+        this == null -> other == null
+        other == null -> false
+        else -> contentEquals(other)
+    }

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/BleAdvertisementHeader.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/BleAdvertisementHeader.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+@file:Suppress("ReturnCount")
+
+package io.github.kyujincho.wvmg.protocol.endpoint
+
+/**
+ * Nearby BLE v2 GATT advertisement header.
+ *
+ * Stock Quick Share may put this compact header in the `0xFEF3`
+ * service-data value instead of the full fast-advertisement body. The header
+ * tells the scanner to connect to the advertiser's GATT service and read one
+ * or more advertisement slots (`00000000-0000-3000-8000-...`) for the actual
+ * [BleServiceData] payload.
+ */
+public data class BleAdvertisementHeader(
+    public val version: Int,
+    public val supportsExtendedAdvertisement: Boolean,
+    public val numSlots: Int,
+    public val serviceIdBloomFilter: ByteArray,
+    public val advertisementHash: ByteArray,
+    public val psm: Int,
+) {
+    init {
+        require(version == VERSION) { "Only BLE advertisement-header v2 is supported, got $version" }
+        require(numSlots in 0..NUM_SLOTS_MASK) { "numSlots must fit in 4 bits, got $numSlots" }
+        require(serviceIdBloomFilter.size == SERVICE_ID_BLOOM_FILTER_LEN) {
+            "serviceIdBloomFilter must be $SERVICE_ID_BLOOM_FILTER_LEN bytes"
+        }
+        require(advertisementHash.size == ADVERTISEMENT_HASH_LEN) {
+            "advertisementHash must be $ADVERTISEMENT_HASH_LEN bytes"
+        }
+        require(psm in 0..MAX_PSM) { "psm must fit in uint16, got $psm" }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is BleAdvertisementHeader) return false
+        return version == other.version &&
+            supportsExtendedAdvertisement == other.supportsExtendedAdvertisement &&
+            numSlots == other.numSlots &&
+            serviceIdBloomFilter.contentEquals(other.serviceIdBloomFilter) &&
+            advertisementHash.contentEquals(other.advertisementHash) &&
+            psm == other.psm
+    }
+
+    override fun hashCode(): Int {
+        var result = version
+        result = 31 * result + supportsExtendedAdvertisement.hashCode()
+        result = 31 * result + numSlots
+        result = 31 * result + serviceIdBloomFilter.contentHashCode()
+        result = 31 * result + advertisementHash.contentHashCode()
+        result = 31 * result + psm
+        return result
+    }
+
+    public companion object {
+        public const val VERSION: Int = 2
+        public const val SERVICE_ID_BLOOM_FILTER_LEN: Int = 10
+        public const val ADVERTISEMENT_HASH_LEN: Int = 4
+        public const val MIN_HEADER_LEN: Int = 1 + SERVICE_ID_BLOOM_FILTER_LEN + ADVERTISEMENT_HASH_LEN
+        public const val HEADER_WITH_PSM_LEN: Int = MIN_HEADER_LEN + 2
+
+        private const val VERSION_MASK: Int = 0xE0
+        private const val VERSION_SHIFT: Int = 5
+        private const val EXTENDED_ADVERTISEMENT_MASK: Int = 0x10
+        private const val NUM_SLOTS_MASK: Int = 0x0F
+        private const val MAX_PSM: Int = 0xFFFF
+        private const val UNSIGNED_BYTE_MASK: Int = 0xFF
+
+        /**
+         * Parses either the stock base64-url encoded service-data header or
+         * the raw decoded bytes. Returns `null` for unrelated `0xFEF3`
+         * payloads, malformed base64, unsupported versions, and truncation.
+         */
+        @Suppress("ReturnCount")
+        @JvmStatic
+        public fun parse(serviceData: ByteArray): BleAdvertisementHeader? {
+            val raw = decodeHeaderBytes(serviceData) ?: return null
+            if (raw.size != MIN_HEADER_LEN && raw.size != HEADER_WITH_PSM_LEN) return null
+
+            val first = raw[0].toInt() and UNSIGNED_BYTE_MASK
+            val version = (first and VERSION_MASK) ushr VERSION_SHIFT
+            if (version != VERSION) return null
+            val supportsExtendedAdvertisement = (first and EXTENDED_ADVERTISEMENT_MASK) != 0
+            val numSlots = first and NUM_SLOTS_MASK
+
+            var offset = 1
+            val serviceIdBloomFilter = raw.copyOfRange(offset, offset + SERVICE_ID_BLOOM_FILTER_LEN)
+            offset += SERVICE_ID_BLOOM_FILTER_LEN
+            val advertisementHash = raw.copyOfRange(offset, offset + ADVERTISEMENT_HASH_LEN)
+            offset += ADVERTISEMENT_HASH_LEN
+            val psm =
+                if (raw.size == HEADER_WITH_PSM_LEN) {
+                    ((raw[offset].toInt() and UNSIGNED_BYTE_MASK) shl Byte.SIZE_BITS) or
+                        (raw[offset + 1].toInt() and UNSIGNED_BYTE_MASK)
+                } else {
+                    0
+                }
+
+            return BleAdvertisementHeader(
+                version = version,
+                supportsExtendedAdvertisement = supportsExtendedAdvertisement,
+                numSlots = numSlots,
+                serviceIdBloomFilter = serviceIdBloomFilter,
+                advertisementHash = advertisementHash,
+                psm = psm,
+            )
+        }
+
+        private fun decodeHeaderBytes(serviceData: ByteArray): ByteArray? {
+            if (serviceData.size == MIN_HEADER_LEN || serviceData.size == HEADER_WITH_PSM_LEN) {
+                return serviceData
+            }
+            val encoded =
+                runCatching { String(serviceData, Charsets.US_ASCII) }
+                    .getOrNull()
+                    ?: return null
+            return Base64Url.decode(encoded)
+        }
+    }
+}

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/BleServiceData.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/BleServiceData.kt
@@ -6,6 +6,7 @@
 package io.github.kyujincho.wvmg.protocol.endpoint
 
 import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
 
 /**
  * Quick Share **fast advertisement** BLE service-data payload (issue #121).
@@ -21,8 +22,14 @@ import java.nio.charset.StandardCharsets
  *
  * ### Wire format
  *
- * Captured verbatim from a Galaxy peer's broadcast during the c0150be
- * triage (see commit message):
+ * Stock Nearby Connections wraps the fast-advertisement body in a BLE v2
+ * frame before placing it in the `0xFEF3` service-data value:
+ *
+ * ```text
+ * [ 0x4a | body_len | versPCP | endpoint_id | info_len | EndpointInfo | device_token[2] ]
+ * ```
+ *
+ * The inner body shape captured from a Galaxy peer is:
  *
  * ```text
  * +--------+-------------------+--------+----------------------+
@@ -33,30 +40,32 @@ import java.nio.charset.StandardCharsets
  * +--------+-------------------+--------+----------------------+
  * ```
  *
- * - **byte 0** packs `version (3 bits, MSB) | pcp (5 bits)`. Stock peers
+ * - **body byte 0** packs `version (3 bits, MSB) | pcp (5 bits)`. Stock peers
  *   emit `version = 1`, `pcp = 3` (`PCP_HIGH` in google/nearby's
  *   `connections/implementation/mediums/ble_v2/ble_advertisement.cc`),
  *   yielding `0x23`.
- * - **bytes 1..4** are an ASCII-printable, 4-byte endpoint identifier.
+ * - **body bytes 1..4** are an ASCII-printable, 4-byte endpoint identifier.
  *   The same string also surfaces as `mDNS instance name`'s 4-byte slug
  *   prefix and in the protocol-level `endpoint_id` of
  *   `ConnectionRequestFrame`. Stock peers use base64-url-style
  *   characters (uppercase + lowercase + digits + `-` / `_`); we accept
  *   any byte in ASCII printable range to stay forward-compatible.
- * - **byte 5** is an unsigned 8-bit length giving how many EndpointInfo
+ * - **body byte 5** is an unsigned 8-bit length giving how many EndpointInfo
  *   bytes follow. Same byte that gates the abbreviated 17-byte hidden
  *   form in NearDrop's BLE captures (`0x11`) and the longer
  *   "name-included" form on Pixel.
- * - **bytes 6..N** are the **raw** [EndpointInfo.serialize] output —
+ * - **body bytes 6..N** are the **raw** [EndpointInfo.serialize] output —
  *   the exact same byte sequence we already put under the mDNS TXT key
  *   `n`, sans the URL-safe base64 wrapper. That keeps the on-the-wire
  *   identity of a peer aligned across the two channels.
  *
  * The payload is intentionally compact: with a hidden EndpointInfo
- * (no inline name, no TLV records) the total is **23 bytes**
- * (1 + 4 + 1 + 17), which fits comfortably alongside the 16-bit
- * `service-data` AD header inside the legacy 31-byte advertising-PDU
- * budget without needing extended advertising.
+ * (no inline name, no TLV records) the inner body is **23 bytes**
+ * (1 + 4 + 1 + 17). Stock peers append a 2-byte device token after the
+ * length-delimited body, making the framed service-data value
+ * **27 bytes**. That still fits alongside the 16-bit `service-data` AD
+ * header inside the legacy 31-byte advertising-PDU budget without
+ * needing extended advertising.
  *
  * ### Why this lives in `:core-protocol`
  *
@@ -89,6 +98,27 @@ public object BleServiceData {
 
     /** Length of the version/PCP header byte. */
     public const val HEADER_LEN: Int = 1
+
+    /** BLE v2 frame type used by stock Nearby for fast advertisements. */
+    public const val FRAME_TYPE_FAST_ADVERTISEMENT: Int = 0x4A
+
+    /** Length of the BLE v2 frame type + frame-length prefix. */
+    public const val FRAME_HEADER_LEN: Int = 2
+
+    /** Length of the trailing Nearby Mediums device token. */
+    public const val DEVICE_TOKEN_LEN: Int = 2
+
+    /** One-byte extra-field mask appended by stock Nearby extended BLE advertisements. */
+    public const val EXTRA_FIELDS_MASK_LEN: Int = 1
+
+    /** Extra-field bit that indicates a following two-byte BLE L2CAP PSM value. */
+    public const val EXTRA_FIELD_PSM_MASK: Int = 0x01
+
+    /** Length of a PSM value in Nearby's BLE extra-field trailer. */
+    public const val PSM_LEN: Int = 2
+
+    /** Maximum unsigned 16-bit PSM value. */
+    public const val MAX_PSM: Int = 0xFFFF
 
     /** Length of the ASCII endpoint_id slug. */
     public const val ENDPOINT_ID_LEN: Int = 4
@@ -136,6 +166,9 @@ public object BleServiceData {
      * sub-field limits; this only constrains the BLE framing.
      */
     public const val MAX_ENDPOINT_INFO_LEN: Int = 0xFF
+
+    /** Maximum inner body length describable by the BLE v2 frame prefix. */
+    public const val MAX_FRAME_BODY_LEN: Int = 0xFF
 
     /**
      * Encodes the canonical fast-advertisement service-data payload.
@@ -186,6 +219,111 @@ public object BleServiceData {
     }
 
     /**
+     * Encodes the stock `0xFEF3` service-data value.
+     *
+     * This wraps [encode]'s fast-advertisement body in the two-byte BLE
+     * v2 frame prefix captured from stock peers:
+     *
+     * ```text
+     * [ FRAME_TYPE_FAST_ADVERTISEMENT (0x4a) | body_len | body... | device_token[2] ]
+     * ```
+     *
+     * The trailing two bytes are outside the length-delimited body.
+     * Stock Nearby Mediums surfaces them as `deviceToken`; leaving them
+     * absent still lets the lower Nearby Connections scanner report an
+     * endpoint, but Samsung's Quick Share UI does not promote that peer
+     * to a visible share target in off-LAN discovery.
+     */
+    @JvmOverloads
+    @JvmStatic
+    public fun encodeFramed(
+        endpointId: ByteArray,
+        endpointInfo: EndpointInfo,
+        version: Int = DEFAULT_VERSION,
+        pcp: Int = DEFAULT_PCP,
+    ): ByteArray {
+        val body = encode(endpointId, endpointInfo, version, pcp)
+        require(body.size <= MAX_FRAME_BODY_LEN) {
+            "fast-advertisement body must fit in 1 byte (0..$MAX_FRAME_BODY_LEN), got ${body.size}"
+        }
+        val deviceToken = deriveDeviceToken(body)
+        val out = ByteArray(FRAME_HEADER_LEN + body.size + DEVICE_TOKEN_LEN)
+        out[0] = FRAME_TYPE_FAST_ADVERTISEMENT.toByte()
+        out[1] = body.size.toByte()
+        body.copyInto(out, destinationOffset = FRAME_HEADER_LEN)
+        deviceToken.copyInto(out, destinationOffset = FRAME_HEADER_LEN + body.size)
+        return out
+    }
+
+    /**
+     * Encodes the extended-advertising form of [encodeFramed] with Nearby's
+     * extra-field trailer carrying the BLE L2CAP PSM:
+     *
+     * ```text
+     * [ framed_fast_advertisement | extra_mask(0x01) | psm_be16 ]
+     * ```
+     *
+     * Stock Nearby only appends these extra fields to extended advertisements;
+     * the compact legacy 27-byte shape has no remaining AD budget.
+     */
+    @JvmOverloads
+    @JvmStatic
+    public fun encodeFramedWithPsm(
+        endpointId: ByteArray,
+        endpointInfo: EndpointInfo,
+        psm: Int,
+        version: Int = DEFAULT_VERSION,
+        pcp: Int = DEFAULT_PCP,
+    ): ByteArray {
+        require(psm in 1..MAX_PSM) { "psm must fit in uint16 and be non-zero, got $psm" }
+        val framed = encodeFramed(endpointId, endpointInfo, version, pcp)
+        val out = ByteArray(framed.size + EXTRA_FIELDS_MASK_LEN + PSM_LEN)
+        framed.copyInto(out)
+        out[framed.size] = EXTRA_FIELD_PSM_MASK.toByte()
+        out[framed.size + 1] = ((psm ushr Byte.SIZE_BITS) and UNSIGNED_BYTE_MASK).toByte()
+        out[framed.size + 2] = (psm and UNSIGNED_BYTE_MASK).toByte()
+        return out
+    }
+
+    /**
+     * String overload of [encodeFramedWithPsm].
+     */
+    @JvmOverloads
+    @JvmStatic
+    public fun encodeFramedWithPsm(
+        endpointId: String,
+        endpointInfo: EndpointInfo,
+        psm: Int,
+        version: Int = DEFAULT_VERSION,
+        pcp: Int = DEFAULT_PCP,
+    ): ByteArray =
+        encodeFramedWithPsm(
+            endpointId = asciiEndpointId(endpointId),
+            endpointInfo = endpointInfo,
+            psm = psm,
+            version = version,
+            pcp = pcp,
+        )
+
+    /**
+     * String overload of [encodeFramed].
+     */
+    @JvmOverloads
+    @JvmStatic
+    public fun encodeFramed(
+        endpointId: String,
+        endpointInfo: EndpointInfo,
+        version: Int = DEFAULT_VERSION,
+        pcp: Int = DEFAULT_PCP,
+    ): ByteArray =
+        encodeFramed(
+            endpointId = asciiEndpointId(endpointId),
+            endpointInfo = endpointInfo,
+            version = version,
+            pcp = pcp,
+        )
+
+    /**
      * Convenience wrapper that accepts the endpoint_id as an ASCII
      * [String]. The string must be exactly [ENDPOINT_ID_LEN] code units
      * long and contain only ASCII bytes — all stock peers do.
@@ -197,19 +335,7 @@ public object BleServiceData {
         endpointInfo: EndpointInfo,
         version: Int = DEFAULT_VERSION,
         pcp: Int = DEFAULT_PCP,
-    ): ByteArray {
-        // String.toByteArray(US_ASCII) silently substitutes '?' for any
-        // non-ASCII code point, so length-equality alone misses the case
-        // where every non-ASCII char encodes to a single byte. Walk the
-        // string explicitly and reject any code unit outside ASCII range.
-        for (ch in endpointId) {
-            require(ch.code in 0..ASCII_MAX) {
-                "endpointId must be ASCII (got non-ASCII char in '$endpointId')"
-            }
-        }
-        val bytes = endpointId.toByteArray(StandardCharsets.US_ASCII)
-        return encode(bytes, endpointInfo, version, pcp)
-    }
+    ): ByteArray = encode(asciiEndpointId(endpointId), endpointInfo, version, pcp)
 
     /**
      * Parses a fast-advertisement service-data payload back into its
@@ -226,6 +352,31 @@ public object BleServiceData {
     @Suppress("ReturnCount")
     @JvmStatic
     public fun parse(bytes: ByteArray): Parsed? {
+        unwrapFrame(bytes)?.let { framed ->
+            return parseBody(framed)
+        }
+        return parseBody(bytes)
+    }
+
+    /**
+     * Returns the BLE L2CAP PSM from a framed fast-advertisement extra-field
+     * trailer, or `null` when the payload is legacy, malformed, or has no PSM.
+     */
+    @Suppress("ReturnCount")
+    @JvmStatic
+    public fun parsePsmExtraField(bytes: ByteArray): Int? {
+        val offset = extraFieldsOffset(bytes) ?: return null
+        if (offset >= bytes.size) return null
+        val mask = bytes[offset].toInt() and UNSIGNED_BYTE_MASK
+        if ((mask and EXTRA_FIELD_PSM_MASK) == 0) return null
+        val psmOffset = offset + EXTRA_FIELDS_MASK_LEN
+        if (psmOffset + PSM_LEN > bytes.size) return null
+        return ((bytes[psmOffset].toInt() and UNSIGNED_BYTE_MASK) shl Byte.SIZE_BITS) or
+            (bytes[psmOffset + 1].toInt() and UNSIGNED_BYTE_MASK)
+    }
+
+    @Suppress("ReturnCount")
+    private fun parseBody(bytes: ByteArray): Parsed? {
         if (bytes.size < FIXED_HEADER_LEN) return null
         val header = bytes[0].toInt() and UNSIGNED_BYTE_MASK
         val version = (header ushr VERSION_SHIFT) and VERSION_MASK
@@ -243,6 +394,38 @@ public object BleServiceData {
         )
     }
 
+    @Suppress("ReturnCount")
+    private fun unwrapFrame(bytes: ByteArray): ByteArray? {
+        if (bytes.size < FRAME_HEADER_LEN) return null
+        if ((bytes[0].toInt() and UNSIGNED_BYTE_MASK) != FRAME_TYPE_FAST_ADVERTISEMENT) return null
+        val len = bytes[1].toInt() and UNSIGNED_BYTE_MASK
+        if (FRAME_HEADER_LEN + len > bytes.size) return null
+        return bytes.copyOfRange(FRAME_HEADER_LEN, FRAME_HEADER_LEN + len)
+    }
+
+    @Suppress("ReturnCount")
+    private fun extraFieldsOffset(bytes: ByteArray): Int? {
+        if (bytes.size < FRAME_HEADER_LEN) return null
+        if ((bytes[0].toInt() and UNSIGNED_BYTE_MASK) != FRAME_TYPE_FAST_ADVERTISEMENT) return null
+        val len = bytes[1].toInt() and UNSIGNED_BYTE_MASK
+        val offset = FRAME_HEADER_LEN + len + DEVICE_TOKEN_LEN
+        if (offset > bytes.size) return null
+        return offset
+    }
+
+    private fun asciiEndpointId(endpointId: String): ByteArray {
+        // String.toByteArray(US_ASCII) silently substitutes '?' for any
+        // non-ASCII code point, so length-equality alone misses the case
+        // where every non-ASCII char encodes to a single byte. Walk the
+        // string explicitly and reject any code unit outside ASCII range.
+        for (ch in endpointId) {
+            require(ch.code in 0..ASCII_MAX) {
+                "endpointId must be ASCII (got non-ASCII char in '$endpointId')"
+            }
+        }
+        return endpointId.toByteArray(StandardCharsets.US_ASCII)
+    }
+
     /**
      * Pack the version (top 3 bits) and PCP (bottom 5 bits) into byte 0.
      * `version=1, pcp=3` yields `0x23`, matching the captured Galaxy
@@ -252,6 +435,12 @@ public object BleServiceData {
         version: Int,
         pcp: Int,
     ): Byte = (((version and VERSION_MASK) shl VERSION_SHIFT) or (pcp and PCP_MASK)).toByte()
+
+    private fun deriveDeviceToken(body: ByteArray): ByteArray =
+        MessageDigest
+            .getInstance("SHA-256")
+            .digest(body)
+            .copyOfRange(0, DEVICE_TOKEN_LEN)
 
     /**
      * Validate that [bytes] is exactly [ENDPOINT_ID_LEN] long. We do not

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/DctAdvertisement.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/DctAdvertisement.kt
@@ -1,0 +1,317 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.endpoint
+
+import io.github.kyujincho.wvmg.protocol.crypto.Hkdf
+import java.io.ByteArrayOutputStream
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+
+/**
+ * Nearby Connections DCT BLE advertisement (`0xFC73`) used by stock Quick
+ * Share to expose a short receiver name without exceeding the 27-byte fast
+ * advertisement budget.
+ *
+ * Stock Nearby handles this service before normal fast-advertisement parsing:
+ * it parses the DCT fields, derives an endpoint id from the truncated device
+ * name, then builds a normal Nearby advertisement internally. WVMG uses this
+ * as the off-LAN identity hint while the canonical `0xFEF3` fast advertisement
+ * remains the compact hidden 27-byte shape.
+ */
+public object DctAdvertisement {
+    /** 16-bit DCT service UUID used by Nearby Connections BLE discovery. */
+    public const val SERVICE_UUID_SHORT: Int = 0xFC73
+
+    /** Canonical Bluetooth Base UUID expansion of [SERVICE_UUID_SHORT]. */
+    public const val SERVICE_UUID_128_STRING: String =
+        "0000fc73-0000-1000-8000-00805f9b34fb"
+
+    /** Current DCT advertisement version. Encoded in the top 3 bits of byte 0. */
+    public const val VERSION: Int = 1
+
+    /** Maximum UTF-8 byte length of the inline DCT device-name prefix. */
+    public const val MAX_DEVICE_NAME_BYTES: Int = 7
+
+    /** Default dedup value used by google/nearby's DCT tests. */
+    public const val DEFAULT_DEDUP: Int = 1
+
+    /** DCT PSM value meaning "no L2CAP PSM advertised"; keep BLE GATT as the data path. */
+    public const val DEFAULT_PSM: Int = 0
+
+    private const val SERVICE_ID_HASH_LEN = 2
+    private const val DEVICE_TOKEN_LEN = 2
+    private const val ENDPOINT_ID_LEN = 4
+    private const val DEDUP_MASK = 0x7F
+    private const val TRUNCATED_FLAG = 0x80
+    private const val VERSION_SHIFT = 5
+    private const val DATA_TYPE_SERVICE_ID_HASH = 0x05
+    private const val DATA_TYPE_PSM = 0x04
+    private const val DATA_TYPE_DEVICE_INFORMATION = 0x07
+    private const val UNSIGNED_BYTE_MASK = 0xFF
+    private const val TWO_BYTE_DE_FLAG = 0x80
+    private const val ONE_BYTE_DE_LENGTH_SHIFT = 4
+    private const val ONE_BYTE_DE_LENGTH_MASK = 0x07
+    private const val ONE_BYTE_DE_TYPE_MASK = 0x0F
+    private const val PSM_LEN = 2
+    private const val DEVICE_INFO_FIXED_LEN = 1
+    private const val HASH_ALGORITHM = "SHA-256"
+    private const val SERVICE_ID_HASH_SALT = "DCT Protocol"
+    private const val SERVICE_ID_HASH_INFO = "Service ID Hash"
+    private const val ENDPOINT_ID_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
+
+    /**
+     * Encodes a DCT advertisement service-data value.
+     *
+     * The production receiver intentionally allows [psm] to be `0`: stock
+     * parser code accepts it, and it prevents senders from preferring L2CAP
+     * before WVMG implements an L2CAP BLE socket server.
+     */
+    @JvmOverloads
+    @JvmStatic
+    public fun encode(
+        serviceId: String,
+        deviceName: String,
+        psm: Int = DEFAULT_PSM,
+        dedup: Int = DEFAULT_DEDUP,
+    ): ByteArray {
+        require(serviceId.isNotEmpty()) { "serviceId must not be empty" }
+        require(deviceName.isNotEmpty()) { "deviceName must not be empty" }
+        require(psm in 0..0xFFFF) { "psm must fit in uint16, got $psm" }
+        require(dedup in 0..DEDUP_MASK) { "dedup must fit in 7 bits (0..$DEDUP_MASK), got $dedup" }
+        require(hasValidSurrogates(deviceName)) { "deviceName must be valid Unicode" }
+
+        val originalNameBytes = deviceName.toByteArray(StandardCharsets.UTF_8)
+        val truncatedName = truncateUtf8(deviceName, MAX_DEVICE_NAME_BYTES)
+        val truncatedNameBytes = truncatedName.toByteArray(StandardCharsets.UTF_8)
+        val truncated = truncatedNameBytes.size < originalNameBytes.size
+        val deviceInfo =
+            byteArrayOf(((if (truncated) TRUNCATED_FLAG else 0) or dedup).toByte()) +
+                truncatedNameBytes
+
+        val output =
+            ByteArrayOutputStream().apply {
+                write(VERSION shl VERSION_SHIFT)
+                writeOneByteDataElement(DATA_TYPE_SERVICE_ID_HASH, computeServiceIdHash(serviceId))
+                writeOneByteDataElement(DATA_TYPE_PSM, psm.toBigEndianU16())
+                writeTwoByteDataElement(DATA_TYPE_DEVICE_INFORMATION, deviceInfo)
+            }
+
+        return output.toByteArray()
+    }
+
+    /**
+     * Parses a DCT service-data value. Returns `null` for malformed or
+     * unsupported data instead of throwing so scanners can ignore bad peers.
+     */
+    @Suppress("ReturnCount")
+    @JvmStatic
+    public fun parse(bytes: ByteArray): Parsed? {
+        val reader = Reader(bytes)
+        val header = reader.readU8() ?: return null
+        if (header != VERSION shl VERSION_SHIFT) return null
+
+        val serviceIdHash = reader.readDataElement() ?: return null
+        if (serviceIdHash.type != DATA_TYPE_SERVICE_ID_HASH ||
+            serviceIdHash.value.size != SERVICE_ID_HASH_LEN
+        ) {
+            return null
+        }
+
+        val psmElement = reader.readDataElement() ?: return null
+        if (psmElement.type != DATA_TYPE_PSM || psmElement.value.size != PSM_LEN) return null
+        val psm =
+            ((psmElement.value[0].toInt() and UNSIGNED_BYTE_MASK) shl Byte.SIZE_BITS) or
+                (psmElement.value[1].toInt() and UNSIGNED_BYTE_MASK)
+
+        val deviceInfo = reader.readDataElement() ?: return null
+        if (deviceInfo.type != DATA_TYPE_DEVICE_INFORMATION ||
+            deviceInfo.value.size < DEVICE_INFO_FIXED_LEN
+        ) {
+            return null
+        }
+        val flags = deviceInfo.value[0].toInt() and UNSIGNED_BYTE_MASK
+        val nameBytes = deviceInfo.value.copyOfRange(DEVICE_INFO_FIXED_LEN, deviceInfo.value.size)
+        val deviceName =
+            runCatching { String(nameBytes, StandardCharsets.UTF_8) }
+                .getOrNull()
+                ?: return null
+
+        return Parsed(
+            serviceIdHash = serviceIdHash.value.copyOf(),
+            psm = psm,
+            deviceName = deviceName,
+            isDeviceNameTruncated = (flags and TRUNCATED_FLAG) != 0,
+            dedup = flags and DEDUP_MASK,
+        )
+    }
+
+    /** HKDF-SHA256 hash used by DCT to match a Nearby service id. */
+    @JvmStatic
+    public fun computeServiceIdHash(serviceId: String): ByteArray =
+        Hkdf.derive(
+            ikm = serviceId.toByteArray(StandardCharsets.UTF_8),
+            salt = SERVICE_ID_HASH_SALT.toByteArray(StandardCharsets.US_ASCII),
+            info = SERVICE_ID_HASH_INFO.toByteArray(StandardCharsets.US_ASCII),
+            length = SERVICE_ID_HASH_LEN,
+        )
+
+    /** Device token stock Nearby derives from the DCT device name. */
+    @JvmStatic
+    public fun generateDeviceToken(deviceName: String): ByteArray =
+        sha256(deviceName.toByteArray(StandardCharsets.UTF_8)).copyOf(DEVICE_TOKEN_LEN)
+
+    /** Endpoint id stock Nearby derives from the DCT device name and dedup byte. */
+    @JvmStatic
+    public fun generateEndpointId(
+        dedup: Int,
+        deviceName: String,
+    ): String? {
+        if (deviceName.isEmpty() || dedup !in 0..DEDUP_MASK || !hasValidSurrogates(deviceName)) {
+            return null
+        }
+        val truncatedName = truncateUtf8(deviceName, MAX_DEVICE_NAME_BYTES)
+        val hashInput =
+            truncatedName.toByteArray(StandardCharsets.UTF_8) + byteArrayOf(dedup.toByte())
+        val hash = sha256(hashInput)
+        return buildString(ENDPOINT_ID_LEN) {
+            repeat(ENDPOINT_ID_LEN) { index ->
+                val unsigned = hash[index].toInt() and UNSIGNED_BYTE_MASK
+                append(ENDPOINT_ID_ALPHABET[unsigned % ENDPOINT_ID_ALPHABET.length])
+            }
+        }
+    }
+
+    private fun ByteArrayOutputStream.writeOneByteDataElement(
+        type: Int,
+        value: ByteArray,
+    ) {
+        require(type in 1..ONE_BYTE_DE_TYPE_MASK) { "one-byte data-element type out of range: $type" }
+        require(value.size <= ONE_BYTE_DE_LENGTH_MASK) {
+            "one-byte data-element value too large: ${value.size}"
+        }
+        write((value.size shl ONE_BYTE_DE_LENGTH_SHIFT) or type)
+        write(value)
+    }
+
+    private fun ByteArrayOutputStream.writeTwoByteDataElement(
+        type: Int,
+        value: ByteArray,
+    ) {
+        require(type in 1..UNSIGNED_BYTE_MASK) { "two-byte data-element type out of range: $type" }
+        require(value.size <= DEDUP_MASK) { "two-byte data-element value too large: ${value.size}" }
+        write(TWO_BYTE_DE_FLAG or value.size)
+        write(type)
+        write(value)
+    }
+
+    private fun Int.toBigEndianU16(): ByteArray =
+        byteArrayOf(
+            ((this ushr Byte.SIZE_BITS) and UNSIGNED_BYTE_MASK).toByte(),
+            (this and UNSIGNED_BYTE_MASK).toByte(),
+        )
+
+    private fun truncateUtf8(
+        value: String,
+        maxBytes: Int,
+    ): String {
+        val out = StringBuilder()
+        var offset = 0
+        var used = 0
+        while (offset < value.length) {
+            val codePoint = value.codePointAt(offset)
+            val next = String(Character.toChars(codePoint))
+            val nextSize = next.toByteArray(StandardCharsets.UTF_8).size
+            if (used + nextSize > maxBytes) break
+            out.append(next)
+            used += nextSize
+            offset += Character.charCount(codePoint)
+        }
+        return out.toString()
+    }
+
+    @Suppress("ReturnCount")
+    private fun hasValidSurrogates(value: String): Boolean {
+        var index = 0
+        while (index < value.length) {
+            val ch = value[index]
+            when {
+                ch.isHighSurrogate() -> {
+                    if (index + 1 >= value.length || !value[index + 1].isLowSurrogate()) {
+                        return false
+                    }
+                    index += 2
+                }
+                ch.isLowSurrogate() -> return false
+                else -> index++
+            }
+        }
+        return true
+    }
+
+    private fun sha256(bytes: ByteArray): ByteArray = MessageDigest.getInstance(HASH_ALGORITHM).digest(bytes)
+
+    /** Parsed DCT advertisement fields. */
+    public data class Parsed(
+        public val serviceIdHash: ByteArray,
+        public val psm: Int,
+        public val deviceName: String,
+        public val isDeviceNameTruncated: Boolean,
+        public val dedup: Int,
+    ) {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is Parsed) return false
+            return serviceIdHash.contentEquals(other.serviceIdHash) &&
+                psm == other.psm &&
+                deviceName == other.deviceName &&
+                isDeviceNameTruncated == other.isDeviceNameTruncated &&
+                dedup == other.dedup
+        }
+
+        override fun hashCode(): Int {
+            var result = serviceIdHash.contentHashCode()
+            result = 31 * result + psm
+            result = 31 * result + deviceName.hashCode()
+            result = 31 * result + isDeviceNameTruncated.hashCode()
+            result = 31 * result + dedup
+            return result
+        }
+    }
+
+    private data class DataElement(
+        val type: Int,
+        val value: ByteArray,
+    )
+
+    private class Reader(
+        private val bytes: ByteArray,
+    ) {
+        private var offset = 0
+
+        fun readU8(): Int? {
+            if (offset >= bytes.size) return null
+            return bytes[offset++].toInt() and UNSIGNED_BYTE_MASK
+        }
+
+        @Suppress("ReturnCount")
+        fun readDataElement(): DataElement? {
+            val first = readU8() ?: return null
+            val type: Int
+            val length: Int
+            if ((first and TWO_BYTE_DE_FLAG) != 0) {
+                length = first and DEDUP_MASK
+                type = readU8() ?: return null
+            } else {
+                length = (first ushr ONE_BYTE_DE_LENGTH_SHIFT) and ONE_BYTE_DE_LENGTH_MASK
+                type = first and ONE_BYTE_DE_TYPE_MASK
+            }
+            if (type == 0 || offset + length > bytes.size) return null
+            val value = bytes.copyOfRange(offset, offset + length)
+            offset += length
+            return DataElement(type, value)
+        }
+    }
+}

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/medium/MediumRegistry.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/medium/MediumRegistry.kt
@@ -21,6 +21,10 @@ package io.github.kyujincho.wvmg.protocol.medium
  *     registered provider's [MediumProvider.isSupported] into the set
  *     used to populate `ConnectionRequestFrame.mediums` on the sender
  *     side and to intersect the peer's mediums on the receiver side.
+ *     [supportedMediumsForCurrentTransport] is the current-medium-aware
+ *     variant for sessions whose initial control channel is not Wi-Fi
+ *     LAN: `WIFI_LAN` is only a meaningful "stay on this socket" marker
+ *     when the current socket is already Wi-Fi LAN.
  *  2. **Provider lookup** — [providerFor] retrieves the registered
  *     adapter for a chosen medium, used by [selectBestUpgrade] when
  *     the framework is ready to perform the bandwidth-upgrade
@@ -79,6 +83,21 @@ public class MediumRegistry(
             .toSet()
 
     /**
+     * Like [supportedMediums], but shaped for a connection already
+     * running on [currentMedium].
+     *
+     * `WIFI_LAN` in our protocol surface does not represent a generic
+     * upgrade path provider; it means "keep using the already-open
+     * LAN socket". Advertising it while the current control channel is
+     * Bluetooth/BLE/etc. would mislead the peer into thinking a LAN
+     * stay-put path exists when it does not.
+     */
+    public fun supportedMediumsForCurrentTransport(currentMedium: Medium): Set<Medium> =
+        supportedMediums().filterTo(linkedSetOf()) { medium ->
+            medium != Medium.WIFI_LAN || currentMedium == Medium.WIFI_LAN
+        }
+
+    /**
      * Return the registered provider for [medium], or `null` when no
      * provider was registered for it. Note this does NOT consult
      * [MediumProvider.isSupported]; the caller is responsible for
@@ -117,6 +136,24 @@ public class MediumRegistry(
     }
 
     /**
+     * Like [selectBestUpgrade], but excludes `WIFI_LAN` unless the
+     * session is already running on Wi-Fi LAN. This keeps a
+     * preconnected Bluetooth/BLE bootstrap from incorrectly resolving
+     * to "stay on current medium" via the Wi-Fi-LAN rung.
+     */
+    public fun selectBestUpgradeForCurrentTransport(
+        peerSupported: Set<Medium>,
+        currentMedium: Medium,
+        ladderOverride: MediumLadder = ladder,
+    ): Medium? {
+        val intersection =
+            supportedMediumsForCurrentTransport(currentMedium)
+                .intersect(peerSupported)
+        if (intersection.isEmpty()) return null
+        return ladderOverride.pickBest(intersection)
+    }
+
+    /**
      * Like [selectBestUpgrade], but attempts the server-side bring-up
      * for each shared medium in ladder order until one succeeds.
      *
@@ -143,6 +180,39 @@ public class MediumRegistry(
         ladderOverride: MediumLadder = ladder,
     ): PreparedUpgradeSelection? {
         val intersection = supportedMediums().intersect(peerSupported)
+        if (intersection.isEmpty()) return null
+        for (medium in ladderOverride.rungs) {
+            if (medium !in intersection) continue
+            val provider = providerFor(medium) ?: continue
+            if (!provider.isSupported()) continue
+            if (medium == Medium.WIFI_LAN) {
+                return PreparedUpgradeSelection.StayOnCurrentMedium
+            }
+            val credentials =
+                runCatching { provider.prepareUpgrade() }
+                    .getOrNull() ?: continue
+            return PreparedUpgradeSelection.Upgrade(credentials)
+        }
+        return null
+    }
+
+    /**
+     * Like [prepareBestUpgrade], but treats `WIFI_LAN` as a valid
+     * "stay on current transport" result only when [currentMedium] is
+     * actually [Medium.WIFI_LAN].
+     */
+    @Suppress(
+        "ReturnCount",
+        "LoopWithTooManyJumpStatements",
+    )
+    public suspend fun prepareBestUpgradeForCurrentTransport(
+        peerSupported: Set<Medium>,
+        currentMedium: Medium,
+        ladderOverride: MediumLadder = ladder,
+    ): PreparedUpgradeSelection? {
+        val intersection =
+            supportedMediumsForCurrentTransport(currentMedium)
+                .intersect(peerSupported)
         if (intersection.isEmpty()) return null
         for (medium in ladderOverride.rungs) {
             if (medium !in intersection) continue

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/medium/NearbyBleSocketFrames.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/medium/NearbyBleSocketFrames.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.medium
+
+import com.google.location.nearby.mediums.proto.BleFramesProto
+import com.google.protobuf.ByteString
+import io.github.kyujincho.wvmg.protocol.endpoint.NearbyServiceId
+
+/**
+ * Helpers for the Nearby BLE socket control packets carried inside the
+ * platform BLE GATT socket.
+ */
+public object NearbyBleSocketFrames {
+    /** Number of bytes in a Nearby service-id hash prefix. */
+    public const val SERVICE_ID_HASH_LEN: Int = 3
+
+    /** Three zero bytes mark a BLE socket control packet. */
+    public const val CONTROL_PACKET_PREFIX_LEN: Int = 3
+
+    private val controlPacketPrefix: ByteArray = ByteArray(CONTROL_PACKET_PREFIX_LEN)
+
+    /** Return a fresh copy of the control-packet prefix. */
+    @JvmStatic
+    public fun controlPacketPrefix(): ByteArray = controlPacketPrefix.copyOf()
+
+    /**
+     * Encode the BLE socket introduction packet stock Nearby sends
+     * immediately after the lower GATT socket is established.
+     */
+    @JvmStatic
+    public fun encodeIntroductionPacket(serviceIdHash: ByteArray = NearbyServiceId.hashPrefix): ByteArray {
+        validateServiceIdHash(serviceIdHash)
+        val introduction =
+            BleFramesProto.IntroductionFrame
+                .newBuilder()
+                .setServiceIdHash(ByteString.copyFrom(serviceIdHash))
+                .setSocketVersion(BleFramesProto.SocketVersion.V2)
+                .build()
+        val frame =
+            BleFramesProto.SocketControlFrame
+                .newBuilder()
+                .setType(BleFramesProto.SocketControlFrame.ControlFrameType.INTRODUCTION)
+                .setIntroduction(introduction)
+                .build()
+                .toByteArray()
+        return controlPacketPrefix + frame
+    }
+
+    /** Encode a BLE socket disconnection control packet. */
+    @JvmStatic
+    public fun encodeDisconnectionPacket(serviceIdHash: ByteArray = NearbyServiceId.hashPrefix): ByteArray {
+        validateServiceIdHash(serviceIdHash)
+        val disconnection =
+            BleFramesProto.DisconnectionFrame
+                .newBuilder()
+                .setServiceIdHash(ByteString.copyFrom(serviceIdHash))
+                .build()
+        val frame =
+            BleFramesProto.SocketControlFrame
+                .newBuilder()
+                .setType(BleFramesProto.SocketControlFrame.ControlFrameType.DISCONNECTION)
+                .setDisconnection(disconnection)
+                .build()
+                .toByteArray()
+        return controlPacketPrefix + frame
+    }
+
+    /** Encode a BLE socket acknowledgement for the last data packet length read. */
+    @JvmStatic
+    public fun encodePacketAcknowledgementPacket(
+        receivedSize: Int,
+        serviceIdHash: ByteArray = NearbyServiceId.hashPrefix,
+    ): ByteArray {
+        validateServiceIdHash(serviceIdHash)
+        require(receivedSize >= 0) { "receivedSize must be non-negative" }
+        val acknowledgement =
+            BleFramesProto.PacketAcknowledgementFrame
+                .newBuilder()
+                .setServiceIdHash(ByteString.copyFrom(serviceIdHash))
+                .setReceivedSize(receivedSize)
+                .build()
+        val frame =
+            BleFramesProto.SocketControlFrame
+                .newBuilder()
+                .setType(BleFramesProto.SocketControlFrame.ControlFrameType.PACKET_ACKNOWLEDGEMENT)
+                .setPacketAcknowledgement(acknowledgement)
+                .build()
+                .toByteArray()
+        return controlPacketPrefix + frame
+    }
+
+    /** Parse a complete prefix + proto BLE socket control packet. */
+    @JvmStatic
+    public fun parseControlPacket(packet: ByteArray): BleFramesProto.SocketControlFrame? {
+        val hasControlPrefix =
+            packet.size > CONTROL_PACKET_PREFIX_LEN &&
+                controlPacketPrefix.indices.all { index -> packet[index] == 0.toByte() }
+        if (!hasControlPrefix) return null
+        val proto = packet.copyOfRange(CONTROL_PACKET_PREFIX_LEN, packet.size)
+        return runCatching { BleFramesProto.SocketControlFrame.parseFrom(proto) }.getOrNull()
+    }
+
+    private fun validateServiceIdHash(serviceIdHash: ByteArray) {
+        require(serviceIdHash.size == SERVICE_ID_HASH_LEN) {
+            "serviceIdHash must be $SERVICE_ID_HASH_LEN bytes, got ${serviceIdHash.size}"
+        }
+    }
+}

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/medium/NearbyMultiplexFrames.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/medium/NearbyMultiplexFrames.kt
@@ -104,6 +104,36 @@ public object NearbyMultiplexFrames {
         return frame.toByteArray()
     }
 
+    /** Build a CONNECTION_REQUEST control frame for opening one virtual socket. */
+    @JvmStatic
+    public fun encodeConnectionRequestFrame(
+        saltedServiceIdHash: ByteArray,
+        serviceIdHashSalt: String,
+    ): ByteArray {
+        validateServiceIdHash(saltedServiceIdHash)
+        val header =
+            MultiplexFramesProto.MultiplexFrameHeader
+                .newBuilder()
+                .setSaltedServiceIdHash(ByteString.copyFrom(saltedServiceIdHash))
+                .setServiceIdHashSalt(serviceIdHashSalt)
+                .build()
+        val controlFrame =
+            MultiplexFramesProto.MultiplexControlFrame
+                .newBuilder()
+                .setControlFrameType(
+                    MultiplexFramesProto.MultiplexControlFrame.MultiplexControlFrameType.CONNECTION_REQUEST,
+                ).setConnectionRequestFrame(MultiplexFramesProto.ConnectionRequestFrame.getDefaultInstance())
+                .build()
+        val frame =
+            MultiplexFramesProto.MultiplexFrame
+                .newBuilder()
+                .setFrameType(MultiplexFramesProto.MultiplexFrame.MultiplexFrameType.CONTROL_FRAME)
+                .setHeader(header)
+                .setControlFrame(controlFrame)
+                .build()
+        return frame.toByteArray()
+    }
+
     /** Build a DATA_FRAME carrying [data] for a virtual socket. */
     @JvmStatic
     public fun encodeDataFrame(

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/medium/NearbyMultiplexFrames.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/medium/NearbyMultiplexFrames.kt
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+@file:Suppress("MagicNumber")
+
+package io.github.kyujincho.wvmg.protocol.medium
+
+import com.google.location.nearby.mediums.proto.MultiplexFramesProto
+import com.google.protobuf.ByteString
+import io.github.kyujincho.wvmg.protocol.endpoint.NearbyServiceId
+import java.security.MessageDigest
+
+/**
+ * Minimal encoder/parser for Nearby's multiplex socket framing.
+ *
+ * A stock BLE socket is only the physical pipe. Nearby wraps it in a
+ * length-prefixed MultiplexFrame stream, then presents a virtual socket to
+ * the normal OfflineFrame protocol.
+ */
+public object NearbyMultiplexFrames {
+    /** 4-byte big-endian physical frame length prefix. */
+    public const val LENGTH_PREFIX_BYTES: Int = 4
+
+    /** Nearby multiplex service-id hashes are SHA-256 prefixes. */
+    public const val SERVICE_ID_HASH_LEN: Int = 3
+
+    /** Return `SHA-256(serviceId).first(3)`. */
+    @JvmStatic
+    public fun serviceIdHash(serviceId: String = NearbyServiceId.VALUE): ByteArray =
+        sha256(serviceId.toByteArray(Charsets.UTF_8)).copyOf(SERVICE_ID_HASH_LEN)
+
+    /** Return `SHA-256(serviceId + salt).first(3)`. */
+    @JvmStatic
+    public fun saltedServiceIdHash(
+        serviceId: String = NearbyServiceId.VALUE,
+        salt: String,
+    ): ByteArray = sha256((serviceId + salt).toByteArray(Charsets.UTF_8)).copyOf(SERVICE_ID_HASH_LEN)
+
+    /** Prefix [payload] with its 4-byte big-endian length. */
+    @JvmStatic
+    public fun encodeLengthPrefixed(payload: ByteArray): ByteArray {
+        val out = ByteArray(LENGTH_PREFIX_BYTES + payload.size)
+        writeLength(payload.size, out, 0)
+        payload.copyInto(out, destinationOffset = LENGTH_PREFIX_BYTES)
+        return out
+    }
+
+    /** Decode a 4-byte big-endian length prefix from [bytes] at [offset]. */
+    @JvmStatic
+    public fun decodeLength(
+        bytes: ByteArray,
+        offset: Int = 0,
+    ): Int? {
+        if (offset < 0 || bytes.size - offset < LENGTH_PREFIX_BYTES) return null
+        return ((bytes[offset].toInt() and 0xFF) shl 24) or
+            ((bytes[offset + 1].toInt() and 0xFF) shl 16) or
+            ((bytes[offset + 2].toInt() and 0xFF) shl 8) or
+            (bytes[offset + 3].toInt() and 0xFF)
+    }
+
+    /** Parse one serialized MultiplexFrame, returning `null` when invalid. */
+    @JvmStatic
+    public fun parseFrame(bytes: ByteArray): MultiplexFramesProto.MultiplexFrame? =
+        runCatching { MultiplexFramesProto.MultiplexFrame.parseFrom(bytes) }
+            .getOrNull()
+            ?.takeIf(::isValid)
+
+    /** Build a CONNECTION_ACCEPTED / NOT_LISTENING response frame. */
+    @JvmStatic
+    public fun encodeConnectionResponseFrame(
+        saltedServiceIdHash: ByteArray,
+        serviceIdHashSalt: String,
+        responseCode: MultiplexFramesProto.ConnectionResponseFrame.ConnectionResponseCode =
+            MultiplexFramesProto.ConnectionResponseFrame.ConnectionResponseCode.CONNECTION_ACCEPTED,
+    ): ByteArray {
+        validateServiceIdHash(saltedServiceIdHash)
+        val header =
+            MultiplexFramesProto.MultiplexFrameHeader
+                .newBuilder()
+                .setSaltedServiceIdHash(ByteString.copyFrom(saltedServiceIdHash))
+                .setServiceIdHashSalt(serviceIdHashSalt)
+                .build()
+        val responseFrame =
+            MultiplexFramesProto.ConnectionResponseFrame
+                .newBuilder()
+                .setConnectionResponseCode(responseCode)
+                .build()
+        val controlFrame =
+            MultiplexFramesProto.MultiplexControlFrame
+                .newBuilder()
+                .setControlFrameType(
+                    MultiplexFramesProto.MultiplexControlFrame.MultiplexControlFrameType.CONNECTION_RESPONSE,
+                ).setConnectionResponseFrame(responseFrame)
+                .build()
+        val frame =
+            MultiplexFramesProto.MultiplexFrame
+                .newBuilder()
+                .setFrameType(MultiplexFramesProto.MultiplexFrame.MultiplexFrameType.CONTROL_FRAME)
+                .setHeader(header)
+                .setControlFrame(controlFrame)
+                .build()
+        return frame.toByteArray()
+    }
+
+    /** Build a DATA_FRAME carrying [data] for a virtual socket. */
+    @JvmStatic
+    public fun encodeDataFrame(
+        saltedServiceIdHash: ByteArray,
+        data: ByteArray,
+        serviceIdHashSalt: String? = null,
+    ): ByteArray {
+        validateServiceIdHash(saltedServiceIdHash)
+        val header =
+            MultiplexFramesProto.MultiplexFrameHeader
+                .newBuilder()
+                .setSaltedServiceIdHash(ByteString.copyFrom(saltedServiceIdHash))
+                .also { builder ->
+                    if (serviceIdHashSalt != null) builder.setServiceIdHashSalt(serviceIdHashSalt)
+                }.build()
+        val dataFrame =
+            MultiplexFramesProto.MultiplexDataFrame
+                .newBuilder()
+                .setData(ByteString.copyFrom(data))
+                .build()
+        val frame =
+            MultiplexFramesProto.MultiplexFrame
+                .newBuilder()
+                .setFrameType(MultiplexFramesProto.MultiplexFrame.MultiplexFrameType.DATA_FRAME)
+                .setHeader(header)
+                .setDataFrame(dataFrame)
+                .build()
+        return frame.toByteArray()
+    }
+
+    /** Build a DISCONNECTION control frame. */
+    @JvmStatic
+    public fun encodeDisconnectionFrame(
+        saltedServiceIdHash: ByteArray,
+        serviceIdHashSalt: String,
+    ): ByteArray {
+        validateServiceIdHash(saltedServiceIdHash)
+        val header =
+            MultiplexFramesProto.MultiplexFrameHeader
+                .newBuilder()
+                .setSaltedServiceIdHash(ByteString.copyFrom(saltedServiceIdHash))
+                .setServiceIdHashSalt(serviceIdHashSalt)
+                .build()
+        val controlFrame =
+            MultiplexFramesProto.MultiplexControlFrame
+                .newBuilder()
+                .setControlFrameType(
+                    MultiplexFramesProto.MultiplexControlFrame.MultiplexControlFrameType.DISCONNECTION,
+                ).build()
+        val frame =
+            MultiplexFramesProto.MultiplexFrame
+                .newBuilder()
+                .setFrameType(MultiplexFramesProto.MultiplexFrame.MultiplexFrameType.CONTROL_FRAME)
+                .setHeader(header)
+                .setControlFrame(controlFrame)
+                .build()
+        return frame.toByteArray()
+    }
+
+    private fun isValid(frame: MultiplexFramesProto.MultiplexFrame): Boolean {
+        if (!frame.hasHeader() || frame.header.saltedServiceIdHash.size() != SERVICE_ID_HASH_LEN) return false
+        return when (frame.frameType) {
+            MultiplexFramesProto.MultiplexFrame.MultiplexFrameType.CONTROL_FRAME -> frame.hasControlFrame()
+            MultiplexFramesProto.MultiplexFrame.MultiplexFrameType.DATA_FRAME -> frame.hasDataFrame()
+            else -> false
+        }
+    }
+
+    private fun validateServiceIdHash(serviceIdHash: ByteArray) {
+        require(serviceIdHash.size == SERVICE_ID_HASH_LEN) {
+            "serviceIdHash must be $SERVICE_ID_HASH_LEN bytes, got ${serviceIdHash.size}"
+        }
+    }
+
+    private fun writeLength(
+        length: Int,
+        out: ByteArray,
+        offset: Int,
+    ) {
+        out[offset] = (length ushr 24).toByte()
+        out[offset + 1] = (length ushr 16).toByte()
+        out[offset + 2] = (length ushr 8).toByte()
+        out[offset + 3] = length.toByte()
+    }
+
+    private fun sha256(bytes: ByteArray): ByteArray = MessageDigest.getInstance("SHA-256").digest(bytes)
+}

--- a/core-protocol/src/main/proto/ble_frames.proto
+++ b/core-protocol/src/main/proto/ble_frames.proto
@@ -1,0 +1,57 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto2";
+
+package location.nearby.mediums;
+
+option optimize_for = LITE_RUNTIME;
+option java_outer_classname = "BleFramesProto";
+option java_package = "com.google.location.nearby.mediums.proto";
+option objc_class_prefix = "GNCM";
+
+enum SocketVersion {
+  UNKNOWN_SOCKET_VERSION = 0;
+  V1 = 1;
+  V2 = 2;
+}
+
+message SocketControlFrame {
+  enum ControlFrameType {
+    UNKNOWN_CONTROL_FRAME_TYPE = 0;
+    INTRODUCTION = 1;
+    DISCONNECTION = 2;
+    PACKET_ACKNOWLEDGEMENT = 3;
+  }
+
+  optional ControlFrameType type = 1;
+  optional IntroductionFrame introduction = 2;
+  optional DisconnectionFrame disconnection = 3;
+  optional PacketAcknowledgementFrame packet_acknowledgement = 4;
+}
+
+message IntroductionFrame {
+  optional bytes service_id_hash = 1;
+  optional SocketVersion socket_version = 2;
+  optional string service_id_hash_salt = 3;
+}
+
+message DisconnectionFrame {
+  optional bytes service_id_hash = 1;
+}
+
+message PacketAcknowledgementFrame {
+  optional bytes service_id_hash = 1;
+  optional int32 received_size = 2;
+}

--- a/core-protocol/src/main/proto/multiplex_frames.proto
+++ b/core-protocol/src/main/proto/multiplex_frames.proto
@@ -1,0 +1,76 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto2";
+
+package location.nearby.mediums;
+
+option optimize_for = LITE_RUNTIME;
+option java_outer_classname = "MultiplexFramesProto";
+option java_package = "com.google.location.nearby.mediums.proto";
+option objc_class_prefix = "GNCM";
+
+message MultiplexFrame {
+  enum MultiplexFrameType {
+    UNKNOWN_FRAME_TYPE = 0;
+    CONTROL_FRAME = 1;
+    DATA_FRAME = 2;
+  }
+
+  optional MultiplexFrameHeader header = 1;
+  optional MultiplexFrameType frame_type = 2;
+  oneof Frame {
+    MultiplexControlFrame control_frame = 3;
+    MultiplexDataFrame data_frame = 4;
+  }
+}
+
+message MultiplexFrameHeader {
+  optional bytes salted_service_id_hash = 1;
+  optional string service_id_hash_salt = 2;
+}
+
+message MultiplexControlFrame {
+  enum MultiplexControlFrameType {
+    UNKNOWN_CONTROL_FRAME_TYPE = 0;
+    CONNECTION_REQUEST = 1;
+    CONNECTION_RESPONSE = 2;
+    DISCONNECTION = 3;
+  }
+
+  optional MultiplexControlFrameType control_frame_type = 1;
+  oneof Frame {
+    ConnectionRequestFrame connection_request_frame = 2;
+    ConnectionResponseFrame connection_response_frame = 3;
+    DisconnectFrame disconnect_frame = 4;
+  }
+}
+
+message ConnectionRequestFrame {}
+
+message ConnectionResponseFrame {
+  enum ConnectionResponseCode {
+    UNKNOWN_RESPONSE_CODE = 0;
+    CONNECTION_ACCEPTED = 1;
+    NOT_LISTENING = 2;
+  }
+
+  optional ConnectionResponseCode connection_response_code = 1;
+}
+
+message DisconnectFrame {}
+
+message MultiplexDataFrame {
+  optional bytes data = 1;
+}

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeFramesTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeFramesTest.kt
@@ -29,6 +29,7 @@ class BandwidthUpgradeFramesTest {
             )
         val parsed = parse(frame)
         assertThat(parsed.eventType).isEqualTo(BandwidthUpgradeNegotiationFrame.EventType.UPGRADE_PATH_AVAILABLE)
+        assertThat(parsed.upgradePathInfo.supportsClientIntroductionAck).isTrue()
         assertThat(parsed.upgradePathInfo.medium.number).isEqualTo(Medium.WIFI_LAN.wireNumber)
         assertThat(parsed.upgradePathInfo.hasWifiLanSocket()).isTrue()
         assertThat(parsed.upgradePathInfo.wifiLanSocket.wifiPort).isEqualTo(4433)
@@ -45,6 +46,7 @@ class BandwidthUpgradeFramesTest {
                 UpgradePathCredentials.Generic(Medium.WIFI_DIRECT),
             )
         val parsed = parse(frame)
+        assertThat(parsed.upgradePathInfo.supportsClientIntroductionAck).isTrue()
         assertThat(parsed.upgradePathInfo.medium.number).isEqualTo(Medium.WIFI_DIRECT.wireNumber)
         assertThat(parsed.upgradePathInfo.hasWifiLanSocket()).isFalse()
     }
@@ -378,6 +380,7 @@ class BandwidthUpgradeFramesTest {
             )
         val parsed = parse(frame)
         assertThat(parsed.upgradePathInfo.medium.number).isEqualTo(Medium.WIFI_DIRECT.wireNumber)
+        assertThat(parsed.upgradePathInfo.supportsClientIntroductionAck).isTrue()
         assertThat(parsed.upgradePathInfo.hasWifiDirectCredentials()).isTrue()
         val direct = parsed.upgradePathInfo.wifiDirectCredentials
         assertThat(direct.ssid).isEqualTo("DIRECT-aB-test")

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeOrchestratorTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeOrchestratorTest.kt
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.connection
+
+import com.google.common.truth.Truth.assertThat
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.BandwidthUpgradeNegotiationFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.KeepAliveFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.V1Frame
+import io.github.kyujincho.wvmg.protocol.crypto.D2DKeyDerivation
+import io.github.kyujincho.wvmg.protocol.crypto.D2DRole
+import io.github.kyujincho.wvmg.protocol.crypto.D2DSessionKeys
+import io.github.kyujincho.wvmg.protocol.crypto.securemessage.SecureChannel
+import io.github.kyujincho.wvmg.protocol.medium.Medium
+import io.github.kyujincho.wvmg.protocol.medium.MediumLadder
+import io.github.kyujincho.wvmg.protocol.medium.MediumProvider
+import io.github.kyujincho.wvmg.protocol.medium.MediumRegistry
+import io.github.kyujincho.wvmg.protocol.medium.UpgradePathCredentials
+import io.github.kyujincho.wvmg.protocol.medium.UpgradedTransport
+import io.github.kyujincho.wvmg.protocol.transport.FramedConnection
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.Socket
+import java.security.SecureRandom
+import java.util.Collections
+
+class BandwidthUpgradeOrchestratorTest {
+    private val openedSockets = mutableListOf<Socket>()
+
+    @AfterEach
+    fun tearDown() {
+        openedSockets.forEach { runCatching { it.close() } }
+    }
+
+    @Test
+    fun `server completes upgrade when peer omits safe-to-close and writes upgraded frame`() =
+        runBlocking {
+            withTimeout(WALLCLOCK_TIMEOUT_MILLIS) {
+                val (oldClientSocket, oldServerSocket) = connectedSocketPair()
+                val (newClientSocket, newServerSocket) = connectedSocketPair()
+                val oldClientChannel =
+                    SecureChannel(
+                        FramedConnection(oldClientSocket),
+                        freshSessionKeys(D2DRole.CLIENT),
+                        SecureRandom(),
+                    )
+                val oldServerChannel =
+                    SecureChannel(
+                        FramedConnection(oldServerSocket),
+                        freshSessionKeys(D2DRole.SERVER),
+                        SecureRandom(),
+                    )
+                val newClientFramed = FramedConnection(newClientSocket)
+                val registry =
+                    MediumRegistry(
+                        providers = listOf(serverProvider(newServerSocket)),
+                        ladder = MediumLadder(listOf(Medium.WIFI_DIRECT)),
+                    )
+                val logs = Collections.synchronizedList(mutableListOf<String>())
+                val upgradedFrame = keepAliveFrame()
+
+                coroutineScope {
+                    val server =
+                        async {
+                            BandwidthUpgradeOrchestrator.runServerUpgradeIfAvailable(
+                                oldChannel = oldServerChannel,
+                                currentMedium = Medium.BLE,
+                                mediumRegistry = registry,
+                                peerSupportedMediums = setOf(Medium.WIFI_DIRECT),
+                                peerEndpointId = ENDPOINT_ID,
+                                logger = logs::add,
+                            )
+                        }
+                    val client =
+                        async {
+                            val offer = oldClientChannel.receiveOfflineFrame()
+                            offer.assertUpgradeEvent(BandwidthUpgradeNegotiationFrame.EventType.UPGRADE_PATH_AVAILABLE)
+                            assertThat(
+                                offer.v1.bandwidthUpgradeNegotiation.upgradePathInfo.supportsClientIntroductionAck,
+                            ).isTrue()
+
+                            newClientFramed.sendFrame(
+                                BandwidthUpgradeFrames
+                                    .clientIntroduction(ENDPOINT_ID)
+                                    .toByteArray(),
+                            )
+                            newClientFramed
+                                .receiveRawOfflineFrame()
+                                .assertUpgradeEvent(
+                                    BandwidthUpgradeNegotiationFrame.EventType.CLIENT_INTRODUCTION_ACK,
+                                )
+                            val newClientChannel = oldClientChannel.withTransport(newClientFramed)
+
+                            oldClientChannel
+                                .receiveOfflineFrame()
+                                .assertUpgradeEvent(
+                                    BandwidthUpgradeNegotiationFrame.EventType.LAST_WRITE_TO_PRIOR_CHANNEL,
+                                )
+                            oldClientChannel.sendOfflineFrame(BandwidthUpgradeFrames.lastWriteToPriorChannel())
+                            oldClientChannel
+                                .receiveOfflineFrame()
+                                .assertUpgradeEvent(
+                                    BandwidthUpgradeNegotiationFrame.EventType.SAFE_TO_CLOSE_PRIOR_CHANNEL,
+                                )
+                            newClientChannel.sendOfflineFrame(upgradedFrame)
+                        }
+
+                    val activeTransport = server.await()
+                    client.await()
+
+                    assertThat(activeTransport.medium).isEqualTo(Medium.WIFI_DIRECT)
+                    assertThat(activeTransport.bufferedFrames).containsExactly(upgradedFrame)
+                }
+
+                assertThat(logs.joinToString("\n")).contains("peer SAFE_TO_CLOSE omitted")
+            }
+        }
+
+    @Test
+    fun `server sends prior-channel safe-to-close after raw introduction ack`() =
+        runBlocking {
+            withTimeout(WALLCLOCK_TIMEOUT_MILLIS) {
+                val (oldClientSocket, oldServerSocket) = connectedSocketPair()
+                val (newClientSocket, newServerSocket) = connectedSocketPair()
+                val oldClientChannel =
+                    SecureChannel(
+                        FramedConnection(oldClientSocket),
+                        freshSessionKeys(D2DRole.CLIENT),
+                        SecureRandom(),
+                    )
+                val oldServerChannel =
+                    SecureChannel(
+                        FramedConnection(oldServerSocket),
+                        freshSessionKeys(D2DRole.SERVER),
+                        SecureRandom(),
+                    )
+                val newClientFramed = FramedConnection(newClientSocket)
+                val registry =
+                    MediumRegistry(
+                        providers = listOf(serverProvider(newServerSocket)),
+                        ladder = MediumLadder(listOf(Medium.WIFI_DIRECT)),
+                    )
+                val logs = Collections.synchronizedList(mutableListOf<String>())
+
+                coroutineScope {
+                    val server =
+                        async {
+                            BandwidthUpgradeOrchestrator.runServerUpgradeIfAvailable(
+                                oldChannel = oldServerChannel,
+                                currentMedium = Medium.BLE,
+                                mediumRegistry = registry,
+                                peerSupportedMediums = setOf(Medium.WIFI_DIRECT),
+                                peerEndpointId = ENDPOINT_ID,
+                                logger = logs::add,
+                            )
+                        }
+                    val client =
+                        async {
+                            oldClientChannel
+                                .receiveOfflineFrame()
+                                .assertUpgradeEvent(BandwidthUpgradeNegotiationFrame.EventType.UPGRADE_PATH_AVAILABLE)
+
+                            newClientFramed.sendFrame(
+                                BandwidthUpgradeFrames
+                                    .clientIntroduction(ENDPOINT_ID)
+                                    .toByteArray(),
+                            )
+                            newClientFramed
+                                .receiveRawOfflineFrame()
+                                .assertUpgradeEvent(
+                                    BandwidthUpgradeNegotiationFrame.EventType.CLIENT_INTRODUCTION_ACK,
+                                )
+
+                            oldClientChannel.sendOfflineFrame(BandwidthUpgradeFrames.lastWriteToPriorChannel())
+                            oldClientChannel
+                                .receiveOfflineFrame()
+                                .assertUpgradeEvent(
+                                    BandwidthUpgradeNegotiationFrame.EventType.LAST_WRITE_TO_PRIOR_CHANNEL,
+                                )
+                            oldClientChannel
+                                .receiveOfflineFrame()
+                                .assertUpgradeEvent(
+                                    BandwidthUpgradeNegotiationFrame.EventType.SAFE_TO_CLOSE_PRIOR_CHANNEL,
+                                )
+                            oldClientChannel.sendOfflineFrame(BandwidthUpgradeFrames.safeToClosePriorChannel())
+                        }
+
+                    assertThat(server.await().medium).isEqualTo(Medium.WIFI_DIRECT)
+                    client.await()
+                }
+
+                assertThat(logs.joinToString("\n")).contains("server consumed peer SAFE_TO_CLOSE on prior channel")
+            }
+        }
+
+    private fun serverProvider(socket: Socket): MediumProvider =
+        object : MediumProvider {
+            override val medium: Medium = Medium.WIFI_DIRECT
+
+            override fun isSupported(): Boolean = true
+
+            override suspend fun prepareUpgrade(): UpgradePathCredentials =
+                UpgradePathCredentials.Generic(Medium.WIFI_DIRECT)
+
+            override suspend fun acceptUpgrade(): UpgradedTransport =
+                UpgradedTransport.SocketBacked(Medium.WIFI_DIRECT, socket)
+        }
+
+    private fun connectedSocketPair(): Pair<Socket, Socket> {
+        val listener = ServerSocket(0, 0, InetAddress.getLoopbackAddress())
+        val client = Socket(InetAddress.getLoopbackAddress(), listener.localPort)
+        val server = listener.accept()
+        listener.close()
+        openedSockets += client
+        openedSockets += server
+        return client to server
+    }
+
+    private fun freshSessionKeys(role: D2DRole): D2DSessionKeys {
+        val dhs = ByteArray(D2DKeyDerivation.KEY_SIZE) { (it + 0x40).toByte() }
+        val clientInit = "upgrade-orchestrator-client-init".toByteArray()
+        val serverInit = "upgrade-orchestrator-server-init".toByteArray()
+        return D2DKeyDerivation.derive(dhs, clientInit, serverInit, role)
+    }
+
+    private fun keepAliveFrame(): OfflineFrame =
+        OfflineFrame
+            .newBuilder()
+            .setVersion(OfflineFrame.Version.V1)
+            .setV1(
+                V1Frame
+                    .newBuilder()
+                    .setType(V1Frame.FrameType.KEEP_ALIVE)
+                    .setKeepAlive(KeepAliveFrame.newBuilder().setAck(false)),
+            ).build()
+
+    private suspend fun FramedConnection.receiveRawOfflineFrame(): OfflineFrame = OfflineFrame.parseFrom(receiveFrame())
+
+    private fun OfflineFrame.assertUpgradeEvent(expected: BandwidthUpgradeNegotiationFrame.EventType) {
+        assertThat(v1.type).isEqualTo(V1Frame.FrameType.BANDWIDTH_UPGRADE_NEGOTIATION)
+        assertThat(v1.bandwidthUpgradeNegotiation.eventType).isEqualTo(expected)
+    }
+
+    private companion object {
+        const val ENDPOINT_ID = "ABCD"
+        const val WALLCLOCK_TIMEOUT_MILLIS = 7_000L
+    }
+}

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionTest.kt
@@ -14,6 +14,7 @@ import io.github.kyujincho.wvmg.protocol.medium.MediumRegistry
 import io.github.kyujincho.wvmg.protocol.medium.UpgradePathCredentials
 import io.github.kyujincho.wvmg.protocol.medium.UpgradedTransport
 import io.github.kyujincho.wvmg.protocol.payload.FileDestinationFactory
+import io.github.kyujincho.wvmg.protocol.transport.asConnectedTransport
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -159,6 +160,16 @@ class OutboundConnectionTest {
         return serverSocket.localPort to accept
     }
 
+    private suspend fun connectedSocketPair(): Pair<Socket, Socket> {
+        val listener = withContext(Dispatchers.IO) { ServerSocket(0, 0, InetAddress.getLoopbackAddress()) }
+        val client = withContext(Dispatchers.IO) { Socket(InetAddress.getLoopbackAddress(), listener.localPort) }
+        val server = withContext(Dispatchers.IO) { listener.accept() }
+        runCatching { listener.close() }
+        openedSockets += client
+        openedSockets += server
+        return client to server
+    }
+
     private class LoopbackUpgradePair {
         private val credentials = UpgradePathCredentials.Generic(Medium.BLUETOOTH)
         private val clientSocket: Socket
@@ -267,6 +278,47 @@ class OutboundConnectionTest {
                 val received = factory.output[payloadId]?.toByteArray()
                 assertThat(received).isEqualTo(fileBytes)
 
+                assertThat(outbound.state.value).isEqualTo(OutboundConnectionState.Completed)
+            }
+        }
+
+    @Test
+    fun `accept path - preconnected transport completes through full lifecycle`() =
+        runBlocking {
+            withTimeout(WALLCLOCK_TIMEOUT_MS) {
+                val (client, server) = connectedSocketPair()
+                val factory = InMemoryFactory()
+                val outbound =
+                    OutboundConnection(
+                        transport = client.asConnectedTransport(Medium.BLUETOOTH),
+                        secureRandom = SecureRandom("outbound-preconnected".toByteArray()),
+                    )
+
+                val fileBytes = ByteArray(2048) { (it and 0xFF).toByte() }
+                val payloadId = 0x5152L
+                val files = listOf(bytesSource("preconnected.bin", fileBytes, payloadId))
+
+                coroutineScope {
+                    val outboundJob = async { outbound.run(files) }
+                    val inbound =
+                        InboundConnection(
+                            transport = server.asConnectedTransport(Medium.BLUETOOTH),
+                            secureRandom = SecureRandom("inbound-preconnected".toByteArray()),
+                        )
+
+                    launch {
+                        inbound.state.first { it is InboundConnectionState.WaitingForUserConsent }
+                        inbound.submitUserConsent(accepted = true)
+                    }
+
+                    val inboundResult = inbound.run(factory)
+                    val outboundResult = outboundJob.await()
+
+                    assertThat(outboundResult).isEqualTo(OutboundResult.Completed)
+                    assertThat(inboundResult).isInstanceOf(InboundResult.Completed::class.java)
+                }
+
+                assertThat(factory.output[payloadId]?.toByteArray()).isEqualTo(fileBytes)
                 assertThat(outbound.state.value).isEqualTo(OutboundConnectionState.Completed)
             }
         }

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionTest.kt
@@ -170,8 +170,10 @@ class OutboundConnectionTest {
         return client to server
     }
 
-    private class LoopbackUpgradePair {
-        private val credentials = UpgradePathCredentials.Generic(Medium.BLUETOOTH)
+    private class LoopbackUpgradePair(
+        private val medium: Medium = Medium.BLUETOOTH,
+    ) {
+        private val credentials = UpgradePathCredentials.Generic(medium)
         private val clientSocket: Socket
         private val serverSocket: Socket
 
@@ -183,24 +185,24 @@ class OutboundConnectionTest {
 
         val clientProvider: MediumProvider =
             object : MediumProvider {
-                override val medium: Medium = Medium.BLUETOOTH
+                override val medium: Medium = this@LoopbackUpgradePair.medium
 
                 override fun isSupported(): Boolean = true
 
                 override suspend fun adoptUpgrade(credentials: UpgradePathCredentials): UpgradedTransport? =
-                    UpgradedTransport.SocketBacked(Medium.BLUETOOTH, clientSocket)
+                    UpgradedTransport.SocketBacked(medium, clientSocket)
             }
 
         val serverProvider: MediumProvider =
             object : MediumProvider {
-                override val medium: Medium = Medium.BLUETOOTH
+                override val medium: Medium = this@LoopbackUpgradePair.medium
 
                 override fun isSupported(): Boolean = true
 
                 override suspend fun prepareUpgrade(): UpgradePathCredentials = credentials
 
                 override suspend fun acceptUpgrade(): UpgradedTransport =
-                    UpgradedTransport.SocketBacked(Medium.BLUETOOTH, serverSocket)
+                    UpgradedTransport.SocketBacked(medium, serverSocket)
             }
 
         fun close() {
@@ -379,6 +381,72 @@ class OutboundConnectionTest {
 
                         assertThat(outboundResult).isEqualTo(OutboundResult.Completed)
                         assertThat(inboundResult).isInstanceOf(InboundResult.Completed::class.java)
+                    }
+
+                    assertThat(factory.output[payloadId]?.toByteArray()).isEqualTo(fileBytes)
+                    assertThat(outbound.state.value).isEqualTo(OutboundConnectionState.Completed)
+                } finally {
+                    upgradePair.close()
+                }
+            }
+        }
+
+    @Test
+    fun `preconnected bluetooth bootstrap ignores Wi-Fi LAN placeholder and upgrades to WebRTC`() =
+        runBlocking {
+            withTimeout(WALLCLOCK_TIMEOUT_MS) {
+                val (client, server) = connectedSocketPair()
+                val factory = InMemoryFactory()
+                val upgradePair = LoopbackUpgradePair(Medium.WEB_RTC)
+                val registry =
+                    MediumRegistry(
+                        providers =
+                            listOf(
+                                MediumRegistry.DefaultWifiLan.providerFor(Medium.WIFI_LAN)!!,
+                                upgradePair.clientProvider,
+                            ),
+                        ladder = MediumLadder(listOf(Medium.WIFI_LAN, Medium.WEB_RTC)),
+                    )
+                val outbound =
+                    OutboundConnection(
+                        transport = client.asConnectedTransport(Medium.BLUETOOTH),
+                        secureRandom = SecureRandom("outbound-bt-bootstrap-upgrade".toByteArray()),
+                        mediumRegistry = registry,
+                    )
+
+                val fileBytes = ByteArray(1024) { (it and 0x7F).toByte() }
+                val payloadId = 0x5153L
+                val files = listOf(bytesSource("bootstrap-upgrade.bin", fileBytes, payloadId))
+
+                try {
+                    coroutineScope {
+                        val outboundJob = async { outbound.run(files) }
+                        val inbound =
+                            InboundConnection(
+                                transport = server.asConnectedTransport(Medium.BLUETOOTH),
+                                secureRandom = SecureRandom("inbound-bt-bootstrap-upgrade".toByteArray()),
+                                mediumRegistry =
+                                    MediumRegistry(
+                                        providers =
+                                            listOf(
+                                                MediumRegistry.DefaultWifiLan.providerFor(Medium.WIFI_LAN)!!,
+                                                upgradePair.serverProvider,
+                                            ),
+                                        ladder = MediumLadder(listOf(Medium.WIFI_LAN, Medium.WEB_RTC)),
+                                    ),
+                            )
+
+                        launch {
+                            inbound.state.first { it is InboundConnectionState.WaitingForUserConsent }
+                            inbound.submitUserConsent(accepted = true)
+                        }
+
+                        val inboundResult = inbound.run(factory)
+                        val outboundResult = outboundJob.await()
+
+                        assertThat(outboundResult).isEqualTo(OutboundResult.Completed)
+                        assertThat(inboundResult).isInstanceOf(InboundResult.Completed::class.java)
+                        assertThat(inbound.activeMedium.value).isEqualTo(Medium.WEB_RTC)
                     }
 
                     assertThat(factory.output[payloadId]?.toByteArray()).isEqualTo(fileBytes)

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/BleAdvertisementHeaderTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/BleAdvertisementHeaderTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.endpoint
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class BleAdvertisementHeaderTest {
+    @Test
+    fun `parse accepts stock base64-url GATT advertisement header`() {
+        val parsed =
+            BleAdvertisementHeader.parse(
+                "VSAUARACAAADAAo8Vu4sAAA".toByteArray(Charsets.US_ASCII),
+            )
+
+        assertThat(parsed).isNotNull()
+        assertThat(parsed!!.version).isEqualTo(2)
+        assertThat(parsed.supportsExtendedAdvertisement).isTrue()
+        assertThat(parsed.numSlots).isEqualTo(5)
+        assertThat(parsed.serviceIdBloomFilter)
+            .isEqualTo(byteArrayOf(0x20, 0x14, 0x01, 0x10, 0x02, 0x00, 0x00, 0x03, 0x00, 0x0a))
+        assertThat(parsed.advertisementHash).isEqualTo(byteArrayOf(0x3c, 0x56, 0xee.toByte(), 0x2c))
+        assertThat(parsed.psm).isEqualTo(0)
+    }
+
+    @Test
+    fun `parse accepts raw GATT advertisement header with PSM`() {
+        val parsed =
+            BleAdvertisementHeader.parse(
+                byteArrayOf(
+                    0x55,
+                    0x20,
+                    0x00,
+                    0x00,
+                    0x10,
+                    0x02,
+                    0x01,
+                    0x21,
+                    0x13,
+                    0x00,
+                    0x00,
+                    0x73,
+                    0x6d,
+                    0x2e,
+                    0x8b.toByte(),
+                    0x12,
+                    0x34,
+                ),
+            )
+
+        assertThat(parsed).isNotNull()
+        assertThat(parsed!!.numSlots).isEqualTo(5)
+        assertThat(parsed.psm).isEqualTo(0x1234)
+    }
+
+    @Test
+    fun `parse ignores normal fast advertisement bytes`() {
+        val info =
+            EndpointInfo(
+                version = 1,
+                hidden = false,
+                deviceType = DeviceType.PHONE,
+                reserved = false,
+                metadata = ByteArray(EndpointInfo.METADATA_LEN) { it.toByte() },
+                deviceName = "Galaxy",
+            )
+        val fast = BleServiceData.encodeFramed("RINE", info)
+
+        assertThat(BleAdvertisementHeader.parse(fast)).isNull()
+    }
+}

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/BleAdvertisementTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/BleAdvertisementTest.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.endpoint
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class BleAdvertisementTest {
+    @Test
+    fun `GATT advertisement wraps endpoint data with service id hash`() {
+        val info = endpointInfo("Galaxy")
+        val bytes =
+            BleAdvertisement.encodeGattAdvertisement(
+                endpointId = "RINE".toByteArray(Charsets.US_ASCII),
+                endpointInfo = info,
+                psm = 0x1234,
+            )
+
+        val parsed = BleAdvertisement.parse(bytes)
+
+        assertThat(parsed).isNotNull()
+        assertThat(parsed!!.version).isEqualTo(2)
+        assertThat(parsed.socketVersion).isEqualTo(2)
+        assertThat(parsed.fastAdvertisement).isFalse()
+        assertThat(parsed.serviceIdHash).isEqualTo(NearbyServiceId.hashPrefix)
+        assertThat(parsed.psm).isEqualTo(0x1234)
+
+        val endpoint = BleServiceData.parse(parsed.data)
+        assertThat(endpoint).isNotNull()
+        assertThat(String(endpoint!!.endpointId, Charsets.US_ASCII)).isEqualTo("RINE")
+        assertThat(endpoint.endpointInfo).isEqualTo(info)
+    }
+
+    @Test
+    fun `parse accepts fast advertisement wrapper`() {
+        val info = endpointInfo("Pixel")
+        val bytes = BleServiceData.encodeFramed("ABCD", info)
+
+        val parsed = BleAdvertisement.parse(bytes)
+
+        assertThat(parsed).isNotNull()
+        assertThat(parsed!!.fastAdvertisement).isTrue()
+        assertThat(parsed.serviceIdHash).isNull()
+        assertThat(BleServiceData.parse(parsed.data)?.endpointInfo).isEqualTo(info)
+    }
+
+    private fun endpointInfo(name: String): EndpointInfo =
+        EndpointInfo(
+            version = 1,
+            hidden = false,
+            deviceType = DeviceType.PHONE,
+            reserved = false,
+            metadata = ByteArray(EndpointInfo.METADATA_LEN) { it.toByte() },
+            deviceName = name,
+        )
+}

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/BleServiceDataTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/BleServiceDataTest.kt
@@ -8,6 +8,7 @@ package io.github.kyujincho.wvmg.protocol.endpoint
 import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.security.MessageDigest
 
 /**
  * Bit-exact regression tests for [BleServiceData] (issue #121).
@@ -16,7 +17,7 @@ import org.junit.jupiter.api.assertThrows
  * pulse during the c0150be triage:
  *
  * ```text
- * [ 0x23 PCP | endpoint_id | 0x11 length | 0x32 ... ]
+ * [ 0x4a frame | 0x17 length | 0x23 PCP | endpoint_id | 0x11 length | 0x32 ... | token ]
  * ```
  *
  * If a regression flips bit packing or field order, every stock Quick
@@ -98,6 +99,90 @@ class BleServiceDataTest {
         assertThat(parsed.pcp).isEqualTo(BleServiceData.DEFAULT_PCP)
         assertThat(parsed.endpointId).isEqualTo(byteArrayOf(0x57, 0x76, 0x6D, 0x67))
         assertThat(parsed.endpointInfo).isEqualTo(info)
+    }
+
+    @Test
+    fun `encodeFramed wraps the fast-advertisement body like stock Nearby`() {
+        val info = hiddenPhoneEndpointInfo()
+        val payload = BleServiceData.encodeFramed("Wvmg", info)
+
+        assertThat(payload).hasLength(27)
+        assertThat(payload[0].toInt() and 0xFF)
+            .isEqualTo(BleServiceData.FRAME_TYPE_FAST_ADVERTISEMENT)
+        assertThat(payload[1].toInt() and 0xFF).isEqualTo(23)
+        assertThat(payload[2].toInt() and 0xFF).isEqualTo(0x23)
+        assertThat(payload.copyOfRange(3, 7)).isEqualTo(byteArrayOf(0x57, 0x76, 0x6D, 0x67))
+        assertThat(payload[7].toInt() and 0xFF).isEqualTo(0x11)
+        assertThat(payload.copyOfRange(25, 27))
+            .isEqualTo(sha256FirstTwo(payload.copyOfRange(2, 25)))
+        assertThat(BleServiceData.parse(payload)?.endpointInfo).isEqualTo(info)
+    }
+
+    @Test
+    fun `encodeFramedWithPsm appends stock extended-advertisement PSM extra field`() {
+        val info = hiddenPhoneEndpointInfo()
+        val payload = BleServiceData.encodeFramedWithPsm("Wvmg", info, psm = 0x1234)
+
+        assertThat(payload).hasLength(30)
+        assertThat(payload[27].toInt() and 0xFF).isEqualTo(BleServiceData.EXTRA_FIELD_PSM_MASK)
+        assertThat(payload[28].toInt() and 0xFF).isEqualTo(0x12)
+        assertThat(payload[29].toInt() and 0xFF).isEqualTo(0x34)
+        assertThat(BleServiceData.parsePsmExtraField(payload)).isEqualTo(0x1234)
+        assertThat(BleServiceData.parse(payload)?.endpointInfo).isEqualTo(info)
+    }
+
+    @Test
+    fun `encodeFramedWithPsm rejects invalid PSM values`() {
+        val info = hiddenPhoneEndpointInfo()
+        assertThrows<IllegalArgumentException> {
+            BleServiceData.encodeFramedWithPsm("Wvmg", info, psm = 0)
+        }
+        assertThrows<IllegalArgumentException> {
+            BleServiceData.encodeFramedWithPsm("Wvmg", info, psm = 0x1_0000)
+        }
+    }
+
+    @Test
+    fun `parse accepts captured stock framed fast advertisement`() {
+        val payload =
+            byteArrayOf(
+                0x4A,
+                0x17,
+                0x23,
+                0x30,
+                0x51,
+                0x52,
+                0x52,
+                0x11,
+                0x32,
+                0x82.toByte(),
+                0x49,
+                0x92.toByte(),
+                0x9C.toByte(),
+                0x32,
+                0xFF.toByte(),
+                0x2B,
+                0x2C,
+                0xC2.toByte(),
+                0x38,
+                0xA4.toByte(),
+                0x62,
+                0xE7.toByte(),
+                0xB1.toByte(),
+                0x35,
+                0xE3.toByte(),
+                0x4A,
+                0xF9.toByte(),
+            )
+
+        val parsed = BleServiceData.parse(payload)
+
+        assertThat(parsed).isNotNull()
+        assertThat(String(parsed!!.endpointId, Charsets.US_ASCII)).isEqualTo("0QRR")
+        assertThat(parsed.version).isEqualTo(BleServiceData.DEFAULT_VERSION)
+        assertThat(parsed.pcp).isEqualTo(BleServiceData.DEFAULT_PCP)
+        assertThat(parsed.endpointInfo.hidden).isTrue()
+        assertThat(parsed.endpointInfo.deviceType).isEqualTo(DeviceType.PHONE)
     }
 
     @Test
@@ -219,4 +304,10 @@ class BleServiceDataTest {
             metadata = ByteArray(EndpointInfo.METADATA_LEN) { 0x00 },
             deviceName = null,
         )
+
+    private fun sha256FirstTwo(bytes: ByteArray): ByteArray =
+        MessageDigest
+            .getInstance("SHA-256")
+            .digest(bytes)
+            .copyOfRange(0, BleServiceData.DEVICE_TOKEN_LEN)
 }

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/DctAdvertisementTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/DctAdvertisementTest.kt
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.endpoint
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class DctAdvertisementTest {
+    @Test
+    fun `service uuid matches Nearby DCT advertisement UUID`() {
+        assertThat(DctAdvertisement.SERVICE_UUID_SHORT).isEqualTo(0xFC73)
+        assertThat(DctAdvertisement.SERVICE_UUID_128_STRING)
+            .isEqualTo("0000fc73-0000-1000-8000-00805f9b34fb")
+    }
+
+    @Test
+    fun `computeServiceIdHash matches google nearby KAT`() {
+        assertThat(DctAdvertisement.computeServiceIdHash("service_id"))
+            .isEqualTo(byteArrayOf(0x96.toByte(), 0x77))
+    }
+
+    @Test
+    fun `encode writes stock DCT data element layout`() {
+        val encoded =
+            DctAdvertisement.encode(
+                serviceId = "service_id",
+                deviceName = "device",
+                psm = 0x1234,
+                dedup = 0x01,
+            )
+
+        assertThat(encoded)
+            .isEqualTo(
+                byteArrayOf(
+                    0x20,
+                    0x25,
+                    0x96.toByte(),
+                    0x77,
+                    0x24,
+                    0x12,
+                    0x34,
+                    0x87.toByte(),
+                    0x07,
+                    0x01,
+                    0x64,
+                    0x65,
+                    0x76,
+                    0x69,
+                    0x63,
+                    0x65,
+                ),
+            )
+    }
+
+    @Test
+    fun `parse accepts google nearby captured DCT advertisement`() {
+        val parsed =
+            DctAdvertisement.parse(
+                byteArrayOf(
+                    0x20,
+                    0x25,
+                    0x6D,
+                    0xFD.toByte(),
+                    0x24,
+                    0x00,
+                    0xC0.toByte(),
+                    0x88.toByte(),
+                    0x07,
+                    0x96.toByte(),
+                    0x74,
+                    0x65,
+                    0x73,
+                    0x74,
+                    0x64,
+                    0x65,
+                    0x76,
+                ),
+            )
+
+        assertThat(parsed).isNotNull()
+        assertThat(parsed!!.deviceName).isEqualTo("testdev")
+        assertThat(parsed.psm).isEqualTo(192)
+        assertThat(parsed.isDeviceNameTruncated).isTrue()
+        assertThat(parsed.dedup).isEqualTo(0x16)
+    }
+
+    @Test
+    fun `encode truncates visible name to seven valid UTF-8 bytes`() {
+        val parsed =
+            DctAdvertisement.parse(
+                DctAdvertisement.encode(
+                    serviceId = "service_id",
+                    deviceName = "WhenVivoMeetsGoogle",
+                    psm = DctAdvertisement.DEFAULT_PSM,
+                    dedup = DctAdvertisement.DEFAULT_DEDUP,
+                ),
+            )
+
+        assertThat(parsed).isNotNull()
+        assertThat(parsed!!.deviceName).isEqualTo("WhenViv")
+        assertThat(parsed.isDeviceNameTruncated).isTrue()
+        assertThat(parsed.psm).isEqualTo(0)
+    }
+
+    @Test
+    fun `encode truncates without splitting multi-byte UTF-8 code points`() {
+        val parsed =
+            DctAdvertisement.parse(
+                DctAdvertisement.encode(
+                    serviceId = "service_id",
+                    deviceName = "\u00e9\u00f1\u00f6\ud83d\ude00",
+                    psm = 0x1234,
+                    dedup = DctAdvertisement.DEFAULT_DEDUP,
+                ),
+            )
+
+        assertThat(parsed).isNotNull()
+        assertThat(parsed!!.deviceName).isEqualTo("\u00e9\u00f1\u00f6")
+    }
+
+    @Test
+    fun `generateEndpointId matches google nearby KAT`() {
+        assertThat(DctAdvertisement.generateEndpointId(0x01, "device")).isEqualTo("IWRE")
+        assertThat(DctAdvertisement.generateEndpointId(0x02, "device")).isEqualTo("HEL4")
+    }
+
+    @Test
+    fun `encode rejects invalid fields`() {
+        assertThrows<IllegalArgumentException> {
+            DctAdvertisement.encode(serviceId = "", deviceName = "device")
+        }
+        assertThrows<IllegalArgumentException> {
+            DctAdvertisement.encode(serviceId = "service_id", deviceName = "")
+        }
+        assertThrows<IllegalArgumentException> {
+            DctAdvertisement.encode(serviceId = "service_id", deviceName = "device", psm = 0x1_0000)
+        }
+        assertThrows<IllegalArgumentException> {
+            DctAdvertisement.encode(serviceId = "service_id", deviceName = "device", dedup = 0x80)
+        }
+    }
+}

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/medium/MediumRegistryTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/medium/MediumRegistryTest.kt
@@ -65,6 +65,22 @@ class MediumRegistryTest {
     }
 
     @Test
+    fun `supportedMediumsForCurrentTransport excludes Wi-Fi LAN off the LAN transport`() {
+        val registry =
+            MediumRegistry(
+                listOf(
+                    FakeProvider(Medium.WIFI_LAN),
+                    FakeProvider(Medium.BLUETOOTH),
+                ),
+            )
+
+        assertThat(registry.supportedMediumsForCurrentTransport(Medium.BLUETOOTH))
+            .containsExactly(Medium.BLUETOOTH)
+        assertThat(registry.supportedMediumsForCurrentTransport(Medium.WIFI_LAN))
+            .containsExactly(Medium.WIFI_LAN, Medium.BLUETOOTH)
+    }
+
+    @Test
     fun `providerFor returns null for unregistered medium`() {
         val registry = MediumRegistry(listOf(FakeProvider(Medium.WIFI_LAN)))
         assertThat(registry.providerFor(Medium.BLE_L2CAP)).isNull()
@@ -139,6 +155,32 @@ class MediumRegistryTest {
                 ladderOverride = override,
             )
         assertThat(pick).isEqualTo(Medium.BLUETOOTH)
+    }
+
+    @Test
+    fun `selectBestUpgradeForCurrentTransport skips Wi-Fi LAN on Bluetooth bootstrap`() {
+        val registry =
+            MediumRegistry(
+                listOf(
+                    FakeProvider(Medium.WIFI_LAN),
+                    FakeProvider(Medium.BLE_L2CAP),
+                ),
+                ladder =
+                    MediumLadder(
+                        listOf(
+                            Medium.WIFI_LAN,
+                            Medium.BLE_L2CAP,
+                        ),
+                    ),
+            )
+
+        val pick =
+            registry.selectBestUpgradeForCurrentTransport(
+                peerSupported = setOf(Medium.WIFI_LAN, Medium.BLE_L2CAP),
+                currentMedium = Medium.BLUETOOTH,
+            )
+
+        assertThat(pick).isEqualTo(Medium.BLE_L2CAP)
     }
 
     @Test
@@ -237,5 +279,33 @@ class MediumRegistryTest {
             assertThat(prepared).isEqualTo(PreparedUpgradeSelection.StayOnCurrentMedium)
             assertThat(direct.prepareCalls).isEqualTo(1)
             assertThat(lan.prepareCalls).isEqualTo(0)
+        }
+
+    @Test
+    fun `prepareBestUpgradeForCurrentTransport skips Wi-Fi LAN on Bluetooth bootstrap`() =
+        runTest {
+            val lan = FakeProvider(Medium.WIFI_LAN)
+            val bleL2cap =
+                FakeProvider(
+                    medium = Medium.BLE_L2CAP,
+                    preparedCredentials = UpgradePathCredentials.Generic(Medium.BLE_L2CAP),
+                )
+            val registry =
+                MediumRegistry(
+                    providers = listOf(lan, bleL2cap),
+                    ladder = MediumLadder(listOf(Medium.WIFI_LAN, Medium.BLE_L2CAP)),
+                )
+
+            val prepared =
+                registry.prepareBestUpgradeForCurrentTransport(
+                    peerSupported = setOf(Medium.WIFI_LAN, Medium.BLE_L2CAP),
+                    currentMedium = Medium.BLUETOOTH,
+                )
+
+            assertThat(prepared).isInstanceOf(PreparedUpgradeSelection.Upgrade::class.java)
+            val upgrade = prepared as PreparedUpgradeSelection.Upgrade
+            assertThat(upgrade.medium).isEqualTo(Medium.BLE_L2CAP)
+            assertThat(lan.prepareCalls).isEqualTo(0)
+            assertThat(bleL2cap.prepareCalls).isEqualTo(1)
         }
 }

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/medium/NearbyBleSocketFramesTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/medium/NearbyBleSocketFramesTest.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.medium
+
+import com.google.common.truth.Truth.assertThat
+import com.google.location.nearby.mediums.proto.BleFramesProto
+import io.github.kyujincho.wvmg.protocol.endpoint.NearbyServiceId
+import org.junit.jupiter.api.Test
+
+class NearbyBleSocketFramesTest {
+    @Test
+    fun `introduction packet has control prefix and NearbySharing hash`() {
+        val packet = NearbyBleSocketFrames.encodeIntroductionPacket()
+        val parsed = NearbyBleSocketFrames.parseControlPacket(packet)
+
+        assertThat(packet.copyOfRange(0, 3)).isEqualTo(byteArrayOf(0, 0, 0))
+        assertThat(parsed).isNotNull()
+        assertThat(parsed!!.type)
+            .isEqualTo(BleFramesProto.SocketControlFrame.ControlFrameType.INTRODUCTION)
+        assertThat(parsed.introduction.socketVersion).isEqualTo(BleFramesProto.SocketVersion.V2)
+        assertThat(parsed.introduction.serviceIdHash.toByteArray()).isEqualTo(NearbyServiceId.hashPrefix)
+    }
+
+    @Test
+    fun `packet acknowledgement carries received size and NearbySharing hash`() {
+        val packet = NearbyBleSocketFrames.encodePacketAcknowledgementPacket(receivedSize = 1234)
+        val parsed = NearbyBleSocketFrames.parseControlPacket(packet)
+
+        assertThat(packet.copyOfRange(0, 3)).isEqualTo(byteArrayOf(0, 0, 0))
+        assertThat(parsed).isNotNull()
+        assertThat(parsed!!.type)
+            .isEqualTo(BleFramesProto.SocketControlFrame.ControlFrameType.PACKET_ACKNOWLEDGEMENT)
+        assertThat(parsed.packetAcknowledgement.serviceIdHash.toByteArray()).isEqualTo(NearbyServiceId.hashPrefix)
+        assertThat(parsed.packetAcknowledgement.receivedSize).isEqualTo(1234)
+    }
+}

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/medium/NearbyMultiplexFramesTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/medium/NearbyMultiplexFramesTest.kt
@@ -41,4 +41,26 @@ class NearbyMultiplexFramesTest {
         assertThat(parsed.header.serviceIdHashSalt).isEqualTo(salt)
         assertThat(parsed.header.saltedServiceIdHash.toByteArray()).isEqualTo(saltedHash)
     }
+
+    @Test
+    fun `connection request roundtrips through parser`() {
+        val salt = "client-salt"
+        val saltedHash = NearbyMultiplexFrames.saltedServiceIdHash(salt = salt)
+        val payload = NearbyMultiplexFrames.encodeConnectionRequestFrame(saltedHash, salt)
+        val framed = NearbyMultiplexFrames.encodeLengthPrefixed(payload)
+        val parsed = NearbyMultiplexFrames.parseFrame(framed.copyOfRange(4, framed.size))
+
+        assertThat(NearbyMultiplexFrames.decodeLength(framed)).isEqualTo(payload.size)
+        assertThat(parsed).isNotNull()
+        assertThat(parsed!!.frameType)
+            .isEqualTo(MultiplexFramesProto.MultiplexFrame.MultiplexFrameType.CONTROL_FRAME)
+        assertThat(parsed.controlFrame.controlFrameType)
+            .isEqualTo(
+                MultiplexFramesProto.MultiplexControlFrame.MultiplexControlFrameType
+                    .CONNECTION_REQUEST,
+            )
+        assertThat(parsed.controlFrame.hasConnectionRequestFrame()).isTrue()
+        assertThat(parsed.header.serviceIdHashSalt).isEqualTo(salt)
+        assertThat(parsed.header.saltedServiceIdHash.toByteArray()).isEqualTo(saltedHash)
+    }
 }

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/medium/NearbyMultiplexFramesTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/medium/NearbyMultiplexFramesTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.protocol.medium
+
+import com.google.common.truth.Truth.assertThat
+import com.google.location.nearby.mediums.proto.MultiplexFramesProto
+import io.github.kyujincho.wvmg.protocol.endpoint.NearbyServiceId
+import org.junit.jupiter.api.Test
+
+class NearbyMultiplexFramesTest {
+    @Test
+    fun `service hash matches NearbyServiceId prefix`() {
+        assertThat(NearbyMultiplexFrames.serviceIdHash()).isEqualTo(NearbyServiceId.hashPrefix)
+    }
+
+    @Test
+    fun `connection response roundtrips through parser`() {
+        val salt = "salt"
+        val saltedHash = NearbyMultiplexFrames.saltedServiceIdHash(salt = salt)
+        val payload = NearbyMultiplexFrames.encodeConnectionResponseFrame(saltedHash, salt)
+        val framed = NearbyMultiplexFrames.encodeLengthPrefixed(payload)
+        val parsed = NearbyMultiplexFrames.parseFrame(framed.copyOfRange(4, framed.size))
+
+        assertThat(NearbyMultiplexFrames.decodeLength(framed)).isEqualTo(payload.size)
+        assertThat(parsed).isNotNull()
+        assertThat(parsed!!.frameType)
+            .isEqualTo(MultiplexFramesProto.MultiplexFrame.MultiplexFrameType.CONTROL_FRAME)
+        assertThat(parsed.controlFrame.controlFrameType)
+            .isEqualTo(
+                MultiplexFramesProto.MultiplexControlFrame.MultiplexControlFrameType
+                    .CONNECTION_RESPONSE,
+            )
+        assertThat(parsed.controlFrame.connectionResponseFrame.connectionResponseCode)
+            .isEqualTo(
+                MultiplexFramesProto.ConnectionResponseFrame.ConnectionResponseCode
+                    .CONNECTION_ACCEPTED,
+            )
+        assertThat(parsed.header.serviceIdHashSalt).isEqualTo(salt)
+        assertThat(parsed.header.saltedServiceIdHash.toByteArray()).isEqualTo(saltedHash)
+    }
+}

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/NearbyPeer.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/NearbyPeer.kt
@@ -39,7 +39,10 @@ public data class NearbyPeer(
             buildSet {
                 if (lanEndpoint != null) add(Medium.WIFI_LAN)
                 if (bluetoothEndpoint != null) add(Medium.BLUETOOTH)
-                if (bleAdvertisement != null) add(Medium.BLE)
+                if (bleAdvertisement != null) {
+                    add(Medium.BLE)
+                    if (bleAdvertisement.l2capPsm != null) add(Medium.BLE_L2CAP)
+                }
             }
 
     /** True when the peer currently exposes at least one bootstrap route. */
@@ -50,8 +53,9 @@ public data class NearbyPeer(
      * Select the initial-control route.
      *
      * LAN remains first priority to preserve the pre-#137 behaviour when
-     * a peer is already reachable by mDNS + TCP. Bluetooth Classic
-     * bootstrap is the off-LAN fallback when no LAN socket target exists.
+     * a peer is already reachable by mDNS + TCP. BLE L2CAP is the preferred
+     * off-LAN bootstrap path when the receiver advertises a PSM; Bluetooth
+     * Classic remains only a fallback for peers that still expose it.
      */
     public fun preferredRoute(): NearbyPeerRoute? {
         val lan = lanEndpoint
@@ -61,6 +65,12 @@ public data class NearbyPeer(
                 address = primaryAddress,
                 port = lan.port,
             )
+        }
+        val ble = bleAdvertisement
+        val bleAddress = ble?.advertiserAddress
+        val l2capPsm = ble?.l2capPsm
+        if (bleAddress != null && l2capPsm != null) {
+            return NearbyPeerRoute.BleL2cap(macAddress = bleAddress, psm = l2capPsm)
         }
         val bluetooth = bluetoothEndpoint
         if (bluetooth != null) {
@@ -104,6 +114,7 @@ public data class NearbyPeer(
     public data class BleAdvertisement(
         val advertiserAddress: String?,
         val rssi: Int?,
+        val l2capPsm: Int?,
     )
 }
 
@@ -127,5 +138,10 @@ public sealed interface NearbyPeerRoute {
 
     public data class BluetoothClassic(
         val macAddress: String,
+    ) : NearbyPeerRoute
+
+    public data class BleL2cap(
+        val macAddress: String,
+        val psm: Int,
     ) : NearbyPeerRoute
 }

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/NearbyPeer.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/NearbyPeer.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+@file:Suppress("ReturnCount")
+
+package io.github.kyujincho.wvmg.discovery
+
+import io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo
+import io.github.kyujincho.wvmg.protocol.medium.Medium
+import java.net.InetAddress
+
+/**
+ * Sender-side Quick Share peer model independent of any single discovery
+ * surface.
+ *
+ * A peer can be discovered by one or more mediums at the same time:
+ * Wi-Fi LAN mDNS, Bluetooth Classic device-name discovery, and BLE fast
+ * advertisements. The sender UI and bootstrap path consume this model
+ * instead of directly binding themselves to [DiscoveredService].
+ */
+public data class NearbyPeer(
+    val stableId: String,
+    val endpointId: String?,
+    val endpointInfo: EndpointInfo?,
+    val lanEndpoint: LanEndpoint? = null,
+    val bluetoothEndpoint: BluetoothEndpoint? = null,
+    val bleAdvertisement: BleAdvertisement? = null,
+) {
+    /**
+     * Discovery / candidate mediums currently known for this peer.
+     *
+     * BLE here means "observed nearby advertisement", not necessarily a
+     * connectable initial-control path.
+     */
+    public val candidateMediums: Set<Medium>
+        get() =
+            buildSet {
+                if (lanEndpoint != null) add(Medium.WIFI_LAN)
+                if (bluetoothEndpoint != null) add(Medium.BLUETOOTH)
+                if (bleAdvertisement != null) add(Medium.BLE)
+            }
+
+    /** True when the peer currently exposes at least one bootstrap route. */
+    public val isConnectable: Boolean
+        get() = preferredRoute() != null
+
+    /**
+     * Select the initial-control route.
+     *
+     * LAN remains first priority to preserve the pre-#137 behaviour when
+     * a peer is already reachable by mDNS + TCP. Bluetooth Classic
+     * bootstrap is the off-LAN fallback when no LAN socket target exists.
+     */
+    public fun preferredRoute(): NearbyPeerRoute? {
+        val lan = lanEndpoint
+        val primaryAddress = lan?.primaryAddress()
+        if (lan != null && primaryAddress != null) {
+            return NearbyPeerRoute.Lan(
+                address = primaryAddress,
+                port = lan.port,
+            )
+        }
+        val bluetooth = bluetoothEndpoint
+        if (bluetooth != null) {
+            return NearbyPeerRoute.BluetoothClassic(bluetooth.macAddress)
+        }
+        return null
+    }
+
+    /** User-facing fallback label shared by the sender UI and tests. */
+    public fun displayName(): String {
+        val name = endpointInfo?.deviceName
+        if (!name.isNullOrBlank()) return name
+        if (!endpointId.isNullOrBlank()) return "Quick Share device ($endpointId)"
+        return stableId
+    }
+
+    /** Wi-Fi LAN candidate surfaced by mDNS browse. */
+    public data class LanEndpoint(
+        val instanceNames: Set<String>,
+        val addresses: List<InetAddress>,
+        val port: Int,
+    ) {
+        public fun primaryAddress(): InetAddress? =
+            addresses.firstOrNull { !it.isLoopbackAddress } ?: addresses.firstOrNull()
+    }
+
+    /**
+     * Bluetooth Classic discovery candidate surfaced via the Nearby
+     * device-name advertisement.
+     */
+    public data class BluetoothEndpoint(
+        val macAddress: String,
+        val advertisedName: String,
+    )
+
+    /**
+     * BLE fast-advertisement candidate. Observation-only today; useful for
+     * dedupe/aggregation even when Bluetooth Classic provides the actual
+     * initial-control path.
+     */
+    public data class BleAdvertisement(
+        val advertiserAddress: String?,
+        val rssi: Int?,
+    )
+}
+
+/** Sender-side peer-list events emitted by [NearbyPeerDiscovery]. */
+public sealed class NearbyPeerEvent {
+    public data class Resolved(
+        val peer: NearbyPeer,
+    ) : NearbyPeerEvent()
+
+    public data class Lost(
+        val stableId: String,
+    ) : NearbyPeerEvent()
+}
+
+/** Initial-control route chosen from a [NearbyPeer]. */
+public sealed interface NearbyPeerRoute {
+    public data class Lan(
+        val address: InetAddress,
+        val port: Int,
+    ) : NearbyPeerRoute
+
+    public data class BluetoothClassic(
+        val macAddress: String,
+    ) : NearbyPeerRoute
+}

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/NearbyPeer.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/NearbyPeer.kt
@@ -54,8 +54,10 @@ public data class NearbyPeer(
      *
      * LAN remains first priority to preserve the pre-#137 behaviour when
      * a peer is already reachable by mDNS + TCP. BLE L2CAP is the preferred
-     * off-LAN bootstrap path when the receiver advertises a PSM; Bluetooth
-     * Classic remains only a fallback for peers that still expose it.
+     * off-LAN bootstrap path when the receiver advertises a PSM. BLE GATT is
+     * the stock off-LAN fallback when the receiver exposes only a GATT-backed
+     * advertisement header; Bluetooth Classic remains only a last fallback for
+     * peers that still expose it.
      */
     public fun preferredRoute(): NearbyPeerRoute? {
         val lan = lanEndpoint
@@ -72,6 +74,9 @@ public data class NearbyPeer(
         if (bleAddress != null && l2capPsm != null) {
             return NearbyPeerRoute.BleL2cap(macAddress = bleAddress, psm = l2capPsm)
         }
+        if (bleAddress != null && ble.gattConnectable) {
+            return NearbyPeerRoute.BleGatt(macAddress = bleAddress)
+        }
         val bluetooth = bluetoothEndpoint
         if (bluetooth != null) {
             return NearbyPeerRoute.BluetoothClassic(bluetooth.macAddress)
@@ -84,6 +89,7 @@ public data class NearbyPeer(
         val name = endpointInfo?.deviceName
         if (!name.isNullOrBlank()) return name
         if (!endpointId.isNullOrBlank()) return "Quick Share device ($endpointId)"
+        if (bleAdvertisement?.gattConnectable == true) return "Quick Share BLE device"
         return stableId
     }
 
@@ -115,6 +121,7 @@ public data class NearbyPeer(
         val advertiserAddress: String?,
         val rssi: Int?,
         val l2capPsm: Int?,
+        val gattConnectable: Boolean,
     )
 }
 
@@ -143,5 +150,9 @@ public sealed interface NearbyPeerRoute {
     public data class BleL2cap(
         val macAddress: String,
         val psm: Int,
+    ) : NearbyPeerRoute
+
+    public data class BleGatt(
+        val macAddress: String,
     ) : NearbyPeerRoute
 }

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/NearbyPeerDiscovery.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/NearbyPeerDiscovery.kt
@@ -168,6 +168,7 @@ private class PeerAggregator {
         state.endpointInfo = chooseEndpointInfo(state.endpointInfo, observation.endpointInfo)
         state.bleAddress = observation.advertiserAddress
         state.bleRssi = observation.rssi
+        state.bleL2capPsm = observation.l2capPsm
         observation.advertiserAddress?.let { bleIndex[it] = state.stableId }
 
         return changeEvents(before, state.toPeerOrNull())
@@ -251,6 +252,7 @@ private data class MutablePeer(
     var bluetoothAdvertisedName: String? = null,
     var bleAddress: String? = null,
     var bleRssi: Int? = null,
+    var bleL2capPsm: Int? = null,
 ) {
     fun toPeerOrNull(): NearbyPeer? {
         val lan =
@@ -273,6 +275,7 @@ private data class MutablePeer(
                 NearbyPeer.BleAdvertisement(
                     advertiserAddress = bleAddress,
                     rssi = bleRssi,
+                    l2capPsm = bleL2capPsm,
                 )
             } else {
                 null

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/NearbyPeerDiscovery.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/NearbyPeerDiscovery.kt
@@ -164,11 +164,12 @@ private class PeerAggregator {
         val before = state.toPeerOrNull()
 
         state.endpointId = state.endpointId ?: observation.endpointId
-        endpointIdIndex[observation.endpointId] = state.stableId
+        observation.endpointId?.let { endpointIdIndex[it] = state.stableId }
         state.endpointInfo = chooseEndpointInfo(state.endpointInfo, observation.endpointInfo)
         state.bleAddress = observation.advertiserAddress
         state.bleRssi = observation.rssi
         state.bleL2capPsm = observation.l2capPsm
+        state.bleGattConnectable = observation.gattConnectable
         observation.advertiserAddress?.let { bleIndex[it] = state.stableId }
 
         return changeEvents(before, state.toPeerOrNull())
@@ -253,6 +254,7 @@ private data class MutablePeer(
     var bleAddress: String? = null,
     var bleRssi: Int? = null,
     var bleL2capPsm: Int? = null,
+    var bleGattConnectable: Boolean = false,
 ) {
     fun toPeerOrNull(): NearbyPeer? {
         val lan =
@@ -276,6 +278,7 @@ private data class MutablePeer(
                     advertiserAddress = bleAddress,
                     rssi = bleRssi,
                     l2capPsm = bleL2capPsm,
+                    gattConnectable = bleGattConnectable,
                 )
             } else {
                 null

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/NearbyPeerDiscovery.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/NearbyPeerDiscovery.kt
@@ -1,0 +1,310 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+@file:Suppress("ReturnCount")
+
+package io.github.kyujincho.wvmg.discovery
+
+import android.content.Context
+import io.github.kyujincho.wvmg.discovery.ble.BleFastAdvertisementScanner
+import io.github.kyujincho.wvmg.discovery.classic.BluetoothClassicPeerScanner
+import io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.launch
+import java.net.InetAddress
+
+/**
+ * Aggregates sender-side peer discovery across multiple media.
+ *
+ * The existing LAN mDNS path remains intact, but its output is merged with
+ * Bluetooth Classic Nearby device-name discovery and BLE fast
+ * advertisements so the sender UI is no longer hard-wired to
+ * [DiscoveredService].
+ */
+public class NearbyPeerDiscovery internal constructor(
+    private val lanEvents: Flow<DiscoveryEvent>,
+    private val bleEvents: Flow<BleFastAdvertisementScanner.Observation>,
+    private val bluetoothEvents: Flow<BluetoothClassicPeerScanner.Observation>,
+) {
+    public constructor(context: Context) : this(
+        lanEvents = Discovery(context.applicationContext).browse(),
+        bleEvents = BleFastAdvertisementScanner(context.applicationContext).scan(),
+        bluetoothEvents = BluetoothClassicPeerScanner(context.applicationContext).scan(),
+    )
+
+    public fun browse(): Flow<NearbyPeerEvent> =
+        callbackFlow {
+            val aggregator = PeerAggregator()
+
+            val lanJob =
+                launch {
+                    lanEvents.collect { event ->
+                        when (event) {
+                            is DiscoveryEvent.Resolved ->
+                                aggregator
+                                    .onLanResolved(event.service)
+                                    .forEach { trySend(it).isSuccess }
+                            is DiscoveryEvent.Lost ->
+                                aggregator
+                                    .onLanLost(event.instanceName)
+                                    .forEach { trySend(it).isSuccess }
+                        }
+                    }
+                }
+
+            val bleJob =
+                launch {
+                    bleEvents.collect { observation ->
+                        aggregator
+                            .onBleObserved(observation)
+                            .forEach { trySend(it).isSuccess }
+                    }
+                }
+
+            val bluetoothJob =
+                launch {
+                    bluetoothEvents.collect { observation ->
+                        aggregator
+                            .onBluetoothObserved(observation)
+                            .forEach { trySend(it).isSuccess }
+                    }
+                }
+
+            awaitClose {
+                lanJob.cancel()
+                bleJob.cancel()
+                bluetoothJob.cancel()
+            }
+        }
+
+    public companion object {
+        @JvmStatic
+        internal fun forTesting(
+            lanEvents: Flow<DiscoveryEvent>,
+            bleEvents: Flow<BleFastAdvertisementScanner.Observation>,
+            bluetoothEvents: Flow<BluetoothClassicPeerScanner.Observation>,
+        ): NearbyPeerDiscovery =
+            NearbyPeerDiscovery(
+                lanEvents = lanEvents,
+                bleEvents = bleEvents,
+                bluetoothEvents = bluetoothEvents,
+            )
+    }
+}
+
+private class PeerAggregator {
+    private val peersById: MutableMap<String, MutablePeer> = LinkedHashMap()
+    private val endpointIdIndex: MutableMap<String, String> = HashMap()
+    private val lanRouteIndex: MutableMap<Pair<String, Int>, String> = HashMap()
+    private val lanInstanceIndex: MutableMap<String, String> = HashMap()
+    private val bluetoothIndex: MutableMap<String, String> = HashMap()
+    private val bleIndex: MutableMap<String, String> = HashMap()
+
+    fun onLanResolved(service: DiscoveredService): List<NearbyPeerEvent> {
+        val endpointId = service.endpointId?.toAsciiLabel()
+        val routeKey = service.lanRouteKey()
+        val peerId =
+            resolvePeerId(
+                endpointId = endpointId,
+                lanRouteKey = routeKey,
+                bluetoothMac = null,
+                bleAddress = null,
+            )
+        val state = peersById.getOrPut(peerId) { MutablePeer(stableId = peerId) }
+        val before = state.toPeerOrNull()
+
+        state.endpointId = state.endpointId ?: endpointId
+        endpointId?.let { endpointIdIndex[it] = state.stableId }
+        state.endpointInfo = chooseEndpointInfo(state.endpointInfo, service.endpointInfo)
+
+        if (state.lanRouteKey != null && state.lanRouteKey != routeKey) {
+            lanRouteIndex.remove(state.lanRouteKey)
+        }
+        state.lanRouteKey = routeKey
+        if (routeKey != null) {
+            lanRouteIndex[routeKey] = state.stableId
+        }
+        state.lanInstanceNames += service.instanceName
+        lanInstanceIndex[service.instanceName] = state.stableId
+        state.lanAddresses = service.addresses
+        state.lanPort = service.port
+
+        return changeEvents(before, state.toPeerOrNull())
+    }
+
+    fun onLanLost(instanceName: String): List<NearbyPeerEvent> {
+        val peerId = lanInstanceIndex.remove(instanceName) ?: return emptyList()
+        val state = peersById[peerId] ?: return emptyList()
+        val before = state.toPeerOrNull()
+
+        state.lanInstanceNames.remove(instanceName)
+        if (state.lanInstanceNames.isEmpty()) {
+            state.lanRouteKey?.let(lanRouteIndex::remove)
+            state.lanRouteKey = null
+            state.lanAddresses = emptyList()
+            state.lanPort = null
+        }
+
+        return finalizeChange(state, before)
+    }
+
+    fun onBleObserved(observation: BleFastAdvertisementScanner.Observation): List<NearbyPeerEvent> {
+        val peerId =
+            resolvePeerId(
+                endpointId = observation.endpointId,
+                lanRouteKey = null,
+                bluetoothMac = null,
+                bleAddress = observation.advertiserAddress,
+            )
+        val state = peersById.getOrPut(peerId) { MutablePeer(stableId = peerId) }
+        val before = state.toPeerOrNull()
+
+        state.endpointId = state.endpointId ?: observation.endpointId
+        endpointIdIndex[observation.endpointId] = state.stableId
+        state.endpointInfo = chooseEndpointInfo(state.endpointInfo, observation.endpointInfo)
+        state.bleAddress = observation.advertiserAddress
+        state.bleRssi = observation.rssi
+        observation.advertiserAddress?.let { bleIndex[it] = state.stableId }
+
+        return changeEvents(before, state.toPeerOrNull())
+    }
+
+    fun onBluetoothObserved(observation: BluetoothClassicPeerScanner.Observation): List<NearbyPeerEvent> {
+        val peerId =
+            resolvePeerId(
+                endpointId = observation.endpointId,
+                lanRouteKey = null,
+                bluetoothMac = observation.macAddress,
+                bleAddress = null,
+            )
+        val state = peersById.getOrPut(peerId) { MutablePeer(stableId = peerId) }
+        val before = state.toPeerOrNull()
+
+        state.endpointId = state.endpointId ?: observation.endpointId
+        endpointIdIndex[observation.endpointId] = state.stableId
+        state.endpointInfo = chooseEndpointInfo(state.endpointInfo, observation.endpointInfo)
+        state.bluetoothMac = observation.macAddress
+        state.bluetoothAdvertisedName = observation.advertisedName
+        bluetoothIndex[observation.macAddress] = state.stableId
+
+        return changeEvents(before, state.toPeerOrNull())
+    }
+
+    private fun finalizeChange(
+        state: MutablePeer,
+        before: NearbyPeer?,
+    ): List<NearbyPeerEvent> {
+        val after = state.toPeerOrNull()
+        if (after != null) {
+            return changeEvents(before, after)
+        }
+        peersById.remove(state.stableId)
+        state.endpointId?.let(endpointIdIndex::remove)
+        state.bluetoothMac?.let(bluetoothIndex::remove)
+        state.bleAddress?.let(bleIndex::remove)
+        state.lanRouteKey?.let(lanRouteIndex::remove)
+        return if (before == null) emptyList() else listOf(NearbyPeerEvent.Lost(state.stableId))
+    }
+
+    private fun resolvePeerId(
+        endpointId: String?,
+        lanRouteKey: Pair<String, Int>?,
+        bluetoothMac: String?,
+        bleAddress: String?,
+    ): String {
+        endpointId?.let(endpointIdIndex::get)?.let { return it }
+        lanRouteKey?.let(lanRouteIndex::get)?.let { return it }
+        bluetoothMac?.let(bluetoothIndex::get)?.let { return it }
+        bleAddress?.let(bleIndex::get)?.let { return it }
+        return when {
+            endpointId != null -> "endpoint:$endpointId"
+            lanRouteKey != null -> "lan:${lanRouteKey.first}:${lanRouteKey.second}"
+            bluetoothMac != null -> "bt:$bluetoothMac"
+            bleAddress != null -> "ble:$bleAddress"
+            else -> error("peer discovery update without any identity key")
+        }
+    }
+
+    private fun changeEvents(
+        before: NearbyPeer?,
+        after: NearbyPeer?,
+    ): List<NearbyPeerEvent> {
+        if (after == null) return emptyList()
+        if (before == after) return emptyList()
+        return listOf(NearbyPeerEvent.Resolved(after))
+    }
+}
+
+private data class MutablePeer(
+    val stableId: String,
+    var endpointId: String? = null,
+    var endpointInfo: EndpointInfo? = null,
+    val lanInstanceNames: MutableSet<String> = LinkedHashSet(),
+    var lanAddresses: List<InetAddress> = emptyList(),
+    var lanPort: Int? = null,
+    var lanRouteKey: Pair<String, Int>? = null,
+    var bluetoothMac: String? = null,
+    var bluetoothAdvertisedName: String? = null,
+    var bleAddress: String? = null,
+    var bleRssi: Int? = null,
+) {
+    fun toPeerOrNull(): NearbyPeer? {
+        val lan =
+            lanPort?.let { port ->
+                NearbyPeer.LanEndpoint(
+                    instanceNames = lanInstanceNames.toSet(),
+                    addresses = lanAddresses,
+                    port = port,
+                )
+            }
+        val bluetooth =
+            bluetoothMac?.let { mac ->
+                NearbyPeer.BluetoothEndpoint(
+                    macAddress = mac,
+                    advertisedName = bluetoothAdvertisedName ?: "",
+                )
+            }
+        val ble =
+            if (bleAddress != null || bleRssi != null) {
+                NearbyPeer.BleAdvertisement(
+                    advertiserAddress = bleAddress,
+                    rssi = bleRssi,
+                )
+            } else {
+                null
+            }
+        if (lan == null && bluetooth == null && ble == null) return null
+        return NearbyPeer(
+            stableId = stableId,
+            endpointId = endpointId,
+            endpointInfo = endpointInfo,
+            lanEndpoint = lan,
+            bluetoothEndpoint = bluetooth,
+            bleAdvertisement = ble,
+        )
+    }
+}
+
+private fun chooseEndpointInfo(
+    existing: EndpointInfo?,
+    incoming: EndpointInfo?,
+): EndpointInfo? {
+    if (existing == null) return incoming
+    if (incoming == null) return existing
+    val existingNamed = !existing.deviceName.isNullOrBlank()
+    val incomingNamed = !incoming.deviceName.isNullOrBlank()
+    return when {
+        incomingNamed && !existingNamed -> incoming
+        !incoming.hidden && existing.hidden -> incoming
+        else -> existing
+    }
+}
+
+private fun DiscoveredService.lanRouteKey(): Pair<String, Int>? =
+    primaryAddress()?.hostAddress?.let { host -> host to port }
+
+private fun ByteArray.toAsciiLabel(): String = String(this, Charsets.US_ASCII)

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleDctPsmHolder.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleDctPsmHolder.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.discovery.ble
+
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Process-local handoff from the receiver-side BLE L2CAP bootstrap listener to
+ * the DCT advertiser.
+ */
+internal object BleDctPsmHolder {
+    private val activePsm: AtomicInteger = AtomicInteger(NO_PSM)
+
+    val currentPsm: Int?
+        get() = activePsm.get().takeIf { it > NO_PSM }
+
+    fun set(psm: Int) {
+        activePsm.set(psm)
+    }
+
+    fun clear(psm: Int) {
+        activePsm.compareAndSet(psm, NO_PSM)
+    }
+
+    fun clear() {
+        activePsm.set(NO_PSM)
+    }
+
+    private const val NO_PSM: Int = 0
+}

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleFastAdvertisementScanner.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleFastAdvertisementScanner.kt
@@ -24,6 +24,7 @@ import android.os.ParcelUuid
 import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.core.content.ContextCompat
+import io.github.kyujincho.wvmg.protocol.endpoint.BleAdvertisementHeader
 import io.github.kyujincho.wvmg.protocol.endpoint.BleServiceData
 import io.github.kyujincho.wvmg.protocol.endpoint.DctAdvertisement
 import io.github.kyujincho.wvmg.protocol.endpoint.DeviceType
@@ -97,11 +98,12 @@ public class BleFastAdvertisementScanner(
         }
 
     public data class Observation(
-        val endpointId: String,
-        val endpointInfo: EndpointInfo,
+        val endpointId: String?,
+        val endpointInfo: EndpointInfo?,
         val advertiserAddress: String?,
         val rssi: Int?,
         val l2capPsm: Int?,
+        val gattConnectable: Boolean,
     )
 
     private fun ScanResult.toObservation(): Observation? {
@@ -132,9 +134,10 @@ public class BleFastAdvertisementScanner(
                     } else {
                         Log.w(
                             TAG,
-                            "BLE fast-advertisement observed endpointId=${observation.endpointId} " +
+                            "BLE fast-advertisement observed endpointId=${observation.endpointId ?: "<none>"} " +
                                 "address=${observation.advertiserAddress} rssi=${observation.rssi} " +
-                                "psm=${observation.l2capPsm} bytes=${serviceData.toHex()}",
+                                "psm=${observation.l2capPsm} gatt=${observation.gattConnectable} " +
+                                "bytes=${serviceData.toHex()}",
                         )
                     }
                 }
@@ -151,9 +154,10 @@ public class BleFastAdvertisementScanner(
                     } else {
                         Log.w(
                             TAG,
-                            "BLE DCT advertisement observed endpointId=${observation.endpointId} " +
+                            "BLE DCT advertisement observed endpointId=${observation.endpointId ?: "<none>"} " +
                                 "address=${observation.advertiserAddress} rssi=${observation.rssi} " +
-                                "psm=${observation.l2capPsm} name=${observation.endpointInfo.deviceName} " +
+                                "psm=${observation.l2capPsm} gatt=${observation.gattConnectable} " +
+                                "name=${observation.endpointInfo?.deviceName} " +
                                 "bytes=${serviceData.toHex()}",
                         )
                     }
@@ -229,6 +233,17 @@ public class BleFastAdvertisementScanner(
             advertiserAddress: String?,
             rssi: Int?,
         ): Observation? {
+            BleAdvertisementHeader.parse(serviceData)?.let { header ->
+                val l2capPsm = header.psm.takeIf { it > 0 }
+                return Observation(
+                    endpointId = null,
+                    endpointInfo = null,
+                    advertiserAddress = advertiserAddress,
+                    rssi = rssi,
+                    l2capPsm = l2capPsm,
+                    gattConnectable = advertiserAddress != null,
+                )
+            }
             val parsed = BleServiceData.parse(serviceData) ?: return null
             val endpointId = String(parsed.endpointId, Charsets.US_ASCII)
             val l2capPsm = BleServiceData.parsePsmExtraField(serviceData)?.takeIf { it > 0 }
@@ -238,6 +253,7 @@ public class BleFastAdvertisementScanner(
                 advertiserAddress = advertiserAddress,
                 rssi = rssi,
                 l2capPsm = l2capPsm,
+                gattConnectable = advertiserAddress != null,
             )
         }
 
@@ -257,6 +273,7 @@ public class BleFastAdvertisementScanner(
                 advertiserAddress = advertiserAddress,
                 rssi = rssi,
                 l2capPsm = l2capPsm,
+                gattConnectable = advertiserAddress != null,
             )
         }
 
@@ -268,7 +285,7 @@ public class BleFastAdvertisementScanner(
                 dctObservation == null -> fastObservation
                 fastObservation == null -> dctObservation
                 dctObservation.l2capPsm != null -> dctObservation
-                !dctObservation.endpointInfo.deviceName.isNullOrBlank() -> dctObservation
+                !dctObservation.endpointInfo?.deviceName.isNullOrBlank() -> dctObservation
                 else -> fastObservation
             }
     }

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleFastAdvertisementScanner.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleFastAdvertisementScanner.kt
@@ -94,6 +94,7 @@ public class BleFastAdvertisementScanner(
         val endpointInfo: EndpointInfo,
         val advertiserAddress: String?,
         val rssi: Int?,
+        val l2capPsm: Int?,
     )
 
     private fun ScanResult.toObservation(): Observation? {
@@ -121,16 +122,18 @@ public class BleFastAdvertisementScanner(
                 return null
             }
         val endpointId = String(parsed.endpointId, Charsets.US_ASCII)
+        val l2capPsm = BleServiceData.parsePsmExtraField(serviceData)?.takeIf { it > 0 }
         Log.w(
             TAG,
             "BLE fast-advertisement observed endpointId=$endpointId " +
-                "address=${device?.address} rssi=$rssi bytes=${serviceData.toHex()}",
+                "address=${device?.address} rssi=$rssi psm=$l2capPsm bytes=${serviceData.toHex()}",
         )
         return Observation(
             endpointId = endpointId,
             endpointInfo = parsed.endpointInfo,
             advertiserAddress = device?.address,
             rssi = rssi,
+            l2capPsm = l2capPsm,
         )
     }
 

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleFastAdvertisementScanner.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleFastAdvertisementScanner.kt
@@ -40,7 +40,7 @@ public class BleFastAdvertisementScanner(
     public fun scan(): Flow<Observation> =
         callbackFlow {
             if (!hasScanPermission()) {
-                Log.i(TAG, "BLE fast-advertisement scan unavailable: missing BLUETOOTH_SCAN")
+                Log.i(TAG, "BLE fast-advertisement scan unavailable: missing runtime permission")
                 close()
                 return@callbackFlow
             }
@@ -71,7 +71,13 @@ public class BleFastAdvertisementScanner(
                     }
                 }
 
-            scanner.startScan(buildFilters(), buildSettings(), callback)
+            try {
+                scanner.startScan(buildFilters(), buildSettings(), callback)
+            } catch (e: SecurityException) {
+                Log.w(TAG, "BLE fast-advertisement scan start rejected by platform", e)
+                close()
+                return@callbackFlow
+            }
             awaitClose {
                 runCatching { scanner.stopScan(callback) }
             }
@@ -103,10 +109,12 @@ public class BleFastAdvertisementScanner(
         return adapter.bluetoothLeScanner
     }
 
-    private fun hasScanPermission(): Boolean {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return true
-        return checkSPermission()
-    }
+    private fun hasScanPermission(): Boolean =
+        when {
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> checkSPermission()
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.M -> hasLegacyLocationPermission()
+            else -> true
+        }
 
     @RequiresApi(Build.VERSION_CODES.S)
     private fun checkSPermission(): Boolean =
@@ -114,6 +122,16 @@ public class BleFastAdvertisementScanner(
             context,
             Manifest.permission.BLUETOOTH_SCAN,
         ) == PackageManager.PERMISSION_GRANTED
+
+    private fun hasLegacyLocationPermission(): Boolean =
+        ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.ACCESS_FINE_LOCATION,
+        ) == PackageManager.PERMISSION_GRANTED ||
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.ACCESS_COARSE_LOCATION,
+            ) == PackageManager.PERMISSION_GRANTED
 
     private fun buildFilters(): List<ScanFilter> =
         listOf(

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleFastAdvertisementScanner.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleFastAdvertisementScanner.kt
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+@file:Suppress("ReturnCount")
+
+@file:android.annotation.SuppressLint("MissingPermission")
+
+package io.github.kyujincho.wvmg.discovery.ble
+
+import android.Manifest
+import android.bluetooth.BluetoothManager
+import android.bluetooth.le.BluetoothLeScanner
+import android.bluetooth.le.ScanCallback
+import android.bluetooth.le.ScanFilter
+import android.bluetooth.le.ScanRecord
+import android.bluetooth.le.ScanResult
+import android.bluetooth.le.ScanSettings
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.ParcelUuid
+import android.util.Log
+import androidx.annotation.RequiresApi
+import androidx.core.content.ContextCompat
+import io.github.kyujincho.wvmg.protocol.endpoint.BleServiceData
+import io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+
+/**
+ * Sender-side scanner for the stock Quick Share receiver fast-advertisement
+ * BLE payload on service UUID `0xFEF3`.
+ */
+public class BleFastAdvertisementScanner(
+    private val context: Context,
+) {
+    public fun scan(): Flow<Observation> =
+        callbackFlow {
+            if (!hasScanPermission()) {
+                Log.i(TAG, "BLE fast-advertisement scan unavailable: missing BLUETOOTH_SCAN")
+                close()
+                return@callbackFlow
+            }
+            val scanner = resolveScanner()
+            if (scanner == null) {
+                Log.i(TAG, "BLE fast-advertisement scan unavailable")
+                close()
+                return@callbackFlow
+            }
+
+            val callback =
+                object : ScanCallback() {
+                    override fun onScanResult(
+                        callbackType: Int,
+                        result: ScanResult?,
+                    ) {
+                        result?.toObservation()?.let { observation ->
+                            trySend(observation).isSuccess
+                        }
+                    }
+
+                    override fun onBatchScanResults(results: MutableList<ScanResult>?) {
+                        results.orEmpty().forEach { result ->
+                            result.toObservation()?.let { observation ->
+                                trySend(observation).isSuccess
+                            }
+                        }
+                    }
+                }
+
+            scanner.startScan(buildFilters(), buildSettings(), callback)
+            awaitClose {
+                runCatching { scanner.stopScan(callback) }
+            }
+        }
+
+    public data class Observation(
+        val endpointId: String,
+        val endpointInfo: EndpointInfo,
+        val advertiserAddress: String?,
+        val rssi: Int?,
+    )
+
+    private fun ScanResult.toObservation(): Observation? {
+        val scanRecord: ScanRecord = scanRecord ?: return null
+        val serviceData = scanRecord.getServiceData(SERVICE_UUID) ?: return null
+        val parsed = BleServiceData.parse(serviceData) ?: return null
+        return Observation(
+            endpointId = String(parsed.endpointId, Charsets.US_ASCII),
+            endpointInfo = parsed.endpointInfo,
+            advertiserAddress = device?.address,
+            rssi = rssi,
+        )
+    }
+
+    private fun resolveScanner(): BluetoothLeScanner? {
+        val manager = context.applicationContext.getSystemService(BluetoothManager::class.java) ?: return null
+        val adapter = manager.adapter ?: return null
+        if (!adapter.isEnabled) return null
+        return adapter.bluetoothLeScanner
+    }
+
+    private fun hasScanPermission(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return true
+        return checkSPermission()
+    }
+
+    @RequiresApi(Build.VERSION_CODES.S)
+    private fun checkSPermission(): Boolean =
+        ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.BLUETOOTH_SCAN,
+        ) == PackageManager.PERMISSION_GRANTED
+
+    private fun buildFilters(): List<ScanFilter> =
+        listOf(
+            ScanFilter
+                .Builder()
+                .setServiceUuid(SERVICE_UUID)
+                .build(),
+        )
+
+    private fun buildSettings(): ScanSettings =
+        ScanSettings
+            .Builder()
+            .setScanMode(ScanSettings.SCAN_MODE_BALANCED)
+            .setReportDelay(0)
+            .build()
+
+    private companion object {
+        private const val TAG: String = "WvmgBleFastScan"
+        private val SERVICE_UUID: ParcelUuid =
+            ParcelUuid.fromString(BleServiceData.SERVICE_UUID_128_STRING)
+    }
+}

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleFastAdvertisementScanner.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleFastAdvertisementScanner.kt
@@ -25,14 +25,17 @@ import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.core.content.ContextCompat
 import io.github.kyujincho.wvmg.protocol.endpoint.BleServiceData
+import io.github.kyujincho.wvmg.protocol.endpoint.DctAdvertisement
+import io.github.kyujincho.wvmg.protocol.endpoint.DeviceType
 import io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo
+import io.github.kyujincho.wvmg.protocol.endpoint.NearbyServiceId
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 
 /**
  * Sender-side scanner for the stock Quick Share receiver fast-advertisement
- * BLE payload on service UUID `0xFEF3`.
+ * BLE payloads on service UUIDs `0xFEF3` and `0xFC73`.
  */
 public class BleFastAdvertisementScanner(
     private val context: Context,
@@ -77,7 +80,11 @@ public class BleFastAdvertisementScanner(
                 }
 
             try {
-                Log.w(TAG, "BLE fast-advertisement scan start uuid=${BleServiceData.SERVICE_UUID_128_STRING}")
+                Log.w(
+                    TAG,
+                    "BLE fast-advertisement scan start uuid=${BleServiceData.SERVICE_UUID_128_STRING} " +
+                        "dctUuid=${DctAdvertisement.SERVICE_UUID_128_STRING}",
+                )
                 scanner.startScan(buildFilters(), buildSettings(), callback)
             } catch (e: SecurityException) {
                 Log.w(TAG, "BLE fast-advertisement scan start rejected by platform", e)
@@ -103,37 +110,58 @@ public class BleFastAdvertisementScanner(
                 Log.w(TAG, "BLE fast-advertisement result without ScanRecord address=${device?.address}")
                 return null
             }
-        val serviceData =
-            scanRecord.getServiceData(SERVICE_UUID) ?: run {
-                Log.w(
-                    TAG,
-                    "BLE fast-advertisement result without service data " +
-                        "address=${device?.address} rssi=$rssi uuids=${scanRecord.serviceUuids}",
-                )
-                return null
+        val fastData = scanRecord.getServiceData(SERVICE_UUID)
+        val dctData = scanRecord.getServiceData(DCT_SERVICE_UUID)
+        if (fastData == null && dctData == null) {
+            Log.w(
+                TAG,
+                "BLE receiver-advertisement result without supported service data " +
+                    "address=${device?.address} rssi=$rssi uuids=${scanRecord.serviceUuids}",
+            )
+            return null
+        }
+        val fastObservation =
+            fastData?.let { serviceData ->
+                parseFastServiceData(serviceData, device?.address, rssi).also { observation ->
+                    if (observation == null) {
+                        Log.w(
+                            TAG,
+                            "BLE fast-advertisement parse failed address=${device?.address} " +
+                                "rssi=$rssi bytes=${serviceData.toHex()}",
+                        )
+                    } else {
+                        Log.w(
+                            TAG,
+                            "BLE fast-advertisement observed endpointId=${observation.endpointId} " +
+                                "address=${observation.advertiserAddress} rssi=${observation.rssi} " +
+                                "psm=${observation.l2capPsm} bytes=${serviceData.toHex()}",
+                        )
+                    }
+                }
             }
-        val parsed =
-            BleServiceData.parse(serviceData) ?: run {
-                Log.w(
-                    TAG,
-                    "BLE fast-advertisement parse failed address=${device?.address} " +
-                        "rssi=$rssi bytes=${serviceData.toHex()}",
-                )
-                return null
+        val dctObservation =
+            dctData?.let { serviceData ->
+                parseDctServiceData(serviceData, device?.address, rssi).also { observation ->
+                    if (observation == null) {
+                        Log.w(
+                            TAG,
+                            "BLE DCT advertisement parse failed or ignored address=${device?.address} " +
+                                "rssi=$rssi bytes=${serviceData.toHex()}",
+                        )
+                    } else {
+                        Log.w(
+                            TAG,
+                            "BLE DCT advertisement observed endpointId=${observation.endpointId} " +
+                                "address=${observation.advertiserAddress} rssi=${observation.rssi} " +
+                                "psm=${observation.l2capPsm} name=${observation.endpointInfo.deviceName} " +
+                                "bytes=${serviceData.toHex()}",
+                        )
+                    }
+                }
             }
-        val endpointId = String(parsed.endpointId, Charsets.US_ASCII)
-        val l2capPsm = BleServiceData.parsePsmExtraField(serviceData)?.takeIf { it > 0 }
-        Log.w(
-            TAG,
-            "BLE fast-advertisement observed endpointId=$endpointId " +
-                "address=${device?.address} rssi=$rssi psm=$l2capPsm bytes=${serviceData.toHex()}",
-        )
-        return Observation(
-            endpointId = endpointId,
-            endpointInfo = parsed.endpointInfo,
-            advertiserAddress = device?.address,
-            rssi = rssi,
-            l2capPsm = l2capPsm,
+        return chooseObservation(
+            fastObservation = fastObservation,
+            dctObservation = dctObservation,
         )
     }
 
@@ -174,6 +202,10 @@ public class BleFastAdvertisementScanner(
                 .Builder()
                 .setServiceData(SERVICE_UUID, ByteArray(0), ByteArray(0))
                 .build(),
+            ScanFilter
+                .Builder()
+                .setServiceData(DCT_SERVICE_UUID, ByteArray(0), ByteArray(0))
+                .build(),
         )
 
     private fun buildSettings(): ScanSettings =
@@ -183,11 +215,73 @@ public class BleFastAdvertisementScanner(
             .setReportDelay(0)
             .build()
 
-    private companion object {
+    public companion object {
         private const val TAG: String = "WvmgBleFastScan"
-        private val SERVICE_UUID: ParcelUuid =
-            ParcelUuid.fromString(BleServiceData.SERVICE_UUID_128_STRING)
+        private val SERVICE_UUID: ParcelUuid
+            get() = ParcelUuid.fromString(BleServiceData.SERVICE_UUID_128_STRING)
+        private val DCT_SERVICE_UUID: ParcelUuid
+            get() = ParcelUuid.fromString(DctAdvertisement.SERVICE_UUID_128_STRING)
+        private val EXPECTED_DCT_SERVICE_ID_HASH: ByteArray =
+            DctAdvertisement.computeServiceIdHash(NearbyServiceId.VALUE)
+
+        internal fun parseFastServiceData(
+            serviceData: ByteArray,
+            advertiserAddress: String?,
+            rssi: Int?,
+        ): Observation? {
+            val parsed = BleServiceData.parse(serviceData) ?: return null
+            val endpointId = String(parsed.endpointId, Charsets.US_ASCII)
+            val l2capPsm = BleServiceData.parsePsmExtraField(serviceData)?.takeIf { it > 0 }
+            return Observation(
+                endpointId = endpointId,
+                endpointInfo = parsed.endpointInfo,
+                advertiserAddress = advertiserAddress,
+                rssi = rssi,
+                l2capPsm = l2capPsm,
+            )
+        }
+
+        internal fun parseDctServiceData(
+            serviceData: ByteArray,
+            advertiserAddress: String?,
+            rssi: Int?,
+        ): Observation? {
+            val parsed = DctAdvertisement.parse(serviceData) ?: return null
+            if (!parsed.serviceIdHash.contentEquals(EXPECTED_DCT_SERVICE_ID_HASH)) return null
+            val endpointId =
+                DctAdvertisement.generateEndpointId(parsed.dedup, parsed.deviceName) ?: return null
+            val l2capPsm = parsed.psm.takeIf { it > 0 }
+            return Observation(
+                endpointId = endpointId,
+                endpointInfo = parsed.toEndpointInfo(),
+                advertiserAddress = advertiserAddress,
+                rssi = rssi,
+                l2capPsm = l2capPsm,
+            )
+        }
+
+        private fun chooseObservation(
+            fastObservation: Observation?,
+            dctObservation: Observation?,
+        ): Observation? =
+            when {
+                dctObservation == null -> fastObservation
+                fastObservation == null -> dctObservation
+                dctObservation.l2capPsm != null -> dctObservation
+                !dctObservation.endpointInfo.deviceName.isNullOrBlank() -> dctObservation
+                else -> fastObservation
+            }
     }
 }
+
+private fun DctAdvertisement.Parsed.toEndpointInfo(): EndpointInfo =
+    EndpointInfo(
+        version = 1,
+        hidden = false,
+        deviceType = DeviceType.PHONE,
+        reserved = false,
+        metadata = ByteArray(EndpointInfo.METADATA_LEN),
+        deviceName = deviceName,
+    )
 
 private fun ByteArray.toHex(): String = joinToString("") { "%02x".format(it) }

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleFastAdvertisementScanner.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleFastAdvertisementScanner.kt
@@ -21,6 +21,7 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.ParcelUuid
+import android.os.SystemClock
 import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.core.content.ContextCompat
@@ -33,6 +34,8 @@ import io.github.kyujincho.wvmg.protocol.endpoint.NearbyServiceId
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.launch
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Sender-side scanner for the stock Quick Share receiver fast-advertisement
@@ -43,6 +46,54 @@ public class BleFastAdvertisementScanner(
 ) {
     public fun scan(): Flow<Observation> =
         callbackFlow {
+            val gattAdvertisementReader = BleGattAdvertisementReader(context.applicationContext)
+            val gattReadAttempts = ConcurrentHashMap<String, Long>()
+            val gattReadInFlight = ConcurrentHashMap.newKeySet<String>()
+            val gattReadSucceeded = ConcurrentHashMap.newKeySet<String>()
+
+            fun scheduleGattAdvertisementRead(
+                header: BleAdvertisementHeader,
+                advertiserAddress: String,
+                rssi: Int?,
+            ) {
+                val key = "$advertiserAddress:${header.advertisementHash.toHex()}:${header.numSlots}"
+                if (key in gattReadSucceeded) return
+                if (!gattReadInFlight.add(key)) return
+                val now = SystemClock.elapsedRealtime()
+                val lastAttempt = gattReadAttempts[key]
+                if (lastAttempt != null && now - lastAttempt < GATT_READ_RETRY_MILLIS) {
+                    gattReadInFlight.remove(key)
+                    return
+                }
+                gattReadAttempts[key] = now
+                launch {
+                    try {
+                        val slotAdvertisements =
+                            gattAdvertisementReader.read(
+                                macAddress = advertiserAddress,
+                                slotCount = header.numSlots,
+                            )
+                        if (slotAdvertisements.isNotEmpty()) {
+                            gattReadSucceeded.add(key)
+                        }
+                        slotAdvertisements.forEach { slot ->
+                            trySend(
+                                Observation(
+                                    endpointId = slot.endpointId,
+                                    endpointInfo = slot.endpointInfo,
+                                    advertiserAddress = advertiserAddress,
+                                    rssi = rssi,
+                                    l2capPsm = slot.l2capPsm ?: header.psm.takeIf { it > 0 },
+                                    gattConnectable = true,
+                                ),
+                            ).isSuccess
+                        }
+                    } finally {
+                        gattReadInFlight.remove(key)
+                    }
+                }
+            }
+
             if (!hasScanPermission()) {
                 Log.i(TAG, "BLE fast-advertisement scan unavailable: missing runtime permission")
                 close()
@@ -61,14 +112,14 @@ public class BleFastAdvertisementScanner(
                         callbackType: Int,
                         result: ScanResult?,
                     ) {
-                        result?.toObservation()?.let { observation ->
+                        result?.toObservation(::scheduleGattAdvertisementRead)?.let { observation ->
                             trySend(observation).isSuccess
                         }
                     }
 
                     override fun onBatchScanResults(results: MutableList<ScanResult>?) {
                         results.orEmpty().forEach { result ->
-                            result.toObservation()?.let { observation ->
+                            result.toObservation(::scheduleGattAdvertisementRead)?.let { observation ->
                                 trySend(observation).isSuccess
                             }
                         }
@@ -106,7 +157,10 @@ public class BleFastAdvertisementScanner(
         val gattConnectable: Boolean,
     )
 
-    private fun ScanResult.toObservation(): Observation? {
+    @Suppress("CyclomaticComplexMethod", "NestedBlockDepth")
+    private fun ScanResult.toObservation(
+        scheduleGattAdvertisementRead: (BleAdvertisementHeader, String, Int?) -> Unit,
+    ): Observation? {
         val scanRecord: ScanRecord =
             scanRecord ?: run {
                 Log.w(TAG, "BLE fast-advertisement result without ScanRecord address=${device?.address}")
@@ -114,6 +168,7 @@ public class BleFastAdvertisementScanner(
             }
         val fastData = scanRecord.getServiceData(SERVICE_UUID)
         val dctData = scanRecord.getServiceData(DCT_SERVICE_UUID)
+        val gattConnectable = isGattConnectable()
         if (fastData == null && dctData == null) {
             Log.w(
                 TAG,
@@ -124,7 +179,14 @@ public class BleFastAdvertisementScanner(
         }
         val fastObservation =
             fastData?.let { serviceData ->
-                parseFastServiceData(serviceData, device?.address, rssi).also { observation ->
+                BleAdvertisementHeader.parse(serviceData)?.let { header ->
+                    device?.address?.let { address ->
+                        if (gattConnectable) {
+                            scheduleGattAdvertisementRead(header, address, rssi)
+                        }
+                    }
+                }
+                parseFastServiceData(serviceData, device?.address, rssi, gattConnectable).also { observation ->
                     if (observation == null) {
                         Log.w(
                             TAG,
@@ -144,7 +206,7 @@ public class BleFastAdvertisementScanner(
             }
         val dctObservation =
             dctData?.let { serviceData ->
-                parseDctServiceData(serviceData, device?.address, rssi).also { observation ->
+                parseDctServiceData(serviceData, device?.address, rssi, gattConnectable).also { observation ->
                     if (observation == null) {
                         Log.w(
                             TAG,
@@ -219,8 +281,16 @@ public class BleFastAdvertisementScanner(
             .setReportDelay(0)
             .build()
 
+    private fun ScanResult.isGattConnectable(): Boolean =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            isConnectable
+        } else {
+            device?.address != null
+        }
+
     public companion object {
         private const val TAG: String = "WvmgBleFastScan"
+        private const val GATT_READ_RETRY_MILLIS: Long = 5_000L
         private val SERVICE_UUID: ParcelUuid
             get() = ParcelUuid.fromString(BleServiceData.SERVICE_UUID_128_STRING)
         private val DCT_SERVICE_UUID: ParcelUuid
@@ -232,6 +302,7 @@ public class BleFastAdvertisementScanner(
             serviceData: ByteArray,
             advertiserAddress: String?,
             rssi: Int?,
+            gattConnectable: Boolean = advertiserAddress != null,
         ): Observation? {
             BleAdvertisementHeader.parse(serviceData)?.let { header ->
                 val l2capPsm = header.psm.takeIf { it > 0 }
@@ -241,7 +312,7 @@ public class BleFastAdvertisementScanner(
                     advertiserAddress = advertiserAddress,
                     rssi = rssi,
                     l2capPsm = l2capPsm,
-                    gattConnectable = advertiserAddress != null,
+                    gattConnectable = gattConnectable && advertiserAddress != null,
                 )
             }
             val parsed = BleServiceData.parse(serviceData) ?: return null
@@ -253,7 +324,7 @@ public class BleFastAdvertisementScanner(
                 advertiserAddress = advertiserAddress,
                 rssi = rssi,
                 l2capPsm = l2capPsm,
-                gattConnectable = advertiserAddress != null,
+                gattConnectable = gattConnectable && advertiserAddress != null,
             )
         }
 
@@ -261,6 +332,7 @@ public class BleFastAdvertisementScanner(
             serviceData: ByteArray,
             advertiserAddress: String?,
             rssi: Int?,
+            gattConnectable: Boolean = advertiserAddress != null,
         ): Observation? {
             val parsed = DctAdvertisement.parse(serviceData) ?: return null
             if (!parsed.serviceIdHash.contentEquals(EXPECTED_DCT_SERVICE_ID_HASH)) return null
@@ -273,7 +345,7 @@ public class BleFastAdvertisementScanner(
                 advertiserAddress = advertiserAddress,
                 rssi = rssi,
                 l2capPsm = l2capPsm,
-                gattConnectable = advertiserAddress != null,
+                gattConnectable = gattConnectable && advertiserAddress != null,
             )
         }
 

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleFastAdvertisementScanner.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleFastAdvertisementScanner.kt
@@ -69,9 +69,15 @@ public class BleFastAdvertisementScanner(
                             }
                         }
                     }
+
+                    override fun onScanFailed(errorCode: Int) {
+                        Log.w(TAG, "BLE fast-advertisement scan failed code=$errorCode")
+                        close()
+                    }
                 }
 
             try {
+                Log.w(TAG, "BLE fast-advertisement scan start uuid=${BleServiceData.SERVICE_UUID_128_STRING}")
                 scanner.startScan(buildFilters(), buildSettings(), callback)
             } catch (e: SecurityException) {
                 Log.w(TAG, "BLE fast-advertisement scan start rejected by platform", e)
@@ -91,11 +97,37 @@ public class BleFastAdvertisementScanner(
     )
 
     private fun ScanResult.toObservation(): Observation? {
-        val scanRecord: ScanRecord = scanRecord ?: return null
-        val serviceData = scanRecord.getServiceData(SERVICE_UUID) ?: return null
-        val parsed = BleServiceData.parse(serviceData) ?: return null
+        val scanRecord: ScanRecord =
+            scanRecord ?: run {
+                Log.w(TAG, "BLE fast-advertisement result without ScanRecord address=${device?.address}")
+                return null
+            }
+        val serviceData =
+            scanRecord.getServiceData(SERVICE_UUID) ?: run {
+                Log.w(
+                    TAG,
+                    "BLE fast-advertisement result without service data " +
+                        "address=${device?.address} rssi=$rssi uuids=${scanRecord.serviceUuids}",
+                )
+                return null
+            }
+        val parsed =
+            BleServiceData.parse(serviceData) ?: run {
+                Log.w(
+                    TAG,
+                    "BLE fast-advertisement parse failed address=${device?.address} " +
+                        "rssi=$rssi bytes=${serviceData.toHex()}",
+                )
+                return null
+            }
+        val endpointId = String(parsed.endpointId, Charsets.US_ASCII)
+        Log.w(
+            TAG,
+            "BLE fast-advertisement observed endpointId=$endpointId " +
+                "address=${device?.address} rssi=$rssi bytes=${serviceData.toHex()}",
+        )
         return Observation(
-            endpointId = String(parsed.endpointId, Charsets.US_ASCII),
+            endpointId = endpointId,
             endpointInfo = parsed.endpointInfo,
             advertiserAddress = device?.address,
             rssi = rssi,
@@ -137,7 +169,7 @@ public class BleFastAdvertisementScanner(
         listOf(
             ScanFilter
                 .Builder()
-                .setServiceUuid(SERVICE_UUID)
+                .setServiceData(SERVICE_UUID, ByteArray(0), ByteArray(0))
                 .build(),
         )
 
@@ -154,3 +186,5 @@ public class BleFastAdvertisementScanner(
             ParcelUuid.fromString(BleServiceData.SERVICE_UUID_128_STRING)
     }
 }
+
+private fun ByteArray.toHex(): String = joinToString("") { "%02x".format(it) }

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleGattAdvertisementReader.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleGattAdvertisementReader.kt
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+@file:android.annotation.SuppressLint("MissingPermission")
+@file:Suppress("DEPRECATION", "MagicNumber", "ReturnCount", "TooGenericExceptionCaught")
+
+package io.github.kyujincho.wvmg.discovery.ble
+
+import android.Manifest
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCallback
+import android.bluetooth.BluetoothGattCharacteristic
+import android.bluetooth.BluetoothManager
+import android.bluetooth.BluetoothProfile
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import android.util.Log
+import androidx.annotation.RequiresApi
+import androidx.core.content.ContextCompat
+import io.github.kyujincho.wvmg.discovery.bootstrap.BleGattInitialControlServer
+import io.github.kyujincho.wvmg.protocol.endpoint.BleAdvertisement
+import io.github.kyujincho.wvmg.protocol.endpoint.BleServiceData
+import io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo
+import io.github.kyujincho.wvmg.protocol.endpoint.NearbyServiceId
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * Reads Nearby BLE v2 GATT advertisement slots referenced by a `0x55`
+ * advertisement header.
+ */
+internal class BleGattAdvertisementReader(
+    private val context: Context,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) {
+    suspend fun read(
+        macAddress: String,
+        slotCount: Int,
+    ): List<SlotAdvertisement> =
+        withContext(dispatcher) {
+            if (!isAvailable() || slotCount <= 0) return@withContext emptyList()
+            val adapter =
+                context
+                    .applicationContext
+                    .getSystemService(BluetoothManager::class.java)
+                    ?.adapter
+                    ?: return@withContext emptyList()
+            val device =
+                try {
+                    adapter.getRemoteDevice(macAddress)
+                } catch (badAddress: IllegalArgumentException) {
+                    Log.w(TAG, "invalid BLE GATT advertisement address=$macAddress", badAddress)
+                    return@withContext emptyList()
+                }
+            val callback = Callback(slotCount.coerceAtMost(MAX_SLOT_COUNT))
+            val gatt =
+                device.connectGatt(
+                    context.applicationContext,
+                    false,
+                    callback,
+                    BluetoothDevice.TRANSPORT_LE,
+                ) ?: return@withContext emptyList()
+            callback.attach(gatt)
+            try {
+                withTimeoutOrNull(READ_TIMEOUT_MILLIS) { callback.result.await() }.orEmpty()
+            } finally {
+                runCatching { gatt.disconnect() }
+                runCatching { gatt.close() }
+            }
+        }
+
+    private fun isAvailable(): Boolean {
+        val appContext = context.applicationContext
+        if (!appContext.packageManager.hasSystemFeature(PackageManager.FEATURE_BLUETOOTH_LE)) return false
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && !hasConnectPermission(appContext)) return false
+        val manager = appContext.getSystemService(BluetoothManager::class.java) ?: return false
+        val adapter = manager.adapter ?: return false
+        return adapter.isEnabled
+    }
+
+    @RequiresApi(Build.VERSION_CODES.S)
+    private fun hasConnectPermission(context: Context): Boolean =
+        ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.BLUETOOTH_CONNECT,
+        ) == PackageManager.PERMISSION_GRANTED
+
+    private class Callback(
+        private val slotCount: Int,
+    ) : BluetoothGattCallback() {
+        val result = CompletableDeferred<List<SlotAdvertisement>>()
+        private val rawSlots = mutableListOf<ByteArray>()
+        private var gatt: BluetoothGatt? = null
+        private var slots: List<BluetoothGattCharacteristic> = emptyList()
+        private var nextSlotIndex: Int = 0
+
+        fun attach(gatt: BluetoothGatt) {
+            this.gatt = gatt
+        }
+
+        override fun onConnectionStateChange(
+            gatt: BluetoothGatt,
+            status: Int,
+            newState: Int,
+        ) {
+            Log.i(TAG, "slot-read state status=$status newState=$newState device=${gatt.device.safeAddress()}")
+            if (status == BluetoothGatt.GATT_SUCCESS && newState == BluetoothProfile.STATE_CONNECTED) {
+                if (!gatt.discoverServices()) complete()
+            } else {
+                complete()
+            }
+        }
+
+        override fun onServicesDiscovered(
+            gatt: BluetoothGatt,
+            status: Int,
+        ) {
+            if (status != BluetoothGatt.GATT_SUCCESS) {
+                Log.w(TAG, "slot-read service discovery failed status=$status")
+                complete()
+                return
+            }
+            val service = gatt.getService(BleGattInitialControlServer.SERVICE_UUID)
+            if (service == null) {
+                Log.w(TAG, "slot-read service missing")
+                complete()
+                return
+            }
+            slots =
+                (0 until slotCount)
+                    .mapNotNull { slot ->
+                        service.getCharacteristic(BleGattInitialControlServer.advertisementSlotUuid(slot))
+                    }
+            readNextSlot()
+        }
+
+        @Deprecated("Android calls this overload before API 33")
+        override fun onCharacteristicRead(
+            gatt: BluetoothGatt,
+            characteristic: BluetoothGattCharacteristic,
+            status: Int,
+        ) {
+            handleCharacteristicRead(characteristic.value ?: ByteArray(0), status)
+        }
+
+        override fun onCharacteristicRead(
+            gatt: BluetoothGatt,
+            characteristic: BluetoothGattCharacteristic,
+            value: ByteArray,
+            status: Int,
+        ) {
+            handleCharacteristicRead(value, status)
+        }
+
+        private fun handleCharacteristicRead(
+            value: ByteArray,
+            status: Int,
+        ) {
+            if (status == BluetoothGatt.GATT_SUCCESS && value.isNotEmpty()) {
+                rawSlots += value.copyOf()
+                Log.i(TAG, "slot-read value len=${value.size} header=${value.firstByteHex()}")
+            } else {
+                Log.i(TAG, "slot-read empty or failed status=$status")
+            }
+            nextSlotIndex += 1
+            readNextSlot()
+        }
+
+        private fun readNextSlot() {
+            val openGatt = gatt
+            if (openGatt == null || nextSlotIndex >= slots.size) {
+                complete()
+                return
+            }
+            if (!openGatt.readCharacteristic(slots[nextSlotIndex])) {
+                Log.w(TAG, "readCharacteristic returned false slot=$nextSlotIndex")
+                nextSlotIndex += 1
+                readNextSlot()
+            }
+        }
+
+        private fun complete() {
+            if (!result.isCompleted) {
+                result.complete(rawSlots.mapNotNull(::parseSlotAdvertisement))
+            }
+        }
+
+        private fun parseSlotAdvertisement(raw: ByteArray): SlotAdvertisement? {
+            val advertisement = BleAdvertisement.parse(raw)
+            val serviceData =
+                when {
+                    advertisement?.serviceIdHash?.contentEquals(NearbyServiceId.hashPrefix) == true ->
+                        advertisement.data
+
+                    advertisement?.fastAdvertisement == true ->
+                        raw
+
+                    advertisement == null ->
+                        raw
+
+                    else ->
+                        return null
+                }
+            val endpoint = BleServiceData.parse(serviceData) ?: return null
+            return SlotAdvertisement(
+                endpointId = String(endpoint.endpointId, Charsets.US_ASCII),
+                endpointInfo = endpoint.endpointInfo,
+                l2capPsm = advertisement?.psm?.takeIf { it > 0 },
+            )
+        }
+    }
+
+    data class SlotAdvertisement(
+        val endpointId: String,
+        val endpointInfo: EndpointInfo,
+        val l2capPsm: Int?,
+    )
+
+    private companion object {
+        private const val TAG: String = "WvmgBleFastScan"
+        private const val MAX_SLOT_COUNT: Int = 16
+        private const val READ_TIMEOUT_MILLIS: Long = 7_000L
+    }
+}
+
+private fun BluetoothDevice.safeAddress(): String = runCatching { address }.getOrNull() ?: "<unknown>"
+
+private fun ByteArray.firstByteHex(): String = firstOrNull()?.let { "%02x".format(it) } ?: "--"

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareAdvertiser.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareAdvertiser.kt
@@ -7,10 +7,13 @@ package io.github.kyujincho.wvmg.discovery.ble
 
 import android.Manifest
 import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothDevice
 import android.bluetooth.BluetoothManager
 import android.bluetooth.le.AdvertiseCallback
 import android.bluetooth.le.AdvertiseData
 import android.bluetooth.le.AdvertiseSettings
+import android.bluetooth.le.AdvertisingSetCallback
+import android.bluetooth.le.AdvertisingSetParameters
 import android.bluetooth.le.BluetoothLeAdvertiser
 import android.content.Context
 import android.content.pm.PackageManager
@@ -21,7 +24,9 @@ import androidx.annotation.RequiresApi
 import androidx.annotation.RequiresPermission
 import androidx.core.content.ContextCompat
 import io.github.kyujincho.wvmg.protocol.endpoint.BleServiceData
+import io.github.kyujincho.wvmg.protocol.endpoint.DctAdvertisement
 import io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo
+import io.github.kyujincho.wvmg.protocol.endpoint.NearbyServiceId
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicReference
 
@@ -41,21 +46,31 @@ import java.util.concurrent.atomic.AtomicReference
  *
  * ### Wire format
  *
- * The service-data payload is built by [BleServiceData.encode] in
+ * The service-data payload is built by [BleServiceData.encodeFramed] in
  * `:core-protocol` (pure-JVM, KAT-tested). The shape captured from a
  * Galaxy peer's broadcast is:
  *
  * ```text
- * [ versPCP(1) | endpoint_id(4 ASCII) | endpoint_info_len(1) | EndpointInfo(N) ]
+ * [ frameType(0x4a) | inner_len | versPCP | endpoint_id(4 ASCII) |
+ *   endpoint_info_len | EndpointInfo(N) | device_token(2) ]
  * ```
  *
- * For our hidden, version=1, PHONE EndpointInfo the total payload is
- * **23 bytes**, which fits alongside the 16-bit service-data AD header
+ * For our hidden, version=1, PHONE EndpointInfo the inner payload is
+ * **23 bytes** and the stock BLE v2 framed service-data value is
+ * **27 bytes**, which fits alongside the 16-bit service-data AD header
  * inside the legacy 31-byte advertising-PDU budget without needing
  * extended advertising. The receiver's mDNS path may carry a visible
  * name-bearing EndpointInfo for stock picker compatibility; the BLE
  * payload factory intentionally emits this compact hidden form so the
  * fast advertisement remains legal on legacy Android BLE advertisers.
+ *
+ * WVMG also submits a second legacy DCT advertisement on `0xFC73`. Stock
+ * Nearby uses DCT as the compact visible identity path: it carries a short
+ * name and a service-id hash without stuffing the name into the 27-byte
+ * `0xFEF3` fast-advertisement value. Keeping this as a legacy advertisement
+ * matters for off-LAN discovery because Samsung's GMS scan path was observed
+ * to ignore WVMG's extended-only DCT set while still consuming legacy
+ * `0xFEF3` scan-response data.
  *
  * ### Lifecycle
  *
@@ -112,14 +127,24 @@ import java.util.concurrent.atomic.AtomicReference
  * @param gate platform-advertiser abstraction; tests inject a fake.
  * @param permissionChecker checks `BLUETOOTH_ADVERTISE` at start time;
  *   defaults to a [ContextCompat]-backed implementation in production.
- * @param payloadFactory builds the compact service-data payload from
+ * @param payloadFactory builds the compact framed service-data payload from
  *   the supplied [EndpointInfo] and the latest endpoint_id. Defaults to
  *   [BleServiceData.encode] over a hidden, no-name copy of the identity.
+ * @param visiblePayloadFactory optionally builds an Android O+ extended
+ *   `0xFEF3` payload carrying the visible [EndpointInfo]. This is the BLE-only
+ *   path Samsung ShareLive was observed to promote into the share sheet when
+ *   DCT was ignored.
+ * @param dctPayloadFactory optionally builds the `0xFC73` DCT payload for
+ *   Android O+ secondary advertising. DCT is the stock Nearby path that
+ *   carries a short visible receiver name without overfilling the 27-byte
+ *   `0xFEF3` fast-advertisement value.
  */
 public class BleQuickShareAdvertiser internal constructor(
     private val gate: BleAdvertiserGate,
     private val permissionChecker: AdvertisePermissionChecker,
     private val payloadFactory: PayloadFactory = DefaultPayloadFactory,
+    private val visiblePayloadFactory: OptionalPayloadFactory = DefaultVisiblePayloadFactory,
+    private val dctPayloadFactory: DctPayloadFactory = DefaultDctPayloadFactory,
 ) {
     /**
      * Production constructor. Builds a real [BleAdvertiserGate] over the
@@ -241,10 +266,28 @@ public class BleQuickShareAdvertiser internal constructor(
                     Log.w(TAG, "start: payload build failed; skipping BLE pulse advertise", t)
                     return@synchronized false
                 }
+            val dctPayload =
+                try {
+                    dctPayloadFactory.build(endpointInfo)
+                } catch (
+                    @Suppress("TooGenericExceptionCaught") t: Throwable,
+                ) {
+                    Log.w(TAG, "start: DCT payload build failed; compact BLE pulse only", t)
+                    null
+                }
+            val visiblePayload =
+                try {
+                    visiblePayloadFactory.build(endpointId, endpointInfo)
+                } catch (
+                    @Suppress("TooGenericExceptionCaught") t: Throwable,
+                ) {
+                    Log.w(TAG, "start: visible extended payload build failed; compact BLE pulse only", t)
+                    null
+                }
 
             val registration =
                 try {
-                    gate.startAdvertising(payload, currentMode)
+                    gate.startAdvertising(payload, currentMode, dctPayload, visiblePayload)
                 } catch (
                     @Suppress("TooGenericExceptionCaught") t: Throwable,
                 ) {
@@ -267,8 +310,12 @@ public class BleQuickShareAdvertiser internal constructor(
             Log.w(
                 TAG,
                 "start: BLE pulse advertise started bytes=${payload.size} " +
+                    "endpointId=${endpointId.toAsciiLabel()} payload=${payload.toHex()} " +
+                    "visibleBytes=${visiblePayload?.size ?: 0} " +
+                    "dctBytes=${dctPayload?.size ?: 0} dctEndpointId=${endpointInfo.dctEndpointId() ?: "-"} " +
                     "uuid=${BleServiceData.SERVICE_UUID_128_STRING} " +
-                    "mode=${describeAdvertiseMode(currentMode)}",
+                    "dctUuid=${DctAdvertisement.SERVICE_UUID_128_STRING} " +
+                    "mode=${describeAdvertiseMode(currentMode)} placement=scan-response+extended-visible+dct-legacy",
             )
             true
         }
@@ -343,9 +390,27 @@ public class BleQuickShareAdvertiser internal constructor(
                     Log.w(TAG, "setAdvertiseMode: payload rebuild threw", t)
                     return@synchronized false
                 }
+            val dctPayload =
+                try {
+                    dctPayloadFactory.build(info)
+                } catch (
+                    @Suppress("TooGenericExceptionCaught") t: Throwable,
+                ) {
+                    Log.w(TAG, "setAdvertiseMode: DCT payload rebuild threw; compact BLE pulse only", t)
+                    null
+                }
+            val visiblePayload =
+                try {
+                    visiblePayloadFactory.build(id, info)
+                } catch (
+                    @Suppress("TooGenericExceptionCaught") t: Throwable,
+                ) {
+                    Log.w(TAG, "setAdvertiseMode: visible extended payload rebuild threw; compact BLE pulse only", t)
+                    null
+                }
             val restarted =
                 try {
-                    gate.startAdvertising(payload, mode)
+                    gate.startAdvertising(payload, mode, dctPayload, visiblePayload)
                 } catch (
                     @Suppress("TooGenericExceptionCaught") t: Throwable,
                 ) {
@@ -363,7 +428,11 @@ public class BleQuickShareAdvertiser internal constructor(
             active.set(restarted)
             Log.w(
                 TAG,
-                "setAdvertiseMode: ${describeAdvertiseMode(previous)} -> ${describeAdvertiseMode(mode)}",
+                "setAdvertiseMode: ${describeAdvertiseMode(previous)} -> ${describeAdvertiseMode(mode)} " +
+                    "endpointId=${id.toAsciiLabel()} payload=${payload.toHex()} " +
+                    "visibleBytes=${visiblePayload?.size ?: 0} " +
+                    "dctBytes=${dctPayload?.size ?: 0} dctEndpointId=${info.dctEndpointId() ?: "-"} " +
+                    "placement=scan-response+extended-visible+dct-legacy",
             )
             true
         }
@@ -400,11 +469,10 @@ public class BleQuickShareAdvertiser internal constructor(
          * Build the platform [AdvertiseSettings] for the given mode.
          *
          * Pinned configuration:
-         *  * `setConnectable(false)` — Quick Share fast advertisements
-         *    are non-connectable. We never accept GATT connections; the
-         *    advertisement only signals presence. Setting this `false`
-         *    also keeps the advertising-PDU budget free for the
-         *    service-data payload.
+         *  * `setConnectable(true)` — stock Quick Share taps a visible
+         *    off-LAN peer by opening a BLE GATT socket against the same
+         *    advertiser address. The service data still lives in the scan
+         *    response so the legacy advertising-PDU budget remains small.
          *  * `setTxPowerLevel(ADVERTISE_TX_POWER_HIGH)` — best chance
          *    of a wake-up across a typical room. Symmetric to the
          *    sender-side `BleAdvertiser` and to the BALANCED scan-mode
@@ -418,11 +486,37 @@ public class BleQuickShareAdvertiser internal constructor(
                 .Builder()
                 .setAdvertiseMode(mode)
                 .setTxPowerLevel(AdvertiseSettings.ADVERTISE_TX_POWER_HIGH)
+                .setConnectable(true)
+                .build()
+
+        /**
+         * Build the secondary legacy DCT advertisement settings. DCT is an
+         * identity hint only in WVMG's current off-LAN path; the connectable
+         * GATT socket remains on the primary `0xFEF3` advertisement.
+         */
+        internal fun buildDctSettings(mode: Int): AdvertiseSettings =
+            AdvertiseSettings
+                .Builder()
+                .setAdvertiseMode(mode)
+                .setTxPowerLevel(AdvertiseSettings.ADVERTISE_TX_POWER_HIGH)
                 .setConnectable(false)
                 .build()
 
         /**
-         * Build the platform [AdvertiseData] containing only the
+         * Build the primary legacy advertisement. The Quick Share fast
+         * payload is carried in the scan response so the platform emits
+         * a legacy, connectable, scannable advertisement shape like
+         * stock Nearby's high-power receiver advertising path.
+         */
+        internal fun buildAdvertiseData(): AdvertiseData =
+            AdvertiseData
+                .Builder()
+                .setIncludeDeviceName(false)
+                .setIncludeTxPowerLevel(false)
+                .build()
+
+        /**
+         * Build the scan-response [AdvertiseData] containing only the
          * 16-bit service-data AD for `0xFEF3`.
          *
          * The service-UUID is embedded inside the service-data
@@ -431,8 +525,18 @@ public class BleQuickShareAdvertiser internal constructor(
          * UUIDs" AD — including both pushes us over the 31-byte
          * legacy budget. This mirrors the comment in [BleAdvertiser].
          */
-        internal fun buildAdvertiseData(payload: ByteArray): AdvertiseData {
-            val parcelUuid = ParcelUuid(UUID.fromString(BleServiceData.SERVICE_UUID_128_STRING))
+        internal fun buildScanResponseData(payload: ByteArray): AdvertiseData =
+            buildServiceData(BleServiceData.SERVICE_UUID_128_STRING, payload)
+
+        /** Build an [AdvertiseData] carrying DCT service data under `0xFC73`. */
+        internal fun buildDctAdvertiseData(payload: ByteArray): AdvertiseData =
+            buildServiceData(DctAdvertisement.SERVICE_UUID_128_STRING, payload)
+
+        private fun buildServiceData(
+            uuid: String,
+            payload: ByteArray,
+        ): AdvertiseData {
+            val parcelUuid = ParcelUuid(UUID.fromString(uuid))
             return AdvertiseData
                 .Builder()
                 .addServiceData(parcelUuid, payload)
@@ -466,11 +570,15 @@ public class BleQuickShareAdvertiser internal constructor(
             gate: BleAdvertiserGate,
             permissionChecker: AdvertisePermissionChecker = AdvertisePermissionChecker { true },
             payloadFactory: PayloadFactory = DefaultPayloadFactory,
+            visiblePayloadFactory: OptionalPayloadFactory = DefaultVisiblePayloadFactory,
+            dctPayloadFactory: DctPayloadFactory = DefaultDctPayloadFactory,
         ): BleQuickShareAdvertiser =
             BleQuickShareAdvertiser(
                 gate = gate,
                 permissionChecker = permissionChecker,
                 payloadFactory = payloadFactory,
+                visiblePayloadFactory = visiblePayloadFactory,
+                dctPayloadFactory = dctPayloadFactory,
             )
     }
 }
@@ -505,8 +613,8 @@ internal class AndroidAdvertisePermissionChecker(
 }
 
 /**
- * Builder for the compact service-data payload. The default implementation
- * delegates to [BleServiceData.encode] in `:core-protocol`; tests can
+ * Builder for the compact framed service-data payload. The default implementation
+ * delegates to [BleServiceData.encodeFramed] in `:core-protocol`; tests can
  * substitute a fake to drive specific failure paths.
  */
 public fun interface PayloadFactory {
@@ -524,7 +632,7 @@ public object DefaultPayloadFactory : PayloadFactory {
     override fun build(
         endpointId: ByteArray,
         endpointInfo: EndpointInfo,
-    ): ByteArray = BleServiceData.encode(endpointId, endpointInfo.compactForFastAdvertisement())
+    ): ByteArray = BleServiceData.encodeFramed(endpointId, endpointInfo.compactForFastAdvertisement())
 
     private fun EndpointInfo.compactForFastAdvertisement(): EndpointInfo =
         EndpointInfo(
@@ -537,6 +645,65 @@ public object DefaultPayloadFactory : PayloadFactory {
             tlvRecords = emptyList(),
         )
 }
+
+/** Optional payload builder for secondary extended advertisements. */
+public fun interface OptionalPayloadFactory {
+    public fun build(
+        endpointId: ByteArray,
+        endpointInfo: EndpointInfo,
+    ): ByteArray?
+}
+
+/**
+ * Builds the visible-name extended `0xFEF3` payload. A visible EndpointInfo
+ * cannot fit in the legacy 31-byte scan-response budget once the BLE v2 frame
+ * wrapper and device token are included, but it fits in an extended advertising
+ * set and is what Samsung ShareLive promoted during off-LAN receiver testing.
+ */
+public object DefaultVisiblePayloadFactory : OptionalPayloadFactory {
+    override fun build(
+        endpointId: ByteArray,
+        endpointInfo: EndpointInfo,
+    ): ByteArray? {
+        if (endpointInfo.hidden || endpointInfo.deviceName == null) return null
+        val psm = BleDctPsmHolder.currentPsm
+        return if (psm != null && psm != DctAdvertisement.DEFAULT_PSM) {
+            BleServiceData.encodeFramedWithPsm(endpointId, endpointInfo, psm)
+        } else {
+            BleServiceData.encodeFramed(endpointId, endpointInfo)
+        }
+    }
+}
+
+/**
+ * Optional builder for the DCT (`0xFC73`) advertisement payload. DCT carries a
+ * short visible name for Nearby's off-LAN discovery path while the primary
+ * `0xFEF3` fast advertisement remains the legal compact hidden shape.
+ */
+public fun interface DctPayloadFactory {
+    public fun build(endpointInfo: EndpointInfo): ByteArray?
+}
+
+public object DefaultDctPayloadFactory : DctPayloadFactory {
+    override fun build(endpointInfo: EndpointInfo): ByteArray? =
+        endpointInfo.deviceName?.takeIf { it.isNotBlank() }?.let { name ->
+            DctAdvertisement.encode(
+                serviceId = NearbyServiceId.VALUE,
+                deviceName = name,
+                psm = BleDctPsmHolder.currentPsm ?: DctAdvertisement.DEFAULT_PSM,
+                dedup = DctAdvertisement.DEFAULT_DEDUP,
+            )
+        }
+}
+
+private fun ByteArray.toAsciiLabel(): String = String(this, Charsets.US_ASCII)
+
+private fun ByteArray.toHex(): String = joinToString("") { "%02x".format(it) }
+
+private fun EndpointInfo.dctEndpointId(): String? =
+    deviceName
+        ?.takeIf { it.isNotBlank() }
+        ?.let { DctAdvertisement.generateEndpointId(DctAdvertisement.DEFAULT_DEDUP, it) }
 
 /**
  * Abstract handle over the platform [BluetoothLeAdvertiser]. The real
@@ -554,17 +721,19 @@ public interface BleAdvertiserGate {
     /**
      * Begins a Quick Share fast-advertisement under
      * [BleServiceData.SERVICE_UUID_128_STRING] with the given
-     * 23-ish-byte service-data payload and platform mode.
+     * 27-byte hidden framed service-data payload and platform mode.
      *
      * Returns a [Registration] handle whose [Registration.close] stops
      * the platform advertisement, or `null` if it could not be started
      * (adapter off, no LE peripheral mode, etc.).
      *
-     * @param serviceData the encoded service-data payload from
-     *   [BleServiceData.encode]. Must be ≤ 23 bytes for the
+     * @param serviceData the encoded `0xFEF3` service-data payload from
+     *   [BleServiceData.encodeFramed]. Must be ≤ 27 bytes for the
      *   default hidden EndpointInfo shape; longer payloads (e.g. with
      *   inline UTF-8 device name) may exceed the 31-byte advertising-PDU
      *   budget and trigger `ADVERTISE_FAILED_DATA_TOO_LARGE`.
+     * @param dctServiceData optional `0xFC73` DCT service-data payload used
+     *   as the stock off-LAN visible-name hint.
      * @param mode one of [AdvertiseSettings.ADVERTISE_MODE_LOW_POWER],
      *   [AdvertiseSettings.ADVERTISE_MODE_BALANCED], or
      *   [AdvertiseSettings.ADVERTISE_MODE_LOW_LATENCY].
@@ -572,6 +741,8 @@ public interface BleAdvertiserGate {
     public fun startAdvertising(
         serviceData: ByteArray,
         mode: Int,
+        dctServiceData: ByteArray? = null,
+        visibleServiceData: ByteArray? = null,
     ): Registration?
 
     /** Token returned from [startAdvertising]; close to stop the underlying advertisement. */
@@ -595,17 +766,45 @@ internal class AndroidBleAdvertiserGate(
     override fun startAdvertising(
         serviceData: ByteArray,
         mode: Int,
+        dctServiceData: ByteArray?,
+        visibleServiceData: ByteArray?,
     ): BleAdvertiserGate.Registration? {
-        val advertiser = resolveAdvertiser() ?: return null
-        val settings = BleQuickShareAdvertiser.buildSettings(mode)
-        val data = BleQuickShareAdvertiser.buildAdvertiseData(serviceData)
-        val callback = AdvertiseCallbackImpl()
-        advertiser.startAdvertising(settings, data, callback)
-        return Registration(advertiser, callback)
+        val resolved = resolveAdvertiser() ?: return null
+        val advertiser = resolved.advertiser
+        val visibleRegistration =
+            startVisibleExtendedAdvertisingIfAvailable(
+                advertiser = advertiser,
+                adapter = resolved.adapter,
+                serviceData = visibleServiceData,
+                mode = mode,
+            )
+        val callback =
+            if (visibleRegistration == null) {
+                val settings = BleQuickShareAdvertiser.buildSettings(mode)
+                val data = BleQuickShareAdvertiser.buildAdvertiseData()
+                val scanResponse = BleQuickShareAdvertiser.buildScanResponseData(serviceData)
+                AdvertiseCallbackImpl(label = "advertise").also { primaryCallback ->
+                    advertiser.startAdvertising(settings, data, scanResponse, primaryCallback)
+                }
+            } else {
+                Log.w(
+                    BleQuickShareAdvertiser.TAG,
+                    "advertise: hidden legacy 0xFEF3 suppressed while visible extended set is active",
+                )
+                null
+            }
+        val dctRegistration =
+            startDctAdvertisingIfAvailable(
+                advertiser = advertiser,
+                adapter = resolved.adapter,
+                serviceData = dctServiceData,
+                mode = mode,
+            )
+        return Registration(advertiser, callback, visibleRegistration, dctRegistration)
     }
 
     @Suppress("ReturnCount")
-    private fun resolveAdvertiser(): BluetoothLeAdvertiser? {
+    private fun resolveAdvertiser(): ResolvedAdvertiser? {
         // Each early-return covers a distinct failure mode that the
         // production logs already differentiate; collapsing them into a
         // single chained ?: hides the cause when one trips. Suppress
@@ -615,16 +814,229 @@ internal class AndroidBleAdvertiserGate(
                 ?: return null
         val adapter: BluetoothAdapter = manager.adapter ?: return null
         if (!adapter.isEnabled) return null
-        return adapter.bluetoothLeAdvertiser
+        val advertiser = adapter.bluetoothLeAdvertiser ?: return null
+        return ResolvedAdvertiser(adapter, advertiser)
     }
 
-    private class AdvertiseCallbackImpl : AdvertiseCallback() {
+    @Suppress("ReturnCount", "TooGenericExceptionCaught")
+    @RequiresPermission(Manifest.permission.BLUETOOTH_ADVERTISE)
+    private fun startDctAdvertisingIfAvailable(
+        advertiser: BluetoothLeAdvertiser,
+        adapter: BluetoothAdapter,
+        serviceData: ByteArray?,
+        mode: Int,
+    ): DctRegistration? {
+        if (serviceData == null) return null
+        val legacyAdvertiseDataSize = SERVICE_DATA_AD_OVERHEAD_BYTES + serviceData.size
+        if (legacyAdvertiseDataSize <= LEGACY_ADVERTISING_DATA_BYTES) {
+            return try {
+                val callback = AdvertiseCallbackImpl(label = "DCT advertise")
+                advertiser.startAdvertising(
+                    BleQuickShareAdvertiser.buildDctSettings(mode),
+                    BleQuickShareAdvertiser.buildDctAdvertiseData(serviceData),
+                    callback,
+                )
+                Log.w(
+                    BleQuickShareAdvertiser.TAG,
+                    "DCT advertise: submitted legacy bytes=${serviceData.size} " +
+                        "uuid=${DctAdvertisement.SERVICE_UUID_128_STRING}",
+                )
+                DctRegistration.Legacy(callback)
+            } catch (t: Throwable) {
+                Log.w(
+                    BleQuickShareAdvertiser.TAG,
+                    "DCT advertise: legacy startAdvertising threw; trying extended set",
+                    t,
+                )
+                startExtendedDctAdvertisingIfAvailable(
+                    advertiser = advertiser,
+                    adapter = adapter,
+                    serviceData = serviceData,
+                    mode = mode,
+                )
+            }
+        }
+
+        Log.w(
+            BleQuickShareAdvertiser.TAG,
+            "DCT advertise: legacy payload too large bytes=$legacyAdvertiseDataSize; trying extended set",
+        )
+        return startExtendedDctAdvertisingIfAvailable(
+            advertiser = advertiser,
+            adapter = adapter,
+            serviceData = serviceData,
+            mode = mode,
+        )
+    }
+
+    @Suppress("ReturnCount", "TooGenericExceptionCaught")
+    @RequiresPermission(Manifest.permission.BLUETOOTH_ADVERTISE)
+    private fun startExtendedDctAdvertisingIfAvailable(
+        advertiser: BluetoothLeAdvertiser,
+        adapter: BluetoothAdapter,
+        serviceData: ByteArray,
+        mode: Int,
+    ): DctRegistration? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return null
+        if (!adapter.isLeExtendedAdvertisingSupported) {
+            Log.w(
+                BleQuickShareAdvertiser.TAG,
+                "DCT advertise: controller does not support LE extended advertising",
+            )
+            return null
+        }
+        val advertiseDataSize = SERVICE_DATA_AD_OVERHEAD_BYTES + serviceData.size
+        if (advertiseDataSize > adapter.leMaximumAdvertisingDataLength) {
+            Log.w(
+                BleQuickShareAdvertiser.TAG,
+                "DCT advertise: payload too large bytes=$advertiseDataSize " +
+                    "max=${adapter.leMaximumAdvertisingDataLength}",
+            )
+            return null
+        }
+        return try {
+            val callback = AdvertisingSetCallbackImpl(label = "DCT advertise")
+            advertiser.startAdvertisingSet(
+                buildExtendedParameters(mode, connectable = false),
+                BleQuickShareAdvertiser.buildDctAdvertiseData(serviceData),
+                null,
+                null,
+                null,
+                0,
+                0,
+                callback,
+            )
+            Log.w(
+                BleQuickShareAdvertiser.TAG,
+                "DCT advertise: submitted extended bytes=${serviceData.size} " +
+                    "uuid=${DctAdvertisement.SERVICE_UUID_128_STRING}",
+            )
+            DctRegistration.Extended(callback)
+        } catch (t: Throwable) {
+            Log.w(
+                BleQuickShareAdvertiser.TAG,
+                "DCT advertise: startAdvertisingSet threw; compact BLE pulse only",
+                t,
+            )
+            null
+        }
+    }
+
+    @Suppress("ReturnCount", "TooGenericExceptionCaught")
+    @RequiresPermission(Manifest.permission.BLUETOOTH_ADVERTISE)
+    private fun startVisibleExtendedAdvertisingIfAvailable(
+        advertiser: BluetoothLeAdvertiser,
+        adapter: BluetoothAdapter,
+        serviceData: ByteArray?,
+        mode: Int,
+    ): ExtendedRegistration? {
+        if (serviceData == null) return null
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return null
+        if (!adapter.isLeExtendedAdvertisingSupported) {
+            Log.w(
+                BleQuickShareAdvertiser.TAG,
+                "visible advertise: controller does not support LE extended advertising",
+            )
+            return null
+        }
+        val advertiseDataSize = SERVICE_DATA_AD_OVERHEAD_BYTES + serviceData.size
+        if (advertiseDataSize > adapter.leMaximumAdvertisingDataLength) {
+            Log.w(
+                BleQuickShareAdvertiser.TAG,
+                "visible advertise: payload too large bytes=$advertiseDataSize " +
+                    "max=${adapter.leMaximumAdvertisingDataLength}",
+            )
+            return null
+        }
+        return try {
+            val callback = AdvertisingSetCallbackImpl(label = "visible advertise")
+            advertiser.startAdvertisingSet(
+                buildExtendedParameters(mode, connectable = true),
+                BleQuickShareAdvertiser.buildScanResponseData(serviceData),
+                null,
+                null,
+                null,
+                0,
+                0,
+                callback,
+            )
+            Log.w(
+                BleQuickShareAdvertiser.TAG,
+                "visible advertise: submitted extended bytes=${serviceData.size} " +
+                    "uuid=${BleServiceData.SERVICE_UUID_128_STRING}",
+            )
+            ExtendedRegistration(callback)
+        } catch (t: Throwable) {
+            Log.w(
+                BleQuickShareAdvertiser.TAG,
+                "visible advertise: startAdvertisingSet threw; compact BLE pulse only",
+                t,
+            )
+            null
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private fun buildExtendedParameters(
+        mode: Int,
+        connectable: Boolean,
+    ): AdvertisingSetParameters =
+        AdvertisingSetParameters
+            .Builder()
+            .setLegacyMode(false)
+            .setConnectable(connectable)
+            .setScannable(false)
+            .setAnonymous(false)
+            .setIncludeTxPower(false)
+            .setPrimaryPhy(BluetoothDevice.PHY_LE_1M)
+            .setSecondaryPhy(BluetoothDevice.PHY_LE_1M)
+            .setInterval(mode.toExtendedInterval())
+            .setTxPowerLevel(AdvertisingSetParameters.TX_POWER_HIGH)
+            .build()
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private fun Int.toExtendedInterval(): Int =
+        when (this) {
+            AdvertiseSettings.ADVERTISE_MODE_LOW_POWER -> AdvertisingSetParameters.INTERVAL_HIGH
+            AdvertiseSettings.ADVERTISE_MODE_LOW_LATENCY -> AdvertisingSetParameters.INTERVAL_LOW
+            else -> AdvertisingSetParameters.INTERVAL_MEDIUM
+        }
+
+    private data class ResolvedAdvertiser(
+        val adapter: BluetoothAdapter,
+        val advertiser: BluetoothLeAdvertiser,
+    )
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private class AdvertisingSetCallbackImpl(
+        private val label: String,
+    ) : AdvertisingSetCallback() {
+        @Volatile
+        var lastStatus: Int? = null
+            private set
+
+        override fun onAdvertisingSetStarted(
+            advertisingSet: android.bluetooth.le.AdvertisingSet?,
+            txPower: Int,
+            status: Int,
+        ) {
+            lastStatus = status
+            Log.w(
+                BleQuickShareAdvertiser.TAG,
+                "$label: onAdvertisingSetStarted status=$status txPower=$txPower",
+            )
+        }
+    }
+
+    private class AdvertiseCallbackImpl(
+        private val label: String,
+    ) : AdvertiseCallback() {
         @Volatile
         var lastError: Int? = null
             private set
 
         override fun onStartSuccess(settingsInEffect: AdvertiseSettings?) {
-            Log.w(BleQuickShareAdvertiser.TAG, "advertise: onStartSuccess settings=$settingsInEffect")
+            Log.w(BleQuickShareAdvertiser.TAG, "$label: onStartSuccess settings=$settingsInEffect")
         }
 
         @Suppress("MagicNumber")
@@ -639,13 +1051,49 @@ internal class AndroidBleAdvertiserGate(
                     ADVERTISE_FAILED_FEATURE_UNSUPPORTED -> "FEATURE_UNSUPPORTED"
                     else -> "UNKNOWN"
                 }
-            Log.w(BleQuickShareAdvertiser.TAG, "advertise: onStartFailure code=$errorCode ($label)")
+            Log.w(BleQuickShareAdvertiser.TAG, "${this.label}: onStartFailure code=$errorCode ($label)")
+        }
+    }
+
+    private sealed class DctRegistration {
+        @RequiresPermission(Manifest.permission.BLUETOOTH_ADVERTISE)
+        abstract fun close(advertiser: BluetoothLeAdvertiser)
+
+        class Legacy(
+            private val callback: AdvertiseCallbackImpl,
+        ) : DctRegistration() {
+            @RequiresPermission(Manifest.permission.BLUETOOTH_ADVERTISE)
+            override fun close(advertiser: BluetoothLeAdvertiser) {
+                advertiser.stopAdvertising(callback)
+            }
+        }
+
+        @RequiresApi(Build.VERSION_CODES.O)
+        class Extended(
+            private val callback: AdvertisingSetCallbackImpl,
+        ) : DctRegistration() {
+            @RequiresPermission(Manifest.permission.BLUETOOTH_ADVERTISE)
+            override fun close(advertiser: BluetoothLeAdvertiser) {
+                advertiser.stopAdvertisingSet(callback)
+            }
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private class ExtendedRegistration(
+        private val callback: AdvertisingSetCallbackImpl,
+    ) {
+        @RequiresPermission(Manifest.permission.BLUETOOTH_ADVERTISE)
+        fun close(advertiser: BluetoothLeAdvertiser) {
+            advertiser.stopAdvertisingSet(callback)
         }
     }
 
     private inner class Registration(
         private val advertiser: BluetoothLeAdvertiser,
-        private val callback: AdvertiseCallbackImpl,
+        private val callback: AdvertiseCallbackImpl?,
+        private val visibleRegistration: ExtendedRegistration?,
+        private val dctRegistration: DctRegistration?,
     ) : BleAdvertiserGate.Registration {
         @Volatile
         private var closed: Boolean = false
@@ -654,15 +1102,40 @@ internal class AndroidBleAdvertiserGate(
         override fun close() {
             if (closed) return
             closed = true
-            try {
-                advertiser.stopAdvertising(callback)
-            } catch (
-                @Suppress("TooGenericExceptionCaught") t: Throwable,
-            ) {
-                // Adapter may have been turned off after startAdvertising
-                // succeeded; we still want the registration discarded.
-                Log.w(BleQuickShareAdvertiser.TAG, "stopAdvertising threw", t)
+            if (dctRegistration != null) {
+                try {
+                    dctRegistration.close(advertiser)
+                } catch (
+                    @Suppress("TooGenericExceptionCaught") t: Throwable,
+                ) {
+                    Log.w(BleQuickShareAdvertiser.TAG, "stop DCT advertise threw", t)
+                }
+            }
+            if (visibleRegistration != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                try {
+                    visibleRegistration.close(advertiser)
+                } catch (
+                    @Suppress("TooGenericExceptionCaught") t: Throwable,
+                ) {
+                    Log.w(BleQuickShareAdvertiser.TAG, "stop visible advertise threw", t)
+                }
+            }
+            if (callback != null) {
+                try {
+                    advertiser.stopAdvertising(callback)
+                } catch (
+                    @Suppress("TooGenericExceptionCaught") t: Throwable,
+                ) {
+                    // Adapter may have been turned off after startAdvertising
+                    // succeeded; we still want the registration discarded.
+                    Log.w(BleQuickShareAdvertiser.TAG, "stopAdvertising threw", t)
+                }
             }
         }
+    }
+
+    private companion object {
+        private const val SERVICE_DATA_AD_OVERHEAD_BYTES: Int = 4
+        private const val LEGACY_ADVERTISING_DATA_BYTES: Int = 31
     }
 }

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareAdvertiser.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareAdvertiser.kt
@@ -49,11 +49,13 @@ import java.util.concurrent.atomic.AtomicReference
  * [ versPCP(1) | endpoint_id(4 ASCII) | endpoint_info_len(1) | EndpointInfo(N) ]
  * ```
  *
- * For our hidden, version=1, PHONE EndpointInfo (matching
- * `ReceiverForegroundService.defaultEndpointInfo`) the total payload is
+ * For our hidden, version=1, PHONE EndpointInfo the total payload is
  * **23 bytes**, which fits alongside the 16-bit service-data AD header
  * inside the legacy 31-byte advertising-PDU budget without needing
- * extended advertising.
+ * extended advertising. The receiver's mDNS path may carry a visible
+ * name-bearing EndpointInfo for stock picker compatibility; the BLE
+ * payload factory intentionally emits this compact hidden form so the
+ * fast advertisement remains legal on legacy Android BLE advertisers.
  *
  * ### Lifecycle
  *
@@ -110,9 +112,9 @@ import java.util.concurrent.atomic.AtomicReference
  * @param gate platform-advertiser abstraction; tests inject a fake.
  * @param permissionChecker checks `BLUETOOTH_ADVERTISE` at start time;
  *   defaults to a [ContextCompat]-backed implementation in production.
- * @param payloadFactory builds the 23-byte service-data payload from
+ * @param payloadFactory builds the compact service-data payload from
  *   the supplied [EndpointInfo] and the latest endpoint_id. Defaults to
- *   [BleServiceData.encode].
+ *   [BleServiceData.encode] over a hidden, no-name copy of the identity.
  */
 public class BleQuickShareAdvertiser internal constructor(
     private val gate: BleAdvertiserGate,
@@ -503,9 +505,9 @@ internal class AndroidAdvertisePermissionChecker(
 }
 
 /**
- * Builder for the 23-byte service-data payload. The default
- * implementation delegates to [BleServiceData.encode] in `:core-protocol`;
- * tests can substitute a fake to drive specific failure paths.
+ * Builder for the compact service-data payload. The default implementation
+ * delegates to [BleServiceData.encode] in `:core-protocol`; tests can
+ * substitute a fake to drive specific failure paths.
  */
 public fun interface PayloadFactory {
     public fun build(
@@ -522,7 +524,18 @@ public object DefaultPayloadFactory : PayloadFactory {
     override fun build(
         endpointId: ByteArray,
         endpointInfo: EndpointInfo,
-    ): ByteArray = BleServiceData.encode(endpointId, endpointInfo)
+    ): ByteArray = BleServiceData.encode(endpointId, endpointInfo.compactForFastAdvertisement())
+
+    private fun EndpointInfo.compactForFastAdvertisement(): EndpointInfo =
+        EndpointInfo(
+            version = version,
+            hidden = true,
+            deviceType = deviceType,
+            reserved = reserved,
+            metadata = metadata.copyOf(),
+            deviceName = null,
+            tlvRecords = emptyList(),
+        )
 }
 
 /**

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BleGattInitialControlClient.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BleGattInitialControlClient.kt
@@ -31,13 +31,10 @@ import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.core.content.ContextCompat
 import com.google.location.nearby.mediums.proto.BleFramesProto
-import com.google.location.nearby.mediums.proto.MultiplexFramesProto
 import io.github.kyujincho.wvmg.protocol.endpoint.NearbyServiceId
 import io.github.kyujincho.wvmg.protocol.medium.Medium
 import io.github.kyujincho.wvmg.protocol.medium.NearbyBleSocketFrames
-import io.github.kyujincho.wvmg.protocol.medium.NearbyMultiplexFrames
 import io.github.kyujincho.wvmg.protocol.transport.ConnectedTransport
-import io.github.kyujincho.wvmg.protocol.transport.FramedConnection
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -48,7 +45,6 @@ import java.io.InputStream
 import java.io.OutputStream
 import java.io.PipedInputStream
 import java.io.PipedOutputStream
-import java.security.SecureRandom
 import java.util.ArrayDeque
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicReference
@@ -65,7 +61,6 @@ import java.util.concurrent.atomic.AtomicReference
 public class BleGattInitialControlClient internal constructor(
     private val appContext: Context,
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
-    private val saltFactory: () -> String = ::randomSalt,
 ) {
     public constructor(context: Context) : this(context.applicationContext, Dispatchers.IO)
 
@@ -93,7 +88,6 @@ public class BleGattInitialControlClient internal constructor(
                 BleGattClientTransport(
                     context = appContext,
                     device = device,
-                    salt = saltFactory(),
                     onClose = { activeTransport.compareAndSet(it, null) },
                 )
             activeTransport.getAndSet(transport)?.close()
@@ -140,7 +134,6 @@ public class BleGattInitialControlClient internal constructor(
 private class BleGattClientTransport(
     private val context: Context,
     private val device: BluetoothDevice,
-    private val salt: String,
     private val onClose: (BleGattClientTransport) -> Unit,
 ) : BluetoothGattCallback(),
     ConnectedTransport {
@@ -149,9 +142,7 @@ private class BleGattClientTransport(
     private val ready = CompletableDeferred<Boolean>()
     private val writeQueue: ArrayDeque<ByteArray> = ArrayDeque()
     private val incomingMessage = ArrayList<Byte>()
-    private val saltedHash: ByteArray = NearbyMultiplexFrames.saltedServiceIdHash(salt = salt)
 
-    private var pendingMultiplexBytes: ByteArray = ByteArray(0)
     private var gatt: BluetoothGatt? = null
     private var toPeripheral: BluetoothGattCharacteristic? = null
     private var fromPeripheral: BluetoothGattCharacteristic? = null
@@ -181,14 +172,7 @@ private class BleGattClientTransport(
                 len: Int,
             ) {
                 if (len == 0) return
-                sendMultiplexBytes(
-                    NearbyMultiplexFrames.encodeLengthPrefixed(
-                        NearbyMultiplexFrames.encodeDataFrame(
-                            saltedServiceIdHash = saltedHash,
-                            data = b.copyOfRange(off, off + len),
-                        ),
-                    ),
-                )
+                sendSocketServiceBytes(b.copyOfRange(off, off + len))
             }
 
             override fun flush() {
@@ -396,9 +380,9 @@ private class BleGattClientTransport(
                 ?.coerceAtMost(WeaveFrames.MAX_PACKET_SIZE)
                 ?: WeaveFrames.MIN_PACKET_SIZE
         weaveConnected = true
-        Log.i(TAG, "Weave connected packetSize=$negotiatedPacketSize device=${device.safeAddress()}")
+        Log.i(TAG, "Weave connected raw Nearby stream packetSize=$negotiatedPacketSize device=${device.safeAddress()}")
         sendWeaveMessage(NearbyBleSocketFrames.encodeIntroductionPacket())
-        sendConnectionRequest()
+        if (!ready.isCompleted) ready.complete(true)
     }
 
     private fun handleDataPacket(packet: WeavePacket.Data) {
@@ -423,7 +407,7 @@ private class BleGattClientTransport(
             prefix.contentEquals(NearbyServiceId.hashPrefix) -> {
                 val payload = message.copyOfRange(SERVICE_ID_HASH_LEN, message.size)
                 sendWeaveMessage(NearbyBleSocketFrames.encodePacketAcknowledgementPacket(payload.size))
-                receiveMultiplexBytes(payload)
+                feedIncoming(payload)
             }
             else -> {
                 Log.w(TAG, "discarded BLE GATT socket message for unexpected service hash")
@@ -445,74 +429,6 @@ private class BleGattClientTransport(
         }
     }
 
-    private fun sendConnectionRequest() {
-        sendMultiplexBytes(
-            NearbyMultiplexFrames.encodeLengthPrefixed(
-                NearbyMultiplexFrames.encodeConnectionRequestFrame(
-                    saltedServiceIdHash = saltedHash,
-                    serviceIdHashSalt = salt,
-                ),
-            ),
-        )
-    }
-
-    private fun receiveMultiplexBytes(bytes: ByteArray) {
-        pendingMultiplexBytes += bytes
-        var keepParsing = true
-        while (keepParsing && pendingMultiplexBytes.size >= NearbyMultiplexFrames.LENGTH_PREFIX_BYTES) {
-            val length = NearbyMultiplexFrames.decodeLength(pendingMultiplexBytes)
-            if (
-                length == null ||
-                length < 0 ||
-                length >= FramedConnection.SANE_FRAME_LENGTH ||
-                pendingMultiplexBytes.size < NearbyMultiplexFrames.LENGTH_PREFIX_BYTES + length
-            ) {
-                keepParsing = false
-            } else {
-                val frameBytes =
-                    pendingMultiplexBytes.copyOfRange(
-                        NearbyMultiplexFrames.LENGTH_PREFIX_BYTES,
-                        NearbyMultiplexFrames.LENGTH_PREFIX_BYTES + length,
-                    )
-                pendingMultiplexBytes =
-                    pendingMultiplexBytes.copyOfRange(
-                        NearbyMultiplexFrames.LENGTH_PREFIX_BYTES + length,
-                        pendingMultiplexBytes.size,
-                    )
-                handleMultiplexFrame(frameBytes)
-            }
-        }
-    }
-
-    private fun handleMultiplexFrame(frameBytes: ByteArray) {
-        val frame =
-            NearbyMultiplexFrames.parseFrame(frameBytes) ?: run {
-                Log.w(TAG, "discarded invalid multiplex frame=${frameBytes.toHex()}")
-                return
-            }
-        when (frame.frameType) {
-            MultiplexFramesProto.MultiplexFrame.MultiplexFrameType.CONTROL_FRAME -> handleMultiplexControlFrame(frame)
-            MultiplexFramesProto.MultiplexFrame.MultiplexFrameType.DATA_FRAME ->
-                feedIncoming(frame.dataFrame.data.toByteArray())
-            else -> Unit
-        }
-    }
-
-    private fun handleMultiplexControlFrame(frame: MultiplexFramesProto.MultiplexFrame) {
-        when (frame.controlFrame.controlFrameType) {
-            MultiplexFramesProto.MultiplexControlFrame.MultiplexControlFrameType.CONNECTION_RESPONSE -> {
-                val accepted =
-                    frame.controlFrame.connectionResponseFrame.connectionResponseCode ==
-                        MultiplexFramesProto.ConnectionResponseFrame.ConnectionResponseCode.CONNECTION_ACCEPTED
-                if (!ready.isCompleted) ready.complete(accepted)
-                if (!accepted) close()
-            }
-
-            MultiplexFramesProto.MultiplexControlFrame.MultiplexControlFrameType.DISCONNECTION -> close()
-            else -> Unit
-        }
-    }
-
     private fun feedIncoming(bytes: ByteArray) {
         if (closed) return
         try {
@@ -524,7 +440,7 @@ private class BleGattClientTransport(
         }
     }
 
-    private fun sendMultiplexBytes(bytes: ByteArray) {
+    private fun sendSocketServiceBytes(bytes: ByteArray) {
         if (bytes.isEmpty()) return
         sendWeaveMessage(NearbyServiceId.hashPrefix + bytes)
     }
@@ -601,9 +517,3 @@ private fun BluetoothDevice.safeAddress(): String = runCatching { address }.getO
 private fun ByteArray.toHex(): String = joinToString("") { "%02x".format(it) }
 
 private fun ByteArray.firstByteHex(): String = firstOrNull()?.let { "%02x".format(it) } ?: "--"
-
-private fun randomSalt(): String {
-    val bytes = ByteArray(8)
-    SecureRandom().nextBytes(bytes)
-    return bytes.toHex()
-}

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BleGattInitialControlClient.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BleGattInitialControlClient.kt
@@ -1,0 +1,593 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+@file:android.annotation.SuppressLint("MissingPermission")
+@file:Suppress(
+    "ComplexCondition",
+    "DEPRECATION",
+    "MagicNumber",
+    "ReturnCount",
+    "TooGenericExceptionCaught",
+    "TooManyFunctions",
+)
+
+package io.github.kyujincho.wvmg.discovery.bootstrap
+
+import android.Manifest
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCallback
+import android.bluetooth.BluetoothGattCharacteristic
+import android.bluetooth.BluetoothGattDescriptor
+import android.bluetooth.BluetoothGattService
+import android.bluetooth.BluetoothManager
+import android.bluetooth.BluetoothProfile
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import android.util.Log
+import androidx.annotation.RequiresApi
+import androidx.core.content.ContextCompat
+import com.google.location.nearby.mediums.proto.BleFramesProto
+import com.google.location.nearby.mediums.proto.MultiplexFramesProto
+import io.github.kyujincho.wvmg.protocol.endpoint.NearbyServiceId
+import io.github.kyujincho.wvmg.protocol.medium.Medium
+import io.github.kyujincho.wvmg.protocol.medium.NearbyBleSocketFrames
+import io.github.kyujincho.wvmg.protocol.medium.NearbyMultiplexFrames
+import io.github.kyujincho.wvmg.protocol.transport.ConnectedTransport
+import io.github.kyujincho.wvmg.protocol.transport.FramedConnection
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import java.security.SecureRandom
+import java.util.ArrayDeque
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Sender-side BLE GATT initial-control client for stock Quick Share receivers.
+ *
+ * Nearby's BLE v2 path first opens a small Weave-over-GATT socket on the
+ * connectable `0xFEF3` advertiser, then wraps the normal Nearby multiplex
+ * socket inside that stream. This client performs that bootstrap and exposes
+ * the accepted virtual socket as a [ConnectedTransport] for the existing
+ * outbound protocol driver.
+ */
+public class BleGattInitialControlClient internal constructor(
+    private val appContext: Context,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val saltFactory: () -> String = ::randomSalt,
+) {
+    public constructor(context: Context) : this(context.applicationContext, Dispatchers.IO)
+
+    private val activeTransport: AtomicReference<BleGattClientTransport?> = AtomicReference(null)
+
+    public suspend fun connect(macAddress: String): ConnectedTransport? =
+        withContext(dispatcher) {
+            if (!isAvailable()) {
+                Log.i(TAG, "BLE GATT initial connect unavailable")
+                return@withContext null
+            }
+            val adapter =
+                appContext
+                    .getSystemService(BluetoothManager::class.java)
+                    ?.adapter
+                    ?: return@withContext null
+            val device =
+                try {
+                    adapter.getRemoteDevice(macAddress)
+                } catch (badAddress: IllegalArgumentException) {
+                    Log.w(TAG, "invalid BLE GATT address=$macAddress", badAddress)
+                    return@withContext null
+                }
+            val transport =
+                BleGattClientTransport(
+                    context = appContext,
+                    device = device,
+                    salt = saltFactory(),
+                    onClose = { activeTransport.compareAndSet(it, null) },
+                )
+            activeTransport.getAndSet(transport)?.close()
+            if (!transport.start()) {
+                transport.close()
+                return@withContext null
+            }
+            val ready = transport.awaitReady(CONNECTION_READY_TIMEOUT_MILLIS)
+            if (!ready) {
+                Log.w(TAG, "BLE GATT initial connect timed out waiting for multiplex accept")
+                transport.close()
+                return@withContext null
+            }
+            Log.i(TAG, "BLE GATT initial connect ready mac=$macAddress")
+            transport
+        }
+
+    public fun cancelPendingConnect() {
+        activeTransport.getAndSet(null)?.close()
+    }
+
+    private fun isAvailable(): Boolean {
+        val manager = appContext.getSystemService(BluetoothManager::class.java) ?: return false
+        val adapter = manager.adapter ?: return false
+        if (!adapter.isEnabled) return false
+        if (!appContext.packageManager.hasSystemFeature(PackageManager.FEATURE_BLUETOOTH_LE)) return false
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && !checkSPermission()) return false
+        return true
+    }
+
+    @RequiresApi(Build.VERSION_CODES.S)
+    private fun checkSPermission(): Boolean =
+        ContextCompat.checkSelfPermission(
+            appContext,
+            Manifest.permission.BLUETOOTH_CONNECT,
+        ) == PackageManager.PERMISSION_GRANTED
+
+    private companion object {
+        private const val TAG: String = "WvmgBleGattClient"
+        private const val CONNECTION_READY_TIMEOUT_MILLIS: Long = 10_000L
+    }
+}
+
+private class BleGattClientTransport(
+    private val context: Context,
+    private val device: BluetoothDevice,
+    private val salt: String,
+    private val onClose: (BleGattClientTransport) -> Unit,
+) : BluetoothGattCallback(),
+    ConnectedTransport {
+    private val input = PipedInputStream(INPUT_PIPE_SIZE)
+    private val inputWriter = PipedOutputStream(input)
+    private val ready = CompletableDeferred<Boolean>()
+    private val writeQueue: ArrayDeque<ByteArray> = ArrayDeque()
+    private val incomingMessage = ArrayList<Byte>()
+    private val saltedHash: ByteArray = NearbyMultiplexFrames.saltedServiceIdHash(salt = salt)
+
+    private var pendingMultiplexBytes: ByteArray = ByteArray(0)
+    private var gatt: BluetoothGatt? = null
+    private var toPeripheral: BluetoothGattCharacteristic? = null
+    private var fromPeripheral: BluetoothGattCharacteristic? = null
+    private var serviceDiscoveryStarted: Boolean = false
+    private var writeInFlight: Boolean = false
+    private var mtuPayloadSize: Int = WeaveFrames.DEFAULT_ATT_PAYLOAD_SIZE
+    private var negotiatedPacketSize: Int = WeaveFrames.MIN_PACKET_SIZE
+    private var sendPacketCounter: Int = 0
+    private var weaveConnected: Boolean = false
+
+    @Volatile
+    private var closed: Boolean = false
+
+    override val medium: Medium = Medium.BLE
+
+    override val inputStream: InputStream = input
+
+    override val outputStream: OutputStream =
+        object : OutputStream() {
+            override fun write(b: Int) {
+                write(byteArrayOf(b.toByte()))
+            }
+
+            override fun write(
+                b: ByteArray,
+                off: Int,
+                len: Int,
+            ) {
+                if (len == 0) return
+                sendMultiplexBytes(
+                    NearbyMultiplexFrames.encodeLengthPrefixed(
+                        NearbyMultiplexFrames.encodeDataFrame(
+                            saltedServiceIdHash = saltedHash,
+                            data = b.copyOfRange(off, off + len),
+                        ),
+                    ),
+                )
+            }
+
+            override fun flush() {
+                // GATT writes are queued immediately by write().
+            }
+
+            override fun close() {
+                this@BleGattClientTransport.close()
+            }
+        }
+
+    fun start(): Boolean {
+        val opened =
+            device.connectGatt(
+                context,
+                false,
+                this,
+                BluetoothDevice.TRANSPORT_LE,
+            )
+        gatt = opened
+        return opened != null
+    }
+
+    suspend fun awaitReady(timeoutMillis: Long): Boolean = withTimeoutOrNull(timeoutMillis) { ready.await() } == true
+
+    override fun onConnectionStateChange(
+        gatt: BluetoothGatt,
+        status: Int,
+        newState: Int,
+    ) {
+        Log.i(TAG, "gatt state device=${device.safeAddress()} status=$status newState=$newState")
+        if (status != BluetoothGatt.GATT_SUCCESS || newState != BluetoothProfile.STATE_CONNECTED) {
+            close()
+            return
+        }
+        val requested = gatt.requestMtu(REQUESTED_MTU)
+        if (!requested) discoverServicesOnce(gatt)
+    }
+
+    override fun onMtuChanged(
+        gatt: BluetoothGatt,
+        mtu: Int,
+        status: Int,
+    ) {
+        Log.i(TAG, "mtu changed mtu=$mtu status=$status device=${device.safeAddress()}")
+        if (status == BluetoothGatt.GATT_SUCCESS) {
+            mtuPayloadSize = (mtu - GATT_ATT_HEADER_BYTES).coerceAtLeast(WeaveFrames.DEFAULT_ATT_PAYLOAD_SIZE)
+        }
+        discoverServicesOnce(gatt)
+    }
+
+    override fun onServicesDiscovered(
+        gatt: BluetoothGatt,
+        status: Int,
+    ) {
+        if (status != BluetoothGatt.GATT_SUCCESS) {
+            Log.w(TAG, "service discovery failed status=$status")
+            close()
+            return
+        }
+        val service = gatt.getService(BleGattInitialControlServer.SERVICE_UUID)
+        if (service == null || !bindCharacteristics(service)) {
+            Log.w(TAG, "BLE GATT bootstrap service missing required characteristics")
+            close()
+            return
+        }
+        val outgoing = fromPeripheral ?: return close()
+        if (!gatt.setCharacteristicNotification(outgoing, true)) {
+            Log.w(TAG, "setCharacteristicNotification returned false")
+            close()
+            return
+        }
+        val descriptor = outgoing.getDescriptor(CLIENT_CHARACTERISTIC_CONFIG_UUID)
+        if (descriptor == null) {
+            Log.w(TAG, "notification descriptor missing")
+            close()
+            return
+        }
+        descriptor.value = BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
+        if (!gatt.writeDescriptor(descriptor)) {
+            Log.w(TAG, "write notification descriptor returned false")
+            close()
+        }
+    }
+
+    override fun onDescriptorWrite(
+        gatt: BluetoothGatt,
+        descriptor: BluetoothGattDescriptor,
+        status: Int,
+    ) {
+        if (descriptor.uuid != CLIENT_CHARACTERISTIC_CONFIG_UUID || status != BluetoothGatt.GATT_SUCCESS) {
+            Log.w(TAG, "descriptor write failed uuid=${descriptor.uuid} status=$status")
+            close()
+            return
+        }
+        sendWeaveConnectionRequest()
+    }
+
+    override fun onCharacteristicWrite(
+        gatt: BluetoothGatt,
+        characteristic: BluetoothGattCharacteristic,
+        status: Int,
+    ) {
+        synchronized(this) {
+            writeInFlight = false
+            if (status != BluetoothGatt.GATT_SUCCESS) {
+                Log.w(TAG, "characteristic write failed status=$status")
+                close()
+                return
+            }
+            drainWritesLocked()
+        }
+    }
+
+    @Deprecated("Android calls this overload before API 33")
+    override fun onCharacteristicChanged(
+        gatt: BluetoothGatt,
+        characteristic: BluetoothGattCharacteristic,
+    ) {
+        handleNotification(characteristic.value ?: ByteArray(0))
+    }
+
+    override fun onCharacteristicChanged(
+        gatt: BluetoothGatt,
+        characteristic: BluetoothGattCharacteristic,
+        value: ByteArray,
+    ) {
+        handleNotification(value)
+    }
+
+    @Synchronized
+    override fun close() {
+        if (closed) return
+        closed = true
+        if (!ready.isCompleted) ready.complete(false)
+        runCatching { inputWriter.close() }
+        runCatching { input.close() }
+        val openGatt = gatt
+        gatt = null
+        runCatching { openGatt?.disconnect() }
+        runCatching { openGatt?.close() }
+        onClose(this)
+    }
+
+    private fun discoverServicesOnce(gatt: BluetoothGatt) {
+        if (serviceDiscoveryStarted) return
+        serviceDiscoveryStarted = true
+        if (!gatt.discoverServices()) {
+            Log.w(TAG, "discoverServices returned false")
+            close()
+        }
+    }
+
+    private fun bindCharacteristics(service: BluetoothGattService): Boolean {
+        toPeripheral = service.getCharacteristic(BleGattInitialControlServer.TO_PERIPHERAL_UUID)
+        fromPeripheral = service.getCharacteristic(BleGattInitialControlServer.FROM_PERIPHERAL_UUID)
+        return toPeripheral != null && fromPeripheral != null
+    }
+
+    @Synchronized
+    private fun sendWeaveConnectionRequest() {
+        negotiatedPacketSize =
+            minOf(WeaveFrames.MAX_PACKET_SIZE, mtuPayloadSize)
+                .coerceAtLeast(WeaveFrames.MIN_PACKET_SIZE)
+        enqueueWriteLocked(
+            WeaveFrames.connectionRequest(
+                packetCounter = sendPacketCounter,
+                minVersion = WeaveFrames.VERSION,
+                maxVersion = WeaveFrames.VERSION,
+                maxPacketSize = negotiatedPacketSize,
+            ),
+        )
+        sendPacketCounter = (sendPacketCounter + 1) % WeaveFrames.MAX_PACKET_COUNTER
+    }
+
+    @Synchronized
+    private fun handleNotification(packetBytes: ByteArray) {
+        if (closed) return
+        Log.i(TAG, "notification len=${packetBytes.size} header=${packetBytes.firstByteHex()}")
+        when (val packet = WeaveFrames.parse(packetBytes)) {
+            is WeavePacket.ConnectionConfirm -> handleConnectionConfirm(packet)
+            is WeavePacket.Data -> handleDataPacket(packet)
+            is WeavePacket.ConnectionClose -> close()
+            is WeavePacket.ConnectionRequest -> Unit
+            null -> Log.w(TAG, "invalid Weave packet ${packetBytes.toHex()}")
+        }
+    }
+
+    private fun handleConnectionConfirm(packet: WeavePacket.ConnectionConfirm) {
+        if (packet.version != WeaveFrames.VERSION) {
+            Log.w(TAG, "unsupported Weave version=${packet.version}")
+            close()
+            return
+        }
+        negotiatedPacketSize =
+            packet.packetSize
+                .takeIf { it >= WeaveFrames.MIN_PACKET_SIZE }
+                ?.coerceAtMost(WeaveFrames.MAX_PACKET_SIZE)
+                ?: WeaveFrames.MIN_PACKET_SIZE
+        weaveConnected = true
+        Log.i(TAG, "Weave connected packetSize=$negotiatedPacketSize device=${device.safeAddress()}")
+        sendWeaveMessage(NearbyBleSocketFrames.encodeIntroductionPacket())
+        sendConnectionRequest()
+    }
+
+    private fun handleDataPacket(packet: WeavePacket.Data) {
+        if (packet.firstPacket) incomingMessage.clear()
+        incomingMessage.addAll(packet.data.asList())
+        if (!packet.lastPacket) return
+
+        val message = incomingMessage.toByteArray()
+        incomingMessage.clear()
+        handleSocketMessage(message)
+    }
+
+    private fun handleSocketMessage(message: ByteArray) {
+        if (message.size < SERVICE_ID_HASH_LEN) {
+            Log.w(TAG, "discarded undersized BLE GATT socket message")
+            close()
+            return
+        }
+        val prefix = message.copyOfRange(0, SERVICE_ID_HASH_LEN)
+        when {
+            prefix.contentEquals(CONTROL_PACKET_PREFIX) -> handleControlPacket(message)
+            prefix.contentEquals(NearbyServiceId.hashPrefix) -> {
+                receiveMultiplexBytes(message.copyOfRange(SERVICE_ID_HASH_LEN, message.size))
+            }
+            else -> {
+                Log.w(TAG, "discarded BLE GATT socket message for unexpected service hash")
+                close()
+            }
+        }
+    }
+
+    private fun handleControlPacket(packet: ByteArray) {
+        val control = NearbyBleSocketFrames.parseControlPacket(packet)
+        if (control == null) {
+            Log.w(TAG, "BLE GATT unknown control packet raw=${packet.toHex()}")
+            return
+        }
+        when (control.type) {
+            BleFramesProto.SocketControlFrame.ControlFrameType.PACKET_ACKNOWLEDGEMENT -> Unit
+            BleFramesProto.SocketControlFrame.ControlFrameType.DISCONNECTION -> close()
+            else -> Log.i(TAG, "BLE GATT control frame type=${control.type}")
+        }
+    }
+
+    private fun sendConnectionRequest() {
+        sendMultiplexBytes(
+            NearbyMultiplexFrames.encodeLengthPrefixed(
+                NearbyMultiplexFrames.encodeConnectionRequestFrame(
+                    saltedServiceIdHash = saltedHash,
+                    serviceIdHashSalt = salt,
+                ),
+            ),
+        )
+    }
+
+    private fun receiveMultiplexBytes(bytes: ByteArray) {
+        pendingMultiplexBytes += bytes
+        var keepParsing = true
+        while (keepParsing && pendingMultiplexBytes.size >= NearbyMultiplexFrames.LENGTH_PREFIX_BYTES) {
+            val length = NearbyMultiplexFrames.decodeLength(pendingMultiplexBytes)
+            if (
+                length == null ||
+                length < 0 ||
+                length >= FramedConnection.SANE_FRAME_LENGTH ||
+                pendingMultiplexBytes.size < NearbyMultiplexFrames.LENGTH_PREFIX_BYTES + length
+            ) {
+                keepParsing = false
+            } else {
+                val frameBytes =
+                    pendingMultiplexBytes.copyOfRange(
+                        NearbyMultiplexFrames.LENGTH_PREFIX_BYTES,
+                        NearbyMultiplexFrames.LENGTH_PREFIX_BYTES + length,
+                    )
+                pendingMultiplexBytes =
+                    pendingMultiplexBytes.copyOfRange(
+                        NearbyMultiplexFrames.LENGTH_PREFIX_BYTES + length,
+                        pendingMultiplexBytes.size,
+                    )
+                handleMultiplexFrame(frameBytes)
+            }
+        }
+    }
+
+    private fun handleMultiplexFrame(frameBytes: ByteArray) {
+        val frame =
+            NearbyMultiplexFrames.parseFrame(frameBytes) ?: run {
+                Log.w(TAG, "discarded invalid multiplex frame=${frameBytes.toHex()}")
+                return
+            }
+        when (frame.frameType) {
+            MultiplexFramesProto.MultiplexFrame.MultiplexFrameType.CONTROL_FRAME -> handleMultiplexControlFrame(frame)
+            MultiplexFramesProto.MultiplexFrame.MultiplexFrameType.DATA_FRAME ->
+                feedIncoming(frame.dataFrame.data.toByteArray())
+            else -> Unit
+        }
+    }
+
+    private fun handleMultiplexControlFrame(frame: MultiplexFramesProto.MultiplexFrame) {
+        when (frame.controlFrame.controlFrameType) {
+            MultiplexFramesProto.MultiplexControlFrame.MultiplexControlFrameType.CONNECTION_RESPONSE -> {
+                val accepted =
+                    frame.controlFrame.connectionResponseFrame.connectionResponseCode ==
+                        MultiplexFramesProto.ConnectionResponseFrame.ConnectionResponseCode.CONNECTION_ACCEPTED
+                if (!ready.isCompleted) ready.complete(accepted)
+                if (!accepted) close()
+            }
+
+            MultiplexFramesProto.MultiplexControlFrame.MultiplexControlFrameType.DISCONNECTION -> close()
+            else -> Unit
+        }
+    }
+
+    private fun feedIncoming(bytes: ByteArray) {
+        if (closed) return
+        try {
+            inputWriter.write(bytes)
+            inputWriter.flush()
+        } catch (io: IOException) {
+            Log.w(TAG, "BLE GATT virtual input closed while feeding data", io)
+            close()
+        }
+    }
+
+    private fun sendMultiplexBytes(bytes: ByteArray) {
+        if (bytes.isEmpty()) return
+        sendWeaveMessage(NearbyServiceId.hashPrefix + bytes)
+    }
+
+    @Synchronized
+    private fun sendWeaveMessage(payload: ByteArray) {
+        if (closed || !weaveConnected || payload.isEmpty()) return
+        var offset = 0
+        do {
+            val maxChunkSize = (negotiatedPacketSize - WeaveFrames.HEADER_SIZE).coerceAtLeast(1)
+            val chunkSize = maxChunkSize.coerceAtMost(payload.size - offset)
+            val nextOffset = offset + chunkSize
+            enqueueWriteLocked(
+                WeaveFrames.dataPacket(
+                    packetCounter = sendPacketCounter,
+                    firstPacket = offset == 0,
+                    lastPacket = nextOffset >= payload.size,
+                    data = payload.copyOfRange(offset, nextOffset),
+                ),
+            )
+            sendPacketCounter = (sendPacketCounter + 1) % WeaveFrames.MAX_PACKET_COUNTER
+            offset = nextOffset
+        } while (offset < payload.size)
+    }
+
+    private fun enqueueWriteLocked(packet: ByteArray) {
+        if (closed) return
+        Log.i(TAG, "enqueue write len=${packet.size} header=${packet.firstByteHex()} device=${device.safeAddress()}")
+        writeQueue.add(packet)
+        drainWritesLocked()
+    }
+
+    private fun drainWritesLocked() {
+        if (closed || writeInFlight) return
+        val packet = if (writeQueue.isEmpty()) return else writeQueue.removeFirst()
+        val openGatt = gatt ?: return close()
+        val outgoing = toPeripheral ?: return close()
+        outgoing.writeType = BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT
+        outgoing.value = packet
+        writeInFlight = openGatt.writeCharacteristic(outgoing)
+        if (!writeInFlight) {
+            Log.w(TAG, "writeCharacteristic returned false")
+            close()
+        }
+    }
+
+    private companion object {
+        private const val TAG: String = "WvmgBleGattClient"
+        private const val REQUESTED_MTU: Int = 512
+        private const val GATT_ATT_HEADER_BYTES: Int = 3
+        private const val INPUT_PIPE_SIZE: Int = 1024 * 1024
+        private const val SERVICE_ID_HASH_LEN: Int = 3
+        private val CONTROL_PACKET_PREFIX: ByteArray = ByteArray(SERVICE_ID_HASH_LEN)
+        private val CLIENT_CHARACTERISTIC_CONFIG_UUID: UUID =
+            UUID.fromString("00002902-0000-1000-8000-00805f9b34fb")
+    }
+}
+
+private fun ArrayList<Byte>.toByteArray(): ByteArray {
+    val out = ByteArray(size)
+    for (index in indices) out[index] = this[index]
+    return out
+}
+
+private fun BluetoothDevice.safeAddress(): String = runCatching { address }.getOrNull() ?: "<unknown>"
+
+private fun ByteArray.toHex(): String = joinToString("") { "%02x".format(it) }
+
+private fun ByteArray.firstByteHex(): String = firstOrNull()?.let { "%02x".format(it) } ?: "--"
+
+private fun randomSalt(): String {
+    val bytes = ByteArray(8)
+    SecureRandom().nextBytes(bytes)
+    return bytes.toHex()
+}

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BleGattInitialControlClient.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BleGattInitialControlClient.kt
@@ -267,7 +267,7 @@ private class BleGattClientTransport(
             close()
             return
         }
-        descriptor.value = BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
+        descriptor.value = cccdValueFor(outgoing)
         if (!gatt.writeDescriptor(descriptor)) {
             Log.w(TAG, "write notification descriptor returned false")
             close()
@@ -348,6 +348,13 @@ private class BleGattClientTransport(
         return toPeripheral != null && fromPeripheral != null
     }
 
+    private fun cccdValueFor(characteristic: BluetoothGattCharacteristic): ByteArray =
+        if ((characteristic.properties and BluetoothGattCharacteristic.PROPERTY_NOTIFY) != 0) {
+            BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
+        } else {
+            BluetoothGattDescriptor.ENABLE_INDICATION_VALUE
+        }
+
     @Synchronized
     private fun sendWeaveConnectionRequest() {
         negotiatedPacketSize =
@@ -414,7 +421,9 @@ private class BleGattClientTransport(
         when {
             prefix.contentEquals(CONTROL_PACKET_PREFIX) -> handleControlPacket(message)
             prefix.contentEquals(NearbyServiceId.hashPrefix) -> {
-                receiveMultiplexBytes(message.copyOfRange(SERVICE_ID_HASH_LEN, message.size))
+                val payload = message.copyOfRange(SERVICE_ID_HASH_LEN, message.size)
+                sendWeaveMessage(NearbyBleSocketFrames.encodePacketAcknowledgementPacket(payload.size))
+                receiveMultiplexBytes(payload)
             }
             else -> {
                 Log.w(TAG, "discarded BLE GATT socket message for unexpected service hash")
@@ -553,7 +562,7 @@ private class BleGattClientTransport(
         val packet = if (writeQueue.isEmpty()) return else writeQueue.removeFirst()
         val openGatt = gatt ?: return close()
         val outgoing = toPeripheral ?: return close()
-        outgoing.writeType = BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT
+        outgoing.writeType = writeTypeFor(outgoing)
         outgoing.value = packet
         writeInFlight = openGatt.writeCharacteristic(outgoing)
         if (!writeInFlight) {
@@ -573,6 +582,13 @@ private class BleGattClientTransport(
             UUID.fromString("00002902-0000-1000-8000-00805f9b34fb")
     }
 }
+
+private fun writeTypeFor(characteristic: BluetoothGattCharacteristic): Int =
+    if ((characteristic.properties and BluetoothGattCharacteristic.PROPERTY_WRITE) != 0) {
+        BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT
+    } else {
+        BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE
+    }
 
 private fun ArrayList<Byte>.toByteArray(): ByteArray {
     val out = ByteArray(size)

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BleGattInitialControlServer.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BleGattInitialControlServer.kt
@@ -1,0 +1,992 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+@file:Suppress("DEPRECATION", "MagicNumber", "TooManyFunctions")
+@file:android.annotation.SuppressLint("MissingPermission")
+
+package io.github.kyujincho.wvmg.discovery.bootstrap
+
+import android.Manifest
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCharacteristic
+import android.bluetooth.BluetoothGattDescriptor
+import android.bluetooth.BluetoothGattServer
+import android.bluetooth.BluetoothGattServerCallback
+import android.bluetooth.BluetoothGattService
+import android.bluetooth.BluetoothManager
+import android.bluetooth.BluetoothProfile
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import android.util.Log
+import androidx.annotation.RequiresApi
+import androidx.annotation.RequiresPermission
+import androidx.core.content.ContextCompat
+import com.google.location.nearby.mediums.proto.BleFramesProto
+import com.google.location.nearby.mediums.proto.MultiplexFramesProto
+import io.github.kyujincho.wvmg.protocol.endpoint.BleServiceData
+import io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo
+import io.github.kyujincho.wvmg.protocol.endpoint.NearbyServiceId
+import io.github.kyujincho.wvmg.protocol.medium.Medium
+import io.github.kyujincho.wvmg.protocol.medium.NearbyBleSocketFrames
+import io.github.kyujincho.wvmg.protocol.medium.NearbyMultiplexFrames
+import io.github.kyujincho.wvmg.protocol.transport.ConnectedTransport
+import io.github.kyujincho.wvmg.protocol.transport.InitialControlServer
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import java.util.ArrayDeque
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Receiver-side BLE GATT initial-control server for stock Nearby senders.
+ *
+ * Stock Quick Share's off-LAN path connects to a connectable `0xFEF3`
+ * advertiser and establishes a small Weave-over-GATT socket before the normal
+ * Nearby OfflineFrame stream begins. This server implements that physical
+ * GATT socket and demultiplexes the first virtual Nearby socket back into the
+ * existing [ConnectedTransport] pipeline.
+ */
+public class BleGattInitialControlServer(
+    context: Context,
+    private val endpointIdProvider: () -> ByteArray,
+) : InitialControlServer {
+    private val appContext: Context = context.applicationContext
+    private val active: AtomicReference<ActiveState?> = AtomicReference(null)
+    private val lifecycleLock: Any = Any()
+
+    override val isActive: Boolean
+        get() = active.get() != null
+
+    override fun start(
+        endpointInfo: EndpointInfo,
+        acceptTransport: (ConnectedTransport) -> Unit,
+    ): Boolean =
+        synchronized(lifecycleLock) {
+            if (isActive) return true
+            if (!isAvailable()) {
+                Log.i(TAG, "BLE GATT bootstrap unavailable")
+                return false
+            }
+            val manager = appContext.getSystemService(BluetoothManager::class.java) ?: return false
+            val callback =
+                Callback(
+                    endpointInfo = endpointInfo,
+                    endpointId = endpointIdProvider(),
+                    acceptTransport = acceptTransport,
+                )
+            val server =
+                manager.openGattServer(appContext, callback)
+                    ?: run {
+                        Log.w(TAG, "BluetoothManager.openGattServer returned null")
+                        return false
+                    }
+            callback.attach(server)
+            if (!server.addService(callback.service)) {
+                Log.w(TAG, "BluetoothGattServer.addService failed")
+                server.close()
+                return false
+            }
+            val state = ActiveState(server = server, callback = callback)
+            if (!active.compareAndSet(null, state)) {
+                server.close()
+                callback.close()
+                return true
+            }
+            Log.i(TAG, "BLE GATT bootstrap active service=$SERVICE_UUID")
+            true
+        }
+
+    override fun stop() {
+        synchronized(lifecycleLock) {
+            val state = active.getAndSet(null) ?: return
+            state.callback.close()
+            runCatching { state.server.clearServices() }
+            runCatching { state.server.close() }
+        }
+    }
+
+    @Suppress("ReturnCount")
+    private fun isAvailable(): Boolean {
+        val pm = appContext.packageManager
+        if (!pm.hasSystemFeature(PackageManager.FEATURE_BLUETOOTH_LE)) return false
+        if (!hasConnectPermission()) return false
+        val manager = appContext.getSystemService(BluetoothManager::class.java) ?: return false
+        val adapter = manager.adapter ?: return false
+        return adapter.isEnabled
+    }
+
+    private fun hasConnectPermission(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return true
+        return checkSPermission()
+    }
+
+    @RequiresApi(Build.VERSION_CODES.S)
+    private fun checkSPermission(): Boolean =
+        ContextCompat.checkSelfPermission(
+            appContext,
+            Manifest.permission.BLUETOOTH_CONNECT,
+        ) == PackageManager.PERMISSION_GRANTED
+
+    private data class ActiveState(
+        val server: BluetoothGattServer,
+        val callback: Callback,
+    )
+
+    private class Callback(
+        endpointInfo: EndpointInfo,
+        endpointId: ByteArray,
+        private val acceptTransport: (ConnectedTransport) -> Unit,
+    ) : BluetoothGattServerCallback() {
+        val service: BluetoothGattService = buildService(endpointInfo, endpointId)
+
+        private val sessions: ConcurrentHashMap<String, BleWeaveGattSession> = ConcurrentHashMap()
+        private val fromPeripheral: BluetoothGattCharacteristic =
+            requireNotNull(service.getCharacteristic(FROM_PERIPHERAL_UUID))
+        private var server: BluetoothGattServer? = null
+
+        fun attach(server: BluetoothGattServer) {
+            this.server = server
+        }
+
+        fun close() {
+            sessions.values.forEach { it.close() }
+            sessions.clear()
+            server = null
+        }
+
+        override fun onConnectionStateChange(
+            device: BluetoothDevice,
+            status: Int,
+            newState: Int,
+        ) {
+            Log.i(TAG, "gatt state device=${device.safeAddress()} status=$status newState=$newState")
+            if (newState == BluetoothProfile.STATE_CONNECTED) {
+                sessionFor(device)
+            } else if (newState == BluetoothProfile.STATE_DISCONNECTED) {
+                sessions.remove(device.key())?.close()
+            }
+        }
+
+        override fun onServiceAdded(
+            status: Int,
+            service: BluetoothGattService,
+        ) {
+            Log.i(TAG, "service added status=$status uuid=${service.uuid}")
+        }
+
+        override fun onCharacteristicReadRequest(
+            device: BluetoothDevice,
+            requestId: Int,
+            offset: Int,
+            characteristic: BluetoothGattCharacteristic,
+        ) {
+            Log.i(TAG, "read characteristic=${characteristic.uuid} offset=$offset device=${device.safeAddress()}")
+            val value = characteristic.value ?: ByteArray(0)
+            val response =
+                if (offset in 0..value.size) {
+                    value.copyOfRange(offset, value.size)
+                } else {
+                    ByteArray(0)
+                }
+            server?.sendResponse(
+                device,
+                requestId,
+                if (offset in 0..value.size) BluetoothGatt.GATT_SUCCESS else BluetoothGatt.GATT_INVALID_OFFSET,
+                offset,
+                response,
+            )
+        }
+
+        override fun onCharacteristicWriteRequest(
+            device: BluetoothDevice,
+            requestId: Int,
+            characteristic: BluetoothGattCharacteristic,
+            preparedWrite: Boolean,
+            responseNeeded: Boolean,
+            offset: Int,
+            value: ByteArray,
+        ) {
+            Log.i(
+                TAG,
+                "write characteristic=${characteristic.uuid} len=${value.size} header=${value.firstByteHex()} " +
+                    "offset=$offset prepared=$preparedWrite response=$responseNeeded " +
+                    "device=${device.safeAddress()}",
+            )
+            val status =
+                if (characteristic.uuid == TO_PERIPHERAL_UUID && offset == 0) {
+                    sessionFor(device).onIncomingWeavePacket(value)
+                    BluetoothGatt.GATT_SUCCESS
+                } else {
+                    BluetoothGatt.GATT_FAILURE
+                }
+            if (responseNeeded) {
+                server?.sendResponse(device, requestId, status, offset, null)
+            }
+        }
+
+        override fun onDescriptorWriteRequest(
+            device: BluetoothDevice,
+            requestId: Int,
+            descriptor: BluetoothGattDescriptor,
+            preparedWrite: Boolean,
+            responseNeeded: Boolean,
+            offset: Int,
+            value: ByteArray,
+        ) {
+            Log.i(
+                TAG,
+                "write descriptor=${descriptor.uuid} char=${descriptor.characteristic?.uuid} " +
+                    "value=${value.toHex()} offset=$offset device=${device.safeAddress()}",
+            )
+            val enablesNotifications =
+                value.contentEquals(BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE) ||
+                    value.contentEquals(BluetoothGattDescriptor.ENABLE_INDICATION_VALUE)
+            if (descriptor.uuid == CLIENT_CHARACTERISTIC_CONFIG_UUID &&
+                descriptor.characteristic?.uuid == FROM_PERIPHERAL_UUID
+            ) {
+                sessionFor(device).setSubscribed(enablesNotifications)
+            }
+            if (responseNeeded) {
+                server?.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, null)
+            }
+        }
+
+        override fun onMtuChanged(
+            device: BluetoothDevice,
+            mtu: Int,
+        ) {
+            Log.i(TAG, "mtu changed mtu=$mtu device=${device.safeAddress()}")
+            sessionFor(device).setMtu(mtu)
+        }
+
+        override fun onNotificationSent(
+            device: BluetoothDevice,
+            status: Int,
+        ) {
+            sessionFor(device).onNotificationSent(status)
+        }
+
+        private fun sessionFor(device: BluetoothDevice): BleWeaveGattSession {
+            val gattServer = server ?: error("GATT server not attached")
+            return sessions.getOrPut(device.key()) {
+                BleWeaveGattSession(
+                    device = device,
+                    server = gattServer,
+                    outgoingCharacteristic = fromPeripheral,
+                    acceptTransport = acceptTransport,
+                )
+            }
+        }
+
+        private companion object {
+            private fun buildService(
+                endpointInfo: EndpointInfo,
+                endpointId: ByteArray,
+            ): BluetoothGattService {
+                val service =
+                    BluetoothGattService(
+                        SERVICE_UUID,
+                        BluetoothGattService.SERVICE_TYPE_PRIMARY,
+                    )
+                val toPeripheral =
+                    BluetoothGattCharacteristic(
+                        TO_PERIPHERAL_UUID,
+                        BluetoothGattCharacteristic.PROPERTY_WRITE or
+                            BluetoothGattCharacteristic.PROPERTY_WRITE_NO_RESPONSE,
+                        BluetoothGattCharacteristic.PERMISSION_WRITE,
+                    )
+                val fromPeripheral =
+                    BluetoothGattCharacteristic(
+                        FROM_PERIPHERAL_UUID,
+                        BluetoothGattCharacteristic.PROPERTY_READ or
+                            BluetoothGattCharacteristic.PROPERTY_NOTIFY or
+                            BluetoothGattCharacteristic.PROPERTY_INDICATE,
+                        BluetoothGattCharacteristic.PERMISSION_READ,
+                    )
+                fromPeripheral.addDescriptor(
+                    BluetoothGattDescriptor(
+                        CLIENT_CHARACTERISTIC_CONFIG_UUID,
+                        BluetoothGattDescriptor.PERMISSION_READ or BluetoothGattDescriptor.PERMISSION_WRITE,
+                    ),
+                )
+                service.addCharacteristic(toPeripheral)
+                service.addCharacteristic(fromPeripheral)
+                buildAdvertisementSlots(endpointInfo, endpointId).forEach(service::addCharacteristic)
+                return service
+            }
+
+            private fun buildAdvertisementSlots(
+                endpointInfo: EndpointInfo,
+                endpointId: ByteArray,
+            ): List<BluetoothGattCharacteristic> {
+                val visibleAdvertisement =
+                    runCatching { BleServiceData.encodeFramed(endpointId, endpointInfo) }
+                        .getOrDefault(ByteArray(0))
+
+                return (0 until GATT_ADVERTISEMENT_SLOT_COUNT).map { slot ->
+                    BluetoothGattCharacteristic(
+                        advertisementSlotUuid(slot),
+                        BluetoothGattCharacteristic.PROPERTY_READ,
+                        BluetoothGattCharacteristic.PERMISSION_READ,
+                    ).apply {
+                        value = if (slot == 0) visibleAdvertisement else ByteArray(0)
+                    }
+                }
+            }
+        }
+    }
+
+    public companion object {
+        internal const val TAG: String = "WvmgBleGatt"
+
+        /** Copresence / Nearby BLE socket service UUID. */
+        public val SERVICE_UUID: UUID = UUID.fromString(BleServiceData.SERVICE_UUID_128_STRING)
+
+        /** Central writes Weave packets here. */
+        public val TO_PERIPHERAL_UUID: UUID = UUID.fromString("00000100-0004-1000-8000-001a11000101")
+
+        /** Peripheral notifies Weave packets here. */
+        public val FROM_PERIPHERAL_UUID: UUID = UUID.fromString("00000100-0004-1000-8000-001a11000102")
+
+        /** GATT-backed advertisement slot zero, used by Nearby's BLE v2 scanner. */
+        public val GATT_SLOT_0_UUID: UUID = UUID.fromString("00000000-0000-3000-8000-000000000000")
+
+        private val CLIENT_CHARACTERISTIC_CONFIG_UUID: UUID =
+            UUID.fromString("00002902-0000-1000-8000-00805f9b34fb")
+
+        private const val GATT_ADVERTISEMENT_SLOT_COUNT: Int = 16
+
+        private fun advertisementSlotUuid(slot: Int): UUID =
+            UUID.fromString("00000000-0000-3000-8000-${slot.toString(radix = 16).padStart(12, '0')}")
+    }
+}
+
+private class BleWeaveGattSession(
+    private val device: BluetoothDevice,
+    private val server: BluetoothGattServer,
+    private val outgoingCharacteristic: BluetoothGattCharacteristic,
+    private val acceptTransport: (ConnectedTransport) -> Unit,
+) {
+    private val notificationQueue: ArrayDeque<ByteArray> = ArrayDeque()
+    private val multiplexBridge =
+        BleMultiplexBridge(
+            tag = BleGattInitialControlServer.TAG,
+            medium = Medium.BLE,
+            sendPhysical = ::sendPhysicalSocketBytes,
+            acceptTransport = acceptTransport,
+        )
+    private val incomingMessage = ArrayList<Byte>()
+    private var subscribed: Boolean = false
+    private var sending: Boolean = false
+    private var introReceived: Boolean = false
+    private var mtuPayloadSize: Int = WeaveFrames.DEFAULT_ATT_PAYLOAD_SIZE
+    private var negotiatedPacketSize: Int = WeaveFrames.MIN_PACKET_SIZE
+    private var sendPacketCounter: Int = 0
+    private var closed: Boolean = false
+
+    @Synchronized
+    fun setSubscribed(enabled: Boolean) {
+        subscribed = enabled
+        Log.i(BleGattInitialControlServer.TAG, "subscription enabled=$enabled device=${device.safeAddress()}")
+        drainNotificationsLocked()
+    }
+
+    @Synchronized
+    fun setMtu(mtu: Int) {
+        mtuPayloadSize = (mtu - GATT_ATT_HEADER_BYTES).coerceAtLeast(WeaveFrames.DEFAULT_ATT_PAYLOAD_SIZE)
+    }
+
+    @Synchronized
+    fun onIncomingWeavePacket(packetBytes: ByteArray) {
+        if (closed) return
+        when (val packet = WeaveFrames.parse(packetBytes)) {
+            is WeavePacket.ConnectionRequest -> handleConnectionRequest(packet)
+            is WeavePacket.Data -> handleDataPacket(packet)
+            is WeavePacket.ConnectionClose -> close()
+            null -> Log.w(BleGattInitialControlServer.TAG, "invalid Weave packet ${packetBytes.toHex()}")
+        }
+    }
+
+    @Synchronized
+    fun onNotificationSent(status: Int) {
+        Log.i(BleGattInitialControlServer.TAG, "notification sent status=$status device=${device.safeAddress()}")
+        sending = false
+        if (status != BluetoothGatt.GATT_SUCCESS) {
+            Log.w(BleGattInitialControlServer.TAG, "notification failed status=$status")
+        }
+        drainNotificationsLocked()
+    }
+
+    @Synchronized
+    fun close() {
+        if (closed) return
+        closed = true
+        notificationQueue.clear()
+        multiplexBridge.close()
+    }
+
+    private fun handleConnectionRequest(packet: WeavePacket.ConnectionRequest) {
+        if (packet.maxVersion < WeaveFrames.VERSION || packet.minVersion > WeaveFrames.VERSION) {
+            enqueueNotificationLocked(
+                WeaveFrames.connectionClosePacket(
+                    packetCounter = sendPacketCounter,
+                    reason = WeaveFrames.CLOSE_NO_COMMON_VERSION,
+                ),
+            )
+            sendPacketCounter = (sendPacketCounter + 1) % WeaveFrames.MAX_PACKET_COUNTER
+            return
+        }
+        val requestedPacketSize = packet.maxPacketSize.takeIf { it > 0 } ?: mtuPayloadSize
+        negotiatedPacketSize =
+            minOf(requestedPacketSize, mtuPayloadSize, WeaveFrames.MAX_PACKET_SIZE)
+                .coerceAtLeast(WeaveFrames.MIN_PACKET_SIZE)
+        enqueueNotificationLocked(
+            WeaveFrames.connectionConfirm(
+                version = WeaveFrames.VERSION,
+                packetSize = negotiatedPacketSize,
+            ),
+        )
+        sendPacketCounter = 1
+        Log.i(
+            BleGattInitialControlServer.TAG,
+            "Weave connected packetSize=$negotiatedPacketSize peerMax=${packet.maxPacketSize} " +
+                "device=${device.safeAddress()}",
+        )
+    }
+
+    private fun handleDataPacket(packet: WeavePacket.Data) {
+        if (packet.firstPacket) incomingMessage.clear()
+        incomingMessage.addAll(packet.data.asList())
+        if (!packet.lastPacket) return
+
+        val message = incomingMessage.toByteArray()
+        incomingMessage.clear()
+        handleSocketMessage(message)
+    }
+
+    private fun handleSocketMessage(message: ByteArray) {
+        if (!introReceived) {
+            handleIntroductionMessage(message)
+        } else {
+            handleServiceMessage(message)
+        }
+    }
+
+    private fun handleIntroductionMessage(message: ByteArray) {
+        val control = NearbyBleSocketFrames.parseControlPacket(message)
+        val isIntroduction =
+            control?.type == BleFramesProto.SocketControlFrame.ControlFrameType.INTRODUCTION &&
+                control.introduction.socketVersion == BleFramesProto.SocketVersion.V2 &&
+                control.introduction.serviceIdHash
+                    .toByteArray()
+                    .contentEquals(NearbyServiceId.hashPrefix)
+        if (isIntroduction) {
+            introReceived = true
+            Log.i(BleGattInitialControlServer.TAG, "BLE socket introduction accepted")
+        } else {
+            Log.w(BleGattInitialControlServer.TAG, "discarded non-introduction first socket message")
+        }
+    }
+
+    private fun handleServiceMessage(message: ByteArray) {
+        when {
+            message.size < NearbyServiceId.hashPrefix.size -> {
+                Log.w(BleGattInitialControlServer.TAG, "discarded undersized BLE socket payload")
+            }
+
+            !message.copyOfRange(0, NearbyServiceId.hashPrefix.size).contentEquals(NearbyServiceId.hashPrefix) -> {
+                Log.w(BleGattInitialControlServer.TAG, "discarded BLE payload for unexpected service hash")
+            }
+
+            else -> {
+                multiplexBridge.receivePhysicalBytes(
+                    message.copyOfRange(NearbyServiceId.hashPrefix.size, message.size),
+                )
+            }
+        }
+    }
+
+    private fun sendPhysicalSocketBytes(bytes: ByteArray) {
+        val payload = NearbyServiceId.hashPrefix + bytes
+        sendWeaveMessage(payload)
+    }
+
+    @Synchronized
+    private fun sendWeaveMessage(payload: ByteArray) {
+        var offset = 0
+        do {
+            val maxChunkSize = (negotiatedPacketSize - WeaveFrames.HEADER_SIZE).coerceAtLeast(1)
+            val chunkSize = maxChunkSize.coerceAtMost(payload.size - offset)
+            val nextOffset = offset + chunkSize
+            enqueueNotificationLocked(
+                WeaveFrames.dataPacket(
+                    packetCounter = sendPacketCounter,
+                    firstPacket = offset == 0,
+                    lastPacket = nextOffset >= payload.size,
+                    data = payload.copyOfRange(offset, nextOffset),
+                ),
+            )
+            sendPacketCounter = (sendPacketCounter + 1) % WeaveFrames.MAX_PACKET_COUNTER
+            offset = nextOffset
+        } while (offset < payload.size)
+    }
+
+    private fun enqueueNotificationLocked(packet: ByteArray) {
+        Log.i(
+            BleGattInitialControlServer.TAG,
+            "enqueue notification len=${packet.size} header=${packet.firstByteHex()} device=${device.safeAddress()}",
+        )
+        notificationQueue.add(packet)
+        drainNotificationsLocked()
+    }
+
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
+    private fun drainNotificationsLocked() {
+        if (!subscribed || sending || closed) return
+        val packet = if (notificationQueue.isEmpty()) return else notificationQueue.removeFirst()
+        Log.i(
+            BleGattInitialControlServer.TAG,
+            "send notification len=${packet.size} header=${packet.firstByteHex()} device=${device.safeAddress()}",
+        )
+        outgoingCharacteristic.value = packet
+        sending =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                server.notifyCharacteristicChanged(device, outgoingCharacteristic, false, packet) ==
+                    android.bluetooth.BluetoothStatusCodes.SUCCESS
+            } else {
+                server.notifyCharacteristicChanged(device, outgoingCharacteristic, false)
+            }
+        if (!sending) {
+            Log.w(BleGattInitialControlServer.TAG, "notifyCharacteristicChanged returned false")
+        }
+    }
+
+    private companion object {
+        private const val GATT_ATT_HEADER_BYTES: Int = 3
+    }
+}
+
+internal class BleMultiplexBridge(
+    private val tag: String,
+    private val medium: Medium,
+    private val sendPhysical: (ByteArray) -> Unit,
+    private val acceptTransport: (ConnectedTransport) -> Unit,
+) {
+    private var pending: ByteArray = ByteArray(0)
+    private var virtualTransport: MultiplexVirtualTransport? = null
+    private var rawTransport: RawBleVirtualTransport? = null
+    private var closed: Boolean = false
+
+    @Synchronized
+    fun receivePhysicalBytes(bytes: ByteArray) {
+        if (!closed) {
+            pending += bytes
+        }
+        var keepParsing = !closed
+        while (keepParsing && pending.size >= NearbyMultiplexFrames.LENGTH_PREFIX_BYTES) {
+            val length = NearbyMultiplexFrames.decodeLength(pending)
+            if (length == null || length < 0 || pending.size < NearbyMultiplexFrames.LENGTH_PREFIX_BYTES + length) {
+                keepParsing = false
+            } else {
+                val frameBytes =
+                    pending.copyOfRange(
+                        NearbyMultiplexFrames.LENGTH_PREFIX_BYTES,
+                        NearbyMultiplexFrames.LENGTH_PREFIX_BYTES + length,
+                    )
+                val original = pending.copyOfRange(0, NearbyMultiplexFrames.LENGTH_PREFIX_BYTES + length)
+                pending = pending.copyOfRange(NearbyMultiplexFrames.LENGTH_PREFIX_BYTES + length, pending.size)
+                handlePhysicalFrame(frameBytes, original)
+            }
+        }
+    }
+
+    @Synchronized
+    fun close() {
+        if (closed) return
+        closed = true
+        virtualTransport?.close()
+        rawTransport?.close()
+    }
+
+    private fun handlePhysicalFrame(
+        frameBytes: ByteArray,
+        originalLengthPrefixedBytes: ByteArray,
+    ) {
+        rawTransport?.let { transport ->
+            transport.feedIncoming(originalLengthPrefixedBytes)
+            return
+        }
+
+        val frame = NearbyMultiplexFrames.parseFrame(frameBytes)
+        if (frame == null) {
+            virtualTransport?.feedIncoming(originalLengthPrefixedBytes)
+                ?: ensureRawTransport().feedIncoming(originalLengthPrefixedBytes)
+            return
+        }
+        when (frame.frameType) {
+            MultiplexFramesProto.MultiplexFrame.MultiplexFrameType.CONTROL_FRAME -> handleControlFrame(frame)
+            MultiplexFramesProto.MultiplexFrame.MultiplexFrameType.DATA_FRAME -> handleDataFrame(frame)
+            else -> Unit
+        }
+    }
+
+    private fun handleControlFrame(frame: MultiplexFramesProto.MultiplexFrame) {
+        when (frame.controlFrame.controlFrameType) {
+            MultiplexFramesProto.MultiplexControlFrame.MultiplexControlFrameType.CONNECTION_REQUEST -> {
+                val salt = frame.header.serviceIdHashSalt
+                val saltedHash = frame.header.saltedServiceIdHash.toByteArray()
+                val expected = NearbyMultiplexFrames.saltedServiceIdHash(salt = salt)
+                val response =
+                    if (saltedHash.contentEquals(expected)) {
+                        ensureVirtualTransport(saltedHash, salt)
+                        MultiplexFramesProto.ConnectionResponseFrame.ConnectionResponseCode.CONNECTION_ACCEPTED
+                    } else {
+                        MultiplexFramesProto.ConnectionResponseFrame.ConnectionResponseCode.NOT_LISTENING
+                    }
+                sendPhysical(
+                    NearbyMultiplexFrames.encodeLengthPrefixed(
+                        NearbyMultiplexFrames.encodeConnectionResponseFrame(
+                            saltedServiceIdHash = saltedHash,
+                            serviceIdHashSalt = salt,
+                            responseCode = response,
+                        ),
+                    ),
+                )
+            }
+
+            MultiplexFramesProto.MultiplexControlFrame.MultiplexControlFrameType.DISCONNECTION -> {
+                virtualTransport?.close()
+                virtualTransport = null
+            }
+
+            else -> Unit
+        }
+    }
+
+    private fun handleDataFrame(frame: MultiplexFramesProto.MultiplexFrame) {
+        val salt = frame.header.serviceIdHashSalt
+        val saltedHash = frame.header.saltedServiceIdHash.toByteArray()
+        val transport = virtualTransport ?: ensureVirtualTransport(saltedHash, salt)
+        transport.feedIncoming(frame.dataFrame.data.toByteArray())
+    }
+
+    private fun ensureVirtualTransport(
+        saltedHash: ByteArray,
+        salt: String,
+    ): MultiplexVirtualTransport {
+        virtualTransport?.let { return it }
+        rawTransport?.close()
+        rawTransport = null
+        Log.i(tag, "BLE socket using multiplex stream")
+        val transport =
+            MultiplexVirtualTransport(
+                tag = tag,
+                transportMedium = medium,
+                saltedHash = saltedHash,
+                salt = salt,
+                sendPhysical = sendPhysical,
+            )
+        virtualTransport = transport
+        acceptTransport(transport)
+        return transport
+    }
+
+    private fun ensureRawTransport(): RawBleVirtualTransport {
+        rawTransport?.let { return it }
+        Log.i(tag, "BLE socket using raw Nearby stream")
+        val transport = RawBleVirtualTransport(tag = tag, transportMedium = medium, sendPhysical = sendPhysical)
+        rawTransport = transport
+        acceptTransport(transport)
+        return transport
+    }
+}
+
+private class RawBleVirtualTransport(
+    private val tag: String,
+    private val transportMedium: Medium,
+    private val sendPhysical: (ByteArray) -> Unit,
+) : ConnectedTransport {
+    private val input = PipedInputStream(INPUT_PIPE_SIZE)
+    private val inputWriter = PipedOutputStream(input)
+    private var closed: Boolean = false
+
+    override val medium: Medium = transportMedium
+
+    override val inputStream: InputStream = input
+
+    override val outputStream: OutputStream =
+        object : OutputStream() {
+            override fun write(b: Int) {
+                write(byteArrayOf(b.toByte()))
+            }
+
+            override fun write(
+                b: ByteArray,
+                off: Int,
+                len: Int,
+            ) {
+                if (len == 0) return
+                sendPhysical(b.copyOfRange(off, off + len))
+            }
+
+            override fun flush() {
+                // GATT notifications are queued immediately by write().
+            }
+
+            override fun close() {
+                this@RawBleVirtualTransport.close()
+            }
+        }
+
+    @Synchronized
+    fun feedIncoming(bytes: ByteArray) {
+        if (closed) return
+        try {
+            inputWriter.write(bytes)
+            inputWriter.flush()
+        } catch (io: IOException) {
+            Log.w(tag, "raw BLE input closed while feeding data", io)
+            close()
+        }
+    }
+
+    @Synchronized
+    override fun close() {
+        if (closed) return
+        closed = true
+        runCatching { inputWriter.close() }
+        runCatching { input.close() }
+    }
+
+    private companion object {
+        private const val INPUT_PIPE_SIZE: Int = 1024 * 1024
+    }
+}
+
+private class MultiplexVirtualTransport(
+    private val tag: String,
+    private val transportMedium: Medium,
+    private val saltedHash: ByteArray,
+    private val salt: String,
+    private val sendPhysical: (ByteArray) -> Unit,
+) : ConnectedTransport {
+    private val input = PipedInputStream(INPUT_PIPE_SIZE)
+    private val inputWriter = PipedOutputStream(input)
+    private var closed: Boolean = false
+
+    override val medium: Medium = transportMedium
+
+    override val inputStream: InputStream = input
+
+    override val outputStream: OutputStream =
+        object : OutputStream() {
+            override fun write(b: Int) {
+                write(byteArrayOf(b.toByte()))
+            }
+
+            override fun write(
+                b: ByteArray,
+                off: Int,
+                len: Int,
+            ) {
+                if (len == 0) return
+                val data = b.copyOfRange(off, off + len)
+                sendPhysical(
+                    NearbyMultiplexFrames.encodeLengthPrefixed(
+                        NearbyMultiplexFrames.encodeDataFrame(
+                            saltedServiceIdHash = saltedHash,
+                            data = data,
+                        ),
+                    ),
+                )
+            }
+
+            override fun flush() {
+                // GATT notifications are queued immediately by write().
+            }
+
+            override fun close() {
+                this@MultiplexVirtualTransport.close()
+            }
+        }
+
+    @Synchronized
+    fun feedIncoming(bytes: ByteArray) {
+        if (closed) return
+        try {
+            inputWriter.write(bytes)
+            inputWriter.flush()
+        } catch (io: IOException) {
+            Log.w(tag, "virtual BLE input closed while feeding data", io)
+            close()
+        }
+    }
+
+    @Synchronized
+    override fun close() {
+        if (closed) return
+        closed = true
+        runCatching {
+            sendPhysical(
+                NearbyMultiplexFrames.encodeLengthPrefixed(
+                    NearbyMultiplexFrames.encodeDisconnectionFrame(
+                        saltedServiceIdHash = saltedHash,
+                        serviceIdHashSalt = salt,
+                    ),
+                ),
+            )
+        }
+        runCatching { inputWriter.close() }
+        runCatching { input.close() }
+    }
+
+    private companion object {
+        private const val INPUT_PIPE_SIZE: Int = 1024 * 1024
+    }
+}
+
+private sealed class WeavePacket {
+    data class ConnectionRequest(
+        val minVersion: Int,
+        val maxVersion: Int,
+        val maxPacketSize: Int,
+    ) : WeavePacket()
+
+    data class Data(
+        val counter: Int,
+        val firstPacket: Boolean,
+        val lastPacket: Boolean,
+        val data: ByteArray,
+    ) : WeavePacket()
+
+    data class ConnectionClose(
+        val reason: Int,
+    ) : WeavePacket()
+}
+
+private object WeaveFrames {
+    const val VERSION: Int = 1
+    const val HEADER_SIZE: Int = 1
+    const val MIN_PACKET_SIZE: Int = 20
+    const val MAX_PACKET_SIZE: Int = 509
+    const val DEFAULT_ATT_PAYLOAD_SIZE: Int = 20
+    const val MAX_PACKET_COUNTER: Int = 8
+    const val CLOSE_NO_COMMON_VERSION: Int = 2
+
+    private const val PACKET_TYPE_CONTROL: Int = 0x80
+    private const val PACKET_COUNTER_MASK: Int = 0x70
+    private const val PACKET_COUNTER_SHIFT: Int = 4
+    private const val CONTROL_COMMAND_MASK: Int = 0x0F
+    private const val CONTROL_CONNECTION_REQUEST: Int = 0
+    private const val CONTROL_CONNECTION_CONFIRM: Int = 1
+    private const val CONTROL_CONNECTION_CLOSE: Int = 2
+    private const val DATA_FIRST_FLAG: Int = 0x08
+    private const val DATA_LAST_FLAG: Int = 0x04
+    private const val MIN_CONNECTION_REQUEST_LEN: Int = 7
+    private const val CONNECTION_CLOSE_LEN: Int = 3
+
+    fun parse(bytes: ByteArray): WeavePacket? {
+        if (bytes.isEmpty()) return null
+        val header = bytes[0].toInt() and 0xFF
+        val counter = (header and PACKET_COUNTER_MASK) ushr PACKET_COUNTER_SHIFT
+        return if ((header and PACKET_TYPE_CONTROL) != 0) {
+            parseControl(header, bytes)
+        } else {
+            WeavePacket.Data(
+                counter = counter,
+                firstPacket = (header and DATA_FIRST_FLAG) != 0,
+                lastPacket = (header and DATA_LAST_FLAG) != 0,
+                data = bytes.copyOfRange(HEADER_SIZE, bytes.size),
+            )
+        }
+    }
+
+    fun connectionConfirm(
+        version: Int,
+        packetSize: Int,
+    ): ByteArray =
+        byteArrayOf(
+            (PACKET_TYPE_CONTROL or CONTROL_CONNECTION_CONFIRM).toByte(),
+            (version ushr 8).toByte(),
+            version.toByte(),
+            (packetSize ushr 8).toByte(),
+            packetSize.toByte(),
+        )
+
+    fun connectionClosePacket(
+        packetCounter: Int,
+        reason: Int,
+    ): ByteArray {
+        val header =
+            PACKET_TYPE_CONTROL or
+                ((packetCounter % MAX_PACKET_COUNTER) shl PACKET_COUNTER_SHIFT) or
+                CONTROL_CONNECTION_CLOSE
+        return byteArrayOf(
+            header.toByte(),
+            (reason ushr 8).toByte(),
+            reason.toByte(),
+        )
+    }
+
+    fun dataPacket(
+        packetCounter: Int,
+        firstPacket: Boolean,
+        lastPacket: Boolean,
+        data: ByteArray,
+    ): ByteArray {
+        val header =
+            ((packetCounter % MAX_PACKET_COUNTER) shl PACKET_COUNTER_SHIFT) or
+                (if (firstPacket) DATA_FIRST_FLAG else 0) or
+                (if (lastPacket) DATA_LAST_FLAG else 0)
+        return byteArrayOf(header.toByte()) + data
+    }
+
+    private fun parseControl(
+        header: Int,
+        bytes: ByteArray,
+    ): WeavePacket? {
+        return when (header and CONTROL_COMMAND_MASK) {
+            CONTROL_CONNECTION_REQUEST -> {
+                if (bytes.size < MIN_CONNECTION_REQUEST_LEN) return null
+                WeavePacket.ConnectionRequest(
+                    minVersion = bytes.readUInt16(1),
+                    maxVersion = bytes.readUInt16(3),
+                    maxPacketSize = bytes.readUInt16(5),
+                )
+            }
+
+            CONTROL_CONNECTION_CLOSE -> {
+                WeavePacket.ConnectionClose(
+                    reason = if (bytes.size >= CONNECTION_CLOSE_LEN) bytes.readUInt16(1) else 0,
+                )
+            }
+
+            else -> null
+        }
+    }
+}
+
+private fun ByteArray.readUInt16(offset: Int): Int =
+    ((this[offset].toInt() and 0xFF) shl 8) or (this[offset + 1].toInt() and 0xFF)
+
+private fun ArrayList<Byte>.toByteArray(): ByteArray {
+    val out = ByteArray(size)
+    for (index in indices) out[index] = this[index]
+    return out
+}
+
+private fun BluetoothDevice.key(): String = address ?: toString()
+
+private fun BluetoothDevice.safeAddress(): String = runCatching { address }.getOrNull() ?: "<unknown>"
+
+private fun ByteArray.toHex(): String = joinToString("") { "%02x".format(it) }
+
+private fun ByteArray.firstByteHex(): String = firstOrNull()?.let { "%02x".format(it) } ?: "--"

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BleGattInitialControlServer.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BleGattInitialControlServer.kt
@@ -27,6 +27,7 @@ import androidx.annotation.RequiresPermission
 import androidx.core.content.ContextCompat
 import com.google.location.nearby.mediums.proto.BleFramesProto
 import com.google.location.nearby.mediums.proto.MultiplexFramesProto
+import io.github.kyujincho.wvmg.protocol.endpoint.BleAdvertisement
 import io.github.kyujincho.wvmg.protocol.endpoint.BleServiceData
 import io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo
 import io.github.kyujincho.wvmg.protocol.endpoint.NearbyServiceId
@@ -328,7 +329,7 @@ public class BleGattInitialControlServer(
                 endpointId: ByteArray,
             ): List<BluetoothGattCharacteristic> {
                 val visibleAdvertisement =
-                    runCatching { BleServiceData.encodeFramed(endpointId, endpointInfo) }
+                    runCatching { BleAdvertisement.encodeGattAdvertisement(endpointId, endpointInfo) }
                         .getOrDefault(ByteArray(0))
 
                 return (0 until GATT_ADVERTISEMENT_SLOT_COUNT).map { slot ->
@@ -364,7 +365,7 @@ public class BleGattInitialControlServer(
 
         private const val GATT_ADVERTISEMENT_SLOT_COUNT: Int = 16
 
-        private fun advertisementSlotUuid(slot: Int): UUID =
+        internal fun advertisementSlotUuid(slot: Int): UUID =
             UUID.fromString("00000000-0000-3000-8000-${slot.toString(radix = 16).padStart(12, '0')}")
     }
 }
@@ -508,8 +509,10 @@ private class BleWeaveGattSession(
             }
 
             else -> {
+                val payload = message.copyOfRange(NearbyServiceId.hashPrefix.size, message.size)
+                sendWeaveMessage(NearbyBleSocketFrames.encodePacketAcknowledgementPacket(payload.size))
                 multiplexBridge.receivePhysicalBytes(
-                    message.copyOfRange(NearbyServiceId.hashPrefix.size, message.size),
+                    payload,
                 )
             }
         }

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BleGattInitialControlServer.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BleGattInitialControlServer.kt
@@ -409,6 +409,7 @@ private class BleWeaveGattSession(
         if (closed) return
         when (val packet = WeaveFrames.parse(packetBytes)) {
             is WeavePacket.ConnectionRequest -> handleConnectionRequest(packet)
+            is WeavePacket.ConnectionConfirm -> Unit
             is WeavePacket.Data -> handleDataPacket(packet)
             is WeavePacket.ConnectionClose -> close()
             null -> Log.w(BleGattInitialControlServer.TAG, "invalid Weave packet ${packetBytes.toHex()}")
@@ -852,130 +853,6 @@ private class MultiplexVirtualTransport(
         private const val INPUT_PIPE_SIZE: Int = 1024 * 1024
     }
 }
-
-private sealed class WeavePacket {
-    data class ConnectionRequest(
-        val minVersion: Int,
-        val maxVersion: Int,
-        val maxPacketSize: Int,
-    ) : WeavePacket()
-
-    data class Data(
-        val counter: Int,
-        val firstPacket: Boolean,
-        val lastPacket: Boolean,
-        val data: ByteArray,
-    ) : WeavePacket()
-
-    data class ConnectionClose(
-        val reason: Int,
-    ) : WeavePacket()
-}
-
-private object WeaveFrames {
-    const val VERSION: Int = 1
-    const val HEADER_SIZE: Int = 1
-    const val MIN_PACKET_SIZE: Int = 20
-    const val MAX_PACKET_SIZE: Int = 509
-    const val DEFAULT_ATT_PAYLOAD_SIZE: Int = 20
-    const val MAX_PACKET_COUNTER: Int = 8
-    const val CLOSE_NO_COMMON_VERSION: Int = 2
-
-    private const val PACKET_TYPE_CONTROL: Int = 0x80
-    private const val PACKET_COUNTER_MASK: Int = 0x70
-    private const val PACKET_COUNTER_SHIFT: Int = 4
-    private const val CONTROL_COMMAND_MASK: Int = 0x0F
-    private const val CONTROL_CONNECTION_REQUEST: Int = 0
-    private const val CONTROL_CONNECTION_CONFIRM: Int = 1
-    private const val CONTROL_CONNECTION_CLOSE: Int = 2
-    private const val DATA_FIRST_FLAG: Int = 0x08
-    private const val DATA_LAST_FLAG: Int = 0x04
-    private const val MIN_CONNECTION_REQUEST_LEN: Int = 7
-    private const val CONNECTION_CLOSE_LEN: Int = 3
-
-    fun parse(bytes: ByteArray): WeavePacket? {
-        if (bytes.isEmpty()) return null
-        val header = bytes[0].toInt() and 0xFF
-        val counter = (header and PACKET_COUNTER_MASK) ushr PACKET_COUNTER_SHIFT
-        return if ((header and PACKET_TYPE_CONTROL) != 0) {
-            parseControl(header, bytes)
-        } else {
-            WeavePacket.Data(
-                counter = counter,
-                firstPacket = (header and DATA_FIRST_FLAG) != 0,
-                lastPacket = (header and DATA_LAST_FLAG) != 0,
-                data = bytes.copyOfRange(HEADER_SIZE, bytes.size),
-            )
-        }
-    }
-
-    fun connectionConfirm(
-        version: Int,
-        packetSize: Int,
-    ): ByteArray =
-        byteArrayOf(
-            (PACKET_TYPE_CONTROL or CONTROL_CONNECTION_CONFIRM).toByte(),
-            (version ushr 8).toByte(),
-            version.toByte(),
-            (packetSize ushr 8).toByte(),
-            packetSize.toByte(),
-        )
-
-    fun connectionClosePacket(
-        packetCounter: Int,
-        reason: Int,
-    ): ByteArray {
-        val header =
-            PACKET_TYPE_CONTROL or
-                ((packetCounter % MAX_PACKET_COUNTER) shl PACKET_COUNTER_SHIFT) or
-                CONTROL_CONNECTION_CLOSE
-        return byteArrayOf(
-            header.toByte(),
-            (reason ushr 8).toByte(),
-            reason.toByte(),
-        )
-    }
-
-    fun dataPacket(
-        packetCounter: Int,
-        firstPacket: Boolean,
-        lastPacket: Boolean,
-        data: ByteArray,
-    ): ByteArray {
-        val header =
-            ((packetCounter % MAX_PACKET_COUNTER) shl PACKET_COUNTER_SHIFT) or
-                (if (firstPacket) DATA_FIRST_FLAG else 0) or
-                (if (lastPacket) DATA_LAST_FLAG else 0)
-        return byteArrayOf(header.toByte()) + data
-    }
-
-    private fun parseControl(
-        header: Int,
-        bytes: ByteArray,
-    ): WeavePacket? {
-        return when (header and CONTROL_COMMAND_MASK) {
-            CONTROL_CONNECTION_REQUEST -> {
-                if (bytes.size < MIN_CONNECTION_REQUEST_LEN) return null
-                WeavePacket.ConnectionRequest(
-                    minVersion = bytes.readUInt16(1),
-                    maxVersion = bytes.readUInt16(3),
-                    maxPacketSize = bytes.readUInt16(5),
-                )
-            }
-
-            CONTROL_CONNECTION_CLOSE -> {
-                WeavePacket.ConnectionClose(
-                    reason = if (bytes.size >= CONNECTION_CLOSE_LEN) bytes.readUInt16(1) else 0,
-                )
-            }
-
-            else -> null
-        }
-    }
-}
-
-private fun ByteArray.readUInt16(offset: Int): Int =
-    ((this[offset].toInt() and 0xFF) shl 8) or (this[offset + 1].toInt() and 0xFF)
 
 private fun ArrayList<Byte>.toByteArray(): ByteArray {
     val out = ByteArray(size)

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BleL2capInitialControlClient.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BleL2capInitialControlClient.kt
@@ -1,0 +1,406 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+@file:android.annotation.SuppressLint("MissingPermission")
+@file:Suppress("MagicNumber", "TooGenericExceptionCaught")
+
+package io.github.kyujincho.wvmg.discovery.bootstrap
+
+import android.content.Context
+import android.os.Build
+import android.util.Log
+import androidx.annotation.ChecksSdkIntAtLeast
+import androidx.annotation.RequiresApi
+import com.google.location.nearby.mediums.proto.BleFramesProto
+import com.google.location.nearby.mediums.proto.MultiplexFramesProto
+import io.github.kyujincho.wvmg.discovery.medium.BluetoothL2capIo
+import io.github.kyujincho.wvmg.discovery.medium.DefaultBluetoothL2capIo
+import io.github.kyujincho.wvmg.discovery.medium.L2capChannel
+import io.github.kyujincho.wvmg.protocol.endpoint.NearbyServiceId
+import io.github.kyujincho.wvmg.protocol.medium.Medium
+import io.github.kyujincho.wvmg.protocol.medium.NearbyBleSocketFrames
+import io.github.kyujincho.wvmg.protocol.medium.NearbyMultiplexFrames
+import io.github.kyujincho.wvmg.protocol.transport.ConnectedTransport
+import io.github.kyujincho.wvmg.protocol.transport.FramedConnection
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import java.io.EOFException
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import java.security.SecureRandom
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Sender-side BLE L2CAP initial-control client for stock Quick Share receivers.
+ *
+ * Receiver fast advertisements may carry a CoC PSM. When present, WVMG can
+ * connect to that PSM, open Nearby's BLE socket, establish one multiplexed
+ * virtual socket, and then hand that stream to the normal outbound protocol.
+ */
+public class BleL2capInitialControlClient internal constructor(
+    private val io: BluetoothL2capIo,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val saltFactory: () -> String = ::randomSalt,
+) {
+    public constructor(context: Context) : this(DefaultBluetoothL2capIo(context.applicationContext))
+
+    private val activeTransport: AtomicReference<BleL2capClientTransport?> = AtomicReference(null)
+
+    public suspend fun connect(
+        macAddress: String,
+        psm: Int,
+    ): ConnectedTransport? =
+        withContext(dispatcher) {
+            if (!isAvailable() || psm !in PSM_RANGE) {
+                Log.i(TAG, "BLE L2CAP initial connect unavailable psm=$psm")
+                return@withContext null
+            }
+            val channel = connectOnQ(macAddress, psm) ?: return@withContext null
+            val transport =
+                BleL2capClientTransport(
+                    channel = channel,
+                    salt = saltFactory(),
+                    onClose = { activeTransport.compareAndSet(it, null) },
+                )
+            activeTransport.getAndSet(transport)?.close()
+            transport.start()
+            val ready = transport.awaitReady(CONNECTION_READY_TIMEOUT_MILLIS)
+            if (!ready) {
+                Log.w(TAG, "BLE L2CAP initial connect timed out waiting for multiplex accept")
+                transport.close()
+                return@withContext null
+            }
+            Log.i(TAG, "BLE L2CAP initial connect ready mac=$macAddress psm=$psm")
+            transport
+        }
+
+    public fun cancelPendingConnect() {
+        activeTransport.getAndSet(null)?.close()
+    }
+
+    @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.Q)
+    private fun isAvailable(): Boolean =
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q &&
+            io.apiLevel >= Build.VERSION_CODES.Q &&
+            io.hasBleHardware() &&
+            io.hasConnectPermission() &&
+            io.isBluetoothEnabled()
+
+    @RequiresApi(Build.VERSION_CODES.Q)
+    private fun connectOnQ(
+        macAddress: String,
+        psm: Int,
+    ): L2capChannel? = io.connect(macAddress, psm)
+
+    private companion object {
+        private const val TAG: String = "WvmgBleL2capClient"
+        private const val CONNECTION_READY_TIMEOUT_MILLIS: Long = 8_000L
+        private val PSM_RANGE: IntRange = 1..0xFFFF
+    }
+}
+
+private class BleL2capClientTransport(
+    private val channel: L2capChannel,
+    private val salt: String,
+    private val onClose: (BleL2capClientTransport) -> Unit,
+) : ConnectedTransport {
+    private val input = PipedInputStream(INPUT_PIPE_SIZE)
+    private val inputWriter = PipedOutputStream(input)
+    private val ready = CompletableDeferred<Boolean>()
+    private val writeLock = Any()
+    private val saltedHash: ByteArray = NearbyMultiplexFrames.saltedServiceIdHash(salt = salt)
+    private var pendingMultiplexBytes: ByteArray = ByteArray(0)
+
+    @Volatile
+    private var closed: Boolean = false
+
+    override val medium: Medium = Medium.BLE_L2CAP
+
+    override val inputStream: InputStream = input
+
+    override val outputStream: OutputStream =
+        object : OutputStream() {
+            override fun write(b: Int) {
+                write(byteArrayOf(b.toByte()))
+            }
+
+            override fun write(
+                b: ByteArray,
+                off: Int,
+                len: Int,
+            ) {
+                if (len == 0) return
+                sendMultiplexBytes(
+                    NearbyMultiplexFrames.encodeLengthPrefixed(
+                        NearbyMultiplexFrames.encodeDataFrame(
+                            saltedServiceIdHash = saltedHash,
+                            data = b.copyOfRange(off, off + len),
+                        ),
+                    ),
+                )
+            }
+
+            override fun flush() {
+                channel.outputStream.flush()
+            }
+
+            override fun close() {
+                this@BleL2capClientTransport.close()
+            }
+        }
+
+    fun start() {
+        Thread({ runPump() }, "wvmg-ble-l2cap-client").apply {
+            isDaemon = true
+            start()
+        }
+    }
+
+    suspend fun awaitReady(timeoutMillis: Long): Boolean = withTimeoutOrNull(timeoutMillis) { ready.await() } == true
+
+    @Synchronized
+    override fun close() {
+        if (closed) return
+        closed = true
+        if (!ready.isCompleted) ready.complete(false)
+        runCatching {
+            sendControlPacket(NearbyBleSocketFrames.encodeDisconnectionPacket())
+        }
+        runCatching {
+            sendMultiplexBytes(
+                NearbyMultiplexFrames.encodeLengthPrefixed(
+                    NearbyMultiplexFrames.encodeDisconnectionFrame(
+                        saltedServiceIdHash = saltedHash,
+                        serviceIdHashSalt = salt,
+                    ),
+                ),
+            )
+        }
+        runCatching { inputWriter.close() }
+        runCatching { input.close() }
+        runCatching { channel.close() }
+        onClose(this)
+    }
+
+    private fun runPump() {
+        try {
+            if (!openDataConnection()) {
+                close()
+                return
+            }
+            sendControlPacket(NearbyBleSocketFrames.encodeIntroductionPacket())
+            sendConnectionRequest()
+            while (!closed) {
+                val packetLengthPrefix = channel.inputStream.readExactly(L2CAP_PACKET_LENGTH_BYTES)
+                val packetLength = packetLengthPrefix.decodeLength()
+                if (packetLength <= 0 || packetLength >= FramedConnection.SANE_FRAME_LENGTH) {
+                    Log.w(TAG, "invalid BLE L2CAP packet length=$packetLength")
+                    close()
+                    return
+                }
+                handleIncomingPacket(channel.inputStream.readExactly(packetLength))
+            }
+        } catch (_: EOFException) {
+            close()
+        } catch (io: IOException) {
+            if (!closed) Log.w(TAG, "BLE L2CAP client pump failed", io)
+            close()
+        } catch (t: Throwable) {
+            if (!closed) Log.w(TAG, "BLE L2CAP client pump crashed", t)
+            close()
+        }
+    }
+
+    private fun openDataConnection(): Boolean {
+        channel.outputStream.write(COMMAND_REQUEST_DATA_CONNECTION)
+        channel.outputStream.flush()
+        val response = channel.inputStream.read()
+        if (response == COMMAND_RESPONSE_DATA_CONNECTION_READY) {
+            Log.i(TAG, "BLE L2CAP data connection ready")
+            return true
+        }
+        Log.w(TAG, "unexpected BLE L2CAP data-connection response=$response")
+        return false
+    }
+
+    private fun sendConnectionRequest() {
+        sendMultiplexBytes(
+            NearbyMultiplexFrames.encodeLengthPrefixed(
+                NearbyMultiplexFrames.encodeConnectionRequestFrame(
+                    saltedServiceIdHash = saltedHash,
+                    serviceIdHashSalt = salt,
+                ),
+            ),
+        )
+    }
+
+    private fun handleIncomingPacket(packet: ByteArray) {
+        if (packet.size < SERVICE_ID_HASH_LEN) {
+            Log.w(TAG, "discarded undersized BLE L2CAP packet=${packet.toHex()}")
+            close()
+            return
+        }
+        val prefix = packet.copyOfRange(0, SERVICE_ID_HASH_LEN)
+        when {
+            prefix.contentEquals(CONTROL_PACKET_PREFIX) -> handleControlPacket(packet)
+            prefix.contentEquals(NearbyServiceId.hashPrefix) -> {
+                val payload = packet.copyOfRange(SERVICE_ID_HASH_LEN, packet.size)
+                sendControlPacket(NearbyBleSocketFrames.encodePacketAcknowledgementPacket(payload.size))
+                receiveMultiplexBytes(payload)
+            }
+            else -> {
+                Log.w(TAG, "discarded BLE L2CAP packet for unexpected service hash packet=${packet.toHex()}")
+                close()
+            }
+        }
+    }
+
+    private fun handleControlPacket(packet: ByteArray) {
+        val control = NearbyBleSocketFrames.parseControlPacket(packet)
+        if (control == null) {
+            Log.w(TAG, "BLE L2CAP unknown control packet raw=${packet.toHex()}")
+            return
+        }
+        when (control.type) {
+            BleFramesProto.SocketControlFrame.ControlFrameType.PACKET_ACKNOWLEDGEMENT -> Unit
+            BleFramesProto.SocketControlFrame.ControlFrameType.DISCONNECTION -> close()
+            else -> Log.i(TAG, "BLE L2CAP control frame type=${control.type}")
+        }
+    }
+
+    private fun receiveMultiplexBytes(bytes: ByteArray) {
+        pendingMultiplexBytes += bytes
+        var keepParsing = true
+        while (keepParsing && pendingMultiplexBytes.size >= NearbyMultiplexFrames.LENGTH_PREFIX_BYTES) {
+            val length = NearbyMultiplexFrames.decodeLength(pendingMultiplexBytes)
+            if (
+                length == null ||
+                length < 0 ||
+                pendingMultiplexBytes.size < NearbyMultiplexFrames.LENGTH_PREFIX_BYTES + length
+            ) {
+                keepParsing = false
+            } else {
+                val frameBytes =
+                    pendingMultiplexBytes.copyOfRange(
+                        NearbyMultiplexFrames.LENGTH_PREFIX_BYTES,
+                        NearbyMultiplexFrames.LENGTH_PREFIX_BYTES + length,
+                    )
+                pendingMultiplexBytes =
+                    pendingMultiplexBytes.copyOfRange(
+                        NearbyMultiplexFrames.LENGTH_PREFIX_BYTES + length,
+                        pendingMultiplexBytes.size,
+                    )
+                handleMultiplexFrame(frameBytes)
+            }
+        }
+    }
+
+    private fun handleMultiplexFrame(frameBytes: ByteArray) {
+        val frame =
+            NearbyMultiplexFrames.parseFrame(frameBytes) ?: run {
+                Log.w(TAG, "discarded invalid multiplex frame=${frameBytes.toHex()}")
+                return
+            }
+        when (frame.frameType) {
+            MultiplexFramesProto.MultiplexFrame.MultiplexFrameType.CONTROL_FRAME -> handleMultiplexControlFrame(frame)
+            MultiplexFramesProto.MultiplexFrame.MultiplexFrameType.DATA_FRAME ->
+                feedIncoming(frame.dataFrame.data.toByteArray())
+            else -> Unit
+        }
+    }
+
+    private fun handleMultiplexControlFrame(frame: MultiplexFramesProto.MultiplexFrame) {
+        when (frame.controlFrame.controlFrameType) {
+            MultiplexFramesProto.MultiplexControlFrame.MultiplexControlFrameType.CONNECTION_RESPONSE -> {
+                val accepted =
+                    frame.controlFrame.connectionResponseFrame.connectionResponseCode ==
+                        MultiplexFramesProto.ConnectionResponseFrame.ConnectionResponseCode.CONNECTION_ACCEPTED
+                if (!ready.isCompleted) ready.complete(accepted)
+                if (!accepted) close()
+            }
+            MultiplexFramesProto.MultiplexControlFrame.MultiplexControlFrameType.DISCONNECTION -> close()
+            else -> Unit
+        }
+    }
+
+    private fun feedIncoming(bytes: ByteArray) {
+        if (closed) return
+        try {
+            inputWriter.write(bytes)
+            inputWriter.flush()
+        } catch (io: IOException) {
+            Log.w(TAG, "BLE L2CAP virtual input closed while feeding data", io)
+            close()
+        }
+    }
+
+    private fun sendControlPacket(packet: ByteArray) {
+        synchronized(writeLock) {
+            channel.outputStream.writeLengthPrefixedPacket(packet)
+        }
+    }
+
+    private fun sendMultiplexBytes(bytes: ByteArray) {
+        if (bytes.isEmpty()) return
+        synchronized(writeLock) {
+            channel.outputStream.writeLengthPrefixedPacket(NearbyServiceId.hashPrefix + bytes)
+        }
+    }
+
+    private companion object {
+        private const val TAG: String = "WvmgBleL2capClient"
+        private const val INPUT_PIPE_SIZE: Int = 1024 * 1024
+        private const val COMMAND_REQUEST_DATA_CONNECTION: Int = 3
+        private const val COMMAND_RESPONSE_DATA_CONNECTION_READY: Int = 23
+        private const val SERVICE_ID_HASH_LEN: Int = 3
+        private const val L2CAP_PACKET_LENGTH_BYTES: Int = 4
+        private val CONTROL_PACKET_PREFIX: ByteArray = ByteArray(SERVICE_ID_HASH_LEN)
+    }
+}
+
+private fun InputStream.readExactly(length: Int): ByteArray {
+    val out = ByteArray(length)
+    var offset = 0
+    while (offset < length) {
+        val read = read(out, offset, length - offset)
+        if (read < 0) throw EOFException("stream closed after $offset of $length bytes")
+        offset += read
+    }
+    return out
+}
+
+private fun ByteArray.decodeLength(offset: Int = 0): Int =
+    ((this[offset].toInt() and 0xFF) shl 24) or
+        ((this[offset + 1].toInt() and 0xFF) shl 16) or
+        ((this[offset + 2].toInt() and 0xFF) shl 8) or
+        (this[offset + 3].toInt() and 0xFF)
+
+private fun Int.encodeLength(): ByteArray =
+    byteArrayOf(
+        (this ushr 24).toByte(),
+        (this ushr 16).toByte(),
+        (this ushr 8).toByte(),
+        this.toByte(),
+    )
+
+private fun OutputStream.writeLengthPrefixedPacket(packet: ByteArray) {
+    write(packet.size.encodeLength())
+    write(packet)
+    flush()
+}
+
+private fun ByteArray.toHex(): String = joinToString("") { "%02x".format(it) }
+
+private fun randomSalt(): String {
+    val bytes = ByteArray(8)
+    SecureRandom().nextBytes(bytes)
+    return bytes.toHex()
+}

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BleL2capInitialControlServer.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BleL2capInitialControlServer.kt
@@ -1,0 +1,399 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+@file:android.annotation.SuppressLint("MissingPermission")
+@file:Suppress("MagicNumber", "TooGenericExceptionCaught")
+
+package io.github.kyujincho.wvmg.discovery.bootstrap
+
+import android.content.Context
+import android.os.Build
+import android.util.Log
+import androidx.annotation.ChecksSdkIntAtLeast
+import androidx.annotation.RequiresApi
+import com.google.location.nearby.mediums.proto.BleFramesProto
+import io.github.kyujincho.wvmg.discovery.ble.BleDctPsmHolder
+import io.github.kyujincho.wvmg.discovery.medium.BluetoothL2capIo
+import io.github.kyujincho.wvmg.discovery.medium.DefaultBluetoothL2capIo
+import io.github.kyujincho.wvmg.discovery.medium.L2capChannel
+import io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo
+import io.github.kyujincho.wvmg.protocol.endpoint.NearbyServiceId
+import io.github.kyujincho.wvmg.protocol.medium.Medium
+import io.github.kyujincho.wvmg.protocol.medium.NearbyBleSocketFrames
+import io.github.kyujincho.wvmg.protocol.transport.ConnectedTransport
+import io.github.kyujincho.wvmg.protocol.transport.FramedConnection
+import io.github.kyujincho.wvmg.protocol.transport.InitialControlServer
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import java.io.ByteArrayInputStream
+import java.io.EOFException
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+import java.io.SequenceInputStream
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Receiver-side BLE L2CAP initial-control server for DCT advertisements.
+ *
+ * Stock Nearby encodes the listening CoC PSM in the `0xFC73` DCT service data.
+ * A sender that sees a non-zero PSM connects here and sends a one-byte
+ * data-connection request before the normal BLE socket packet stream begins.
+ */
+public class BleL2capInitialControlServer internal constructor(
+    private val io: BluetoothL2capIo,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : InitialControlServer {
+    public constructor(context: Context) : this(DefaultBluetoothL2capIo(context.applicationContext))
+
+    private val active: AtomicReference<ActiveState?> = AtomicReference(null)
+    private val lifecycleLock: Any = Any()
+
+    override val isActive: Boolean
+        get() = active.get() != null
+
+    override fun start(
+        endpointInfo: EndpointInfo,
+        acceptTransport: (ConnectedTransport) -> Unit,
+    ): Boolean =
+        synchronized(lifecycleLock) {
+            if (isActive) return true
+            if (!isAvailable()) {
+                Log.i(TAG, "BLE L2CAP bootstrap unavailable")
+                return false
+            }
+
+            val listener = listenOnQ() ?: return false
+            if (listener.psm <= 0) {
+                Log.w(TAG, "BLE L2CAP listener returned invalid psm=${listener.psm}")
+                listener.close()
+                return false
+            }
+
+            val scope = CoroutineScope(SupervisorJob() + dispatcher)
+            val state = ActiveState(listener = listener, psm = listener.psm, scope = scope)
+            if (!active.compareAndSet(null, state)) {
+                listener.close()
+                scope.cancel()
+                return true
+            }
+
+            BleDctPsmHolder.set(listener.psm)
+            scope.launch { runAcceptLoop(state, acceptTransport) }
+            Log.i(TAG, "BLE L2CAP bootstrap active psm=${listener.psm}")
+            true
+        }
+
+    override fun stop() {
+        synchronized(lifecycleLock) {
+            stopLocked()
+        }
+    }
+
+    private fun stopLocked() {
+        val state = active.getAndSet(null) ?: return
+        BleDctPsmHolder.clear(state.psm)
+        runCatching { state.listener.close() }
+        state.scope.cancel()
+    }
+
+    @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.Q)
+    private fun isAvailable(): Boolean =
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q &&
+            io.apiLevel >= Build.VERSION_CODES.Q &&
+            io.hasBleHardware() &&
+            io.hasConnectPermission() &&
+            io.isBluetoothEnabled()
+
+    @RequiresApi(Build.VERSION_CODES.Q)
+    private fun listenOnQ(): BluetoothL2capIo.Listener? = io.listen()
+
+    @RequiresApi(Build.VERSION_CODES.Q)
+    private fun runAcceptLoop(
+        state: ActiveState,
+        acceptTransport: (ConnectedTransport) -> Unit,
+    ) {
+        while (active.get() === state) {
+            val channel =
+                try {
+                    state.listener.accept()
+                } catch (ioException: IOException) {
+                    if (active.get() === state) Log.w(TAG, "BLE L2CAP accept failed", ioException)
+                    stop()
+                    return
+                } catch (t: Throwable) {
+                    if (active.get() === state) Log.w(TAG, "BLE L2CAP accept crashed", t)
+                    stop()
+                    return
+                }
+            state.scope.launch { acceptL2capChannel(channel, acceptTransport) }
+        }
+    }
+
+    private fun acceptL2capChannel(
+        channel: L2capChannel,
+        acceptTransport: (ConnectedTransport) -> Unit,
+    ) {
+        try {
+            val initialBytes = processDataConnectionRequest(channel)
+            if (initialBytes == null) {
+                channel.close()
+                return
+            }
+            BleL2capInitialTransport(
+                channel = channel,
+                initialBytes = initialBytes,
+                acceptTransport = acceptTransport,
+            ).start()
+        } catch (t: Throwable) {
+            Log.w(TAG, "BLE L2CAP channel setup failed", t)
+            channel.close()
+        }
+    }
+
+    private fun processDataConnectionRequest(channel: L2capChannel): ByteArray? {
+        val command = channel.inputStream.read()
+        return when {
+            command < 0 -> null
+            command == COMMAND_REQUEST_DATA_CONNECTION -> {
+                channel.outputStream.write(byteArrayOf(COMMAND_RESPONSE_DATA_CONNECTION_READY.toByte()))
+                channel.outputStream.flush()
+                Log.i(TAG, "BLE L2CAP data connection ready")
+                ByteArray(0)
+            }
+            else -> processInitialSocketPacket(channel, command)
+        }
+    }
+
+    private fun processInitialSocketPacket(
+        channel: L2capChannel,
+        command: Int,
+    ): ByteArray? {
+        val packetPrefix =
+            runCatching {
+                byteArrayOf(command.toByte()) + channel.inputStream.readExactly(L2CAP_PACKET_LENGTH_BYTES - 1)
+            }.getOrElse {
+                Log.w(TAG, "BLE L2CAP command prefix truncated", it)
+                null
+            }
+        return packetPrefix?.let { processInitialSocketPacket(channel, it) }
+    }
+
+    private fun processInitialSocketPacket(
+        channel: L2capChannel,
+        packetPrefix: ByteArray,
+    ): ByteArray {
+        val packetLength = packetPrefix.decodeLength()
+        return if (packetLength <= 0 || packetLength > MAX_INITIAL_PACKET_LENGTH) {
+            Log.i(
+                TAG,
+                "BLE L2CAP socket stream started without validation prefix=${packetPrefix.toHex()}",
+            )
+            packetPrefix
+        } else {
+            val packet = channel.inputStream.readExactly(packetLength)
+            val packetCommand = packet.firstOrNull()?.toInt()?.and(0xFF) ?: -1
+            when (packetCommand) {
+                COMMAND_REQUEST_DATA_CONNECTION -> {
+                    channel.outputStream.writeLengthPrefixedPacket(
+                        byteArrayOf(COMMAND_RESPONSE_DATA_CONNECTION_READY.toByte()),
+                    )
+                    Log.i(TAG, "BLE L2CAP framed data connection ready")
+                    ByteArray(0)
+                }
+
+                else -> {
+                    Log.w(
+                        TAG,
+                        "unexpected BLE L2CAP framed command=$packetCommand before data connection; " +
+                            "treating as socket data",
+                    )
+                    packetPrefix + packet
+                }
+            }
+        }
+    }
+
+    private data class ActiveState(
+        val listener: BluetoothL2capIo.Listener,
+        val psm: Int,
+        val scope: CoroutineScope,
+    )
+
+    public companion object {
+        internal const val TAG: String = "WvmgBleL2cap"
+        private const val COMMAND_REQUEST_DATA_CONNECTION: Int = 3
+        private const val COMMAND_RESPONSE_DATA_CONNECTION_READY: Int = 23
+        private const val L2CAP_PACKET_LENGTH_BYTES: Int = 4
+        private const val MAX_INITIAL_PACKET_LENGTH: Int = 512
+    }
+}
+
+private class BleL2capInitialTransport(
+    private val channel: L2capChannel,
+    initialBytes: ByteArray,
+    acceptTransport: (ConnectedTransport) -> Unit,
+) {
+    private val sourceInput: InputStream =
+        if (initialBytes.isEmpty()) {
+            channel.inputStream
+        } else {
+            SequenceInputStream(ByteArrayInputStream(initialBytes), channel.inputStream)
+        }
+    private val writeLock = Any()
+    private val multiplexBridge =
+        BleMultiplexBridge(
+            tag = BleL2capInitialControlServer.TAG,
+            medium = Medium.BLE_L2CAP,
+            sendPhysical = ::sendPhysicalSocketBytes,
+            acceptTransport = acceptTransport,
+        )
+
+    @Volatile
+    private var closed: Boolean = false
+
+    fun start() {
+        Thread({ pumpIncoming() }, "wvmg-ble-l2cap-initial").apply {
+            isDaemon = true
+            start()
+        }
+    }
+
+    fun close() {
+        if (closed) return
+        closed = true
+        multiplexBridge.close()
+        runCatching { channel.close() }
+    }
+
+    private fun pumpIncoming() {
+        try {
+            while (!closed && pumpIncomingPacket()) Unit
+        } catch (_: EOFException) {
+            close()
+        } catch (io: IOException) {
+            if (!closed) Log.w(BleL2capInitialControlServer.TAG, "BLE L2CAP input pump failed", io)
+            close()
+        }
+    }
+
+    private fun pumpIncomingPacket(): Boolean {
+        val packetLengthPrefix = sourceInput.readExactly(L2CAP_PACKET_LENGTH_BYTES)
+        val packetLength = packetLengthPrefix.decodeLength()
+        return if (packetLength <= 0 || packetLength >= FramedConnection.SANE_FRAME_LENGTH) {
+            Log.w(BleL2capInitialControlServer.TAG, "invalid BLE L2CAP packet length=$packetLength")
+            close()
+            false
+        } else {
+            handleIncomingPacket(sourceInput.readExactly(packetLength))
+        }
+    }
+
+    private fun handleIncomingPacket(packet: ByteArray): Boolean =
+        when {
+            packet.size < SERVICE_ID_HASH_LEN -> {
+                Log.w(BleL2capInitialControlServer.TAG, "discarded undersized BLE L2CAP packet=${packet.toHex()}")
+                close()
+                false
+            }
+
+            packet.copyOfRange(0, SERVICE_ID_HASH_LEN).contentEquals(CONTROL_PACKET_PREFIX) -> {
+                handleControlPacket(packet)
+                true
+            }
+
+            !packet.copyOfRange(0, SERVICE_ID_HASH_LEN).contentEquals(NearbyServiceId.hashPrefix) -> {
+                Log.w(
+                    BleL2capInitialControlServer.TAG,
+                    "discarded BLE L2CAP packet for unexpected service hash " +
+                        "packet=${packet.toHex()}",
+                )
+                close()
+                false
+            }
+
+            else -> {
+                val payload = packet.copyOfRange(SERVICE_ID_HASH_LEN, packet.size)
+                writeControlPacket(NearbyBleSocketFrames.encodePacketAcknowledgementPacket(payload.size))
+                multiplexBridge.receivePhysicalBytes(payload)
+                true
+            }
+        }
+
+    private fun handleControlPacket(packet: ByteArray) {
+        val control = NearbyBleSocketFrames.parseControlPacket(packet)
+        if (control == null) {
+            Log.w(BleL2capInitialControlServer.TAG, "BLE L2CAP unknown control packet raw=${packet.toHex()}")
+            return
+        }
+        val isIntroduction =
+            control.type == BleFramesProto.SocketControlFrame.ControlFrameType.INTRODUCTION &&
+                control.introduction.socketVersion == BleFramesProto.SocketVersion.V2 &&
+                control.introduction.serviceIdHash
+                    .toByteArray()
+                    .contentEquals(NearbyServiceId.hashPrefix)
+        when {
+            isIntroduction -> Log.i(BleL2capInitialControlServer.TAG, "BLE L2CAP socket introduction accepted")
+            control.type == BleFramesProto.SocketControlFrame.ControlFrameType.DISCONNECTION -> close()
+            else -> Log.i(BleL2capInitialControlServer.TAG, "BLE L2CAP control frame type=${control.type}")
+        }
+    }
+
+    private fun writeControlPacket(packet: ByteArray) {
+        synchronized(writeLock) {
+            channel.outputStream.writeLengthPrefixedPacket(packet)
+        }
+    }
+
+    private fun sendPhysicalSocketBytes(bytes: ByteArray) {
+        if (bytes.isEmpty()) return
+        synchronized(writeLock) {
+            channel.outputStream.writeLengthPrefixedPacket(NearbyServiceId.hashPrefix + bytes)
+        }
+    }
+
+    private companion object {
+        private const val SERVICE_ID_HASH_LEN: Int = 3
+        private const val L2CAP_PACKET_LENGTH_BYTES: Int = 4
+        private val CONTROL_PACKET_PREFIX: ByteArray = ByteArray(SERVICE_ID_HASH_LEN)
+    }
+}
+
+private fun InputStream.readExactly(length: Int): ByteArray {
+    val out = ByteArray(length)
+    var offset = 0
+    while (offset < length) {
+        val read = read(out, offset, length - offset)
+        if (read < 0) throw EOFException("stream closed after $offset of $length bytes")
+        offset += read
+    }
+    return out
+}
+
+private fun ByteArray.decodeLength(offset: Int = 0): Int =
+    ((this[offset].toInt() and 0xFF) shl 24) or
+        ((this[offset + 1].toInt() and 0xFF) shl 16) or
+        ((this[offset + 2].toInt() and 0xFF) shl 8) or
+        (this[offset + 3].toInt() and 0xFF)
+
+private fun Int.encodeLength(): ByteArray =
+    byteArrayOf(
+        (this ushr 24).toByte(),
+        (this ushr 16).toByte(),
+        (this ushr 8).toByte(),
+        this.toByte(),
+    )
+
+private fun OutputStream.writeLengthPrefixedPacket(packet: ByteArray) {
+    write(packet.size.encodeLength())
+    write(packet)
+    flush()
+}
+
+private fun ByteArray.toHex(): String = joinToString("") { "%02x".format(it) }

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BluetoothClassicBootstrapClient.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BluetoothClassicBootstrapClient.kt
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+@file:Suppress("ReturnCount")
+
+@file:android.annotation.SuppressLint("MissingPermission")
+
+package io.github.kyujincho.wvmg.discovery.bootstrap
+
+import android.Manifest
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothManager
+import android.bluetooth.BluetoothSocket
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import android.util.Log
+import androidx.annotation.RequiresApi
+import androidx.annotation.RequiresPermission
+import androidx.core.content.ContextCompat
+import io.github.kyujincho.wvmg.protocol.endpoint.NearbyServiceId
+import io.github.kyujincho.wvmg.protocol.medium.Medium
+import io.github.kyujincho.wvmg.protocol.transport.ConnectedTransport
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.Closeable
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Sender-side Bluetooth Classic initial-control bootstrap.
+ *
+ * Connects to the stock Nearby / Quick Share RFCOMM service advertised
+ * under [NearbyServiceId.bluetoothServiceUuid] and returns the resulting
+ * byte stream as a [ConnectedTransport] so the existing sender protocol
+ * stack can run unchanged above it.
+ */
+public class BluetoothClassicBootstrapClient internal constructor(
+    private val bluetooth: BluetoothClassicBootstrapClientIo,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val serviceUuid: UUID = NearbyServiceId.bluetoothServiceUuid,
+) {
+    public constructor(context: Context) : this(
+        bluetooth = DefaultBluetoothClassicBootstrapClientIo(context.applicationContext),
+    )
+
+    private val pendingSocket: AtomicReference<BluetoothClassicClientSocket?> = AtomicReference(null)
+
+    /**
+     * Open an insecure RFCOMM socket to [macAddress] using the stock Nearby
+     * service UUID. Returns `null` when Bluetooth is unavailable, the
+     * permission gate is missing, or the connect fails.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    public suspend fun connect(macAddress: String): ConnectedTransport? =
+        withContext(dispatcher) {
+            if (!bluetooth.isAvailable()) {
+                Log.i(TAG, "Bluetooth Classic bootstrap connect unavailable")
+                return@withContext null
+            }
+            val socket =
+                try {
+                    bluetooth.openSocket(macAddress, serviceUuid)
+                } catch (t: Throwable) {
+                    Log.w(TAG, "Cannot open Bluetooth Classic bootstrap socket", t)
+                    null
+                } ?: return@withContext null
+            if (!pendingSocket.compareAndSet(null, socket)) {
+                runCatching { socket.close() }
+                Log.w(TAG, "Bluetooth Classic bootstrap connect already in progress")
+                return@withContext null
+            }
+            try {
+                socket.connect()
+                BluetoothClassicConnectedTransport(socket)
+            } catch (t: Throwable) {
+                Log.w(TAG, "Bluetooth Classic bootstrap connect failed", t)
+                runCatching { socket.close() }
+                null
+            } finally {
+                pendingSocket.compareAndSet(socket, null)
+            }
+        }
+
+    /**
+     * Best-effort cancellation for a pending RFCOMM connect. Closing the
+     * socket is the only reliable way to unblock `BluetoothSocket.connect()`.
+     */
+    public fun cancelPendingConnect() {
+        pendingSocket.getAndSet(null)?.let { socket ->
+            runCatching { socket.close() }
+        }
+    }
+
+    public companion object {
+        private const val TAG: String = "WvmgBtBootstrap"
+    }
+}
+
+internal interface BluetoothClassicBootstrapClientIo {
+    fun isAvailable(): Boolean
+
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
+    fun openSocket(
+        macAddress: String,
+        uuid: UUID,
+    ): BluetoothClassicClientSocket?
+}
+
+internal interface BluetoothClassicClientSocket : Closeable {
+    val inputStream: InputStream
+    val outputStream: OutputStream
+
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
+    fun connect()
+}
+
+private class DefaultBluetoothClassicBootstrapClientIo(
+    private val context: Context,
+) : BluetoothClassicBootstrapClientIo {
+    @Suppress("ReturnCount")
+    override fun isAvailable(): Boolean {
+        val pm = context.packageManager
+        if (!pm.hasSystemFeature(PackageManager.FEATURE_BLUETOOTH)) return false
+        if (!hasConnectPermission()) return false
+        val adapter = adapter() ?: return false
+        return adapter.isEnabled
+    }
+
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
+    override fun openSocket(
+        macAddress: String,
+        uuid: UUID,
+    ): BluetoothClassicClientSocket? {
+        val adapter = adapter() ?: return null
+        runCatching { adapter.cancelDiscovery() }
+        val device = adapter.getRemoteDevice(macAddress) ?: return null
+        val socket = device.createInsecureRfcommSocketToServiceRecord(uuid) ?: return null
+        return AndroidBluetoothClassicClientSocket(socket)
+    }
+
+    private fun adapter(): BluetoothAdapter? {
+        val manager = context.getSystemService(BluetoothManager::class.java) ?: return null
+        return manager.adapter
+    }
+
+    private fun hasConnectPermission(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return true
+        return checkSPermission()
+    }
+
+    @RequiresApi(Build.VERSION_CODES.S)
+    private fun checkSPermission(): Boolean =
+        ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.BLUETOOTH_CONNECT,
+        ) == PackageManager.PERMISSION_GRANTED
+}
+
+private class AndroidBluetoothClassicClientSocket(
+    private val socket: BluetoothSocket,
+) : BluetoothClassicClientSocket {
+    override val inputStream: InputStream
+        get() = socket.inputStream
+
+    override val outputStream: OutputStream
+        get() = socket.outputStream
+
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
+    override fun connect() {
+        socket.connect()
+    }
+
+    override fun close() {
+        closeQuietly(socket)
+    }
+}
+
+private class BluetoothClassicConnectedTransport(
+    private val socket: BluetoothClassicClientSocket,
+) : ConnectedTransport {
+    override val medium: Medium = Medium.BLUETOOTH
+
+    override val inputStream: InputStream
+        get() = socket.inputStream
+
+    override val outputStream: OutputStream
+        get() = socket.outputStream
+
+    override fun close() {
+        closeQuietly(socket)
+    }
+}
+
+private fun closeQuietly(closeable: Closeable) {
+    try {
+        closeable.close()
+    } catch (_: IOException) {
+        // Cleanup only.
+    }
+}

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/WeaveFrames.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/WeaveFrames.kt
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+@file:Suppress("MagicNumber", "ReturnCount")
+
+package io.github.kyujincho.wvmg.discovery.bootstrap
+
+internal sealed class WeavePacket {
+    data class ConnectionRequest(
+        val minVersion: Int,
+        val maxVersion: Int,
+        val maxPacketSize: Int,
+    ) : WeavePacket()
+
+    data class ConnectionConfirm(
+        val version: Int,
+        val packetSize: Int,
+    ) : WeavePacket()
+
+    data class Data(
+        val counter: Int,
+        val firstPacket: Boolean,
+        val lastPacket: Boolean,
+        val data: ByteArray,
+    ) : WeavePacket()
+
+    data class ConnectionClose(
+        val reason: Int,
+    ) : WeavePacket()
+}
+
+internal object WeaveFrames {
+    const val VERSION: Int = 1
+    const val HEADER_SIZE: Int = 1
+    const val MIN_PACKET_SIZE: Int = 20
+    const val MAX_PACKET_SIZE: Int = 509
+    const val DEFAULT_ATT_PAYLOAD_SIZE: Int = 20
+    const val MAX_PACKET_COUNTER: Int = 8
+    const val CLOSE_NO_COMMON_VERSION: Int = 2
+
+    private const val PACKET_TYPE_CONTROL: Int = 0x80
+    private const val PACKET_COUNTER_MASK: Int = 0x70
+    private const val PACKET_COUNTER_SHIFT: Int = 4
+    private const val CONTROL_COMMAND_MASK: Int = 0x0F
+    private const val CONTROL_CONNECTION_REQUEST: Int = 0
+    private const val CONTROL_CONNECTION_CONFIRM: Int = 1
+    private const val CONTROL_CONNECTION_CLOSE: Int = 2
+    private const val DATA_FIRST_FLAG: Int = 0x08
+    private const val DATA_LAST_FLAG: Int = 0x04
+    private const val MIN_CONNECTION_REQUEST_LEN: Int = 7
+    private const val CONNECTION_CONFIRM_LEN: Int = 5
+    private const val CONNECTION_CLOSE_LEN: Int = 3
+
+    fun parse(bytes: ByteArray): WeavePacket? {
+        if (bytes.isEmpty()) return null
+        val header = bytes[0].toInt() and 0xFF
+        val counter = (header and PACKET_COUNTER_MASK) ushr PACKET_COUNTER_SHIFT
+        return if ((header and PACKET_TYPE_CONTROL) != 0) {
+            parseControl(header, bytes)
+        } else {
+            WeavePacket.Data(
+                counter = counter,
+                firstPacket = (header and DATA_FIRST_FLAG) != 0,
+                lastPacket = (header and DATA_LAST_FLAG) != 0,
+                data = bytes.copyOfRange(HEADER_SIZE, bytes.size),
+            )
+        }
+    }
+
+    fun connectionRequest(
+        packetCounter: Int,
+        minVersion: Int,
+        maxVersion: Int,
+        maxPacketSize: Int,
+    ): ByteArray {
+        val header =
+            PACKET_TYPE_CONTROL or
+                ((packetCounter % MAX_PACKET_COUNTER) shl PACKET_COUNTER_SHIFT) or
+                CONTROL_CONNECTION_REQUEST
+        return byteArrayOf(
+            header.toByte(),
+            (minVersion ushr Byte.SIZE_BITS).toByte(),
+            minVersion.toByte(),
+            (maxVersion ushr Byte.SIZE_BITS).toByte(),
+            maxVersion.toByte(),
+            (maxPacketSize ushr Byte.SIZE_BITS).toByte(),
+            maxPacketSize.toByte(),
+        )
+    }
+
+    fun connectionConfirm(
+        version: Int,
+        packetSize: Int,
+    ): ByteArray =
+        byteArrayOf(
+            (PACKET_TYPE_CONTROL or CONTROL_CONNECTION_CONFIRM).toByte(),
+            (version ushr Byte.SIZE_BITS).toByte(),
+            version.toByte(),
+            (packetSize ushr Byte.SIZE_BITS).toByte(),
+            packetSize.toByte(),
+        )
+
+    fun connectionClosePacket(
+        packetCounter: Int,
+        reason: Int,
+    ): ByteArray {
+        val header =
+            PACKET_TYPE_CONTROL or
+                ((packetCounter % MAX_PACKET_COUNTER) shl PACKET_COUNTER_SHIFT) or
+                CONTROL_CONNECTION_CLOSE
+        return byteArrayOf(
+            header.toByte(),
+            (reason ushr Byte.SIZE_BITS).toByte(),
+            reason.toByte(),
+        )
+    }
+
+    fun dataPacket(
+        packetCounter: Int,
+        firstPacket: Boolean,
+        lastPacket: Boolean,
+        data: ByteArray,
+    ): ByteArray {
+        val header =
+            ((packetCounter % MAX_PACKET_COUNTER) shl PACKET_COUNTER_SHIFT) or
+                (if (firstPacket) DATA_FIRST_FLAG else 0) or
+                (if (lastPacket) DATA_LAST_FLAG else 0)
+        return byteArrayOf(header.toByte()) + data
+    }
+
+    private fun parseControl(
+        header: Int,
+        bytes: ByteArray,
+    ): WeavePacket? {
+        return when (header and CONTROL_COMMAND_MASK) {
+            CONTROL_CONNECTION_REQUEST -> {
+                if (bytes.size < MIN_CONNECTION_REQUEST_LEN) return null
+                WeavePacket.ConnectionRequest(
+                    minVersion = bytes.readUInt16(1),
+                    maxVersion = bytes.readUInt16(3),
+                    maxPacketSize = bytes.readUInt16(5),
+                )
+            }
+
+            CONTROL_CONNECTION_CONFIRM -> {
+                if (bytes.size < CONNECTION_CONFIRM_LEN) return null
+                WeavePacket.ConnectionConfirm(
+                    version = bytes.readUInt16(1),
+                    packetSize = bytes.readUInt16(3),
+                )
+            }
+
+            CONTROL_CONNECTION_CLOSE -> {
+                WeavePacket.ConnectionClose(
+                    reason = if (bytes.size >= CONNECTION_CLOSE_LEN) bytes.readUInt16(1) else 0,
+                )
+            }
+
+            else -> null
+        }
+    }
+
+    private fun ByteArray.readUInt16(offset: Int): Int =
+        ((this[offset].toInt() and 0xFF) shl Byte.SIZE_BITS) or (this[offset + 1].toInt() and 0xFF)
+}

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/classic/BluetoothClassicPeerScanner.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/classic/BluetoothClassicPeerScanner.kt
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+@file:Suppress("ReturnCount")
+
+@file:android.annotation.SuppressLint("MissingPermission")
+
+package io.github.kyujincho.wvmg.discovery.classic
+
+import android.Manifest
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothManager
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.pm.PackageManager
+import android.os.Build
+import android.util.Log
+import androidx.annotation.RequiresApi
+import androidx.core.content.ContextCompat
+import io.github.kyujincho.wvmg.protocol.endpoint.BluetoothDeviceName
+import io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo
+import io.github.kyujincho.wvmg.protocol.endpoint.NearbyServiceId
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+
+/**
+ * Bluetooth Classic discovery scanner for Nearby / Quick Share device-name
+ * advertisements.
+ *
+ * Stock Quick Share can expose sender/receiver identity through the local
+ * adapter name. This scanner watches the platform discovery broadcast stream,
+ * parses Nearby-shaped device names, and surfaces the MAC address needed for
+ * the RFCOMM bootstrap client.
+ */
+public class BluetoothClassicPeerScanner internal constructor(
+    private val bluetooth: BluetoothClassicPeerScannerIo,
+) {
+    public constructor(context: Context) : this(
+        bluetooth = DefaultBluetoothClassicPeerScannerIo(context.applicationContext),
+    )
+
+    public fun scan(): Flow<Observation> =
+        callbackFlow {
+            if (!bluetooth.isAvailable()) {
+                Log.i(TAG, "Bluetooth Classic discovery unavailable")
+                close()
+                return@callbackFlow
+            }
+
+            val receiver =
+                object : BroadcastReceiver() {
+                    override fun onReceive(
+                        context: Context?,
+                        intent: Intent?,
+                    ) {
+                        when (intent?.action) {
+                            BluetoothDevice.ACTION_FOUND -> {
+                                val device = intent.bluetoothDevice()
+                                val advertisedName =
+                                    device?.name
+                                        ?: intent.getStringExtra(BluetoothDevice.EXTRA_NAME)
+                                        ?: return
+                                val parsed = BluetoothDeviceName.parse(advertisedName) ?: return
+                                if (!parsed.serviceIdHash.contentEquals(NearbyServiceId.hashPrefix)) return
+                                val macAddress = device?.address ?: return
+                                trySend(
+                                    Observation(
+                                        endpointId = parsed.endpointId.toAsciiLabel(),
+                                        endpointInfo = parsed.endpointInfo,
+                                        macAddress = macAddress,
+                                        advertisedName = advertisedName,
+                                    ),
+                                ).isSuccess
+                            }
+                            BluetoothAdapter.ACTION_DISCOVERY_FINISHED -> {
+                                bluetooth.restartDiscovery()
+                            }
+                        }
+                    }
+                }
+
+            bluetooth.registerReceiver(receiver)
+            bluetooth.restartDiscovery()
+            awaitClose {
+                bluetooth.unregisterReceiver(receiver)
+                bluetooth.stopDiscovery()
+            }
+        }
+
+    public data class Observation(
+        val endpointId: String,
+        val endpointInfo: EndpointInfo,
+        val macAddress: String,
+        val advertisedName: String,
+    )
+
+    public companion object {
+        internal const val TAG: String = "WvmgBtScan"
+    }
+}
+
+internal interface BluetoothClassicPeerScannerIo {
+    fun isAvailable(): Boolean
+
+    fun registerReceiver(receiver: BroadcastReceiver)
+
+    fun unregisterReceiver(receiver: BroadcastReceiver)
+
+    fun restartDiscovery()
+
+    fun stopDiscovery()
+}
+
+private class DefaultBluetoothClassicPeerScannerIo(
+    private val context: Context,
+) : BluetoothClassicPeerScannerIo {
+    override fun isAvailable(): Boolean {
+        val pm = context.packageManager
+        if (!pm.hasSystemFeature(PackageManager.FEATURE_BLUETOOTH)) return false
+        if (!hasScanPermission()) return false
+        if (!hasConnectPermission()) return false
+        if (!hasLegacyLocationPermission()) return false
+        val adapter = adapter() ?: return false
+        return adapter.isEnabled
+    }
+
+    override fun registerReceiver(receiver: BroadcastReceiver) {
+        val filter =
+            IntentFilter().apply {
+                addAction(BluetoothDevice.ACTION_FOUND)
+                addAction(BluetoothAdapter.ACTION_DISCOVERY_FINISHED)
+            }
+        context.registerReceiver(receiver, filter)
+    }
+
+    override fun unregisterReceiver(receiver: BroadcastReceiver) {
+        runCatching { context.unregisterReceiver(receiver) }
+    }
+
+    override fun restartDiscovery() {
+        val adapter = adapter() ?: return
+        runCatching { adapter.cancelDiscovery() }
+        runCatching { adapter.startDiscovery() }
+    }
+
+    override fun stopDiscovery() {
+        val adapter = adapter() ?: return
+        runCatching { adapter.cancelDiscovery() }
+    }
+
+    private fun adapter(): BluetoothAdapter? {
+        val manager = context.getSystemService(BluetoothManager::class.java) ?: return null
+        return manager.adapter
+    }
+
+    private fun hasScanPermission(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return true
+        return checkSPermission(Manifest.permission.BLUETOOTH_SCAN)
+    }
+
+    private fun hasConnectPermission(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return true
+        return checkSPermission(Manifest.permission.BLUETOOTH_CONNECT)
+    }
+
+    private fun hasLegacyLocationPermission(): Boolean {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) return true
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) return true
+        return ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.ACCESS_FINE_LOCATION,
+        ) == PackageManager.PERMISSION_GRANTED ||
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.ACCESS_COARSE_LOCATION,
+            ) == PackageManager.PERMISSION_GRANTED
+    }
+
+    @RequiresApi(Build.VERSION_CODES.S)
+    private fun checkSPermission(permission: String): Boolean =
+        ContextCompat.checkSelfPermission(
+            context,
+            permission,
+        ) == PackageManager.PERMISSION_GRANTED
+}
+
+private fun Intent.bluetoothDevice(): BluetoothDevice? =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        getParcelableExtra(BluetoothDevice.EXTRA_DEVICE, BluetoothDevice::class.java)
+    } else {
+        @Suppress("DEPRECATION")
+        getParcelableExtra(BluetoothDevice.EXTRA_DEVICE)
+    }
+
+private fun ByteArray.toAsciiLabel(): String = String(this, Charsets.US_ASCII)

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/medium/BleGattMediumProvider.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/medium/BleGattMediumProvider.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+@file:android.annotation.SuppressLint("MissingPermission")
+@file:Suppress("ReturnCount")
+
+package io.github.kyujincho.wvmg.discovery.medium
+
+import android.Manifest
+import android.bluetooth.BluetoothManager
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.core.content.ContextCompat
+import io.github.kyujincho.wvmg.protocol.medium.Medium
+import io.github.kyujincho.wvmg.protocol.medium.MediumProvider
+
+/**
+ * Capability-only provider for the BLE GATT initial-control path.
+ *
+ * BLE GATT is not a bandwidth-upgrade target in WVMG; it is the already-open
+ * bootstrap socket used before the normal Nearby negotiation can move the
+ * transfer to Wi-Fi Direct / Hotspot / LAN. Registering this provider lets the
+ * connection request accurately advertise that the current initial transport
+ * is BLE.
+ */
+public class BleGattMediumProvider(
+    private val context: Context,
+) : MediumProvider {
+    override val medium: Medium = Medium.BLE
+
+    override fun isSupported(): Boolean {
+        val appContext = context.applicationContext
+        if (!appContext.packageManager.hasSystemFeature(PackageManager.FEATURE_BLUETOOTH_LE)) return false
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && !hasConnectPermission(appContext)) return false
+        val manager = appContext.getSystemService(BluetoothManager::class.java) ?: return false
+        val adapter = manager.adapter ?: return false
+        return adapter.isEnabled
+    }
+
+    @RequiresApi(Build.VERSION_CODES.S)
+    private fun hasConnectPermission(context: Context): Boolean =
+        ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.BLUETOOTH_CONNECT,
+        ) == PackageManager.PERMISSION_GRANTED
+}

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/medium/MediumRegistries.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/medium/MediumRegistries.kt
@@ -60,7 +60,10 @@ public object MediumRegistries {
             WifiDirectMediumProvider(context),
             WifiHotspotMediumProviderFactory.create(context),
             BleL2capMediumProvider(context).asProvider(),
-            BluetoothRfcommMediumProvider(context),
+            // Bluetooth Classic RFCOMM is intentionally omitted from the
+            // production ladder. Stock Quick Share's off-LAN tap path is
+            // BLE/GATT, and keeping Classic active causes discovery and
+            // permission side effects without helping Galaxy interop.
         )
 
     /**

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/medium/MediumRegistries.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/medium/MediumRegistries.kt
@@ -59,6 +59,7 @@ public object MediumRegistries {
             WifiAwareMediumProvider(context),
             WifiDirectMediumProvider(context),
             WifiHotspotMediumProviderFactory.create(context),
+            BleGattMediumProvider(context),
             BleL2capMediumProvider(context).asProvider(),
             // Bluetooth Classic RFCOMM is intentionally omitted from the
             // production ladder. Stock Quick Share's off-LAN tap path is

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/medium/WifiDirectGroupController.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/medium/WifiDirectGroupController.kt
@@ -21,6 +21,7 @@ import android.net.wifi.p2p.WifiP2pManager
 import android.os.Build
 import android.os.Looper
 import android.util.Log
+import androidx.annotation.RequiresApi
 import androidx.annotation.RequiresPermission
 import androidx.core.content.ContextCompat
 import io.github.kyujincho.wvmg.protocol.medium.UpgradePathCredentials
@@ -195,16 +196,18 @@ internal class WifiDirectGroupController(
             return null
         }
         val strings = selectServerCredentialStrings(group, requested) ?: return null
+        val frequency = selectServerFrequency(group)
         Log.w(
             TAG,
-            "Wi-Fi Direct group ready ssid='${strings.ssid}' passphraseLength=${strings.passphrase.length}",
+            "Wi-Fi Direct group ready ssid='${strings.ssid}' " +
+                "passphraseLength=${strings.passphrase.length} frequency=$frequency",
         )
         return UpgradePathCredentials.WifiDirect(
             ipAddress = ipBytes,
             port = serverPort,
             ssid = strings.ssid,
             passphrase = strings.passphrase,
-            frequency = UpgradePathCredentials.WifiDirect.FREQUENCY_NOT_SET,
+            frequency = frequency,
         )
     }
 
@@ -229,10 +232,20 @@ internal class WifiDirectGroupController(
         return ServerCredentialStrings(ssid, passphrase)
     }
 
+    private fun selectServerFrequency(group: WifiP2pGroup): Int {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            return UpgradePathCredentials.WifiDirect.FREQUENCY_NOT_SET
+        }
+        return group.frequency
+            .takeIf { it > 0 }
+            ?: UpgradePathCredentials.WifiDirect.FREQUENCY_NOT_SET
+    }
+
     private data class RequestedWifiDirectCredentials(
         val networkName: String = WifiDirectCredentialShape.generateNetworkName(),
         val passphrase: String = WifiDirectCredentialShape.generatePassphrase(),
     ) {
+        @RequiresApi(Build.VERSION_CODES.Q)
         fun toConfig(): WifiP2pConfig =
             WifiP2pConfig
                 .Builder()

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/medium/WifiDirectMediumProvider.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/medium/WifiDirectMediumProvider.kt
@@ -232,6 +232,7 @@ public class WifiDirectMediumProvider internal constructor(
             // to call connect on this exact port. Close the listening socket
             // once accept returns to free the port.
             val socket = pending.serverSocket.use { listener -> listener.accept() }
+            Log.w(TAG, "Wi-Fi Direct ServerSocket accepted peer=${socket.remoteSocketAddress}")
             claimAcceptedServerTransport(pending, socket)
         } catch (e: IOException) {
             Log.w(TAG, "Wi-Fi Direct ServerSocket.accept threw", e)

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/NearbyPeerDiscoveryTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/NearbyPeerDiscoveryTest.kt
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.discovery
+
+import com.google.common.truth.Truth.assertThat
+import io.github.kyujincho.wvmg.discovery.ble.BleFastAdvertisementScanner
+import io.github.kyujincho.wvmg.discovery.classic.BluetoothClassicPeerScanner
+import io.github.kyujincho.wvmg.protocol.endpoint.DeviceType
+import io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo
+import io.github.kyujincho.wvmg.protocol.medium.Medium
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.net.InetAddress
+
+class NearbyPeerDiscoveryTest {
+    @Test
+    fun `bluetooth and LAN sightings merge into one LAN-first peer`() =
+        runTest {
+            val lanEvents = MutableSharedFlow<DiscoveryEvent>()
+            val bleEvents = MutableSharedFlow<BleFastAdvertisementScanner.Observation>()
+            val bluetoothEvents = MutableSharedFlow<BluetoothClassicPeerScanner.Observation>()
+            val discovery =
+                NearbyPeerDiscovery.forTesting(
+                    lanEvents = lanEvents,
+                    bleEvents = bleEvents,
+                    bluetoothEvents = bluetoothEvents,
+                )
+            val seen = mutableListOf<NearbyPeerEvent>()
+            val collector =
+                backgroundScope.launch {
+                    discovery.browse().collect { seen += it }
+                }
+            runCurrent()
+            runCurrent()
+
+            val endpointInfo = endpointInfo(name = "Pixel 9")
+            bluetoothEvents.emit(
+                BluetoothClassicPeerScanner.Observation(
+                    endpointId = "ABCD",
+                    endpointInfo = endpointInfo,
+                    macAddress = "AA:BB:CC:DD:EE:FF",
+                    advertisedName = "nearby-bt",
+                ),
+            )
+            lanEvents.emit(
+                DiscoveryEvent.Resolved(
+                    DiscoveredService(
+                        instanceName = "instance-1",
+                        endpointId = "ABCD".toByteArray(Charsets.US_ASCII),
+                        addresses = listOf(InetAddress.getByName("192.168.1.44")),
+                        port = 54321,
+                        endpointInfo = endpointInfo,
+                    ),
+                ),
+            )
+            runCurrent()
+
+            val resolved = seen.filterIsInstance<NearbyPeerEvent.Resolved>().last().peer
+            assertThat(seen.filterIsInstance<NearbyPeerEvent.Resolved>()).hasSize(2)
+            assertThat(resolved.stableId).isEqualTo("endpoint:ABCD")
+            assertThat(resolved.candidateMediums).containsExactly(Medium.WIFI_LAN, Medium.BLUETOOTH)
+            assertThat(resolved.preferredRoute()).isEqualTo(
+                NearbyPeerRoute.Lan(
+                    address = InetAddress.getByName("192.168.1.44"),
+                    port = 54321,
+                ),
+            )
+
+            collector.cancel()
+        }
+
+    @Test
+    fun `LAN loss keeps bluetooth-discovered peer alive`() =
+        runTest {
+            val lanEvents = MutableSharedFlow<DiscoveryEvent>()
+            val bleEvents = MutableSharedFlow<BleFastAdvertisementScanner.Observation>()
+            val bluetoothEvents = MutableSharedFlow<BluetoothClassicPeerScanner.Observation>()
+            val discovery =
+                NearbyPeerDiscovery.forTesting(
+                    lanEvents = lanEvents,
+                    bleEvents = bleEvents,
+                    bluetoothEvents = bluetoothEvents,
+                )
+            val seen = mutableListOf<NearbyPeerEvent>()
+            val collector =
+                backgroundScope.launch {
+                    discovery.browse().collect { seen += it }
+                }
+            runCurrent()
+
+            val endpointInfo = endpointInfo(name = "Nearby peer")
+            bluetoothEvents.emit(
+                BluetoothClassicPeerScanner.Observation(
+                    endpointId = "WXYZ",
+                    endpointInfo = endpointInfo,
+                    macAddress = "11:22:33:44:55:66",
+                    advertisedName = "nearby-bt",
+                ),
+            )
+            lanEvents.emit(
+                DiscoveryEvent.Resolved(
+                    DiscoveredService(
+                        instanceName = "instance-2",
+                        endpointId = "WXYZ".toByteArray(Charsets.US_ASCII),
+                        addresses = listOf(InetAddress.getByName("192.168.1.45")),
+                        port = 11111,
+                        endpointInfo = endpointInfo,
+                    ),
+                ),
+            )
+            lanEvents.emit(DiscoveryEvent.Lost("instance-2"))
+            runCurrent()
+
+            assertThat(seen.filterIsInstance<NearbyPeerEvent.Lost>()).isEmpty()
+            val resolved = seen.filterIsInstance<NearbyPeerEvent.Resolved>().last().peer
+            assertThat(resolved.candidateMediums).containsExactly(Medium.BLUETOOTH)
+            assertThat(resolved.preferredRoute()).isEqualTo(
+                NearbyPeerRoute.BluetoothClassic("11:22:33:44:55:66"),
+            )
+
+            collector.cancel()
+        }
+
+    @Test
+    fun `BLE fast advertisement merges into bluetooth bootstrap candidate`() =
+        runTest {
+            val lanEvents = MutableSharedFlow<DiscoveryEvent>()
+            val bleEvents = MutableSharedFlow<BleFastAdvertisementScanner.Observation>()
+            val bluetoothEvents = MutableSharedFlow<BluetoothClassicPeerScanner.Observation>()
+            val discovery =
+                NearbyPeerDiscovery.forTesting(
+                    lanEvents = lanEvents,
+                    bleEvents = bleEvents,
+                    bluetoothEvents = bluetoothEvents,
+                )
+            val seen = mutableListOf<NearbyPeerEvent>()
+            val collector =
+                backgroundScope.launch {
+                    discovery.browse().collect { seen += it }
+                }
+            runCurrent()
+
+            val endpointInfo = endpointInfo(name = "Galaxy")
+            bleEvents.emit(
+                BleFastAdvertisementScanner.Observation(
+                    endpointId = "RINE",
+                    endpointInfo = endpointInfo,
+                    advertiserAddress = "77:88:99:AA:BB:CC",
+                    rssi = -47,
+                ),
+            )
+            bluetoothEvents.emit(
+                BluetoothClassicPeerScanner.Observation(
+                    endpointId = "RINE",
+                    endpointInfo = endpointInfo,
+                    macAddress = "66:55:44:33:22:11",
+                    advertisedName = "nearby-bt",
+                ),
+            )
+            runCurrent()
+
+            val resolved = seen.filterIsInstance<NearbyPeerEvent.Resolved>().last().peer
+            assertThat(resolved.candidateMediums).containsExactly(Medium.BLE, Medium.BLUETOOTH)
+            assertThat(resolved.bleAdvertisement?.advertiserAddress).isEqualTo("77:88:99:AA:BB:CC")
+            assertThat(resolved.preferredRoute()).isEqualTo(
+                NearbyPeerRoute.BluetoothClassic("66:55:44:33:22:11"),
+            )
+
+            collector.cancel()
+        }
+
+    private fun endpointInfo(name: String?): EndpointInfo =
+        EndpointInfo(
+            version = 1,
+            hidden = false,
+            deviceType = DeviceType.PHONE,
+            reserved = false,
+            metadata = ByteArray(EndpointInfo.METADATA_LEN) { it.toByte() },
+            deviceName = name,
+        )
+}

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/NearbyPeerDiscoveryTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/NearbyPeerDiscoveryTest.kt
@@ -153,6 +153,7 @@ class NearbyPeerDiscoveryTest {
                     endpointInfo = endpointInfo,
                     advertiserAddress = "77:88:99:AA:BB:CC",
                     rssi = -47,
+                    l2capPsm = null,
                 ),
             )
             bluetoothEvents.emit(
@@ -170,6 +171,50 @@ class NearbyPeerDiscoveryTest {
             assertThat(resolved.bleAdvertisement?.advertiserAddress).isEqualTo("77:88:99:AA:BB:CC")
             assertThat(resolved.preferredRoute()).isEqualTo(
                 NearbyPeerRoute.BluetoothClassic("66:55:44:33:22:11"),
+            )
+
+            collector.cancel()
+        }
+
+    @Test
+    fun `BLE fast advertisement with PSM is connectable over L2CAP`() =
+        runTest {
+            val lanEvents = MutableSharedFlow<DiscoveryEvent>()
+            val bleEvents = MutableSharedFlow<BleFastAdvertisementScanner.Observation>()
+            val bluetoothEvents = MutableSharedFlow<BluetoothClassicPeerScanner.Observation>()
+            val discovery =
+                NearbyPeerDiscovery.forTesting(
+                    lanEvents = lanEvents,
+                    bleEvents = bleEvents,
+                    bluetoothEvents = bluetoothEvents,
+                )
+            val seen = mutableListOf<NearbyPeerEvent>()
+            val collector =
+                backgroundScope.launch {
+                    discovery.browse().collect { seen += it }
+                }
+            runCurrent()
+
+            val endpointInfo = endpointInfo(name = "Galaxy")
+            bleEvents.emit(
+                BleFastAdvertisementScanner.Observation(
+                    endpointId = "RINE",
+                    endpointInfo = endpointInfo,
+                    advertiserAddress = "77:88:99:AA:BB:CC",
+                    rssi = -47,
+                    l2capPsm = 0x1234,
+                ),
+            )
+            runCurrent()
+
+            val resolved = seen.filterIsInstance<NearbyPeerEvent.Resolved>().last().peer
+            assertThat(resolved.isConnectable).isTrue()
+            assertThat(resolved.candidateMediums).containsExactly(Medium.BLE, Medium.BLE_L2CAP)
+            assertThat(resolved.preferredRoute()).isEqualTo(
+                NearbyPeerRoute.BleL2cap(
+                    macAddress = "77:88:99:AA:BB:CC",
+                    psm = 0x1234,
+                ),
             )
 
             collector.cancel()

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/NearbyPeerDiscoveryTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/NearbyPeerDiscoveryTest.kt
@@ -154,6 +154,7 @@ class NearbyPeerDiscoveryTest {
                     advertiserAddress = "77:88:99:AA:BB:CC",
                     rssi = -47,
                     l2capPsm = null,
+                    gattConnectable = false,
                 ),
             )
             bluetoothEvents.emit(
@@ -203,6 +204,7 @@ class NearbyPeerDiscoveryTest {
                     advertiserAddress = "77:88:99:AA:BB:CC",
                     rssi = -47,
                     l2capPsm = 0x1234,
+                    gattConnectable = true,
                 ),
             )
             runCurrent()
@@ -215,6 +217,48 @@ class NearbyPeerDiscoveryTest {
                     macAddress = "77:88:99:AA:BB:CC",
                     psm = 0x1234,
                 ),
+            )
+
+            collector.cancel()
+        }
+
+    @Test
+    fun `BLE GATT advertisement is connectable without Classic or L2CAP`() =
+        runTest {
+            val lanEvents = MutableSharedFlow<DiscoveryEvent>()
+            val bleEvents = MutableSharedFlow<BleFastAdvertisementScanner.Observation>()
+            val bluetoothEvents = MutableSharedFlow<BluetoothClassicPeerScanner.Observation>()
+            val discovery =
+                NearbyPeerDiscovery.forTesting(
+                    lanEvents = lanEvents,
+                    bleEvents = bleEvents,
+                    bluetoothEvents = bluetoothEvents,
+                )
+            val seen = mutableListOf<NearbyPeerEvent>()
+            val collector =
+                backgroundScope.launch {
+                    discovery.browse().collect { seen += it }
+                }
+            runCurrent()
+
+            bleEvents.emit(
+                BleFastAdvertisementScanner.Observation(
+                    endpointId = null,
+                    endpointInfo = null,
+                    advertiserAddress = "28:1B:3E:BA:B1:1B",
+                    rssi = -41,
+                    l2capPsm = null,
+                    gattConnectable = true,
+                ),
+            )
+            runCurrent()
+
+            val resolved = seen.filterIsInstance<NearbyPeerEvent.Resolved>().last().peer
+            assertThat(resolved.isConnectable).isTrue()
+            assertThat(resolved.candidateMediums).containsExactly(Medium.BLE)
+            assertThat(resolved.displayName()).isEqualTo("Quick Share BLE device")
+            assertThat(resolved.preferredRoute()).isEqualTo(
+                NearbyPeerRoute.BleGatt(macAddress = "28:1B:3E:BA:B1:1B"),
             )
 
             collector.cancel()

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleFastAdvertisementScannerTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleFastAdvertisementScannerTest.kt
@@ -6,6 +6,8 @@
 package io.github.kyujincho.wvmg.discovery.ble
 
 import com.google.common.truth.Truth.assertThat
+import io.github.kyujincho.wvmg.protocol.endpoint.Base64Url
+import io.github.kyujincho.wvmg.protocol.endpoint.BleAdvertisementHeader
 import io.github.kyujincho.wvmg.protocol.endpoint.BleServiceData
 import io.github.kyujincho.wvmg.protocol.endpoint.DctAdvertisement
 import io.github.kyujincho.wvmg.protocol.endpoint.DeviceType
@@ -37,6 +39,47 @@ class BleFastAdvertisementScannerTest {
         assertThat(observed.advertiserAddress).isEqualTo("77:88:99:AA:BB:CC")
         assertThat(observed.rssi).isEqualTo(-47)
         assertThat(observed.l2capPsm).isEqualTo(0x1234)
+        assertThat(observed.gattConnectable).isTrue()
+    }
+
+    @Test
+    fun `GATT advertisement header becomes a connectable BLE observation`() {
+        val rawHeader =
+            byteArrayOf(
+                0x55,
+                0x20,
+                0x14,
+                0x01,
+                0x10,
+                0x02,
+                0x00,
+                0x00,
+                0x03,
+                0x00,
+                0x0a,
+                0x3c,
+                0x56,
+                0xee.toByte(),
+                0x2c,
+                0x00,
+                0x00,
+            )
+
+        val observed =
+            BleFastAdvertisementScanner.parseFastServiceData(
+                serviceData = Base64Url.encode(rawHeader).toByteArray(Charsets.US_ASCII),
+                advertiserAddress = "28:1B:3E:BA:B1:1B",
+                rssi = -41,
+            )
+
+        assertThat(observed).isNotNull()
+        assertThat(BleAdvertisementHeader.parse(Base64Url.encode(rawHeader).toByteArray(Charsets.US_ASCII))).isNotNull()
+        assertThat(observed!!.endpointId).isNull()
+        assertThat(observed.endpointInfo).isNull()
+        assertThat(observed.advertiserAddress).isEqualTo("28:1B:3E:BA:B1:1B")
+        assertThat(observed.rssi).isEqualTo(-41)
+        assertThat(observed.l2capPsm).isNull()
+        assertThat(observed.gattConnectable).isTrue()
     }
 
     @Test
@@ -60,12 +103,13 @@ class BleFastAdvertisementScannerTest {
         assertThat(observed).isNotNull()
         assertThat(observed!!.endpointId)
             .isEqualTo(DctAdvertisement.generateEndpointId(dct.dedup, dct.deviceName))
-        assertThat(observed.endpointInfo.hidden).isFalse()
+        assertThat(observed.endpointInfo!!.hidden).isFalse()
         assertThat(observed.endpointInfo.deviceType).isEqualTo(DeviceType.PHONE)
         assertThat(observed.endpointInfo.deviceName).isEqualTo(dct.deviceName)
         assertThat(observed.advertiserAddress).isEqualTo("28:1B:3E:BA:B1:1B")
         assertThat(observed.rssi).isEqualTo(-41)
         assertThat(observed.l2capPsm).isEqualTo(0x00C0)
+        assertThat(observed.gattConnectable).isTrue()
     }
 
     @Test

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleFastAdvertisementScannerTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleFastAdvertisementScannerTest.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.discovery.ble
+
+import com.google.common.truth.Truth.assertThat
+import io.github.kyujincho.wvmg.protocol.endpoint.BleServiceData
+import io.github.kyujincho.wvmg.protocol.endpoint.DctAdvertisement
+import io.github.kyujincho.wvmg.protocol.endpoint.DeviceType
+import io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo
+import io.github.kyujincho.wvmg.protocol.endpoint.NearbyServiceId
+import org.junit.jupiter.api.Test
+
+class BleFastAdvertisementScannerTest {
+    @Test
+    fun `fast advertisement service data preserves L2CAP PSM`() {
+        val info = endpointInfo("Galaxy")
+        val payload =
+            BleServiceData.encodeFramedWithPsm(
+                endpointId = "RINE",
+                endpointInfo = info,
+                psm = 0x1234,
+            )
+
+        val observed =
+            BleFastAdvertisementScanner.parseFastServiceData(
+                serviceData = payload,
+                advertiserAddress = "77:88:99:AA:BB:CC",
+                rssi = -47,
+            )
+
+        assertThat(observed).isNotNull()
+        assertThat(observed!!.endpointId).isEqualTo("RINE")
+        assertThat(observed.endpointInfo).isEqualTo(info)
+        assertThat(observed.advertiserAddress).isEqualTo("77:88:99:AA:BB:CC")
+        assertThat(observed.rssi).isEqualTo(-47)
+        assertThat(observed.l2capPsm).isEqualTo(0x1234)
+    }
+
+    @Test
+    fun `DCT service data becomes a named L2CAP observation`() {
+        val payload =
+            DctAdvertisement.encode(
+                serviceId = NearbyServiceId.VALUE,
+                deviceName = "Galaxy S25",
+                psm = 0x00C0,
+                dedup = 0x16,
+            )
+        val dct = DctAdvertisement.parse(payload)!!
+
+        val observed =
+            BleFastAdvertisementScanner.parseDctServiceData(
+                serviceData = payload,
+                advertiserAddress = "28:1B:3E:BA:B1:1B",
+                rssi = -41,
+            )
+
+        assertThat(observed).isNotNull()
+        assertThat(observed!!.endpointId)
+            .isEqualTo(DctAdvertisement.generateEndpointId(dct.dedup, dct.deviceName))
+        assertThat(observed.endpointInfo.hidden).isFalse()
+        assertThat(observed.endpointInfo.deviceType).isEqualTo(DeviceType.PHONE)
+        assertThat(observed.endpointInfo.deviceName).isEqualTo(dct.deviceName)
+        assertThat(observed.advertiserAddress).isEqualTo("28:1B:3E:BA:B1:1B")
+        assertThat(observed.rssi).isEqualTo(-41)
+        assertThat(observed.l2capPsm).isEqualTo(0x00C0)
+    }
+
+    @Test
+    fun `DCT service data ignores other Nearby service ids`() {
+        val payload =
+            DctAdvertisement.encode(
+                serviceId = "service_id",
+                deviceName = "Galaxy",
+                psm = 0x00C0,
+                dedup = 0x16,
+            )
+
+        val observed =
+            BleFastAdvertisementScanner.parseDctServiceData(
+                serviceData = payload,
+                advertiserAddress = "28:1B:3E:BA:B1:1B",
+                rssi = -41,
+            )
+
+        assertThat(observed).isNull()
+    }
+
+    private fun endpointInfo(name: String): EndpointInfo =
+        EndpointInfo(
+            version = 1,
+            hidden = false,
+            deviceType = DeviceType.PHONE,
+            reserved = false,
+            metadata = ByteArray(EndpointInfo.METADATA_LEN) { it.toByte() },
+            deviceName = name,
+        )
+}

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleFastAdvertisementScannerTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleFastAdvertisementScannerTest.kt
@@ -83,6 +83,20 @@ class BleFastAdvertisementScannerTest {
     }
 
     @Test
+    fun `GATT advertisement header preserves non-connectable scan result`() {
+        val observed =
+            BleFastAdvertisementScanner.parseFastServiceData(
+                serviceData = "VSAUARACAAADAAo8Vu4sAAA".toByteArray(Charsets.US_ASCII),
+                advertiserAddress = "28:1B:3E:BA:B1:1B",
+                rssi = -41,
+                gattConnectable = false,
+            )
+
+        assertThat(observed).isNotNull()
+        assertThat(observed!!.gattConnectable).isFalse()
+    }
+
+    @Test
     fun `DCT service data becomes a named L2CAP observation`() {
         val payload =
             DctAdvertisement.encode(

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareAdvertiserTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareAdvertiserTest.kt
@@ -95,6 +95,36 @@ class BleQuickShareAdvertiserTest {
     }
 
     @Test
+    fun `start compacts visible EndpointInfo to hidden BLE payload`() {
+        val gate = RecordingGate(failOnStart = false)
+        val advertiser =
+            BleQuickShareAdvertiser.forTesting(
+                gate = gate,
+                permissionChecker = { true },
+            )
+        val info =
+            EndpointInfo(
+                version = 1,
+                hidden = false,
+                deviceType = DeviceType.PHONE,
+                reserved = false,
+                metadata = ByteArray(EndpointInfo.METADATA_LEN) { it.toByte() },
+                deviceName = "WhenVivoMeetsGoogle",
+            )
+
+        val started = advertiser.start(info, endpointId("Wvmg"))
+
+        assertThat(started).isTrue()
+        val (payload, _) = gate.startCalls.single()
+        assertThat(payload).hasLength(23)
+        val parsedInfo = BleServiceData.parse(payload)!!.endpointInfo
+        assertThat(parsedInfo.hidden).isTrue()
+        assertThat(parsedInfo.deviceName).isNull()
+        assertThat(parsedInfo.deviceType).isEqualTo(info.deviceType)
+        assertThat(parsedInfo.metadata).isEqualTo(info.metadata)
+    }
+
+    @Test
     fun `start rejects an endpoint_id of the wrong length`() {
         val advertiser =
             BleQuickShareAdvertiser.forTesting(

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareAdvertiserTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareAdvertiserTest.kt
@@ -8,6 +8,7 @@ package io.github.kyujincho.wvmg.discovery.ble
 import android.bluetooth.le.AdvertiseSettings
 import com.google.common.truth.Truth.assertThat
 import io.github.kyujincho.wvmg.protocol.endpoint.BleServiceData
+import io.github.kyujincho.wvmg.protocol.endpoint.DctAdvertisement
 import io.github.kyujincho.wvmg.protocol.endpoint.DeviceType
 import io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo
 import org.junit.jupiter.api.Test
@@ -53,6 +54,8 @@ class BleQuickShareAdvertiserTest {
                 override fun startAdvertising(
                     serviceData: ByteArray,
                     mode: Int,
+                    dctServiceData: ByteArray?,
+                    visibleServiceData: ByteArray?,
                 ): BleAdvertiserGate.Registration? = null
             }
         val advertiser =
@@ -83,15 +86,22 @@ class BleQuickShareAdvertiserTest {
         // The default mode is BALANCED until the lifecycle observer
         // upgrades it to LOW_LATENCY. Pinning it here catches drift.
         assertThat(mode).isEqualTo(AdvertiseSettings.ADVERTISE_MODE_BALANCED)
+        assertThat(gate.startCalls.last().dctPayload).isNull()
 
-        // Byte 0 is the canonical 0x23 (version=1, PCP=3); byte 5 is
-        // the EndpointInfo length (17 for hidden); byte 6 is the
-        // EndpointInfo header (0x32 = hidden + version=1 + PHONE).
-        assertThat(payload).hasLength(BleServiceData.FIXED_HEADER_LEN + info.serialize().size)
-        assertThat(payload[0].toInt() and 0xFF).isEqualTo(0x23)
-        assertThat(payload.copyOfRange(1, 5)).isEqualTo(endpointId("Wvmg"))
-        assertThat(payload[5].toInt() and 0xFF).isEqualTo(0x11)
-        assertThat(payload[6].toInt() and 0xFF).isEqualTo(0x32)
+        // The service data is the stock BLE v2 frame wrapper followed
+        // by the canonical 0x23 (version=1, PCP=3) inner body.
+        val expectedPayloadSize =
+            BleServiceData.FRAME_HEADER_LEN +
+                BleServiceData.FIXED_HEADER_LEN +
+                info.serialize().size +
+                BleServiceData.DEVICE_TOKEN_LEN
+        assertThat(payload).hasLength(expectedPayloadSize)
+        assertThat(payload[0].toInt() and 0xFF).isEqualTo(BleServiceData.FRAME_TYPE_FAST_ADVERTISEMENT)
+        assertThat(payload[1].toInt() and 0xFF).isEqualTo(BleServiceData.FIXED_HEADER_LEN + info.serialize().size)
+        assertThat(payload[2].toInt() and 0xFF).isEqualTo(0x23)
+        assertThat(payload.copyOfRange(3, 7)).isEqualTo(endpointId("Wvmg"))
+        assertThat(payload[7].toInt() and 0xFF).isEqualTo(0x11)
+        assertThat(payload[8].toInt() and 0xFF).isEqualTo(0x32)
     }
 
     @Test
@@ -115,13 +125,52 @@ class BleQuickShareAdvertiserTest {
         val started = advertiser.start(info, endpointId("Wvmg"))
 
         assertThat(started).isTrue()
-        val (payload, _) = gate.startCalls.single()
-        assertThat(payload).hasLength(23)
+        val call = gate.startCalls.single()
+        val payload = call.payload
+        val dctPayload = call.dctPayload
+        val visiblePayload = call.visiblePayload
+        assertThat(payload).hasLength(27)
         val parsedInfo = BleServiceData.parse(payload)!!.endpointInfo
         assertThat(parsedInfo.hidden).isTrue()
         assertThat(parsedInfo.deviceName).isNull()
         assertThat(parsedInfo.deviceType).isEqualTo(info.deviceType)
         assertThat(parsedInfo.metadata).isEqualTo(info.metadata)
+
+        assertThat(dctPayload).isNotNull()
+        val dct = DctAdvertisement.parse(dctPayload!!)!!
+        assertThat(dct.deviceName).isEqualTo("WhenViv")
+        assertThat(dct.isDeviceNameTruncated).isTrue()
+        assertThat(dct.psm).isEqualTo(DctAdvertisement.DEFAULT_PSM)
+
+        assertThat(visiblePayload).isNotNull()
+        val visibleInfo = BleServiceData.parse(visiblePayload!!)!!.endpointInfo
+        assertThat(visibleInfo.hidden).isFalse()
+        assertThat(visibleInfo.deviceName).isEqualTo("WhenVivoMeetsGoogle")
+        assertThat(BleServiceData.parsePsmExtraField(visiblePayload)).isNull()
+        assertThat(visiblePayload.size).isGreaterThan(27)
+    }
+
+    @Test
+    fun `DCT and visible fast payloads carry active L2CAP PSM when available`() {
+        BleDctPsmHolder.set(0x1234)
+        try {
+            val gate = RecordingGate(failOnStart = false)
+            val advertiser =
+                BleQuickShareAdvertiser.forTesting(
+                    gate = gate,
+                    permissionChecker = { true },
+                )
+
+            val started = advertiser.start(visiblePhone(), endpointId("Wvmg"))
+
+            assertThat(started).isTrue()
+            val call = gate.startCalls.single()
+            val dct = DctAdvertisement.parse(call.dctPayload!!)!!
+            assertThat(dct.psm).isEqualTo(0x1234)
+            assertThat(BleServiceData.parsePsmExtraField(call.visiblePayload!!)).isEqualTo(0x1234)
+        } finally {
+            BleDctPsmHolder.clear()
+        }
     }
 
     @Test
@@ -155,9 +204,9 @@ class BleQuickShareAdvertiserTest {
         assertThat(gate.firstRegistration?.closed).isTrue()
         assertThat(gate.lastRegistration?.closed).isFalse()
 
-        // Bytes 1..4 of the latest payload reflect the second endpoint_id.
+        // Bytes 3..6 of the latest payload reflect the second endpoint_id.
         val (payload, _) = gate.startCalls.last()
-        assertThat(payload.copyOfRange(1, 5)).isEqualTo(endpointId("BBBB"))
+        assertThat(payload.copyOfRange(3, 7)).isEqualTo(endpointId("BBBB"))
     }
 
     @Test
@@ -219,7 +268,7 @@ class BleQuickShareAdvertiserTest {
 
         // Subsequent start should use the pinned mode.
         advertiser.start(hiddenPhone(), endpointId("Wvmg"))
-        assertThat(gate.startCalls.last().second)
+        assertThat(gate.startCalls.last().mode)
             .isEqualTo(AdvertiseSettings.ADVERTISE_MODE_LOW_LATENCY)
     }
 
@@ -251,7 +300,7 @@ class BleQuickShareAdvertiserTest {
         val ok = advertiser.setAdvertiseMode(AdvertiseSettings.ADVERTISE_MODE_LOW_LATENCY)
         assertThat(ok).isTrue()
         assertThat(gate.startCalls).hasSize(2)
-        assertThat(gate.startCalls.last().second)
+        assertThat(gate.startCalls.last().mode)
             .isEqualTo(AdvertiseSettings.ADVERTISE_MODE_LOW_LATENCY)
         // First registration was torn down; second is still live.
         assertThat(gate.firstRegistration?.closed).isTrue()
@@ -322,6 +371,43 @@ class BleQuickShareAdvertiserTest {
         assertThat(gate.startCalls).isEmpty()
     }
 
+    @Test
+    fun `start keeps legacy advertisement when DCT payload factory throws`() {
+        val gate = RecordingGate(failOnStart = false)
+        val advertiser =
+            BleQuickShareAdvertiser.forTesting(
+                gate = gate,
+                permissionChecker = { true },
+                dctPayloadFactory = { _ -> error("synthetic DCT payload failure") },
+            )
+
+        val started = advertiser.start(hiddenPhone(), endpointId("Wvmg"))
+
+        assertThat(started).isTrue()
+        assertThat(advertiser.isAdvertising).isTrue()
+        assertThat(gate.startCalls).hasSize(1)
+        assertThat(gate.startCalls.single().dctPayload).isNull()
+        assertThat(gate.startCalls.single().visiblePayload).isNull()
+    }
+
+    @Test
+    fun `start keeps legacy advertisement when visible payload factory throws`() {
+        val gate = RecordingGate(failOnStart = false)
+        val advertiser =
+            BleQuickShareAdvertiser.forTesting(
+                gate = gate,
+                permissionChecker = { true },
+                visiblePayloadFactory = { _, _ -> error("synthetic visible payload failure") },
+            )
+
+        val started = advertiser.start(visiblePhone(), endpointId("Wvmg"))
+
+        assertThat(started).isTrue()
+        assertThat(advertiser.isAdvertising).isTrue()
+        assertThat(gate.startCalls).hasSize(1)
+        assertThat(gate.startCalls.single().visiblePayload).isNull()
+    }
+
     private fun hiddenPhone(): EndpointInfo =
         EndpointInfo(
             version = 1,
@@ -332,6 +418,16 @@ class BleQuickShareAdvertiserTest {
             deviceName = null,
         )
 
+    private fun visiblePhone(): EndpointInfo =
+        EndpointInfo(
+            version = 1,
+            hidden = false,
+            deviceType = DeviceType.PHONE,
+            reserved = false,
+            metadata = ByteArray(EndpointInfo.METADATA_LEN) { it.toByte() },
+            deviceName = "WhenVivoMeetsGoogle",
+        )
+
     private fun endpointId(s: String): ByteArray {
         require(s.length == BleServiceData.ENDPOINT_ID_LEN)
         return s.toByteArray(Charsets.US_ASCII)
@@ -339,13 +435,13 @@ class BleQuickShareAdvertiserTest {
 
     /**
      * Test double for the platform [BleAdvertiserGate]. Records each
-     * `startAdvertising` call as a `(payload, mode)` pair and tracks
-     * whether the resulting registration was subsequently closed.
+     * `startAdvertising` call and tracks whether the resulting
+     * registration was subsequently closed.
      */
     private class RecordingGate(
         @Volatile var failOnStart: Boolean,
     ) : BleAdvertiserGate {
-        val startCalls: MutableList<Pair<ByteArray, Int>> = mutableListOf()
+        val startCalls: MutableList<StartCall> = mutableListOf()
         val registrations: MutableList<RecordingRegistration> = mutableListOf()
 
         val firstRegistration: RecordingRegistration?
@@ -356,14 +452,23 @@ class BleQuickShareAdvertiserTest {
         override fun startAdvertising(
             serviceData: ByteArray,
             mode: Int,
+            dctServiceData: ByteArray?,
+            visibleServiceData: ByteArray?,
         ): BleAdvertiserGate.Registration? {
-            startCalls += serviceData to mode
+            startCalls += StartCall(serviceData, mode, dctServiceData, visibleServiceData)
             if (failOnStart) return null
             val reg = RecordingRegistration()
             registrations += reg
             return reg
         }
     }
+
+    private data class StartCall(
+        val payload: ByteArray,
+        val mode: Int,
+        val dctPayload: ByteArray?,
+        val visiblePayload: ByteArray?,
+    )
 
     private class RecordingRegistration : BleAdvertiserGate.Registration {
         @Volatile

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BluetoothClassicBootstrapClientTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BluetoothClassicBootstrapClientTest.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.discovery.bootstrap
+
+import com.google.common.truth.Truth.assertThat
+import io.github.kyujincho.wvmg.protocol.endpoint.NearbyServiceId
+import io.github.kyujincho.wvmg.protocol.medium.Medium
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+class BluetoothClassicBootstrapClientTest {
+    @Test
+    fun `connect uses stock Nearby UUID and returns bluetooth transport`() =
+        runBlocking {
+            val io = FakeIo()
+            val client =
+                BluetoothClassicBootstrapClient(
+                    bluetooth = io,
+                    dispatcher = Dispatchers.IO,
+                )
+
+            val transport = client.connect("AA:BB:CC:DD:EE:FF")
+
+            assertThat(io.openCalls).hasSize(1)
+            assertThat(io.openCalls.single().uuid).isEqualTo(NearbyServiceId.bluetoothServiceUuid)
+            assertThat(io.openCalls.single().macAddress).isEqualTo("AA:BB:CC:DD:EE:FF")
+            assertThat(transport).isNotNull()
+            assertThat(transport!!.medium).isEqualTo(Medium.BLUETOOTH)
+        }
+
+    @Test
+    fun `cancelPendingConnect closes in-flight socket and returns null`() =
+        runBlocking {
+            val io = FakeIo(socket = BlockingSocket())
+            val client =
+                BluetoothClassicBootstrapClient(
+                    bluetooth = io,
+                    dispatcher = Dispatchers.IO,
+                )
+            val socket = io.socket as BlockingSocket
+            val result = AtomicReference<Any?>("pending")
+            val worker =
+                Thread {
+                    result.set(
+                        runBlocking {
+                            client.connect("11:22:33:44:55:66")
+                        },
+                    )
+                }
+            worker.start()
+            assertThat(socket.connectStarted.await(5, TimeUnit.SECONDS)).isTrue()
+            client.cancelPendingConnect()
+            worker.join(5_000)
+
+            assertThat(worker.isAlive).isFalse()
+            assertThat(result.get()).isNull()
+            assertThat(socket.closed).isTrue()
+        }
+
+    private class FakeIo(
+        val socket: BluetoothClassicClientSocket = ImmediateSocket(),
+    ) : BluetoothClassicBootstrapClientIo {
+        val openCalls: MutableList<OpenCall> = mutableListOf()
+
+        override fun isAvailable(): Boolean = true
+
+        override fun openSocket(
+            macAddress: String,
+            uuid: UUID,
+        ): BluetoothClassicClientSocket {
+            openCalls += OpenCall(macAddress, uuid)
+            return socket
+        }
+    }
+
+    private data class OpenCall(
+        val macAddress: String,
+        val uuid: UUID,
+    )
+
+    private interface TestSocket : BluetoothClassicClientSocket {
+        val closed: Boolean
+    }
+
+    private class ImmediateSocket : TestSocket {
+        override val inputStream: InputStream = ByteArrayInputStream(ByteArray(0))
+        override val outputStream: OutputStream = ByteArrayOutputStream()
+        override val closed: Boolean = false
+
+        override fun connect() {}
+
+        override fun close() {}
+    }
+
+    private class BlockingSocket : TestSocket {
+        val connectStarted = CountDownLatch(1)
+
+        @Volatile
+        override var closed: Boolean = false
+
+        override val inputStream: InputStream = ByteArrayInputStream(ByteArray(0))
+        override val outputStream: OutputStream = ByteArrayOutputStream()
+
+        override fun connect() {
+            connectStarted.countDown()
+            while (!closed) {
+                Thread.sleep(10)
+            }
+            throw IOException("closed")
+        }
+
+        override fun close() {
+            closed = true
+        }
+    }
+}

--- a/docs/testing/interop-stock-quick-share-android.md
+++ b/docs/testing/interop-stock-quick-share-android.md
@@ -9,16 +9,14 @@ This runbook tracks issue
 [#30](https://github.com/kyujin-cho/WhenVivoMeetsGoogle/issues/30) under
 the [Phase 1 epic](https://github.com/kyujin-cho/WhenVivoMeetsGoogle/issues/1).
 
-> **Phase 1 scope reminder.** Phase 1 is Wi-Fi LAN parity with NearDrop.
-> BLE auto-trigger (the "ping nearby devices" pulse that lights up a
-> stock receiver's "Sharing nearby" sheet automatically) is **out of
-> scope** and is tracked under Phase 2. In Phase 1, the **only reliable
-> path** to start a transfer to a stock Android device is the **QR-code
-> path**: WVMG renders a QR code, the peer scans it with their camera,
-> and stock Quick Share opens with our endpoint pre-selected. Discovery
-> in the other direction (stock Android sends to WVMG) is also Wi-Fi-only
-> in Phase 1: WVMG must already be advertising on mDNS for the peer's
-> device picker to list us.
+> **Current scope note.** Phase 1 originally shipped as Wi-Fi LAN parity
+> with NearDrop, and the QR path below remains the lowest-risk fallback.
+> Issue #137 adds a sender-side non-LAN bootstrap path: WVMG can now
+> discover stock peers through Bluetooth-adjacent discovery surfaces and
+> start the initial control channel without requiring the same Wi-Fi LAN.
+> Shared-LAN mDNS is still the baseline regression path, and stock sender
+> -> WVMG receiver regression should still be exercised on a shared LAN
+> unless a future issue changes the receiver-side bootstrap story.
 
 ---
 
@@ -26,21 +24,31 @@ the [Phase 1 epic](https://github.com/kyujin-cho/WhenVivoMeetsGoogle/issues/1).
 
 ### Networking requirements
 
-Phase 1 uses Wi-Fi LAN discovery (mDNS), so both devices **must** be on
-the same Wi-Fi network. BLE auto-discovery is Phase 2 and out of scope
-for this runbook. The receiver's persistent notification surfaces the
-current Wi-Fi SSID (`Receiving on "<SSID>"`) — use it to confirm both
-ends match before you start each test.
+Two network topologies matter now:
+
+- **Shared-LAN regression path:** both devices on the same Wi-Fi network
+  so mDNS discovery can work exactly as it did before issue #137.
+- **Off-LAN sender path:** WVMG sender and the stock receiver are on
+  different Wi-Fi networks, on a client-isolated Wi-Fi, or otherwise
+  unable to reach each other by LAN mDNS alone. Bluetooth must stay on
+  so the initial control channel can bootstrap, and the subsequent
+  bandwidth upgrade may or may not move to Wi-Fi depending on what the
+  peer offers.
 
 ### Network
 
-- [ ] Both devices are on the **same Wi-Fi SSID and the same VLAN** —
-      mDNS does not cross routed subnets.
+- [ ] For the **shared-LAN regression** cells below, both devices are on
+      the **same Wi-Fi SSID and the same VLAN** — mDNS does not cross
+      routed subnets.
+- [ ] For the **off-LAN sender** cells below, deliberately place the
+      devices on different Wi-Fi networks (or an AP with client
+      isolation) and record the topology in the test log.
 - [ ] The Wi-Fi network has **mDNS / multicast traffic enabled**. Many
       enterprise / guest networks block multicast and silently break
       Quick Share. Use a phone hotspot if in doubt.
-- [ ] Both devices have **Wi-Fi turned on**. Bluetooth is **not**
-      required in Phase 1 (BLE pulse is Phase 2).
+- [ ] Both devices have **Wi-Fi turned on**.
+- [ ] For the **off-LAN sender** cells, both devices also have
+      **Bluetooth turned on**.
 - [ ] Location permission is granted to Google Play Services on the
       stock device (Quick Share requires it for Wi-Fi scans).
 
@@ -95,12 +103,14 @@ each test, and record which:
 
 Every cell in the matrix must be exercised once per RC build.
 
-| # | Direction        | Peer    | Path used                | Visibility setting on peer | Result |
-|---|------------------|---------|--------------------------|----------------------------|--------|
-| 1 | WVMG -> Pixel    | Pixel   | QR code (Phase 1)        | Everyone                   |        |
-| 2 | WVMG -> Samsung  | Samsung | QR code (Phase 1)        | Everyone                   |        |
-| 3 | Pixel -> WVMG    | Pixel   | Pixel device picker      | n/a (sender side picks us) |        |
-| 4 | Samsung -> WVMG  | Samsung | Samsung Quick Share UI   | n/a                        |        |
+| # | Direction        | Peer    | Path used                                | Visibility setting on peer | Result |
+|---|------------------|---------|------------------------------------------|----------------------------|--------|
+| 1 | WVMG -> Pixel    | Pixel   | Shared-LAN picker / mDNS regression      | Everyone                   |        |
+| 2 | WVMG -> Pixel    | Pixel   | Off-LAN sender bootstrap (#137)          | Everyone                   |        |
+| 3 | WVMG -> Samsung  | Samsung | Shared-LAN picker / mDNS regression      | Everyone                   |        |
+| 4 | WVMG -> Samsung  | Samsung | Off-LAN sender bootstrap (#137)          | Everyone                   |        |
+| 5 | Pixel -> WVMG    | Pixel   | Pixel device picker                      | n/a (sender side picks us) |        |
+| 6 | Samsung -> WVMG  | Samsung | Samsung Quick Share UI                   | n/a                        |        |
 
 For each cell, run **both** a small file (≤ 1 MB, e.g. a JPEG) and a
 large file (≥ 200 MB, e.g. a video). The large-file run is what catches
@@ -114,11 +124,55 @@ that fit in one chunk, so it was invisible in large-file-only testing.
 
 ## Procedure
 
-### Test 1 / Test 2: Send file from WVMG to a stock Android phone (QR-code path)
+### Test 1 / Test 3: Send file from WVMG to a stock Android phone (shared-LAN regression)
 
-The QR path is the only Phase-1-supported path. Stock Android only
-implements QR scanning as the receiver-side entry point — there is no
-"manual IP entry" — so the flow below is mandatory.
+- [ ] Put both devices on the **same Wi-Fi SSID / VLAN**.
+- [ ] On the **WVMG device**: open the system share sheet for the file
+      under test and route into `SendActivity`.
+- [ ] Wait for the peer row to appear in the picker. Record the
+      `picked target:` log line from `adb logcat -s WvmgOutbound` after
+      selection; for the shared-LAN regression it should show
+      `route=lan=<ip>:<port>`.
+- [ ] Select the peer row, compare the 4-digit PIN on both sides, and
+      complete the transfer.
+- [ ] Verify the received file and SHA-256 hash on the peer.
+
+### Test 2 / Test 4: Send file from WVMG to a stock Android phone (off-LAN sender bootstrap)
+
+This is the issue #137 checklist. It validates that the sender can
+discover and start the session without relying on same-LAN mDNS.
+
+- [ ] Put the devices on **different Wi-Fi networks** (or on a network
+      with client isolation) so a pure LAN dial would fail.
+- [ ] On the **stock peer**: set Quick Share visibility to **Everyone**
+      and confirm **Bluetooth is on**.
+- [ ] On the **WVMG device**: open the system share sheet for the file
+      under test and route into `SendActivity`.
+- [ ] Wait for the peer row to appear in the picker. If the row appears
+      but is disabled, record that as a partial discovery result and
+      capture the discovery log before continuing.
+- [ ] Capture `adb logcat -s WvmgOutbound WvmgBtScan WvmgBleFastScan`
+      while the picker is open. Record the discovery surfaces reported
+      in the `picked target:` line's `mediums=[...]` field.
+- [ ] Select the peer row and record the initial control route from the
+      same `picked target:` line. For the off-LAN bootstrap path it
+      should show `route=bluetooth=<mac>` unless the devices happen to
+      regain LAN reachability.
+- [ ] Confirm the 4-digit PIN matches on both devices.
+- [ ] Wait for the transfer to complete and verify the received file's
+      SHA-256 hash on the peer.
+- [ ] Record whether the connection stayed on the initial medium or
+      upgraded. Look for `step 1: initial transport open medium=...`
+      and any `medium-upgrade:` lines in `WvmgOutbound`.
+- [ ] Immediately rerun the same peer pair on a **shared LAN** and
+      confirm the regression path still chooses `route=lan=<ip>:<port>`.
+
+### Legacy fallback: QR-code path
+
+Keep this path around as a manual fallback when the nearby-picker path is
+under active debugging. Stock Android still implements QR scanning as a
+receiver-side entry point, and it remains useful for isolating
+discovery/bootstrap failures from later protocol failures.
 
 - [ ] On the **stock peer**: open Settings → Connected devices →
       Connection preferences → Quick Share, and set visibility to

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
@@ -27,9 +27,11 @@ import androidx.lifecycle.ProcessLifecycleOwner
 import io.github.kyujincho.wvmg.discovery.Discovery
 import io.github.kyujincho.wvmg.discovery.ble.BleQuickShareAdvertiser
 import io.github.kyujincho.wvmg.discovery.ble.BleQuickShareScanner
-import io.github.kyujincho.wvmg.discovery.bootstrap.BluetoothClassicBootstrapServer
+import io.github.kyujincho.wvmg.discovery.bootstrap.BleGattInitialControlServer
+import io.github.kyujincho.wvmg.discovery.bootstrap.BleL2capInitialControlServer
 import io.github.kyujincho.wvmg.discovery.medium.MediumRegistries
 import io.github.kyujincho.wvmg.protocol.endpoint.BleServiceData
+import io.github.kyujincho.wvmg.protocol.endpoint.DctAdvertisement
 import io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo
 import io.github.kyujincho.wvmg.service.downloads.DownloadsWriterFactory
 import io.github.kyujincho.wvmg.service.receiver.consent.ConsentBroadcastReceiver
@@ -461,7 +463,7 @@ public class ReceiverForegroundService : Service() {
         val advertiser = bleAdvertiser ?: return BleVisibilityBroadcaster.Noop
         val endpointInfo =
             EndpointIdentityHolder.snapshot.get() ?: return BleVisibilityBroadcaster.Noop
-        val endpointId = BleEndpointIdHolder.bytes
+        val endpointId = BleEndpointIdHolder.bytesFor(endpointInfo)
         return object : BleVisibilityBroadcaster {
             override fun start(): Boolean {
                 // BleQuickShareAdvertiser.start re-uses the existing
@@ -816,7 +818,7 @@ public class ReceiverForegroundService : Service() {
                 val discovery =
                     Discovery(
                         context = context,
-                        instanceEndpointIdProvider = { BleEndpointIdHolder.bytes.copyOf() },
+                        instanceEndpointIdProvider = { BleEndpointIdHolder.bytesFor(identity) },
                     )
                 ActiveDiscoveryHolder.set(discovery)
                 ReceiverSession(
@@ -833,9 +835,12 @@ public class ReceiverForegroundService : Service() {
                     mediumRegistry = MediumRegistries.defaultForContext(context.applicationContext),
                     initialControlServers =
                         listOf(
-                            BluetoothClassicBootstrapServer(
+                            BleL2capInitialControlServer(
                                 context = context.applicationContext,
-                                endpointIdProvider = { BleEndpointIdHolder.bytes.copyOf() },
+                            ),
+                            BleGattInitialControlServer(
+                                context = context.applicationContext,
+                                endpointIdProvider = { BleEndpointIdHolder.bytesFor(identity) },
                             ),
                         ),
                     // Issue #34: defer mDNS publish to the
@@ -1179,14 +1184,30 @@ internal object ActiveDiscoveryHolder {
  */
 internal object BleEndpointIdHolder {
     /**
-     * The cached 4-byte slug. Generated on first read using
-     * `[A-Za-z0-9]` — same alphabet [InstanceName] uses internally —
-     * so the bytes round-trip cleanly through any future base64-url
-     * conversion.
+     * The cached 4-byte slug. Prefer the DCT-derived endpoint_id for
+     * name-bearing identities so stock Nearby's `0xFC73` parser, our
+     * `0xFEF3` fast advertisement, the GATT slot advertisement, and
+     * mDNS all describe the same logical endpoint. If the identity has
+     * no visible name, fall back to the historical random slug.
      */
-    val bytes: ByteArray by lazy { generate() }
+    private val cached: AtomicReference<ByteArray?> = AtomicReference(null)
 
-    private fun generate(): ByteArray {
+    fun bytesFor(endpointInfo: EndpointInfo): ByteArray {
+        cached.get()?.let { return it.copyOf() }
+        val generated = generate(endpointInfo)
+        return if (cached.compareAndSet(null, generated.copyOf())) {
+            generated.copyOf()
+        } else {
+            cached.get()!!.copyOf()
+        }
+    }
+
+    private fun generate(endpointInfo: EndpointInfo): ByteArray {
+        endpointInfo.deviceName
+            ?.takeIf { it.isNotBlank() }
+            ?.let { DctAdvertisement.generateEndpointId(DctAdvertisement.DEFAULT_DEDUP, it) }
+            ?.let { return it.toByteArray(Charsets.US_ASCII) }
+
         val alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
         val random = java.security.SecureRandom()
         return ByteArray(BleServiceData.ENDPOINT_ID_LEN) {

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
@@ -221,8 +221,8 @@ public class ReceiverForegroundService : Service() {
         // Multiple startService calls are idempotent — the second one
         // just keeps the existing session alive.
         if (session == null) {
-            startReceiverSession()
             startBleScanner()
+            startReceiverSession()
         }
 
         return START_STICKY
@@ -439,7 +439,9 @@ public class ReceiverForegroundService : Service() {
      * Build a [BleVisibilityBroadcaster] that hands the gate's
      * publish/unpublish decisions to the [bleAdvertiser] using the
      * receiver's stable [EndpointInfo] and a process-stable 4-byte
-     * endpoint_id slug.
+     * endpoint_id slug. The advertiser compacts the EndpointInfo into
+     * the hidden, no-name BLE shape so it fits the legacy advertisement
+     * budget; the mDNS path keeps the visible, name-bearing identity.
      *
      * The endpoint_id we feed into BLE is the same process-stable slug
      * that production `Discovery` uses for the mDNS instance name.


### PR DESCRIPTION
## Summary

- add a sender-side `NearbyPeer` model and aggregate LAN mDNS, BLE fast advertisements, BLE GATT/private advertisements, and Bluetooth observations into a single picker flow
- add sender-side off-LAN bootstrap paths and complete stock Quick Share BLE GATT initial transport using the raw Nearby stream after Weave socket setup
- keep the sender file metadata usable for app-owned/file URI debug shares by resolving size from `AssetFileDescriptor` when cursor size is unavailable
- refactor `SendActivity` around the new peer picker/resolver helpers, add focused transport/bootstrap tests, and document the off-LAN sender checklist

## Testing

- `git diff --check`
- `./gradlew staticAnalysis`
- `./gradlew :app:assembleDebug`
- `./gradlew :app:testDebugUnitTest`
- `./gradlew :discovery-android:testDebugUnitTest :core-protocol:test`

## Manual validation

- Installed the debug APK on vivo `10AG3Y378B001L3` and shared `wvmg-ble-debug.txt` to Galaxy/S26 `R5KL10EMF9P` using the BLE GATT/private Quick Share receiver row.
- Galaxy stock Quick Share accepted the connection, received 23 bytes, verified `wvmg-ble-debug.txt`, and completed safe-disconnect over `ENCRYPTED_BLE`.
- vivo sender UI ended at `Sent successfully`; logs showed raw Nearby stream, UKEY2, introduction, payload streaming, and safe-disconnect completion.

## Follow-up

- The BLE GATT/private row still falls back to a generic `Quick Share BLE device` label when WVMG cannot parse a receiver device name from the discovery metadata.

Refs #137