### PR TITLE
feat: allow customizing advertised Quick Share device name

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ lifecycle logic lives in a pure-JVM `ReceiverSession` helper that the
 `Service` only thinly wraps, keeping the start/stop/error-rollback paths
 exhaustively unit-testable without Robolectric.
 
+The launcher also exposes a persisted "Advertised Quick Share name"
+override for the receiver. When unset, WVMG resolves the advertised
+name from Android's device-name chain (`Settings.Global.DEVICE_NAME` on
+API 25+, then the Bluetooth adapter name when it is safely readable,
+then `Build.MODEL`, then the app label) and clamps the final
+`EndpointInfo.deviceName` to 19 UTF-8 bytes to avoid stock Quick Share
+interop regressions with longer names.
+
 ## Toolchain
 
 | Component       | Version |

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/MainActivity.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/MainActivity.kt
@@ -12,6 +12,7 @@ import android.os.Bundle
 import android.util.Log
 import android.view.View
 import android.widget.Button
+import android.widget.EditText
 import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
@@ -25,6 +26,7 @@ import io.github.kyujincho.wvmg.onboarding.PermissionsOnboardingActivity
 import io.github.kyujincho.wvmg.send.SendActivity
 import io.github.kyujincho.wvmg.service.downloads.SaveLocationDisplayName
 import io.github.kyujincho.wvmg.service.downloads.SaveLocationPreferences
+import io.github.kyujincho.wvmg.service.receiver.AdvertisedDeviceNames
 import io.github.kyujincho.wvmg.service.receiver.MdnsVisibilityOverrideHolder
 import io.github.kyujincho.wvmg.service.receiver.ReceiverForegroundService
 
@@ -48,6 +50,9 @@ import io.github.kyujincho.wvmg.service.receiver.ReceiverForegroundService
  *    the BLE-pulse gate. Useful on devices where BLE scan is
  *    unavailable (no permission, no LE hardware) or whenever the user
  *    wants to stay discoverable.
