### PR TITLE
fix: parse BLE receiver names

### DIFF
--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendPeerPickerController.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendPeerPickerController.kt
@@ -151,8 +151,18 @@ internal class SendPeerPickerController(
                 is NearbyPeerRoute.BleGatt -> "ble-gatt=${chosenRoute.macAddress}"
                 null -> "<none>"
             }
+        val bleIdentitySummary =
+            formatBleIdentitySnapshot(peer)
         return "peer=${peer.stableId} endpointId=$endpointId mediums=${peer.candidateMediums} " +
-            "addrs=[$addressList] route=$routeSummary endpointInfo={$infoSummary}"
+            "addrs=[$addressList] route=$routeSummary displayName=\"${peer.displayName()}\" " +
+            "displayNameSource=${peer.displayNameSource()}$bleIdentitySummary endpointInfo={$infoSummary}"
+    }
+
+    private fun formatBleIdentitySnapshot(peer: NearbyPeer): String {
+        val ble = peer.bleAdvertisement ?: return ""
+        val displayName = ble.displayName?.let { "\"$it\"" } ?: "<none>"
+        val displayNameSource = ble.displayNameSource ?: "<none>"
+        return " bleName=$displayName bleNameSource=$displayNameSource"
     }
 
     private fun startDiscovery() {
@@ -272,7 +282,8 @@ internal class SendPeerPickerController(
                         is NearbyPeerRoute.BleGatt -> preferredRoute.macAddress
                         null -> "<none>"
                     }
-                "${peer.stableId}/${peer.endpointId ?: "<none>"}/$route/${peer.displayName()}"
+                "${peer.stableId}/${peer.endpointId ?: "<none>"}/$route/" +
+                    "${peer.displayName()}(${peer.displayNameSource()})"
             }
         }
 

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendPeerPickerController.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendPeerPickerController.kt
@@ -293,13 +293,13 @@ internal class SendPeerPickerController(
     }
 }
 
-private fun String?.toQuotedLogValue(nullToken: String = "<none>"): String =
+internal fun String?.toQuotedLogValue(nullToken: String = "<none>"): String =
     this
         ?.toSanitizedLogValue()
         ?.let { "\"$it\"" }
         ?: nullToken
 
-private fun String.toSanitizedLogValue(): String =
+internal fun String.toSanitizedLogValue(): String =
     buildString(length) {
         this@toSanitizedLogValue.forEach { ch ->
             when (ch) {

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendPeerPickerController.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendPeerPickerController.kt
@@ -132,7 +132,7 @@ internal class SendPeerPickerController(
                     append(" hidden=").append(info.hidden)
                     append(" type=").append(info.deviceType.name)
                     append(" name=")
-                    append(info.deviceName?.let { "\"$it\"" } ?: "<null>")
+                    append(info.deviceName.toQuotedLogValue(nullToken = "<null>"))
                     if (info.tlvRecords.isNotEmpty()) {
                         append(" tlv=").append(
                             info.tlvRecords.joinToString(",") { tlv ->
@@ -154,13 +154,13 @@ internal class SendPeerPickerController(
         val bleIdentitySummary =
             formatBleIdentitySnapshot(peer)
         return "peer=${peer.stableId} endpointId=$endpointId mediums=${peer.candidateMediums} " +
-            "addrs=[$addressList] route=$routeSummary displayName=\"${peer.displayName()}\" " +
+            "addrs=[$addressList] route=$routeSummary displayName=${peer.displayName().toQuotedLogValue()} " +
             "displayNameSource=${peer.displayNameSource()}$bleIdentitySummary endpointInfo={$infoSummary}"
     }
 
     private fun formatBleIdentitySnapshot(peer: NearbyPeer): String {
         val ble = peer.bleAdvertisement ?: return ""
-        val displayName = ble.displayName?.let { "\"$it\"" } ?: "<none>"
+        val displayName = ble.displayName.toQuotedLogValue()
         val displayNameSource = ble.displayNameSource ?: "<none>"
         return " bleName=$displayName bleNameSource=$displayNameSource"
     }
@@ -283,7 +283,7 @@ internal class SendPeerPickerController(
                         null -> "<none>"
                     }
                 "${peer.stableId}/${peer.endpointId ?: "<none>"}/$route/" +
-                    "${peer.displayName()}(${peer.displayNameSource()})"
+                    "${peer.displayName().toSanitizedLogValue()}(${peer.displayNameSource()})"
             }
         }
 
@@ -292,3 +292,23 @@ internal class SendPeerPickerController(
         private const val DISABLED_PEER_ALPHA: Float = 0.6f
     }
 }
+
+private fun String?.toQuotedLogValue(nullToken: String = "<none>"): String =
+    this
+        ?.toSanitizedLogValue()
+        ?.let { "\"$it\"" }
+        ?: nullToken
+
+private fun String.toSanitizedLogValue(): String =
+    buildString(length) {
+        this@toSanitizedLogValue.forEach { ch ->
+            when (ch) {
+                '\\' -> append("\\\\")
+                '"' -> append("\\\"")
+                '\n' -> append("\\n")
+                '\r' -> append("\\r")
+                '\t' -> append("\\t")
+                else -> append(ch)
+            }
+        }
+    }

--- a/app/src/test/kotlin/io/github/kyujincho/wvmg/send/SendPeerPickerLogSanitizationTest.kt
+++ b/app/src/test/kotlin/io/github/kyujincho/wvmg/send/SendPeerPickerLogSanitizationTest.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.send
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SendPeerPickerLogSanitizationTest {
+    @Test
+    fun `sanitized log value escapes control characters and quotes`() {
+        val raw = "Galaxy\tS26\nReceiver\r\"quoted\"\\tail"
+
+        assertEquals(
+            "Galaxy\\tS26\\nReceiver\\r\\\"quoted\\\"\\\\tail",
+            raw.toSanitizedLogValue(),
+        )
+    }
+
+    @Test
+    fun `quoted log value wraps sanitized text`() {
+        assertEquals("\"Galaxy\\nS26\"", "Galaxy\nS26".toQuotedLogValue())
+    }
+
+    @Test
+    fun `quoted log value keeps explicit null token`() {
+        assertEquals("<null>", (null as String?).toQuotedLogValue(nullToken = "<null>"))
+    }
+}

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/NearbyPeer.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/NearbyPeer.kt
@@ -86,11 +86,32 @@ public data class NearbyPeer(
 
     /** User-facing fallback label shared by the sender UI and tests. */
     public fun displayName(): String {
-        val name = endpointInfo?.deviceName
-        if (!name.isNullOrBlank()) return name
+        val name = endpointInfo?.deviceName.toDisplayNameOrNull()
+        if (name != null) return name
+        val bleName = bleAdvertisement?.displayName.toDisplayNameOrNull()
+        if (bleName != null) return bleName
         if (!endpointId.isNullOrBlank()) return "Quick Share device ($endpointId)"
         if (bleAdvertisement?.gattConnectable == true) return "Quick Share BLE device"
         return stableId
+    }
+
+    /** Diagnostic source for the label selected by [displayName]. */
+    public fun displayNameSource(): String {
+        val endpointName = endpointInfo?.deviceName.toDisplayNameOrNull()
+        val bleName = bleAdvertisement?.displayName.toDisplayNameOrNull()
+        return when {
+            endpointName != null ->
+                if (endpointName == bleName) {
+                    bleAdvertisement?.displayNameSource ?: "endpoint-info"
+                } else {
+                    "endpoint-info"
+                }
+            bleName != null ->
+                bleAdvertisement?.displayNameSource ?: "ble-metadata"
+            !endpointId.isNullOrBlank() -> "endpoint-id"
+            bleAdvertisement?.gattConnectable == true -> "ble-gatt-fallback"
+            else -> "stable-id"
+        }
     }
 
     /** Wi-Fi LAN candidate surfaced by mDNS browse. */
@@ -122,8 +143,15 @@ public data class NearbyPeer(
         val rssi: Int?,
         val l2capPsm: Int?,
         val gattConnectable: Boolean,
+        val displayName: String? = null,
+        val displayNameSource: String? = null,
     )
 }
+
+private fun String?.toDisplayNameOrNull(): String? =
+    this
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() }
 
 /** Sender-side peer-list events emitted by [NearbyPeerDiscovery]. */
 public sealed class NearbyPeerEvent {

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/NearbyPeerDiscovery.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/NearbyPeerDiscovery.kt
@@ -170,6 +170,10 @@ private class PeerAggregator {
         state.bleRssi = observation.rssi
         state.bleL2capPsm = observation.l2capPsm
         state.bleGattConnectable = observation.gattConnectable
+        observation.displayName?.toDisplayNameOrNull()?.let { displayName ->
+            state.bleDisplayName = displayName
+            state.bleDisplayNameSource = observation.displayNameSource?.logLabel
+        }
         observation.advertiserAddress?.let { bleIndex[it] = state.stableId }
 
         return changeEvents(before, state.toPeerOrNull())
@@ -255,6 +259,8 @@ private data class MutablePeer(
     var bleRssi: Int? = null,
     var bleL2capPsm: Int? = null,
     var bleGattConnectable: Boolean = false,
+    var bleDisplayName: String? = null,
+    var bleDisplayNameSource: String? = null,
 ) {
     fun toPeerOrNull(): NearbyPeer? {
         val lan =
@@ -279,6 +285,8 @@ private data class MutablePeer(
                     rssi = bleRssi,
                     l2capPsm = bleL2capPsm,
                     gattConnectable = bleGattConnectable,
+                    displayName = bleDisplayName,
+                    displayNameSource = bleDisplayNameSource,
                 )
             } else {
                 null
@@ -314,3 +322,8 @@ private fun DiscoveredService.lanRouteKey(): Pair<String, Int>? =
     primaryAddress()?.hostAddress?.let { host -> host to port }
 
 private fun ByteArray.toAsciiLabel(): String = String(this, Charsets.US_ASCII)
+
+private fun String?.toDisplayNameOrNull(): String? =
+    this
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() }

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleFastAdvertisementScanner.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleFastAdvertisementScanner.kt
@@ -180,7 +180,6 @@ public class BleFastAdvertisementScanner(
         DCT_ADVERTISEMENT("dct-advertisement"),
         GATT_SLOT_ENDPOINT_INFO("gatt-slot-endpoint-info"),
         BLE_LOCAL_NAME("ble-local-name"),
-        BLUETOOTH_DEVICE_NAME("bluetooth-device-name"),
     }
 
     @Suppress("CyclomaticComplexMethod", "NestedBlockDepth", "LongMethod")
@@ -203,7 +202,7 @@ public class BleFastAdvertisementScanner(
             )
             return null
         }
-        val localDisplayName = displayNameFromScanResult()
+        val localDisplayName = scanRecord.displayNameCandidate()
         val fastObservation =
             fastData?.let { serviceData ->
                 BleAdvertisementHeader.parse(serviceData)?.let { header ->
@@ -273,17 +272,6 @@ public class BleFastAdvertisementScanner(
             fastObservation = fastObservation,
             dctObservation = dctObservation,
         )
-    }
-
-    private fun ScanResult.displayNameFromScanResult(): DisplayNameCandidate? {
-        scanRecord?.deviceName.toDisplayNameOrNull()?.let { name ->
-            return DisplayNameCandidate(name, DisplayNameSource.BLE_LOCAL_NAME)
-        }
-        val bluetoothName =
-            runCatching { device?.name }
-                .getOrNull()
-                .toDisplayNameOrNull()
-        return bluetoothName?.let { DisplayNameCandidate(it, DisplayNameSource.BLUETOOTH_DEVICE_NAME) }
     }
 
     private fun resolveScanner(): BluetoothLeScanner? {
@@ -460,6 +448,13 @@ private data class DisplayNameCandidate(
     val value: String,
     val source: BleFastAdvertisementScanner.DisplayNameSource,
 )
+
+private fun ScanRecord.displayNameCandidate(): DisplayNameCandidate? =
+    // Only trust the current advertisement's local-name field here. BluetoothDevice.name
+    // is a cached alias gated by BLUETOOTH_CONNECT and can be stale in degraded scan-only mode.
+    deviceName
+        .toDisplayNameOrNull()
+        ?.let { DisplayNameCandidate(it, BleFastAdvertisementScanner.DisplayNameSource.BLE_LOCAL_NAME) }
 
 private fun String?.toDisplayNameOrNull(): String? =
     this

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleFastAdvertisementScanner.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleFastAdvertisementScanner.kt
@@ -44,6 +44,7 @@ import java.util.concurrent.ConcurrentHashMap
 public class BleFastAdvertisementScanner(
     private val context: Context,
 ) {
+    @Suppress("CyclomaticComplexMethod")
     public fun scan(): Flow<Observation> =
         callbackFlow {
             val gattAdvertisementReader = BleGattAdvertisementReader(context.applicationContext)
@@ -77,6 +78,17 @@ public class BleFastAdvertisementScanner(
                             gattReadSucceeded.add(key)
                         }
                         slotAdvertisements.forEach { slot ->
+                            val slotDisplayName = slot.endpointInfo.deviceName.toDisplayNameOrNull()
+                            val slotDisplayNameSource =
+                                slotDisplayName?.let { DisplayNameSource.GATT_SLOT_ENDPOINT_INFO }
+                            Log.w(
+                                TAG,
+                                "BLE GATT slot advertisement observed endpointId=${slot.endpointId} " +
+                                    "address=$advertiserAddress rssi=$rssi " +
+                                    "psm=${slot.l2capPsm ?: header.psm.takeIf { it > 0 }} " +
+                                    "name=${slotDisplayName ?: "<none>"} " +
+                                    "nameSource=${slotDisplayNameSource?.logLabel ?: "<none>"}",
+                            )
                             trySend(
                                 Observation(
                                     endpointId = slot.endpointId,
@@ -85,6 +97,8 @@ public class BleFastAdvertisementScanner(
                                     rssi = rssi,
                                     l2capPsm = slot.l2capPsm ?: header.psm.takeIf { it > 0 },
                                     gattConnectable = true,
+                                    displayName = slotDisplayName,
+                                    displayNameSource = slotDisplayNameSource,
                                 ),
                             ).isSuccess
                         }
@@ -155,9 +169,21 @@ public class BleFastAdvertisementScanner(
         val rssi: Int?,
         val l2capPsm: Int?,
         val gattConnectable: Boolean,
+        val displayName: String? = null,
+        val displayNameSource: DisplayNameSource? = null,
     )
 
-    @Suppress("CyclomaticComplexMethod", "NestedBlockDepth")
+    public enum class DisplayNameSource(
+        public val logLabel: String,
+    ) {
+        FAST_ADVERTISEMENT_ENDPOINT_INFO("fast-advertisement-endpoint-info"),
+        DCT_ADVERTISEMENT("dct-advertisement"),
+        GATT_SLOT_ENDPOINT_INFO("gatt-slot-endpoint-info"),
+        BLE_LOCAL_NAME("ble-local-name"),
+        BLUETOOTH_DEVICE_NAME("bluetooth-device-name"),
+    }
+
+    @Suppress("CyclomaticComplexMethod", "NestedBlockDepth", "LongMethod")
     private fun ScanResult.toObservation(
         scheduleGattAdvertisementRead: (BleAdvertisementHeader, String, Int?) -> Unit,
     ): Observation? {
@@ -177,6 +203,7 @@ public class BleFastAdvertisementScanner(
             )
             return null
         }
+        val localDisplayName = displayNameFromScanResult()
         val fastObservation =
             fastData?.let { serviceData ->
                 BleAdvertisementHeader.parse(serviceData)?.let { header ->
@@ -186,7 +213,14 @@ public class BleFastAdvertisementScanner(
                         }
                     }
                 }
-                parseFastServiceData(serviceData, device?.address, rssi, gattConnectable).also { observation ->
+                parseFastServiceData(
+                    serviceData = serviceData,
+                    advertiserAddress = device?.address,
+                    rssi = rssi,
+                    gattConnectable = gattConnectable,
+                    fallbackDisplayName = localDisplayName?.value,
+                    fallbackDisplayNameSource = localDisplayName?.source,
+                ).also { observation ->
                     if (observation == null) {
                         Log.w(
                             TAG,
@@ -199,6 +233,8 @@ public class BleFastAdvertisementScanner(
                             "BLE fast-advertisement observed endpointId=${observation.endpointId ?: "<none>"} " +
                                 "address=${observation.advertiserAddress} rssi=${observation.rssi} " +
                                 "psm=${observation.l2capPsm} gatt=${observation.gattConnectable} " +
+                                "name=${observation.displayName ?: "<none>"} " +
+                                "nameSource=${observation.displayNameSource?.logLabel ?: "<none>"} " +
                                 "bytes=${serviceData.toHex()}",
                         )
                     }
@@ -206,7 +242,14 @@ public class BleFastAdvertisementScanner(
             }
         val dctObservation =
             dctData?.let { serviceData ->
-                parseDctServiceData(serviceData, device?.address, rssi, gattConnectable).also { observation ->
+                parseDctServiceData(
+                    serviceData = serviceData,
+                    advertiserAddress = device?.address,
+                    rssi = rssi,
+                    gattConnectable = gattConnectable,
+                    fallbackDisplayName = localDisplayName?.value,
+                    fallbackDisplayNameSource = localDisplayName?.source,
+                ).also { observation ->
                     if (observation == null) {
                         Log.w(
                             TAG,
@@ -219,7 +262,8 @@ public class BleFastAdvertisementScanner(
                             "BLE DCT advertisement observed endpointId=${observation.endpointId ?: "<none>"} " +
                                 "address=${observation.advertiserAddress} rssi=${observation.rssi} " +
                                 "psm=${observation.l2capPsm} gatt=${observation.gattConnectable} " +
-                                "name=${observation.endpointInfo?.deviceName} " +
+                                "name=${observation.displayName ?: "<none>"} " +
+                                "nameSource=${observation.displayNameSource?.logLabel ?: "<none>"} " +
                                 "bytes=${serviceData.toHex()}",
                         )
                     }
@@ -229,6 +273,17 @@ public class BleFastAdvertisementScanner(
             fastObservation = fastObservation,
             dctObservation = dctObservation,
         )
+    }
+
+    private fun ScanResult.displayNameFromScanResult(): DisplayNameCandidate? {
+        scanRecord?.deviceName.toDisplayNameOrNull()?.let { name ->
+            return DisplayNameCandidate(name, DisplayNameSource.BLE_LOCAL_NAME)
+        }
+        val bluetoothName =
+            runCatching { device?.name }
+                .getOrNull()
+                .toDisplayNameOrNull()
+        return bluetoothName?.let { DisplayNameCandidate(it, DisplayNameSource.BLUETOOTH_DEVICE_NAME) }
     }
 
     private fun resolveScanner(): BluetoothLeScanner? {
@@ -303,7 +358,10 @@ public class BleFastAdvertisementScanner(
             advertiserAddress: String?,
             rssi: Int?,
             gattConnectable: Boolean = advertiserAddress != null,
+            fallbackDisplayName: String? = null,
+            fallbackDisplayNameSource: DisplayNameSource? = null,
         ): Observation? {
+            val fallbackName = fallbackDisplayName.toDisplayNameOrNull()
             BleAdvertisementHeader.parse(serviceData)?.let { header ->
                 val l2capPsm = header.psm.takeIf { it > 0 }
                 return Observation(
@@ -313,11 +371,15 @@ public class BleFastAdvertisementScanner(
                     rssi = rssi,
                     l2capPsm = l2capPsm,
                     gattConnectable = gattConnectable && advertiserAddress != null,
+                    displayName = fallbackName,
+                    displayNameSource = fallbackName?.let { fallbackDisplayNameSource },
                 )
             }
             val parsed = BleServiceData.parse(serviceData) ?: return null
             val endpointId = String(parsed.endpointId, Charsets.US_ASCII)
             val l2capPsm = BleServiceData.parsePsmExtraField(serviceData)?.takeIf { it > 0 }
+            val endpointName = parsed.endpointInfo.deviceName.toDisplayNameOrNull()
+            val displayName = endpointName ?: fallbackName
             return Observation(
                 endpointId = endpointId,
                 endpointInfo = parsed.endpointInfo,
@@ -325,6 +387,13 @@ public class BleFastAdvertisementScanner(
                 rssi = rssi,
                 l2capPsm = l2capPsm,
                 gattConnectable = gattConnectable && advertiserAddress != null,
+                displayName = displayName,
+                displayNameSource =
+                    when {
+                        endpointName != null -> DisplayNameSource.FAST_ADVERTISEMENT_ENDPOINT_INFO
+                        displayName != null -> fallbackDisplayNameSource
+                        else -> null
+                    },
             )
         }
 
@@ -333,12 +402,17 @@ public class BleFastAdvertisementScanner(
             advertiserAddress: String?,
             rssi: Int?,
             gattConnectable: Boolean = advertiserAddress != null,
+            fallbackDisplayName: String? = null,
+            fallbackDisplayNameSource: DisplayNameSource? = null,
         ): Observation? {
             val parsed = DctAdvertisement.parse(serviceData) ?: return null
             if (!parsed.serviceIdHash.contentEquals(EXPECTED_DCT_SERVICE_ID_HASH)) return null
             val endpointId =
                 DctAdvertisement.generateEndpointId(parsed.dedup, parsed.deviceName) ?: return null
             val l2capPsm = parsed.psm.takeIf { it > 0 }
+            val dctName = parsed.deviceName.toDisplayNameOrNull()
+            val fallbackName = fallbackDisplayName.toDisplayNameOrNull()
+            val displayName = dctName ?: fallbackName
             return Observation(
                 endpointId = endpointId,
                 endpointInfo = parsed.toEndpointInfo(),
@@ -346,6 +420,13 @@ public class BleFastAdvertisementScanner(
                 rssi = rssi,
                 l2capPsm = l2capPsm,
                 gattConnectable = gattConnectable && advertiserAddress != null,
+                displayName = displayName,
+                displayNameSource =
+                    when {
+                        dctName != null -> DisplayNameSource.DCT_ADVERTISEMENT
+                        displayName != null -> fallbackDisplayNameSource
+                        else -> null
+                    },
             )
         }
 
@@ -374,3 +455,13 @@ private fun DctAdvertisement.Parsed.toEndpointInfo(): EndpointInfo =
     )
 
 private fun ByteArray.toHex(): String = joinToString("") { "%02x".format(it) }
+
+private data class DisplayNameCandidate(
+    val value: String,
+    val source: BleFastAdvertisementScanner.DisplayNameSource,
+)
+
+private fun String?.toDisplayNameOrNull(): String? =
+    this
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() }

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/NearbyPeerDiscoveryTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/NearbyPeerDiscoveryTest.kt
@@ -257,9 +257,93 @@ class NearbyPeerDiscoveryTest {
             assertThat(resolved.isConnectable).isTrue()
             assertThat(resolved.candidateMediums).containsExactly(Medium.BLE)
             assertThat(resolved.displayName()).isEqualTo("Quick Share BLE device")
+            assertThat(resolved.displayNameSource()).isEqualTo("ble-gatt-fallback")
             assertThat(resolved.preferredRoute()).isEqualTo(
                 NearbyPeerRoute.BleGatt(macAddress = "28:1B:3E:BA:B1:1B"),
             )
+
+            collector.cancel()
+        }
+
+    @Test
+    fun `BLE GATT advertisement uses parsed BLE display name before endpoint fallback`() =
+        runTest {
+            val lanEvents = MutableSharedFlow<DiscoveryEvent>()
+            val bleEvents = MutableSharedFlow<BleFastAdvertisementScanner.Observation>()
+            val bluetoothEvents = MutableSharedFlow<BluetoothClassicPeerScanner.Observation>()
+            val discovery =
+                NearbyPeerDiscovery.forTesting(
+                    lanEvents = lanEvents,
+                    bleEvents = bleEvents,
+                    bluetoothEvents = bluetoothEvents,
+                )
+            val seen = mutableListOf<NearbyPeerEvent>()
+            val collector =
+                backgroundScope.launch {
+                    discovery.browse().collect { seen += it }
+                }
+            runCurrent()
+
+            bleEvents.emit(
+                BleFastAdvertisementScanner.Observation(
+                    endpointId = "RINE",
+                    endpointInfo = null,
+                    advertiserAddress = "28:1B:3E:BA:B1:1B",
+                    rssi = -41,
+                    l2capPsm = null,
+                    gattConnectable = true,
+                    displayName = "Galaxy S26",
+                    displayNameSource =
+                        BleFastAdvertisementScanner.DisplayNameSource.BLE_LOCAL_NAME,
+                ),
+            )
+            runCurrent()
+
+            val resolved = seen.filterIsInstance<NearbyPeerEvent.Resolved>().last().peer
+            assertThat(resolved.displayName()).isEqualTo("Galaxy S26")
+            assertThat(resolved.displayNameSource()).isEqualTo("ble-local-name")
+            assertThat(resolved.bleAdvertisement?.displayName).isEqualTo("Galaxy S26")
+            assertThat(resolved.preferredRoute()).isEqualTo(
+                NearbyPeerRoute.BleGatt(macAddress = "28:1B:3E:BA:B1:1B"),
+            )
+
+            collector.cancel()
+        }
+
+    @Test
+    fun `BLE GATT advertisement falls back to endpoint id before generic label`() =
+        runTest {
+            val lanEvents = MutableSharedFlow<DiscoveryEvent>()
+            val bleEvents = MutableSharedFlow<BleFastAdvertisementScanner.Observation>()
+            val bluetoothEvents = MutableSharedFlow<BluetoothClassicPeerScanner.Observation>()
+            val discovery =
+                NearbyPeerDiscovery.forTesting(
+                    lanEvents = lanEvents,
+                    bleEvents = bleEvents,
+                    bluetoothEvents = bluetoothEvents,
+                )
+            val seen = mutableListOf<NearbyPeerEvent>()
+            val collector =
+                backgroundScope.launch {
+                    discovery.browse().collect { seen += it }
+                }
+            runCurrent()
+
+            bleEvents.emit(
+                BleFastAdvertisementScanner.Observation(
+                    endpointId = "RINE",
+                    endpointInfo = null,
+                    advertiserAddress = "28:1B:3E:BA:B1:1B",
+                    rssi = -41,
+                    l2capPsm = null,
+                    gattConnectable = true,
+                ),
+            )
+            runCurrent()
+
+            val resolved = seen.filterIsInstance<NearbyPeerEvent.Resolved>().last().peer
+            assertThat(resolved.displayName()).isEqualTo("Quick Share device (RINE)")
+            assertThat(resolved.displayNameSource()).isEqualTo("endpoint-id")
 
             collector.cancel()
         }

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/NearbyPeerDiscoveryTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/NearbyPeerDiscoveryTest.kt
@@ -11,6 +11,7 @@ import io.github.kyujincho.wvmg.discovery.classic.BluetoothClassicPeerScanner
 import io.github.kyujincho.wvmg.protocol.endpoint.DeviceType
 import io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo
 import io.github.kyujincho.wvmg.protocol.medium.Medium
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runCurrent
@@ -18,6 +19,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import java.net.InetAddress
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class NearbyPeerDiscoveryTest {
     @Test
     fun `bluetooth and LAN sightings merge into one LAN-first peer`() =

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleFastAdvertisementScannerTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleFastAdvertisementScannerTest.kt
@@ -40,6 +40,9 @@ class BleFastAdvertisementScannerTest {
         assertThat(observed.rssi).isEqualTo(-47)
         assertThat(observed.l2capPsm).isEqualTo(0x1234)
         assertThat(observed.gattConnectable).isTrue()
+        assertThat(observed.displayName).isEqualTo("Galaxy")
+        assertThat(observed.displayNameSource)
+            .isEqualTo(BleFastAdvertisementScanner.DisplayNameSource.FAST_ADVERTISEMENT_ENDPOINT_INFO)
     }
 
     @Test
@@ -80,6 +83,27 @@ class BleFastAdvertisementScannerTest {
         assertThat(observed.rssi).isEqualTo(-41)
         assertThat(observed.l2capPsm).isNull()
         assertThat(observed.gattConnectable).isTrue()
+        assertThat(observed.displayName).isNull()
+        assertThat(observed.displayNameSource).isNull()
+    }
+
+    @Test
+    fun `GATT advertisement header keeps BLE local name fallback`() {
+        val observed =
+            BleFastAdvertisementScanner.parseFastServiceData(
+                serviceData = "VSAUARACAAADAAo8Vu4sAAA".toByteArray(Charsets.US_ASCII),
+                advertiserAddress = "28:1B:3E:BA:B1:1B",
+                rssi = -41,
+                fallbackDisplayName = " Galaxy S26 ",
+                fallbackDisplayNameSource = BleFastAdvertisementScanner.DisplayNameSource.BLE_LOCAL_NAME,
+            )
+
+        assertThat(observed).isNotNull()
+        assertThat(observed!!.endpointId).isNull()
+        assertThat(observed.endpointInfo).isNull()
+        assertThat(observed.displayName).isEqualTo("Galaxy S26")
+        assertThat(observed.displayNameSource)
+            .isEqualTo(BleFastAdvertisementScanner.DisplayNameSource.BLE_LOCAL_NAME)
     }
 
     @Test
@@ -124,6 +148,9 @@ class BleFastAdvertisementScannerTest {
         assertThat(observed.rssi).isEqualTo(-41)
         assertThat(observed.l2capPsm).isEqualTo(0x00C0)
         assertThat(observed.gattConnectable).isTrue()
+        assertThat(observed.displayName).isEqualTo("Galaxy")
+        assertThat(observed.displayNameSource)
+            .isEqualTo(BleFastAdvertisementScanner.DisplayNameSource.DCT_ADVERTISEMENT)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Thread BLE-derived receiver names through fast advertisement, DCT, GATT slot, and BLE local-name discovery observations.
- Prefer parsed display names before endpoint-id and generic BLE fallback labels in the sender picker.
- Add diagnostics for selected display-name source and regression coverage for BLE GATT fallback ordering.

## Test plan
- ./gradlew :discovery-android:testDebugUnitTest --tests 'io.github.kyujincho.wvmg.discovery.NearbyPeerDiscoveryTest' --tests 'io.github.kyujincho.wvmg.discovery.ble.BleFastAdvertisementScannerTest'
- ./gradlew staticAnalysis :app:testDebugUnitTest :app:assembleDebug
- ./gradlew check :app:assembleDebug

Closes #139