+ *  - Advertised Quick Share name (#141): a small settings block lets
+ *    the user persist a custom receiver name, or fall back to Android's
+ *    device-name chain when no override is set.
  *  - Battery-optimization banner (#47): a one-time, dismissible banner
  *    that detects the OEM family and routes the user to the right
  *    "exempt this app from background killing" Settings page. Hidden
@@ -183,6 +188,19 @@ class MainActivity : AppCompatActivity() {
             SaveLocationPreferences.from(this).clear()
             refreshSaveLocationLabel()
         }
+
+        findViewById<Button>(R.id.main_advertised_name_save).setOnClickListener {
+            val input = findViewById<EditText>(R.id.main_advertised_name_input)
+            val stored = AdvertisedDeviceNames.setCustomName(this, input.text?.toString())
+            input.setText(stored.orEmpty())
+            refreshAdvertisedNameSection()
+            ReceiverForegroundService.start(this)
+        }
+        findViewById<Button>(R.id.main_advertised_name_reset).setOnClickListener {
+            AdvertisedDeviceNames.clearCustomName(this)
+            refreshAdvertisedNameSection()
+            ReceiverForegroundService.start(this)
+        }
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -228,6 +246,7 @@ class MainActivity : AppCompatActivity() {
         // the "Downloads (default)" label when the URI is unset or its
         // grant has been lost.
         refreshSaveLocationLabel()
+        refreshAdvertisedNameSection()
 
         // Bring up the receiver foreground service so the BLE pulse
         // scanner (#33), mDNS-publish gate (#34), and TCP listener are
@@ -330,6 +349,21 @@ class MainActivity : AppCompatActivity() {
                 getString(R.string.main_save_location_default)
             }
         label.text = displayText
+    }
+
+    private fun refreshAdvertisedNameSection() {
+        val input = findViewById<EditText>(R.id.main_advertised_name_input)
+        val custom = AdvertisedDeviceNames.getCustomName(this).orEmpty()
+        if (input.text?.toString() != custom) {
+            input.setText(custom)
+        }
+
+        val current = findViewById<TextView>(R.id.main_advertised_name_current)
+        current.text =
+            getString(
+                R.string.main_advertised_name_current,
+                AdvertisedDeviceNames.resolve(this),
+            )
     }
 
     private fun onBatteryBannerSkipClicked() {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -5,6 +5,7 @@
     The launcher is a thin scaffold (the real device list, transfer
     status, and full settings screens are still tracked elsewhere).
     Today it carries:
+      * #141 advertised Quick Share name setting.
       * #34 always-visible override toggle.
       * #38 folder-send entry point (SAF DocumentTree picker).
       * #47 battery-optimization banner — one-time, OEM-aware prompt
@@ -136,6 +137,63 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="8dp"
                 android:text="@string/main_save_location_clear" />
+
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/main_advertised_name_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:text="@string/main_advertised_name_title"
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/main_advertised_name_subtitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:text="@string/main_advertised_name_subtitle"
+            android:textAppearance="?android:attr/textAppearanceSmall" />
+
+        <EditText
+            android:id="@+id/main_advertised_name_input"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:hint="@string/main_advertised_name_hint"
+            android:inputType="textCapWords"
+            android:maxLines="1" />
+
+        <TextView
+            android:id="@+id/main_advertised_name_current"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            android:textStyle="italic" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:orientation="horizontal">
+
+            <Button
+                android:id="@+id/main_advertised_name_save"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/main_advertised_name_save" />
+
+            <Button
+                android:id="@+id/main_advertised_name_reset"
+                style="?android:attr/borderlessButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:text="@string/main_advertised_name_reset" />
 
         </LinearLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,6 +20,17 @@
     <string name="main_save_location_clear">Reset to Downloads</string>
     <string name="main_save_location_pick_failed">Could not save that folder. Please pick a different location.</string>
 
+    <!-- Advertised Quick Share device name (#141). The receiver uses
+         this custom name when set; otherwise it falls back to Android's
+         device-name chain (system device name, Bluetooth name, model,
+         then app label). -->
+    <string name="main_advertised_name_title">Advertised Quick Share name</string>
+    <string name="main_advertised_name_subtitle">Nearby Quick Share peers see this name when they discover this device. Leave it empty to use the Android device name fallback chain. WVMG trims the final name to 19 UTF-8 bytes to avoid interop issues with longer advertisements.</string>
+    <string name="main_advertised_name_hint">Device name</string>
+    <string name="main_advertised_name_current">Currently advertised: %1$s</string>
+    <string name="main_advertised_name_save">Save name</string>
+    <string name="main_advertised_name_reset">Use device default</string>
+
     <!-- Folder-send entry point (#38). Android's share sheet only routes
          individual files; to ship a directory tree (preserving the
          layout via Quick Share's `parent_folder` field) we surface a

--- a/docs/testing/interop-stock-quick-share-android.md
+++ b/docs/testing/interop-stock-quick-share-android.md
@@ -71,6 +71,17 @@ Two network topologies matter now:
       strictly require synced clocks, but mDNS lease behavior is easier
       to reason about when wall clocks agree).
 
+### Receiver name under test
+
+- [ ] Record which receiver-name mode WVMG is using for this run:
+      **custom advertised name** from the launcher settings, or the
+      **default fallback chain** (`Settings.Global.DEVICE_NAME` on
+      API 25+, then Bluetooth adapter name when safely readable, then
+      `Build.MODEL`, then the app label).
+- [ ] If you are exercising the custom-name path, keep the configured
+      value within WVMG's documented 19-byte UTF-8 budget and note the
+      exact string in the test log.
+
 ### Quick Share visibility on the stock peer
 
 Set the stock peer's Quick Share visibility to one of these states for
@@ -239,6 +250,9 @@ discovery/bootstrap failures from later protocol failures.
       name appears**. The name comes from the packed `EndpointInfo`
       (see preconditions). If the device does **not** appear within
       ~15 seconds, see the troubleshooting section below.
+- [ ] Verify the displayed name matches the selected receiver-name mode:
+      the launcher's custom advertised name when one is set, otherwise
+      the resolved Android default name for the WVMG device.
 - [ ] Pick the WVMG device.
 - [ ] On the **WVMG device**: a consent notification appears (handled
       by
@@ -334,8 +348,10 @@ UX. If a test step fails, walk this list before assuming a WVMG bug.
   If you change WVMG's display name, restart Quick Share on the peer
   before re-checking.
 - Quick Share is **picky about EndpointInfo length**. Names longer
-  than ~63 UTF-8 bytes get truncated by some peers. Keep the WVMG
-  device name short during interop.
+  than WVMG's 19-byte UTF-8 receiver-name budget are now clamped before
+  advertisement. BLE DCT secondary hints may truncate even further to a
+  shorter prefix, so keep test names short and compare against the
+  canonical mDNS / share-sheet label.
 - Some peers close the connection if the consent dialog isn't
   responded to within ~30 seconds. Don't let the WVMG device's screen
   lock during the consent step.

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/AdvertisedDeviceNamePreferences.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/AdvertisedDeviceNamePreferences.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.service.receiver
+
+import android.content.Context
+import android.content.SharedPreferences
+
+/**
+ * Persistent store for the receiver's user-configured advertised device name.
+ *
+ * The surface is intentionally tiny: a single optional string backed by
+ * [SharedPreferences]. The rest of the stack treats `null` as "use the
+ * platform-derived default name" and never has to know how the value is stored.
+ */
+public class AdvertisedDeviceNamePreferences internal constructor(
+    private val prefs: SharedPreferences,
+) {
+    /** Returns the stored custom name, or `null` when the user wants the default resolution path. */
+    public fun getCustomName(): String? =
+        AdvertisedDeviceNameSanitizer.sanitize(
+            prefs.getString(KEY_CUSTOM_NAME, null),
+        )
+
+    /**
+     * Persist [rawName] as the custom advertised name.
+     *
+     * Blank / invalid input is treated as unset and clears the preference.
+     * Returns the canonical stored value after trimming + UTF-8-safe truncation,
+     * or `null` when the preference was cleared.
+     */
+    public fun setCustomName(rawName: String?): String? {
+        val sanitized = AdvertisedDeviceNameSanitizer.sanitize(rawName)
+        prefs
+            .edit()
+            .apply {
+                if (sanitized == null) {
+                    remove(KEY_CUSTOM_NAME)
+                } else {
+                    putString(KEY_CUSTOM_NAME, sanitized)
+                }
+            }.apply()
+        return sanitized
+    }
+
+    /** Clear the custom-name override so default resolution is used again. */
+    public fun clearCustomName() {
+        prefs.edit().remove(KEY_CUSTOM_NAME).apply()
+    }
+
+    public companion object {
+        /** Dedicated preferences file for the advertised-name setting. */
+        public const val PREFS_NAME: String = "wvmg.advertised_device_name"
+
+        internal const val KEY_CUSTOM_NAME: String = "custom_name"
+
+        @JvmStatic
+        public fun from(context: Context): AdvertisedDeviceNamePreferences =
+            AdvertisedDeviceNamePreferences(
+                context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE),
+            )
+    }
+}

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/AdvertisedDeviceNames.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/AdvertisedDeviceNames.kt
@@ -6,6 +6,7 @@
 package io.github.kyujincho.wvmg.service.receiver
 
 import android.Manifest
+import android.annotation.SuppressLint
 import android.bluetooth.BluetoothManager
 import android.content.Context
 import android.content.pm.PackageManager
@@ -227,7 +228,11 @@ internal class AndroidBluetoothNameGateway(
             Manifest.permission.BLUETOOTH_CONNECT,
         ) == PackageManager.PERMISSION_GRANTED
 
+    @SuppressLint("MissingPermission")
     override fun read(): String? =
+        // The policy calls this only after checking BLUETOOTH_CONNECT on
+        // Android 12+, and wraps the read so a late permission revocation
+        // falls through to the next name candidate instead of crashing.
         context
             .getSystemService(BluetoothManager::class.java)
             ?.adapter

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/AdvertisedDeviceNames.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/AdvertisedDeviceNames.kt
@@ -91,13 +91,15 @@ internal class AndroidAdvertisedDeviceNamePolicy(
     private val appLabel: () -> String?,
 ) {
     fun resolve(): String =
-        AdvertisedDeviceNameResolver(
-            customName = preferences.getCustomName(),
-            systemDeviceName = readSystemDeviceName(),
-            bluetoothName = readBluetoothName(),
-            modelName = modelName(),
-            appLabel = appLabel(),
-        ).resolve()
+        sequenceOf<() -> String?>(
+            { preferences.getCustomName() },
+            { AdvertisedDeviceNameSanitizer.sanitize(readSystemDeviceName()) },
+            { AdvertisedDeviceNameSanitizer.sanitize(readBluetoothName()) },
+            { AdvertisedDeviceNameSanitizer.sanitize(modelName()) },
+            { AdvertisedDeviceNameSanitizer.sanitize(appLabel()) },
+        ).mapNotNull { reader -> reader() }
+            .firstOrNull()
+            ?: AdvertisedDeviceNames.DEFAULT_DEVICE_NAME
 
     fun createEndpointInfo(previous: EndpointInfo?): EndpointInfo =
         EndpointInfo(

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/AdvertisedDeviceNames.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/AdvertisedDeviceNames.kt
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.service.receiver
+
+import android.Manifest
+import android.bluetooth.BluetoothManager
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import android.provider.Settings
+import androidx.core.content.ContextCompat
+import io.github.kyujincho.wvmg.protocol.endpoint.DeviceType
+import io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo
+import io.github.kyujincho.wvmg.protocol.endpoint.TlvRecord
+import java.nio.charset.StandardCharsets
+import java.security.SecureRandom
+
+/**
+ * Central advertised-name policy for receiver identity surfaces.
+ *
+ * The same resolved name is fed into the receiver's canonical [EndpointInfo],
+ * which in turn drives mDNS, BLE advertisement generation, and any future QR
+ * path that reuses the receiver identity blob.
+ */
+public object AdvertisedDeviceNames {
+    /**
+     * Interop guardrail for the receiver's canonical Quick Share name.
+     *
+     * Keeping the visible [EndpointInfo.deviceName] under 19 UTF-8 bytes avoids
+     * the advertisement-length regressions observed with longer receiver names
+     * on stock Quick Share surfaces. Secondary BLE hints such as DCT may
+     * truncate even further, but every receiver identity path starts from this
+     * shared canonical budget.
+     */
+    public const val MAX_DEVICE_NAME_BYTES: Int = 19
+
+    /** Last-resort label when every platform-derived candidate is blank or unavailable. */
+    public const val DEFAULT_DEVICE_NAME: String = "Quick Share"
+
+    @JvmStatic
+    public fun getCustomName(context: Context): String? = AdvertisedDeviceNamePreferences.from(context).getCustomName()
+
+    @JvmStatic
+    public fun setCustomName(
+        context: Context,
+        rawName: String?,
+    ): String? = AdvertisedDeviceNamePreferences.from(context).setCustomName(rawName)
+
+    @JvmStatic
+    public fun clearCustomName(context: Context) {
+        AdvertisedDeviceNamePreferences.from(context).clearCustomName()
+    }
+
+    /** Resolve the effective advertised name using the documented fallback order. */
+    @JvmStatic
+    public fun resolve(context: Context): String = policy(context).resolve()
+
+    internal fun createEndpointInfo(
+        context: Context,
+        previous: EndpointInfo? = null,
+    ): EndpointInfo = policy(context).createEndpointInfo(previous)
+
+    private fun policy(context: Context): AndroidAdvertisedDeviceNamePolicy {
+        val app = context.applicationContext
+        return AndroidAdvertisedDeviceNamePolicy(
+            preferences = AdvertisedDeviceNamePreferences.from(app),
+            sdkInt = Build.VERSION.SDK_INT,
+            globalDeviceNameReader =
+                GlobalDeviceNameReader {
+                    Settings.Global.getString(app.contentResolver, Settings.Global.DEVICE_NAME)
+                },
+            bluetoothNameGateway = AndroidBluetoothNameGateway(app),
+            modelName = { Build.MODEL },
+            appLabel = {
+                app.applicationInfo.loadLabel(app.packageManager)?.toString()
+            },
+        )
+    }
+}
+
+internal class AndroidAdvertisedDeviceNamePolicy(
+    private val preferences: AdvertisedDeviceNamePreferences,
+    private val sdkInt: Int,
+    private val globalDeviceNameReader: GlobalDeviceNameReader,
+    private val bluetoothNameGateway: BluetoothNameGateway,
+    private val modelName: () -> String?,
+    private val appLabel: () -> String?,
+) {
+    fun resolve(): String =
+        AdvertisedDeviceNameResolver(
+            customName = preferences.getCustomName(),
+            systemDeviceName = readSystemDeviceName(),
+            bluetoothName = readBluetoothName(),
+            modelName = modelName(),
+            appLabel = appLabel(),
+        ).resolve()
+
+    fun createEndpointInfo(previous: EndpointInfo?): EndpointInfo =
+        EndpointInfo(
+            version = previous?.version ?: DEFAULT_ENDPOINT_VERSION,
+            hidden = false,
+            deviceType = previous?.deviceType ?: DeviceType.PHONE,
+            reserved = previous?.reserved ?: false,
+            metadata = previous?.metadata?.copyOf() ?: randomMetadata(),
+            deviceName = resolve(),
+            tlvRecords = previous?.tlvRecords?.deepCopy() ?: emptyList(),
+        )
+
+    private fun readSystemDeviceName(): String? {
+        if (sdkInt < Build.VERSION_CODES.N_MR1) return null
+        return runCatching { globalDeviceNameReader.read() }.getOrNull()
+    }
+
+    private fun readBluetoothName(): String? {
+        if (sdkInt >= Build.VERSION_CODES.S && !bluetoothNameGateway.hasConnectPermission()) {
+            return null
+        }
+        return runCatching { bluetoothNameGateway.read() }.getOrNull()
+    }
+
+    private fun randomMetadata(): ByteArray = ByteArray(EndpointInfo.METADATA_LEN).also { SecureRandom().nextBytes(it) }
+
+    private companion object {
+        const val DEFAULT_ENDPOINT_VERSION: Int = 1
+    }
+}
+
+internal class AdvertisedDeviceNameResolver(
+    private val customName: String?,
+    private val systemDeviceName: String?,
+    private val bluetoothName: String?,
+    private val modelName: String?,
+    private val appLabel: String?,
+) {
+    fun resolve(): String {
+        val candidates =
+            listOf(
+                customName,
+                systemDeviceName,
+                bluetoothName,
+                modelName,
+                appLabel,
+                AdvertisedDeviceNames.DEFAULT_DEVICE_NAME,
+            )
+        for (candidate in candidates) {
+            val sanitized = AdvertisedDeviceNameSanitizer.sanitize(candidate)
+            if (sanitized != null) return sanitized
+        }
+        return AdvertisedDeviceNames.DEFAULT_DEVICE_NAME
+    }
+}
+
+internal object AdvertisedDeviceNameSanitizer {
+    fun sanitize(rawName: String?): String? {
+        val trimmed = rawName?.trim()
+        return if (trimmed.isNullOrEmpty() || !hasValidSurrogates(trimmed)) {
+            null
+        } else {
+            truncateUtf8(trimmed, AdvertisedDeviceNames.MAX_DEVICE_NAME_BYTES)
+                .takeIf { it.isNotEmpty() }
+        }
+    }
+
+    private fun truncateUtf8(
+        value: String,
+        maxBytes: Int,
+    ): String {
+        val out = StringBuilder()
+        var offset = 0
+        var used = 0
+        while (offset < value.length) {
+            val codePoint = value.codePointAt(offset)
+            val next = String(Character.toChars(codePoint))
+            val nextSize = next.toByteArray(StandardCharsets.UTF_8).size
+            if (used + nextSize > maxBytes) break
+            out.append(next)
+            used += nextSize
+            offset += Character.charCount(codePoint)
+        }
+        return out.toString()
+    }
+
+    private fun hasValidSurrogates(value: String): Boolean {
+        var index = 0
+        var valid = true
+        while (index < value.length) {
+            val ch = value[index]
+            when {
+                ch.isHighSurrogate() -> {
+                    valid = index + 1 < value.length && value[index + 1].isLowSurrogate()
+                    if (valid) {
+                        index += 2
+                    } else {
+                        index = value.length
+                    }
+                }
+                ch.isLowSurrogate() -> {
+                    valid = false
+                    index = value.length
+                }
+                else -> index += 1
+            }
+        }
+        return valid
+    }
+}
+
+internal fun interface GlobalDeviceNameReader {
+    fun read(): String?
+}
+
+internal interface BluetoothNameGateway {
+    fun hasConnectPermission(): Boolean
+
+    fun read(): String?
+}
+
+internal class AndroidBluetoothNameGateway(
+    private val context: Context,
+) : BluetoothNameGateway {
+    override fun hasConnectPermission(): Boolean =
+        ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.BLUETOOTH_CONNECT,
+        ) == PackageManager.PERMISSION_GRANTED
+
+    override fun read(): String? =
+        context
+            .getSystemService(BluetoothManager::class.java)
+            ?.adapter
+            ?.name
+}
+
+private fun List<TlvRecord>.deepCopy(): List<TlvRecord> =
+    map { record -> TlvRecord(record.type, record.value.copyOf()) }

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
@@ -154,6 +154,9 @@ public class ReceiverForegroundService : Service() {
     @Volatile
     private var mdnsGate: MdnsAdvertisementGate? = null
 
+    @Volatile
+    private var discoveryDiagnosticsJob: Job? = null
+
     /**
      * Observer attached to [ProcessLifecycleOwner] that switches the
      * BLE scan mode based on whether the user has the app foregrounded.
@@ -219,9 +222,15 @@ public class ReceiverForegroundService : Service() {
             },
         )
 
+        // Reconcile the receiver identity on every start request so a
+        // newly-saved advertised name takes effect without waiting for
+        // a full process restart. If the identity changed while the
+        // session was already running, we tear the active receiver
+        // stack down and bring it back up with the new EndpointInfo.
+        reconcileReceiverIdentityIfNeeded()
+
         // Bring up the receiver session if it isn't already running.
-        // Multiple startService calls are idempotent — the second one
-        // just keeps the existing session alive.
+        // Multiple startService calls are otherwise idempotent.
         if (session == null) {
             startBleScanner()
             startReceiverSession()
@@ -402,6 +411,32 @@ public class ReceiverForegroundService : Service() {
     }
 
     /**
+     * Refresh the canonical receiver [EndpointInfo] from the current
+     * advertised-name setting and platform defaults.
+     *
+     * The receiver keeps its metadata blob stable across refreshes so
+     * peers still see the same logical device, but a changed device
+     * name requires a new endpoint id and a restarted advertise stack.
+     */
+    private fun reconcileReceiverIdentityIfNeeded() {
+        val current = EndpointIdentityHolder.snapshot.get()
+        val refreshed = AdvertisedDeviceNames.createEndpointInfo(applicationContext, current)
+        if (current == refreshed) return
+
+        val shouldRestartSession = session != null
+        if (shouldRestartSession) {
+            stopActiveReceiverSession()
+        }
+        if (current?.deviceName != refreshed.deviceName) {
+            BleEndpointIdHolder.clear()
+        }
+        EndpointIdentityHolder.snapshot.set(refreshed)
+        if (shouldRestartSession) {
+            startReceiverSession()
+        }
+    }
+
+    /**
      * Construct and launch the [MdnsAdvertisementGate] that drives
      * [ReceiverSession.publishAdvertisement] / `unpublishAdvertisement`
      * from BLE pulse activity (#34). Called after [ReceiverSession.start]
@@ -488,24 +523,26 @@ public class ReceiverForegroundService : Service() {
      * factory) the loop simply skips logging and idles.
      */
     private fun startDiscoveryDiagnosticsLogger() {
-        serviceScope.launch {
-            while (isActive) {
-                val discovery = ActiveDiscoveryHolder.current()
-                if (discovery != null) {
-                    val snap = discovery.snapshot()
-                    Log.i(
-                        DIAGNOSTICS_TAG,
-                        "discovery snapshot: " +
-                            "advertising=${snap.advertising} browsing=${snap.browsing} " +
-                            "lockHeld=${snap.multicastLockHeld} " +
-                            "advBound=${snap.advertiseBoundAddress?.hostAddress ?: "-"} " +
-                            "browseBound=${snap.browseBoundAddress?.hostAddress ?: "-"} " +
-                            "events=${snap.recentEvents.size}",
-                    )
+        if (discoveryDiagnosticsJob != null) return
+        discoveryDiagnosticsJob =
+            serviceScope.launch {
+                while (isActive) {
+                    val discovery = ActiveDiscoveryHolder.current()
+                    if (discovery != null) {
+                        val snap = discovery.snapshot()
+                        Log.i(
+                            DIAGNOSTICS_TAG,
+                            "discovery snapshot: " +
+                                "advertising=${snap.advertising} browsing=${snap.browsing} " +
+                                "lockHeld=${snap.multicastLockHeld} " +
+                                "advBound=${snap.advertiseBoundAddress?.hostAddress ?: "-"} " +
+                                "browseBound=${snap.browseBoundAddress?.hostAddress ?: "-"} " +
+                                "events=${snap.recentEvents.size}",
+                        )
+                    }
+                    delay(DIAGNOSTICS_LOG_INTERVAL_MS)
                 }
-                delay(DIAGNOSTICS_LOG_INTERVAL_MS)
             }
-        }
     }
 
     private fun startInboundDiagnosticsLogger(session: ReceiverSession) {
@@ -674,7 +711,7 @@ public class ReceiverForegroundService : Service() {
         consentReceiver = null
     }
 
-    private fun stopReceiverAndExit() {
+    private fun stopActiveReceiverSession() {
         consentCoordinator?.stop()
         consentCoordinator = null
         progressCoordinator?.stop()
@@ -696,7 +733,6 @@ public class ReceiverForegroundService : Service() {
             TransferCancelRegistry.instance.unregister(id)
             TransferProgressNotification.dismiss(ctx, id)
         }
-        unregisterConsentReceiverIfNeeded()
 
         // Stop the gate before the session so its delayed unpublish
         // coroutine can no longer fire after `session.stop()` has
@@ -707,6 +743,18 @@ public class ReceiverForegroundService : Service() {
         session?.stop()
         session = null
         ActiveDiscoveryHolder.clear()
+        discoveryDiagnosticsJob?.cancel()
+        discoveryDiagnosticsJob = null
+
+        // Stop the receiver-side BLE pulse advertiser after the mDNS
+        // gate and session are down so a stale registration never
+        // outlives the old identity while a new session is starting.
+        bleAdvertiser?.stop()
+    }
+
+    private fun stopReceiverAndExit() {
+        stopActiveReceiverSession()
+        unregisterConsentReceiverIfNeeded()
 
         // Detach the ProcessLifecycleOwner observer first — once the
         // scanner is stopped, any late foreground/background callback
@@ -726,13 +774,6 @@ public class ReceiverForegroundService : Service() {
         bleScanner?.stop()
         bleScanner = null
         ActiveBleScannerHolder.clear()
-
-        // Tear the receiver-side BLE pulse advertiser down (#121). The
-        // gate's stop above already issued a final `stop()` on the
-        // broadcaster as part of its outbound-veto / debounce path,
-        // but we re-stop unconditionally here in case the gate teardown
-        // raced with a fresh "should publish" decision.
-        bleAdvertiser?.stop()
         bleAdvertiser = null
 
         serviceJob.cancel()
@@ -810,8 +851,11 @@ public class ReceiverForegroundService : Service() {
          */
         private val defaultSessionFactory: SessionFactory =
             SessionFactory { context ->
-                val identity = EndpointIdentityHolder.snapshot.get() ?: defaultEndpointInfo(context)
-                EndpointIdentityHolder.snapshot.compareAndSet(null, identity)
+                val identity =
+                    EndpointIdentityHolder.snapshot.get()
+                        ?: AdvertisedDeviceNames.createEndpointInfo(context).also {
+                            EndpointIdentityHolder.snapshot.compareAndSet(null, it)
+                        }
                 // Keep one Discovery per session so the periodic
                 // diagnostic snapshot in [startReceiverSession] reflects
                 // the same instance the advertise lambda is using.
@@ -881,55 +925,6 @@ public class ReceiverForegroundService : Service() {
             context.startService(intent)
         }
 
-        /**
-         * Build the default [EndpointInfo] for this device.
-         *
-         * **Visibility bit = 0 (visible) + inline UTF-8 device name.**
-         * This is the canonical "Everyone" shape that stock Samsung
-         * Quick Share's send sheet renders.
-         *
-         * History: an earlier commit (`c0150be`) flipped this to
-         * `hidden=true, deviceName=null` based on observing a Galaxy
-         * peer's BLE service-data byte (`0x32`) and assuming the same
-         * shape applied to the mDNS `n=` TXT payload. That assumption
-         * was wrong — the BLE pulse and the mDNS TXT carry independent
-         * advertisements with different framing, and `hidden=true` puts
-         * us in **Contacts-only** mode at the mDNS layer. Samsung's
-         * picker then tries to match our 16 random metadata bytes
-         * against its cached contact certificates, fails silently, and
-         * filters us out of the share sheet. Reverting to `hidden=false`
-         * with an inline name restored visibility against a Galaxy S26
-         * sender on One UI 8.x.
-         *
-         * Random salt + encrypted-metadata-key bytes are
-         * indistinguishable to peers from real GMS-issued ones for the
-         * GMS-free use case targeted by this project.
-         *
-         * Receiver-side BLE pulse advertising (the planned follow-up to
-         * `c0150be`) would let us also broadcast the friendly name
-         * through the BLE channel and stay compatible if Samsung's
-         * picker ever tightens its mDNS-acceptance rules; that work is
-         * tracked separately.
-         */
-        private fun defaultEndpointInfo(context: Context): EndpointInfo {
-            val applicationLabel =
-                context.applicationInfo
-                    .loadLabel(context.packageManager)
-                    .toString()
-                    .ifBlank { DEFAULT_DEVICE_NAME }
-                    .take(MAX_DEFAULT_NAME_BYTES)
-            return EndpointInfo(
-                version = 1,
-                hidden = false,
-                deviceType =
-                    io.github.kyujincho.wvmg.protocol.endpoint.DeviceType.PHONE,
-                reserved = false,
-                metadata = ByteArray(EndpointInfo.METADATA_LEN).also { java.security.SecureRandom().nextBytes(it) },
-                deviceName = applicationLabel,
-                tlvRecords = emptyList(),
-            )
-        }
-
         private fun logInboundDiagnostic(
             context: Context,
             line: String,
@@ -941,13 +936,6 @@ public class ReceiverForegroundService : Service() {
                 file.appendText("${System.currentTimeMillis()} $line\n")
             }
         }
-
-        private const val DEFAULT_DEVICE_NAME = "Quick Share"
-
-        // 64 bytes leaves comfortable headroom under the 255-byte
-        // single-byte length limit and is more than enough for typical
-        // app-label names ("Quick Share" is 11).
-        private const val MAX_DEFAULT_NAME_BYTES = 64
 
         /**
          * Cadence for the discovery diagnostics logger spawned in
@@ -1213,6 +1201,10 @@ internal object BleEndpointIdHolder {
         return ByteArray(BleServiceData.ENDPOINT_ID_LEN) {
             alphabet[random.nextInt(alphabet.length)].code.toByte()
         }
+    }
+
+    fun clear() {
+        cached.set(null)
     }
 }
 

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
@@ -225,8 +225,8 @@ public class ReceiverForegroundService : Service() {
         // Reconcile the receiver identity on every start request so a
         // newly-saved advertised name takes effect without waiting for
         // a full process restart. If the identity changed while the
-        // session was already running, we tear the active receiver
-        // stack down and bring it back up with the new EndpointInfo.
+        // session was already running, refresh only the advertise
+        // surfaces in place so active inbound transfers survive.
         reconcileReceiverIdentityIfNeeded()
 
         // Bring up the receiver session if it isn't already running.
@@ -416,23 +416,23 @@ public class ReceiverForegroundService : Service() {
      *
      * The receiver keeps its metadata blob stable across refreshes so
      * peers still see the same logical device, but a changed device
-     * name requires a new endpoint id and a restarted advertise stack.
+     * name requires a new endpoint id and refreshed advertise surfaces.
      */
     private fun reconcileReceiverIdentityIfNeeded() {
         val current = EndpointIdentityHolder.snapshot.get()
         val refreshed = AdvertisedDeviceNames.createEndpointInfo(applicationContext, current)
         if (current == refreshed) return
 
-        val shouldRestartSession = session != null
-        if (shouldRestartSession) {
-            stopActiveReceiverSession()
-        }
         if (current?.deviceName != refreshed.deviceName) {
             BleEndpointIdHolder.clear()
         }
         EndpointIdentityHolder.snapshot.set(refreshed)
-        if (shouldRestartSession) {
-            startReceiverSession()
+        val activeSession = session
+        if (activeSession != null) {
+            activeSession.replaceEndpointInfo(refreshed)
+            if (activeSession.isAdvertising) {
+                buildBleBroadcaster().start()
+            }
         }
     }
 
@@ -466,7 +466,7 @@ public class ReceiverForegroundService : Service() {
                 alwaysVisibleOverride = MdnsVisibilityOverrideHolder.activeFlow,
                 qrSessionActive = QrSessionActiveHolder.activeFlow,
                 outboundSessionActive = OutboundSessionActiveHolder.activeFlow,
-                bleBroadcaster = buildBleBroadcaster(activeSession),
+                bleBroadcaster = buildBleBroadcaster(),
             )
         gate.start(serviceScope)
         mdnsGate = gate
@@ -493,14 +493,14 @@ public class ReceiverForegroundService : Service() {
      * never-active BLE pulse: mDNS still publishes/unpublishes per the
      * other gating signals.
      */
-    @Suppress("UNUSED_PARAMETER", "ReturnCount")
-    private fun buildBleBroadcaster(session: ReceiverSession): BleVisibilityBroadcaster {
+    @Suppress("ReturnCount")
+    private fun buildBleBroadcaster(): BleVisibilityBroadcaster {
         val advertiser = bleAdvertiser ?: return BleVisibilityBroadcaster.Noop
-        val endpointInfo =
-            EndpointIdentityHolder.snapshot.get() ?: return BleVisibilityBroadcaster.Noop
-        val endpointId = BleEndpointIdHolder.bytesFor(endpointInfo)
         return object : BleVisibilityBroadcaster {
             override fun start(): Boolean {
+                val endpointInfo =
+                    EndpointIdentityHolder.snapshot.get() ?: return false
+                val endpointId = BleEndpointIdHolder.bytesFor(endpointInfo)
                 // BleQuickShareAdvertiser.start re-uses the existing
                 // platform registration when the identity is unchanged,
                 // so re-issuing start() while already advertising is
@@ -856,13 +856,14 @@ public class ReceiverForegroundService : Service() {
                         ?: AdvertisedDeviceNames.createEndpointInfo(context).also {
                             EndpointIdentityHolder.snapshot.compareAndSet(null, it)
                         }
+                val currentIdentity = { EndpointIdentityHolder.snapshot.get() ?: identity }
                 // Keep one Discovery per session so the periodic
                 // diagnostic snapshot in [startReceiverSession] reflects
                 // the same instance the advertise lambda is using.
                 val discovery =
                     Discovery(
                         context = context,
-                        instanceEndpointIdProvider = { BleEndpointIdHolder.bytesFor(identity) },
+                        instanceEndpointIdProvider = { BleEndpointIdHolder.bytesFor(currentIdentity()) },
                     )
                 ActiveDiscoveryHolder.set(discovery)
                 ReceiverSession(
@@ -884,7 +885,7 @@ public class ReceiverForegroundService : Service() {
                             ),
                             BleGattInitialControlServer(
                                 context = context.applicationContext,
-                                endpointIdProvider = { BleEndpointIdHolder.bytesFor(identity) },
+                                endpointIdProvider = { BleEndpointIdHolder.bytesFor(currentIdentity()) },
                             ),
                         ),
                     // Issue #34: defer mDNS publish to the

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
@@ -423,15 +423,33 @@ public class ReceiverForegroundService : Service() {
         val refreshed = AdvertisedDeviceNames.createEndpointInfo(applicationContext, current)
         if (current == refreshed) return
 
-        if (current?.deviceName != refreshed.deviceName) {
-            BleEndpointIdHolder.clear()
-        }
-        EndpointIdentityHolder.snapshot.set(refreshed)
         val activeSession = session
-        if (activeSession != null) {
-            activeSession.replaceEndpointInfo(refreshed)
-            if (activeSession.isAdvertising) {
-                buildBleBroadcaster().start()
+        val nameChanged = current?.deviceName != refreshed.deviceName
+        if (activeSession == null) {
+            if (nameChanged) {
+                BleEndpointIdHolder.clear()
+            }
+            EndpointIdentityHolder.snapshot.set(refreshed)
+        } else {
+            if (nameChanged) {
+                BleEndpointIdHolder.clear()
+            }
+            EndpointIdentityHolder.snapshot.set(refreshed)
+            val wasAdvertising = activeSession.isAdvertising
+            val applied = activeSession.replaceEndpointInfo(refreshed)
+            if (applied) {
+                if (activeSession.isAdvertising) {
+                    buildBleBroadcaster().start()
+                }
+            } else if (current != null) {
+                if (nameChanged) {
+                    BleEndpointIdHolder.clear()
+                }
+                EndpointIdentityHolder.snapshot.set(current)
+                activeSession.replaceEndpointInfo(current)
+                if (wasAdvertising) {
+                    runCatching { activeSession.publishAdvertisement() }
+                }
             }
         }
     }

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverSession.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverSession.kt
@@ -89,10 +89,11 @@ import java.util.concurrent.atomic.AtomicBoolean
  *   factory. Production wires `DownloadsWriterFactory.create(context)`
  *   (which yields a fresh `MediaStoreDownloadsFactory` each time); tests
  *   inject a no-op or in-memory provider.
- * @property endpointInfo The receiver's identity. Stable for a service
- *   instance (random-generated on first start, persisted by the caller).
- *   Embedded in the mDNS TXT record so peers can render the device
- *   name and salt+key without a separate request.
+ * @property endpointInfo The receiver's identity. The caller seeds it on
+ *   construction and may replace it later via [replaceEndpointInfo] so the
+ *   advertised device name can change without tearing down the TCP listener or
+ *   aborting in-flight receives. Embedded in the mDNS TXT record so peers can
+ *   render the device name and salt+key without a separate request.
  * @property secureRandomProvider Supplies a fresh [SecureRandom] per
  *   accepted connection (UKEY2 keypairs / SecureMessage IVs). Tests
  *   inject a deterministic stub.
@@ -113,7 +114,7 @@ public class ReceiverSession(
     private val tcpServerFactory: TcpServerFactory,
     private val advertiser: DiscoveryAdvertiser,
     private val factoryProvider: () -> FileDestinationFactory,
-    private val endpointInfo: EndpointInfo,
+    private var endpointInfo: EndpointInfo,
     private val secureRandomProvider: () -> SecureRandom = { SecureRandom() },
     private val mediumRegistry: MediumRegistry = MediumRegistry.DefaultWifiLan,
     private val advertiseGated: Boolean = false,
@@ -331,6 +332,30 @@ public class ReceiverSession(
             advertiseHandle = null
             stopInitialControlServersLocked()
             ReceiverAdvertisementStateHolder.setAdvertising(false)
+        }
+    }
+
+    /**
+     * Swap the identity used by future advertisement publishes.
+     *
+     * If an advertisement or initial-control server is already active, this
+     * method republishes them in place against the existing bound TCP listener
+     * so active inbound connections keep running under the same session.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    internal fun replaceEndpointInfo(endpointInfo: EndpointInfo) {
+        synchronized(advertiseLock) {
+            this.endpointInfo = endpointInfo
+
+            val tcpServer = server ?: return
+            val wasPublished = advertiseHandle != null || initialControlServers.any { it.isActive }
+            if (!wasPublished || stopped.get()) return
+
+            runCatching { advertiseHandle?.close() }
+            advertiseHandle = null
+            stopInitialControlServersLocked()
+            ReceiverAdvertisementStateHolder.setAdvertising(false)
+            publishAdvertisementLocked(tcpServer, tcpServer.boundPort)
         }
     }
 

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverSession.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverSession.kt
@@ -343,21 +343,27 @@ public class ReceiverSession(
      * so active inbound connections keep running under the same session.
      */
     @Suppress("TooGenericExceptionCaught")
-    internal fun replaceEndpointInfo(endpointInfo: EndpointInfo) {
+    internal fun replaceEndpointInfo(endpointInfo: EndpointInfo): Boolean =
         synchronized(advertiseLock) {
             this.endpointInfo = endpointInfo
 
-            val tcpServer = server ?: return
+            val tcpServer = server
             val wasPublished = advertiseHandle != null || initialControlServers.any { it.isActive }
-            if (!wasPublished || stopped.get()) return
-
-            runCatching { advertiseHandle?.close() }
-            advertiseHandle = null
-            stopInitialControlServersLocked()
-            ReceiverAdvertisementStateHolder.setAdvertising(false)
-            publishAdvertisementLocked(tcpServer, tcpServer.boundPort)
+            if (tcpServer == null || !wasPublished || stopped.get()) {
+                true
+            } else {
+                runCatching { advertiseHandle?.close() }
+                advertiseHandle = null
+                stopInitialControlServersLocked()
+                ReceiverAdvertisementStateHolder.setAdvertising(false)
+                runCatching {
+                    publishAdvertisementLocked(tcpServer, tcpServer.boundPort)
+                    true
+                }.getOrElse {
+                    false
+                }
+            }
         }
-    }
 
     private val advertiseLock: Any = Any()
 

--- a/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/AdvertisedDeviceNamePreferencesTest.kt
+++ b/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/AdvertisedDeviceNamePreferencesTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.service.receiver
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import java.nio.charset.StandardCharsets
+
+class AdvertisedDeviceNamePreferencesTest {
+    @Test
+    fun `setCustomName persists the canonical trimmed value`() {
+        val prefs = FakeSharedPreferences()
+        val sut = AdvertisedDeviceNamePreferences(prefs)
+
+        val stored = sut.setCustomName("  Pixel 9 Pro  ")
+
+        assertThat(stored).isEqualTo("Pixel 9 Pro")
+        assertThat(prefs.values[AdvertisedDeviceNamePreferences.KEY_CUSTOM_NAME]).isEqualTo("Pixel 9 Pro")
+        assertThat(AdvertisedDeviceNamePreferences(prefs).getCustomName()).isEqualTo("Pixel 9 Pro")
+    }
+
+    @Test
+    fun `blank custom name is treated as unset`() {
+        val prefs = FakeSharedPreferences()
+        val sut = AdvertisedDeviceNamePreferences(prefs)
+
+        val stored = sut.setCustomName("   ")
+
+        assertThat(stored).isNull()
+        assertThat(prefs.values).doesNotContainKey(AdvertisedDeviceNamePreferences.KEY_CUSTOM_NAME)
+        assertThat(sut.getCustomName()).isNull()
+    }
+
+    @Test
+    fun `setCustomName truncates on a UTF-8 code point boundary`() {
+        val prefs = FakeSharedPreferences()
+        val sut = AdvertisedDeviceNamePreferences(prefs)
+
+        val stored = sut.setCustomName("abcdefghijklmno😀x")
+
+        assertThat(stored).isEqualTo("abcdefghijklmno😀")
+        assertThat(stored!!.toByteArray(StandardCharsets.UTF_8).size)
+            .isEqualTo(AdvertisedDeviceNames.MAX_DEVICE_NAME_BYTES)
+    }
+}

--- a/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/AdvertisedDeviceNamesTest.kt
+++ b/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/AdvertisedDeviceNamesTest.kt
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.service.receiver
+
+import com.google.common.truth.Truth.assertThat
+import io.github.kyujincho.wvmg.protocol.endpoint.DeviceType
+import io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo
+import io.github.kyujincho.wvmg.protocol.endpoint.TlvRecord
+import org.junit.jupiter.api.Test
+import java.nio.charset.StandardCharsets
+
+class AdvertisedDeviceNamesTest {
+    @Test
+    fun `resolver prefers the documented fallback order`() {
+        val resolved =
+            AdvertisedDeviceNameResolver(
+                customName = null,
+                systemDeviceName = "  Pixel 9 Pro  ",
+                bluetoothName = "Bluetooth Name",
+                modelName = "Model Name",
+                appLabel = "WhenVivoMeetsGoogle",
+            ).resolve()
+
+        assertThat(resolved).isEqualTo("Pixel 9 Pro")
+    }
+
+    @Test
+    fun `resolver skips blank candidates and falls through to later sources`() {
+        val resolved =
+            AdvertisedDeviceNameResolver(
+                customName = " ",
+                systemDeviceName = "\n\t",
+                bluetoothName = null,
+                modelName = "Galaxy S25",
+                appLabel = "WhenVivoMeetsGoogle",
+            ).resolve()
+
+        assertThat(resolved).isEqualTo("Galaxy S25")
+    }
+
+    @Test
+    fun `policy does not query Settings Global below API 25`() {
+        val prefs = AdvertisedDeviceNamePreferences(FakeSharedPreferences())
+        var systemReads = 0
+        val bluetooth = FakeBluetoothNameGateway(readValue = "Nearby BT")
+        val policy =
+            AndroidAdvertisedDeviceNamePolicy(
+                preferences = prefs,
+                sdkInt = 24,
+                globalDeviceNameReader =
+                    GlobalDeviceNameReader {
+                        systemReads += 1
+                        "Pixel System"
+                    },
+                bluetoothNameGateway = bluetooth,
+                modelName = { "Pixel Model" },
+                appLabel = { "WhenVivoMeetsGoogle" },
+            )
+
+        val resolved = policy.resolve()
+
+        assertThat(resolved).isEqualTo("Nearby BT")
+        assertThat(systemReads).isEqualTo(0)
+    }
+
+    @Test
+    fun `policy skips bluetooth fallback on Android 12 plus without connect permission`() {
+        val prefs = AdvertisedDeviceNamePreferences(FakeSharedPreferences())
+        val bluetooth = FakeBluetoothNameGateway(hasConnectPermission = false, readValue = "Nearby BT")
+        val policy =
+            AndroidAdvertisedDeviceNamePolicy(
+                preferences = prefs,
+                sdkInt = 31,
+                globalDeviceNameReader = GlobalDeviceNameReader { null },
+                bluetoothNameGateway = bluetooth,
+                modelName = { "Pixel Fold" },
+                appLabel = { "WhenVivoMeetsGoogle" },
+            )
+
+        val resolved = policy.resolve()
+
+        assertThat(resolved).isEqualTo("Pixel Fold")
+        assertThat(bluetooth.readCalls).isEqualTo(0)
+    }
+
+    @Test
+    fun `policy swallows bluetooth lookup failures and falls back safely`() {
+        val prefs = AdvertisedDeviceNamePreferences(FakeSharedPreferences())
+        val bluetooth = FakeBluetoothNameGateway(throwOnRead = SecurityException("denied"))
+        val policy =
+            AndroidAdvertisedDeviceNamePolicy(
+                preferences = prefs,
+                sdkInt = 31,
+                globalDeviceNameReader = GlobalDeviceNameReader { null },
+                bluetoothNameGateway = bluetooth,
+                modelName = { "Pixel Tablet" },
+                appLabel = { "WhenVivoMeetsGoogle" },
+            )
+
+        val resolved = policy.resolve()
+
+        assertThat(resolved).isEqualTo("Pixel Tablet")
+        assertThat(bluetooth.readCalls).isEqualTo(1)
+    }
+
+    @Test
+    fun `policy builds a visible EndpointInfo while preserving stable metadata and tlvs`() {
+        val prefs =
+            AdvertisedDeviceNamePreferences(FakeSharedPreferences()).apply {
+                setCustomName("abcdefghijklmno😀x")
+            }
+        val previous =
+            EndpointInfo(
+                version = 1,
+                hidden = false,
+                deviceType = DeviceType.PHONE,
+                reserved = false,
+                metadata = ByteArray(EndpointInfo.METADATA_LEN) { index -> index.toByte() },
+                deviceName = "Old Name",
+                tlvRecords = listOf(TlvRecord(EndpointInfo.TLV_TYPE_VENDOR_ID, byteArrayOf(0x01))),
+            )
+        val policy =
+            AndroidAdvertisedDeviceNamePolicy(
+                preferences = prefs,
+                sdkInt = 36,
+                globalDeviceNameReader = GlobalDeviceNameReader { "System Name" },
+                bluetoothNameGateway = FakeBluetoothNameGateway(readValue = "Nearby BT"),
+                modelName = { "Pixel Model" },
+                appLabel = { "WhenVivoMeetsGoogle" },
+            )
+
+        val endpointInfo = policy.createEndpointInfo(previous)
+
+        assertThat(endpointInfo.hidden).isFalse()
+        assertThat(endpointInfo.deviceName).isEqualTo("abcdefghijklmno😀")
+        assertThat(endpointInfo.metadata).isEqualTo(previous.metadata)
+        assertThat(endpointInfo.tlvRecords).isEqualTo(previous.tlvRecords)
+        assertThat(endpointInfo.deviceName!!.toByteArray(StandardCharsets.UTF_8).size)
+            .isAtMost(AdvertisedDeviceNames.MAX_DEVICE_NAME_BYTES)
+    }
+}
+
+private class FakeBluetoothNameGateway(
+    private val hasConnectPermission: Boolean = true,
+    private val readValue: String? = null,
+    private val throwOnRead: Throwable? = null,
+) : BluetoothNameGateway {
+    var readCalls: Int = 0
+
+    override fun hasConnectPermission(): Boolean = hasConnectPermission
+
+    override fun read(): String? {
+        readCalls += 1
+        throwOnRead?.let { throw it }
+        return readValue
+    }
+}

--- a/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/AdvertisedDeviceNamesTest.kt
+++ b/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/AdvertisedDeviceNamesTest.kt
@@ -42,6 +42,45 @@ class AdvertisedDeviceNamesTest {
     }
 
     @Test
+    fun `policy short-circuits platform reads when a custom name is stored`() {
+        val prefs =
+            AdvertisedDeviceNamePreferences(FakeSharedPreferences()).apply {
+                setCustomName("Custom Pixel")
+            }
+        var systemReads = 0
+        var modelReads = 0
+        var appLabelReads = 0
+        val bluetooth = FakeBluetoothNameGateway(readValue = "Nearby BT")
+        val policy =
+            AndroidAdvertisedDeviceNamePolicy(
+                preferences = prefs,
+                sdkInt = 36,
+                globalDeviceNameReader =
+                    GlobalDeviceNameReader {
+                        systemReads += 1
+                        "System Pixel"
+                    },
+                bluetoothNameGateway = bluetooth,
+                modelName = {
+                    modelReads += 1
+                    "Pixel Model"
+                },
+                appLabel = {
+                    appLabelReads += 1
+                    "WhenVivoMeetsGoogle"
+                },
+            )
+
+        val resolved = policy.resolve()
+
+        assertThat(resolved).isEqualTo("Custom Pixel")
+        assertThat(systemReads).isEqualTo(0)
+        assertThat(bluetooth.readCalls).isEqualTo(0)
+        assertThat(modelReads).isEqualTo(0)
+        assertThat(appLabelReads).isEqualTo(0)
+    }
+
+    @Test
     fun `policy does not query Settings Global below API 25`() {
         val prefs = AdvertisedDeviceNamePreferences(FakeSharedPreferences())
         var systemReads = 0
@@ -64,6 +103,36 @@ class AdvertisedDeviceNamesTest {
 
         assertThat(resolved).isEqualTo("Nearby BT")
         assertThat(systemReads).isEqualTo(0)
+    }
+
+    @Test
+    fun `policy does not read bluetooth fallback when system device name resolves`() {
+        val prefs = AdvertisedDeviceNamePreferences(FakeSharedPreferences())
+        var modelReads = 0
+        var appLabelReads = 0
+        val bluetooth = FakeBluetoothNameGateway(readValue = "Nearby BT")
+        val policy =
+            AndroidAdvertisedDeviceNamePolicy(
+                preferences = prefs,
+                sdkInt = 36,
+                globalDeviceNameReader = GlobalDeviceNameReader { "  Pixel 9 Pro  " },
+                bluetoothNameGateway = bluetooth,
+                modelName = {
+                    modelReads += 1
+                    "Pixel Model"
+                },
+                appLabel = {
+                    appLabelReads += 1
+                    "WhenVivoMeetsGoogle"
+                },
+            )
+
+        val resolved = policy.resolve()
+
+        assertThat(resolved).isEqualTo("Pixel 9 Pro")
+        assertThat(bluetooth.readCalls).isEqualTo(0)
+        assertThat(modelReads).isEqualTo(0)
+        assertThat(appLabelReads).isEqualTo(0)
     }
 
     @Test

--- a/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/FakeSharedPreferences.kt
+++ b/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/FakeSharedPreferences.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.service.receiver
+
+import android.content.SharedPreferences
+
+internal class FakeSharedPreferences : SharedPreferences {
+    val values: MutableMap<String, Any?> = mutableMapOf()
+
+    override fun getAll(): Map<String, *> = values.toMap()
+
+    override fun getString(
+        key: String?,
+        defValue: String?,
+    ): String? = values[key] as? String ?: defValue
+
+    override fun getStringSet(
+        key: String?,
+        defValues: MutableSet<String>?,
+    ): MutableSet<String>? {
+        @Suppress("UNCHECKED_CAST")
+        return (values[key] as? MutableSet<String>) ?: defValues
+    }
+
+    override fun getInt(
+        key: String?,
+        defValue: Int,
+    ): Int = (values[key] as? Int) ?: defValue
+
+    override fun getLong(
+        key: String?,
+        defValue: Long,
+    ): Long = (values[key] as? Long) ?: defValue
+
+    override fun getFloat(
+        key: String?,
+        defValue: Float,
+    ): Float = (values[key] as? Float) ?: defValue
+
+    override fun getBoolean(
+        key: String?,
+        defValue: Boolean,
+    ): Boolean = (values[key] as? Boolean) ?: defValue
+
+    override fun contains(key: String?): Boolean = key in values
+
+    override fun edit(): SharedPreferences.Editor = FakeEditor(values)
+
+    override fun registerOnSharedPreferenceChangeListener(
+        listener: SharedPreferences.OnSharedPreferenceChangeListener?,
+    ) {
+        // No-op for unit tests.
+    }
+
+    override fun unregisterOnSharedPreferenceChangeListener(
+        listener: SharedPreferences.OnSharedPreferenceChangeListener?,
+    ) {
+        // No-op for unit tests.
+    }
+}
+
+private class FakeEditor(
+    private val values: MutableMap<String, Any?>,
+) : SharedPreferences.Editor {
+    override fun putString(
+        key: String?,
+        value: String?,
+    ): SharedPreferences.Editor =
+        apply {
+            values[key.orEmpty()] = value
+        }
+
+    override fun putStringSet(
+        key: String?,
+        values: MutableSet<String>?,
+    ): SharedPreferences.Editor = throw UnsupportedOperationException()
+
+    override fun putInt(
+        key: String?,
+        value: Int,
+    ): SharedPreferences.Editor = throw UnsupportedOperationException()
+
+    override fun putLong(
+        key: String?,
+        value: Long,
+    ): SharedPreferences.Editor = throw UnsupportedOperationException()
+
+    override fun putFloat(
+        key: String?,
+        value: Float,
+    ): SharedPreferences.Editor = throw UnsupportedOperationException()
+
+    override fun putBoolean(
+        key: String?,
+        value: Boolean,
+    ): SharedPreferences.Editor = throw UnsupportedOperationException()
+
+    override fun remove(key: String?): SharedPreferences.Editor =
+        apply {
+            values.remove(key)
+        }
+
+    override fun clear(): SharedPreferences.Editor =
+        apply {
+            values.clear()
+        }
+
+    override fun commit(): Boolean = true
+
+    override fun apply() {
+        // Changes are applied eagerly above.
+    }
+}

--- a/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverSessionTest.kt
+++ b/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverSessionTest.kt
@@ -380,6 +380,50 @@ class ReceiverSessionTest {
         }
 
     @Test
+    fun `replaceEndpointInfo failure is reported without throwing and can be restored`() =
+        runBlocking {
+            val advertiser = FailingOnAttemptAdvertiser(failOnAttempt = 2)
+            val original = sampleEndpointInfo(name = "Old Name")
+            val updated = sampleEndpointInfo(name = "New Name")
+            val session =
+                makeSession(
+                    advertiser = advertiser,
+                    endpointInfo = original,
+                    advertiseGated = true,
+                )
+
+            session.start()
+            val originalPort = session.boundPort
+            session.publishAdvertisement()
+
+            val replaced = session.replaceEndpointInfo(updated)
+
+            assertThat(replaced).isFalse()
+            assertThat(session.boundPort).isEqualTo(originalPort)
+            assertThat(session.isAdvertising).isFalse()
+            assertThat(advertiser.attempts).hasSize(2)
+            assertThat(advertiser.attempts[0].endpointInfo).isEqualTo(original)
+            assertThat(advertiser.attempts[0].succeeded).isTrue()
+            assertThat(advertiser.attempts[1].endpointInfo).isEqualTo(updated)
+            assertThat(advertiser.attempts[1].succeeded).isFalse()
+
+            val restored = session.replaceEndpointInfo(original)
+
+            assertThat(restored).isTrue()
+            assertThat(session.isAdvertising).isFalse()
+
+            session.publishAdvertisement()
+
+            assertThat(session.isAdvertising).isTrue()
+            assertThat(advertiser.attempts).hasSize(3)
+            assertThat(advertiser.attempts[2].endpointInfo).isEqualTo(original)
+            assertThat(advertiser.attempts[2].port).isEqualTo(originalPort)
+            assertThat(advertiser.attempts[2].succeeded).isTrue()
+
+            session.stop()
+        }
+
+    @Test
     fun `initial control transports are injected into active connection flow`() =
         runBlocking {
             val initialControlServer = RecordingInitialControlServer()
@@ -536,6 +580,33 @@ class ReceiverSessionTest {
             val handle = FakeAdvertiseHandle(port = port)
             calls += Call(endpointInfo, port, handle)
             return handle
+        }
+    }
+
+    private class FailingOnAttemptAdvertiser(
+        private val failOnAttempt: Int,
+    ) : DiscoveryAdvertiser {
+        data class Attempt(
+            val endpointInfo: EndpointInfo,
+            val port: Int,
+            val succeeded: Boolean,
+        )
+
+        val attempts: MutableList<Attempt> = mutableListOf()
+
+        private var callCount: Int = 0
+
+        override fun advertise(
+            endpointInfo: EndpointInfo,
+            port: Int,
+        ): AdvertiseHandle {
+            callCount += 1
+            if (callCount == failOnAttempt) {
+                attempts += Attempt(endpointInfo, port, false)
+                throw java.io.IOException("simulated advertise failure")
+            }
+            attempts += Attempt(endpointInfo, port, true)
+            return FakeAdvertiseHandle(port = port)
         }
     }
 

--- a/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverSessionTest.kt
+++ b/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverSessionTest.kt
@@ -325,6 +325,61 @@ class ReceiverSessionTest {
         }
 
     @Test
+    fun `replaceEndpointInfo republishes active advertisement without rebinding tcp listener`() =
+        runBlocking {
+            val advertiser = RecordingAdvertiser()
+            val initialControlServer = RecordingInitialControlServer()
+            val original = sampleEndpointInfo(name = "Old Name")
+            val updated = sampleEndpointInfo(name = "New Name")
+            val session =
+                makeSession(
+                    advertiser = advertiser,
+                    endpointInfo = original,
+                    advertiseGated = true,
+                    initialControlServers = listOf(initialControlServer),
+                )
+
+            session.start()
+            val originalPort = session.boundPort
+            session.publishAdvertisement()
+
+            session.replaceEndpointInfo(updated)
+
+            assertThat(session.boundPort).isEqualTo(originalPort)
+            assertThat(advertiser.calls).hasSize(2)
+            assertThat(advertiser.calls[0].endpointInfo).isEqualTo(original)
+            assertThat(advertiser.calls[0].handle.isActive).isFalse()
+            assertThat(advertiser.calls[1].endpointInfo).isEqualTo(updated)
+            assertThat(advertiser.calls[1].port).isEqualTo(originalPort)
+            assertThat(initialControlServer.stopCount).isEqualTo(1)
+            assertThat(initialControlServer.startCalls).hasSize(2)
+            assertThat(initialControlServer.startCalls[1].endpointInfo).isEqualTo(updated)
+
+            session.stop()
+        }
+
+    @Test
+    fun `replaceEndpointInfo updates a gated session before first publish`() =
+        runBlocking {
+            val advertiser = RecordingAdvertiser()
+            val updated = sampleEndpointInfo(name = "Renamed Device")
+            val session =
+                makeSession(
+                    advertiser = advertiser,
+                    advertiseGated = true,
+                )
+
+            session.start()
+            session.replaceEndpointInfo(updated)
+            session.publishAdvertisement()
+
+            assertThat(advertiser.calls).hasSize(1)
+            assertThat(advertiser.calls[0].endpointInfo).isEqualTo(updated)
+
+            session.stop()
+        }
+
+    @Test
     fun `initial control transports are injected into active connection flow`() =
         runBlocking {
             val initialControlServer = RecordingInitialControlServer()


### PR DESCRIPTION
## Summary
- add a launcher setting and persisted override for the advertised Quick Share device name
- resolve the advertised name from custom/system/Bluetooth/model/app-label fallbacks with UTF-8-safe 19-byte clamping
- refresh receiver identity surfaces in place so renames update mDNS/BLE/QR inputs without restarting active receives
- document the launcher setting in the README and extend the stock-Android interop checklist for custom/default name coverage

## Review follow-ups
- preserve active receives while swapping the receiver endpoint identity after a rename
- roll back to the previous identity if an in-place advertisement refresh fails

## Verification
- ./gradlew :service-android:testDebugUnitTest --tests '*ReceiverSessionTest' --tests '*AdvertisedDeviceName*' check :app:assembleDebug

Closes #141