### PR TITLE
fix: bootstrap stock receivers over BLE GATT

### DIFF
--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/send/EmptyPeerHintTimer.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/send/EmptyPeerHintTimer.kt
@@ -90,9 +90,10 @@ internal class EmptyPeerHintTimer(
     }
 
     /**
-     * Test/debug accessor for the dismissed latch. Not part of the
-     * public contract — exists so unit tests can verify the latch is
-     * sticky without going through [shouldShowHint].
+     * Accessor for the dismissed latch. The picker uses this when it
+     * surfaces the same hint immediately for visible but unroutable
+     * peers, while tests use it to verify the latch is sticky without
+     * going through [shouldShowHint].
      */
     internal fun isDismissed(): Boolean = dismissed
 

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendActivity.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendActivity.kt
@@ -354,8 +354,12 @@ public class SendActivity : AppCompatActivity() {
         val targetSnapshot = peerPickerController.formatPeerSnapshot(peer, chosenRoute)
         Log.e(OUTBOUND_TAG, "picked target: $targetSnapshot")
         appendOutboundLog("picked target: $targetSnapshot")
-        // Stop discovery once we've made our pick.
+        // Stop discovery and the wake-up pulse once we've made our pick.
+        // BLE GATT bootstrap reuses the Bluetooth controller immediately;
+        // leaving the pulse active during the dial adds avoidable role
+        // churn on stock Quick Share receivers.
         peerPickerController.suspendPicker()
+        peerPickerController.stopBleAdvertise()
 
         // Hide the picker chrome.
         binding.sendPeerList.isVisible = false
@@ -431,9 +435,9 @@ public class SendActivity : AppCompatActivity() {
                 binding.sendStatusMessage.text = peerPickerController.peerSubtitle(peer)
             }
             OutboundConnectionState.Handshaking -> {
-                // TCP socket is up — the BLE wake-up pulse has done its
-                // job, stop broadcasting (#32 acceptance: stops as soon
-                // as the TCP connection to a recipient is established).
+                // The transport is up. The wake-up pulse is already
+                // stopped on selection; keep this idempotent call for any
+                // older path that reaches Handshaking without a picker tap.
                 peerPickerController.stopBleAdvertise()
                 binding.sendStatusPhase.setText(R.string.send_phase_handshaking)
                 binding.sendPin.visibility = View.GONE

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendActivity.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendActivity.kt
@@ -79,6 +79,8 @@ public class SendActivity : AppCompatActivity() {
     private var bluetoothBootstrapClient: BluetoothClassicBootstrapClient? = null
     private var bleL2capBootstrapClient: BleL2capInitialControlClient? = null
     private var bleGattBootstrapClient: BleGattInitialControlClient? = null
+    private lateinit var senderEndpointId: String
+    private lateinit var senderEndpointInfoBytes: ByteArray
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -135,6 +137,7 @@ public class SendActivity : AppCompatActivity() {
                 }
             } ?: return
         files = resolvedFiles
+        prepareSenderIdentity()
         logResolvedFiles(files)
 
         binding.sendPayloadSummary.text = PayloadSummary.forFiles(this, files)
@@ -171,6 +174,7 @@ public class SendActivity : AppCompatActivity() {
                 OutboundConnection(
                     targetAddress = route.address,
                     port = route.port,
+                    endpointId = senderEndpointId,
                     endpointInfo = endpointInfo,
                     mediumRegistry = mediumRegistry,
                     logger = ::logOutboundWireMessage,
@@ -186,6 +190,7 @@ public class SendActivity : AppCompatActivity() {
                     } ?: return null
                 OutboundConnection(
                     transport = transport,
+                    endpointId = senderEndpointId,
                     endpointInfo = endpointInfo,
                     mediumRegistry = mediumRegistry,
                     logger = ::logOutboundWireMessage,
@@ -202,6 +207,7 @@ public class SendActivity : AppCompatActivity() {
                     } ?: return null
                 OutboundConnection(
                     transport = transport,
+                    endpointId = senderEndpointId,
                     endpointInfo = endpointInfo,
                     mediumRegistry = mediumRegistry,
                     logger = ::logOutboundWireMessage,
@@ -218,6 +224,7 @@ public class SendActivity : AppCompatActivity() {
                     } ?: return null
                 OutboundConnection(
                     transport = transport,
+                    endpointId = senderEndpointId,
                     endpointInfo = endpointInfo,
                     mediumRegistry = mediumRegistry,
                     logger = ::logOutboundWireMessage,
@@ -226,19 +233,47 @@ public class SendActivity : AppCompatActivity() {
         }
     }
 
+    private suspend fun buildOutboundConnection(
+        plan: SendBootstrapPlan,
+        endpointInfo: ByteArray,
+    ): PreparedConnection =
+        when (val action = plan.action) {
+            is SendBootstrapPlan.Action.Direct -> {
+                val connection = buildOutboundConnection(action.route, endpointInfo)
+                if (connection != null) {
+                    PreparedConnection.Ready(connection)
+                } else {
+                    logOutboundDiagnostic("bootstrap: initial direct connect failed route=${action.route}")
+                    PreparedConnection.Failed("initial bootstrap connect failed")
+                }
+            }
+
+            SendBootstrapPlan.Action.Unavailable ->
+                PreparedConnection.Failed(plan.failureReason ?: "no usable initial route").also {
+                    logOutboundDiagnostic(
+                        "bootstrap: unavailable ${plan.diagnosticSummary()}",
+                    )
+                }
+        }
+
     // -----------------------------------------------------------------
     // Outbound connection
     // -----------------------------------------------------------------
 
     private fun onPeerSelected(peer: NearbyPeer) {
-        val route =
-            peer.preferredRoute() ?: run {
-                renderTerminal(
-                    getString(R.string.send_phase_failed),
-                    getString(R.string.send_status_failure_reason, peerPickerController.peerFailureReason(peer)),
-                )
-                return
+        val plan = SendBootstrapPlan.resolve(peer = peer)
+        val chosenRoute =
+            when (val action = plan.action) {
+                is SendBootstrapPlan.Action.Direct -> action.route
+                SendBootstrapPlan.Action.Unavailable -> null
             }
+        if (!plan.isConnectable) {
+            renderTerminal(
+                getString(R.string.send_phase_failed),
+                getString(R.string.send_status_failure_reason, peerPickerController.peerFailureReason(peer)),
+            )
+            return
+        }
         // Verbose target snapshot at the moment of pick. Routed through
         // Log.e (and the on-disk outbound log) because Funtouch filters
         // Log.i for non-system apps — without this a Galaxy "peer
@@ -247,7 +282,7 @@ public class SendActivity : AppCompatActivity() {
         // aggregated mediums, the chosen initial route, the full LAN
         // address list (so we can spot IPv6 vs IPv4 selection bugs),
         // and the parsed EndpointInfo header byte / device name.
-        val targetSnapshot = peerPickerController.formatPeerSnapshot(peer, route)
+        val targetSnapshot = peerPickerController.formatPeerSnapshot(peer, chosenRoute)
         Log.e(OUTBOUND_TAG, "picked target: $targetSnapshot")
         appendOutboundLog("picked target: $targetSnapshot")
         // Stop discovery once we've made our pick.
@@ -262,7 +297,7 @@ public class SendActivity : AppCompatActivity() {
 
         binding.sendStatusTarget.text = getString(R.string.send_status_target, peerPickerController.peerLabel(peer))
         binding.sendStatusPhase.setText(R.string.send_phase_connecting)
-        binding.sendStatusMessage.text = peerPickerController.peerSubtitle(peer)
+        binding.sendStatusMessage.text = plan.subtitle
 
         // Build a valid sender EndpointInfo. Stock Quick Share rejects a
         // ConnectionRequestFrame with an empty `endpoint_info` field by
@@ -270,42 +305,46 @@ public class SendActivity : AppCompatActivity() {
         // EndOfFrameStream while the client is awaiting Ukey2ServerInit.
         // Visibility=0 (everyone) is fine — we are the sender, this is
         // not advertised on mDNS.
-        val senderEndpointInfoBytes =
-            EndpointInfo(
-                version = 1,
-                hidden = false,
-                deviceType = DeviceType.PHONE,
-                reserved = false,
-                metadata = ByteArray(EndpointInfo.METADATA_LEN).also { SecureRandom().nextBytes(it) },
-                deviceName = senderDeviceLabel(),
-            ).serialize()
-
         connectionJob =
             lifecycleScope.launch {
-                val connection = buildOutboundConnection(route, senderEndpointInfoBytes)
-                if (connection == null) {
-                    renderTerminal(
-                        getString(R.string.send_phase_failed),
-                        getString(R.string.send_status_failure_reason, "initial bootstrap connect failed"),
-                    )
-                    return@launch
-                }
-                activeConnection = connection
-                val collector =
-                    launch {
-                        connection.state.collect { state ->
-                            renderConnectionState(state, peer)
+                when (val prepared = buildOutboundConnection(plan, senderEndpointInfoBytes)) {
+                    is PreparedConnection.Failed -> {
+                        renderTerminal(
+                            getString(R.string.send_phase_failed),
+                            getString(R.string.send_status_failure_reason, prepared.reason),
+                        )
+                        return@launch
+                    }
+                    is PreparedConnection.Ready -> {
+                        val connection = prepared.connection
+                        activeConnection = connection
+                        val collector =
+                            launch {
+                                connection.state.collect { state ->
+                                    renderConnectionState(state, peer)
+                                }
+                            }
+                        try {
+                            connection.run(files)
+                        } finally {
+                            collector.cancel()
+                            activeConnection = null
+                            bluetoothBootstrapClient = null
+                            bleL2capBootstrapClient = null
                         }
                     }
-                try {
-                    connection.run(files)
-                } finally {
-                    collector.cancel()
-                    activeConnection = null
-                    bluetoothBootstrapClient = null
-                    bleL2capBootstrapClient = null
                 }
             }
+    }
+
+    private sealed interface PreparedConnection {
+        data class Ready(
+            val connection: OutboundConnection,
+        ) : PreparedConnection
+
+        data class Failed(
+            val reason: String,
+        ) : PreparedConnection
     }
 
     private fun renderConnectionState(
@@ -464,6 +503,14 @@ public class SendActivity : AppCompatActivity() {
             )
             return
         }
+        if (connectionJob?.isActive == true && binding.sendStatusPanel.isVisible) {
+            connectionJob?.cancel()
+            renderTerminal(
+                getString(R.string.send_phase_cancelled),
+                getString(R.string.send_status_failure_reason, CancelCause.LOCAL.toString()),
+            )
+            return
+        }
         // Cancel before any peer was selected: stop the BLE pulse now
         // so we don't waste the radio while finish() tears the activity
         // down. onDestroy would also catch this, but stopping here keeps
@@ -482,6 +529,21 @@ public class SendActivity : AppCompatActivity() {
      * when [Build.MODEL] is empty (rare but happens on some emulators).
      */
     private fun senderDeviceLabel(): String = Build.MODEL?.takeIf { it.isNotBlank() } ?: "WhenVivoMeetsGoogle"
+
+    private fun prepareSenderIdentity() {
+        senderEndpointId = OutboundConnection.generateEndpointId()
+        val senderEndpointInfo =
+            EndpointInfo(
+                version = 1,
+                hidden = false,
+                deviceType = DeviceType.PHONE,
+                reserved = false,
+                metadata = ByteArray(EndpointInfo.METADATA_LEN).also { SecureRandom().nextBytes(it) },
+                deviceName = senderDeviceLabel(),
+            )
+        senderEndpointInfoBytes = senderEndpointInfo.serialize()
+        logOutboundDiagnostic("sender identity: endpointId=$senderEndpointId name=${senderDeviceLabel()}")
+    }
 
     private fun logResolvedFiles(files: List<FileSource>) {
         files.forEachIndexed { index, file ->

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendActivity.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendActivity.kt
@@ -5,11 +5,15 @@
  */
 package io.github.kyujincho.wvmg.send
 
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
+import android.provider.Settings
 import android.util.Log
 import android.view.View
+import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
@@ -18,6 +22,7 @@ import io.github.kyujincho.wvmg.databinding.ActivitySendBinding
 import io.github.kyujincho.wvmg.discovery.NearbyPeer
 import io.github.kyujincho.wvmg.discovery.NearbyPeerRoute
 import io.github.kyujincho.wvmg.discovery.bootstrap.BleGattInitialControlClient
+import io.github.kyujincho.wvmg.discovery.bootstrap.BleGattInitialControlServer
 import io.github.kyujincho.wvmg.discovery.bootstrap.BleL2capInitialControlClient
 import io.github.kyujincho.wvmg.discovery.bootstrap.BluetoothClassicBootstrapClient
 import io.github.kyujincho.wvmg.discovery.medium.MediumRegistries
@@ -79,7 +84,9 @@ public class SendActivity : AppCompatActivity() {
     private var bluetoothBootstrapClient: BluetoothClassicBootstrapClient? = null
     private var bleL2capBootstrapClient: BleL2capInitialControlClient? = null
     private var bleGattBootstrapClient: BleGattInitialControlClient? = null
+    private var senderGattServer: BleGattInitialControlServer? = null
     private lateinit var senderEndpointId: String
+    private lateinit var senderEndpointInfo: EndpointInfo
     private lateinit var senderEndpointInfoBytes: ByteArray
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -100,6 +107,18 @@ public class SendActivity : AppCompatActivity() {
         fileSourceFactory = UriFileSourceFactory(contentResolver)
         documentTreeFactory = DocumentTreeFileSourceFactory(contentResolver)
         payloadResolver = SendPayloadResolver(fileSourceFactory, documentTreeFactory)
+        // Generate the sender identity up front so the picker controller
+        // can thread the endpointId into the BLE FastInitiation pulse's
+        // `secret_id_hash`. Stock GMS receivers (Samsung One UI 8.x in
+        // particular) classify pulses with an all-zero hash as
+        // `type=SILENT`, which causes them to skip the per-peer Weave
+        // handler registration on their `0xFEF3` GATT server — every
+        // subsequent ATT write to `00000100-…-0101` then throws
+        // `No handler registered for characteristic …`. The endpointId
+        // bytes form the hash and lift Samsung's classification to
+        // `type=NORMAL`, unblocking the BLE GATT bootstrap.
+        prepareSenderIdentity()
+        startSenderGattServer()
         peerPickerController =
             SendPeerPickerController(
                 context = this,
@@ -108,6 +127,7 @@ public class SendActivity : AppCompatActivity() {
                 scope = lifecycleScope,
                 onPeerSelected = ::onPeerSelected,
                 logDiagnostic = ::logOutboundDiagnostic,
+                senderEndpointId = senderEndpointId,
             )
 
         binding.sendCancelButton.setOnClickListener { onCancelClicked() }
@@ -137,7 +157,6 @@ public class SendActivity : AppCompatActivity() {
                 }
             } ?: return
         files = resolvedFiles
-        prepareSenderIdentity()
         logResolvedFiles(files)
 
         binding.sendPayloadSummary.text = PayloadSummary.forFiles(this, files)
@@ -156,6 +175,8 @@ public class SendActivity : AppCompatActivity() {
         bleL2capBootstrapClient?.cancelPendingConnect()
         bleGattBootstrapClient?.cancelPendingConnect()
         peerPickerController.stop()
+        senderGattServer?.stop()
+        senderGattServer = null
         connectionJob?.cancel()
         // Lift the gate veto so the receiver-side mDNS record can come
         // back up if any of the gate's existing publish signals
@@ -274,6 +295,54 @@ public class SendActivity : AppCompatActivity() {
             )
             return
         }
+        // Pre-flight: BLE-GATT-only into a Samsung receiver is a known
+        // dead end (Google-account-bound sender_certificate gate on
+        // Samsung's Weave handler — see
+        // docs/research/samsung-ble-gatt-cert-gate.md). Surface a
+        // confirmation dialog instead of silently letting the user
+        // burn a 15s handshake timeout. Caller can still opt to "Try
+        // anyway" — leaves a door open if Samsung ever loosens the
+        // gate, and avoids a hard block on false-positive heuristic
+        // matches.
+        if (plan.samsungBleGattCaveat) {
+            confirmSamsungBleGattAttempt(peer, plan, chosenRoute)
+            return
+        }
+        proceedWithPeer(peer, plan, chosenRoute)
+    }
+
+    private fun confirmSamsungBleGattAttempt(
+        peer: NearbyPeer,
+        plan: SendBootstrapPlan,
+        chosenRoute: NearbyPeerRoute?,
+    ) {
+        val deviceName = peerPickerController.peerLabel(peer)
+        AlertDialog
+            .Builder(this)
+            .setTitle(R.string.send_samsung_ble_warning_title)
+            .setMessage(getString(R.string.send_samsung_ble_warning_body, deviceName))
+            .setPositiveButton(R.string.send_samsung_ble_warning_open_wifi) { _, _ ->
+                openWifiSettings()
+            }.setNegativeButton(R.string.send_samsung_ble_warning_try_anyway) { _, _ ->
+                proceedWithPeer(peer, plan, chosenRoute)
+            }.setNeutralButton(R.string.send_samsung_ble_warning_cancel) { dialog, _ -> dialog.dismiss() }
+            .show()
+    }
+
+    private fun openWifiSettings() {
+        val intent = Intent(Settings.ACTION_WIFI_SETTINGS).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        try {
+            startActivity(intent)
+        } catch (_: ActivityNotFoundException) {
+            Toast.makeText(this, R.string.send_samsung_ble_warning_open_wifi, Toast.LENGTH_LONG).show()
+        }
+    }
+
+    private fun proceedWithPeer(
+        peer: NearbyPeer,
+        plan: SendBootstrapPlan,
+        chosenRoute: NearbyPeerRoute?,
+    ) {
         // Verbose target snapshot at the moment of pick. Routed through
         // Log.e (and the on-disk outbound log) because Funtouch filters
         // Log.i for non-system apps — without this a Galaxy "peer
@@ -532,7 +601,7 @@ public class SendActivity : AppCompatActivity() {
 
     private fun prepareSenderIdentity() {
         senderEndpointId = OutboundConnection.generateEndpointId()
-        val senderEndpointInfo =
+        senderEndpointInfo =
             EndpointInfo(
                 version = 1,
                 hidden = false,
@@ -543,6 +612,43 @@ public class SendActivity : AppCompatActivity() {
             )
         senderEndpointInfoBytes = senderEndpointInfo.serialize()
         logOutboundDiagnostic("sender identity: endpointId=$senderEndpointId name=${senderDeviceLabel()}")
+    }
+
+    /**
+     * Bring up a sender-side GATT server exposing the same `0xFEF3`
+     * service shape stock Quick Share peripherals advertise. We do not
+     * intend Samsung to actually open a Weave session into us — the
+     * server's only job is to expose the advertisement-slot
+     * characteristics so Samsung's GMS can read our `EndpointInfo`
+     * back when it correlates an inbound GATT-from-us connection
+     * against a known peer. Without our own GATT server, Samsung sees
+     * us as a "drive-by central" with no reciprocal identity surface,
+     * which appears to be one of the predicates gating its per-peer
+     * Weave handler registration on `gchu`/`gchk`.
+     */
+    @Suppress("MissingPermission")
+    private fun startSenderGattServer() {
+        val server =
+            BleGattInitialControlServer(
+                context = applicationContext,
+                endpointIdProvider = { senderEndpointId.toByteArray(Charsets.US_ASCII) },
+            )
+        // Sender-side server should never actually accept a real
+        // bootstrap from Samsung — log it and immediately close if it
+        // somehow does, so we don't leak a half-open transport.
+        val started =
+            server.start(senderEndpointInfo) { transport ->
+                logOutboundDiagnostic(
+                    "sender GATT server: unexpected inbound transport medium=${transport.medium}; closing",
+                )
+                runCatching { transport.close() }
+            }
+        if (started) {
+            senderGattServer = server
+            logOutboundDiagnostic("sender GATT server: started")
+        } else {
+            logOutboundDiagnostic("sender GATT server: not started (unavailable or addService failed)")
+        }
     }
 
     private fun logResolvedFiles(files: List<FileSource>) {

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendBootstrapPlan.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendBootstrapPlan.kt
@@ -7,12 +7,26 @@ package io.github.kyujincho.wvmg.send
 
 import io.github.kyujincho.wvmg.discovery.NearbyPeer
 import io.github.kyujincho.wvmg.discovery.NearbyPeerRoute
+import io.github.kyujincho.wvmg.discovery.SamsungQuickShareHeuristic
 
 internal data class SendBootstrapPlan(
     val action: Action,
     val subtitle: String,
     val failureReason: String?,
     val rejectedCandidates: List<String>,
+    /**
+     * Set when the only available bootstrap is BLE GATT *and* the peer
+     * is Samsung-class. Samsung One UI's Quick Share receiver enforces
+     * a Google-account-bound `SenderCertificate` lookup before it
+     * registers a per-peer Weave handler — see
+     * `docs/research/samsung-ble-gatt-cert-gate.md` — so attempts to
+     * bootstrap into Samsung over BLE GATT from a non-GMS app
+     * predictably stall at the 15 s handshake timeout. Picker UI uses
+     * this flag to surface a "Wi-Fi recommended" caveat and a
+     * confirmation dialog on tap, instead of silently letting the user
+     * burn a 15 s timeout.
+     */
+    val samsungBleGattCaveat: Boolean = false,
 ) {
     val isConnectable: Boolean
         get() = action !is Action.Unavailable
@@ -71,21 +85,33 @@ internal data class SendBootstrapPlan(
         }
 
         private fun direct(
+            peer: NearbyPeer,
             route: NearbyPeerRoute,
             rejectedCandidates: List<String>,
-        ): SendBootstrapPlan =
-            SendBootstrapPlan(
+        ): SendBootstrapPlan {
+            val samsungCaveat =
+                route is NearbyPeerRoute.BleGatt &&
+                    SamsungQuickShareHeuristic.isLikelySamsungReceiver(peer)
+            val subtitle =
+                when (route) {
+                    is NearbyPeerRoute.Lan -> "Wi-Fi LAN ${route.address.hostAddress}:${route.port}"
+                    is NearbyPeerRoute.BluetoothClassic -> "Bluetooth Classic ${route.macAddress}"
+                    is NearbyPeerRoute.BleL2cap -> "BLE L2CAP ${route.macAddress} psm=${route.psm}"
+                    is NearbyPeerRoute.BleGatt ->
+                        if (samsungCaveat) {
+                            "BLE GATT ${route.macAddress} — Wi-Fi recommended for Samsung"
+                        } else {
+                            "BLE GATT ${route.macAddress}"
+                        }
+                }
+            return SendBootstrapPlan(
                 action = Action.Direct(route),
-                subtitle =
-                    when (route) {
-                        is NearbyPeerRoute.Lan -> "Wi-Fi LAN ${route.address.hostAddress}:${route.port}"
-                        is NearbyPeerRoute.BluetoothClassic -> "Bluetooth Classic ${route.macAddress}"
-                        is NearbyPeerRoute.BleL2cap -> "BLE L2CAP ${route.macAddress} psm=${route.psm}"
-                        is NearbyPeerRoute.BleGatt -> "BLE GATT ${route.macAddress}"
-                    },
+                subtitle = subtitle,
                 failureReason = null,
                 rejectedCandidates = rejectedCandidates,
+                samsungBleGattCaveat = samsungCaveat,
             )
+        }
 
         private fun directRoute(
             peer: NearbyPeer,
@@ -133,6 +159,7 @@ internal data class SendBootstrapPlan(
             when (action) {
                 is Action.Direct ->
                     direct(
+                        peer = peer,
                         route = action.route,
                         rejectedCandidates = rejectedCandidates,
                     )

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendBootstrapPlan.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendBootstrapPlan.kt
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.send
+
+import io.github.kyujincho.wvmg.discovery.NearbyPeer
+import io.github.kyujincho.wvmg.discovery.NearbyPeerRoute
+
+internal data class SendBootstrapPlan(
+    val action: Action,
+    val subtitle: String,
+    val failureReason: String?,
+    val rejectedCandidates: List<String>,
+) {
+    val isConnectable: Boolean
+        get() = action !is Action.Unavailable
+
+    fun diagnosticSummary(): String =
+        buildString {
+            append("selected=").append(action.diagnosticLabel)
+            if (rejectedCandidates.isNotEmpty()) {
+                append(" rejected=[").append(rejectedCandidates.joinToString()).append(']')
+            }
+            when (action) {
+                Action.Unavailable ->
+                    failureReason?.let {
+                        append(" reason=").append(it.toQuotedLogValue())
+                    }
+
+                is Action.Direct -> Unit
+            }
+        }
+
+    internal sealed interface Action {
+        val diagnosticLabel: String
+
+        data class Direct(
+            val route: NearbyPeerRoute,
+        ) : Action {
+            override val diagnosticLabel: String
+                get() =
+                    when (route) {
+                        is NearbyPeerRoute.Lan -> "wifi-lan"
+                        is NearbyPeerRoute.BluetoothClassic -> "bluetooth-classic"
+                        is NearbyPeerRoute.BleL2cap -> "ble-l2cap"
+                        is NearbyPeerRoute.BleGatt -> "ble-gatt"
+                    }
+        }
+
+        data object Unavailable : Action {
+            override val diagnosticLabel: String = "unavailable"
+        }
+    }
+
+    companion object {
+        fun resolve(peer: NearbyPeer): SendBootstrapPlan {
+            val rejected = mutableListOf<String>()
+            val directRoute = directRoute(peer, rejected)
+            val action =
+                when {
+                    directRoute != null -> Action.Direct(directRoute)
+                    else -> Action.Unavailable
+                }
+            return buildPlan(
+                peer = peer,
+                action = action,
+                rejectedCandidates = rejected,
+            )
+        }
+
+        private fun direct(
+            route: NearbyPeerRoute,
+            rejectedCandidates: List<String>,
+        ): SendBootstrapPlan =
+            SendBootstrapPlan(
+                action = Action.Direct(route),
+                subtitle =
+                    when (route) {
+                        is NearbyPeerRoute.Lan -> "Wi-Fi LAN ${route.address.hostAddress}:${route.port}"
+                        is NearbyPeerRoute.BluetoothClassic -> "Bluetooth Classic ${route.macAddress}"
+                        is NearbyPeerRoute.BleL2cap -> "BLE L2CAP ${route.macAddress} psm=${route.psm}"
+                        is NearbyPeerRoute.BleGatt -> "BLE GATT ${route.macAddress}"
+                    },
+                failureReason = null,
+                rejectedCandidates = rejectedCandidates,
+            )
+
+        private fun directRoute(
+            peer: NearbyPeer,
+            rejectedCandidates: MutableList<String>,
+        ): NearbyPeerRoute? {
+            val lanRoute = lanRoute(peer)
+            val bleL2capRoute = bleL2capRoute(peer)
+            val bleGattRoute = bleGattRoute(peer)
+            val bluetoothRoute = bluetoothRoute(peer)
+            return when {
+                lanRoute != null -> lanRoute
+                bleL2capRoute != null -> {
+                    rejectedCandidates += lanRejection(peer)
+                    bleL2capRoute
+                }
+
+                bleGattRoute != null -> {
+                    rejectedCandidates += lanRejection(peer)
+                    rejectedCandidates += bleL2capRejection(peer)
+                    bleGattRoute
+                }
+
+                bluetoothRoute != null -> {
+                    rejectedCandidates += lanRejection(peer)
+                    rejectedCandidates += bleL2capRejection(peer)
+                    rejectedCandidates += bleGattRejection(peer)
+                    bluetoothRoute
+                }
+
+                else -> {
+                    rejectedCandidates += lanRejection(peer)
+                    rejectedCandidates += bleL2capRejection(peer)
+                    rejectedCandidates += bleGattRejection(peer)
+                    rejectedCandidates += "bluetooth-classic=missing"
+                    null
+                }
+            }
+        }
+
+        private fun buildPlan(
+            peer: NearbyPeer,
+            action: Action,
+            rejectedCandidates: List<String>,
+        ): SendBootstrapPlan =
+            when (action) {
+                is Action.Direct ->
+                    direct(
+                        route = action.route,
+                        rejectedCandidates = rejectedCandidates,
+                    )
+
+                Action.Unavailable ->
+                    SendBootstrapPlan(
+                        action = Action.Unavailable,
+                        subtitle = "No supported transfer route is available yet.",
+                        failureReason = unavailableFailureReason(peer),
+                        rejectedCandidates = rejectedCandidates,
+                    )
+            }
+
+        private fun unavailableFailureReason(peer: NearbyPeer): String? =
+            buildList {
+                val lan = peer.lanEndpoint
+                val lanAddress = lan?.primaryAddress()
+                val ble = peer.bleAdvertisement
+                val blePsm = ble?.l2capPsm
+                if (lan == null || lanAddress == null) {
+                    add("no shared Wi-Fi LAN route")
+                }
+                if (ble != null && blePsm == null) {
+                    add("receiver BLE advertisement has no L2CAP PSM")
+                }
+                if (ble != null && blePsm == null && !ble.gattConnectable) {
+                    add("receiver BLE GATT bootstrap is not verified")
+                }
+                if (ble != null) {
+                    add("no Bluetooth Classic bootstrap identity")
+                }
+                if (ble != null && peer.endpointInfo?.hidden != false) {
+                    add("BLE observation does not confirm a visible receiver")
+                }
+            }.distinct().takeIf { it.isNotEmpty() }?.joinToString(separator = "; ")
+
+        private fun lanRoute(peer: NearbyPeer): NearbyPeerRoute.Lan? =
+            peer.lanEndpoint?.let { lan ->
+                lan.primaryAddress()?.let { address ->
+                    NearbyPeerRoute.Lan(address = address, port = lan.port)
+                }
+            }
+
+        private fun lanRejection(peer: NearbyPeer): String {
+            val lan = peer.lanEndpoint
+            val lanAddress = lan?.primaryAddress()
+            return when {
+                lan == null -> "wifi-lan=missing"
+                lanAddress == null -> "wifi-lan=no-primary-address"
+                else -> "wifi-lan=unusable"
+            }
+        }
+
+        private fun bleL2capRoute(peer: NearbyPeer): NearbyPeerRoute.BleL2cap? =
+            peer.bleAdvertisement?.let { ble ->
+                val address = ble.advertiserAddress
+                val psm = ble.l2capPsm
+                if (address != null && psm != null) {
+                    NearbyPeerRoute.BleL2cap(macAddress = address, psm = psm)
+                } else {
+                    null
+                }
+            }
+
+        private fun bleL2capRejection(peer: NearbyPeer): String {
+            val ble = peer.bleAdvertisement
+            val bleAddress = ble?.advertiserAddress
+            val blePsm = ble?.l2capPsm
+            return when {
+                ble == null -> "ble=missing"
+                bleAddress == null -> "ble=no-address"
+                blePsm == null -> "ble-l2cap=peer-psm-missing"
+                else -> "ble-l2cap=unusable"
+            }
+        }
+
+        private fun bleGattRoute(peer: NearbyPeer): NearbyPeerRoute.BleGatt? =
+            peer.bleAdvertisement?.let { ble ->
+                val address = ble.advertiserAddress
+                if (address != null && ble.gattConnectable && peer.endpointInfo?.hidden == false) {
+                    NearbyPeerRoute.BleGatt(macAddress = address)
+                } else {
+                    null
+                }
+            }
+
+        private fun bleGattRejection(peer: NearbyPeer): String {
+            val ble = peer.bleAdvertisement
+            val bleAddress = ble?.advertiserAddress
+            val endpointInfo = peer.endpointInfo
+            return when {
+                ble == null -> "ble-gatt=missing"
+                bleAddress == null -> "ble-gatt=no-address"
+                !ble.gattConnectable -> "ble-gatt=not-verified"
+                endpointInfo == null -> "ble-gatt=no-endpoint-info"
+                endpointInfo.hidden -> "ble-gatt=peer-hidden"
+                else -> "ble-gatt=unusable"
+            }
+        }
+
+        private fun bluetoothRoute(peer: NearbyPeer): NearbyPeerRoute.BluetoothClassic? =
+            peer.bluetoothEndpoint?.let { NearbyPeerRoute.BluetoothClassic(it.macAddress) }
+    }
+}

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendPeerPickerController.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendPeerPickerController.kt
@@ -33,6 +33,16 @@ internal class SendPeerPickerController(
     private val scope: CoroutineScope,
     private val onPeerSelected: (NearbyPeer) -> Unit,
     private val logDiagnostic: (String) -> Unit,
+    /**
+     * Sender's 4-byte endpoint slug. Threaded into the BLE FastInitiation
+     * pulse's `secret_id_hash` so stock GMS receivers (Samsung One UI in
+     * particular) classify the pulse as `type=NORMAL` and wire their
+     * per-peer Weave handler — without this, the receiver drops every
+     * subsequent ATT write to the `00000100-…-0101` characteristic with
+     * `No handler registered for characteristic …` and the BLE GATT
+     * bootstrap stalls at the Weave handshake.
+     */
+    private val senderEndpointId: String,
 ) {
     private val peers: MutableList<NearbyPeer> = mutableListOf()
 
@@ -255,7 +265,7 @@ internal class SendPeerPickerController(
 
     @Suppress("MissingPermission")
     private fun startBleAdvertise() {
-        val advertiser = BleAdvertiser(context.applicationContext)
+        val advertiser = BleAdvertiser(context.applicationContext, senderEndpointId)
         bleAdvertiser = advertiser
         bleAdvertiseHandle = advertiser.start()
         if (bleAdvertiseHandle == null) {

--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendPeerPickerController.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendPeerPickerController.kt
@@ -95,26 +95,15 @@ internal class SendPeerPickerController(
 
     fun peerLabel(peer: NearbyPeer): String = peer.displayName()
 
-    fun peerSubtitle(peer: NearbyPeer): String =
-        when (val route = peer.preferredRoute()) {
-            is NearbyPeerRoute.Lan -> "Wi-Fi LAN ${route.address.hostAddress}:${route.port}"
-            is NearbyPeerRoute.BluetoothClassic -> "Bluetooth Classic ${route.macAddress}"
-            is NearbyPeerRoute.BleL2cap -> "BLE L2CAP ${route.macAddress} psm=${route.psm}"
-            is NearbyPeerRoute.BleGatt -> "BLE GATT ${route.macAddress}"
-            null -> "Nearby via BLE advertisement"
-        }
+    fun peerSubtitle(peer: NearbyPeer): String = planFor(peer).subtitle
 
-    fun peerFailureReason(peer: NearbyPeer): String =
-        when {
-            peer.bluetoothEndpoint == null && peer.bleAdvertisement != null ->
-                "BLE advertisement observed but no initial bootstrap route is available yet"
-            else -> "no usable initial route"
-        }
+    fun peerFailureReason(peer: NearbyPeer): String = planFor(peer).failureReason ?: "no usable initial route"
 
     fun formatPeerSnapshot(
         peer: NearbyPeer,
         chosenRoute: NearbyPeerRoute? = null,
     ): String {
+        val plan = planFor(peer)
         val endpointId = peer.endpointId ?: "<none>"
         val addressList =
             peer.lanEndpoint
@@ -149,13 +138,14 @@ internal class SendPeerPickerController(
                 is NearbyPeerRoute.BluetoothClassic -> "bluetooth=${chosenRoute.macAddress}"
                 is NearbyPeerRoute.BleL2cap -> "ble-l2cap=${chosenRoute.macAddress}:${chosenRoute.psm}"
                 is NearbyPeerRoute.BleGatt -> "ble-gatt=${chosenRoute.macAddress}"
-                null -> "<none>"
+                null -> plan.action.diagnosticLabel
             }
         val bleIdentitySummary =
             formatBleIdentitySnapshot(peer)
         return "peer=${peer.stableId} endpointId=$endpointId mediums=${peer.candidateMediums} " +
             "addrs=[$addressList] route=$routeSummary displayName=${peer.displayName().toQuotedLogValue()} " +
-            "displayNameSource=${peer.displayNameSource()}$bleIdentitySummary endpointInfo={$infoSummary}"
+            "displayNameSource=${peer.displayNameSource()} bootstrap={${plan.diagnosticSummary()}}" +
+            "$bleIdentitySummary endpointInfo={$infoSummary}"
     }
 
     private fun formatBleIdentitySnapshot(peer: NearbyPeer): String {
@@ -210,7 +200,7 @@ internal class SendPeerPickerController(
             peers.add(incoming)
         }
         peers.sortWith(
-            compareByDescending<NearbyPeer> { it.isConnectable }
+            compareByDescending<NearbyPeer> { planFor(it).isConnectable }
                 .thenBy { it.displayName().lowercase() },
         )
     }
@@ -219,20 +209,26 @@ internal class SendPeerPickerController(
         val container = binding.sendPeerList
         container.removeAllViews()
         val inflater = LayoutInflater.from(context)
+        val hasConnectablePeer = peers.any { planFor(it).isConnectable }
         for (peer in peers) {
+            val plan = planFor(peer)
             val row = ItemPeerRowBinding.inflate(inflater, container, false)
             row.peerRowTitle.text = peerLabel(peer)
-            row.peerRowSubtitle.text = peerSubtitle(peer)
-            row.root.isEnabled = peer.isConnectable
-            row.root.alpha = if (peer.isConnectable) 1f else DISABLED_PEER_ALPHA
+            row.peerRowSubtitle.text = plan.subtitle
+            row.root.isEnabled = plan.isConnectable
+            row.root.alpha = if (plan.isConnectable) 1f else DISABLED_PEER_ALPHA
             row.root.setOnClickListener {
-                if (peer.isConnectable) onPeerSelected(peer)
+                if (plan.isConnectable) onPeerSelected(peer)
             }
             container.addView(row.root)
         }
         binding.sendEmptyState.visibility = if (peers.isEmpty()) View.VISIBLE else View.GONE
         binding.sendSubtitle.setText(
-            if (peers.isEmpty()) R.string.send_subtitle_discovering else R.string.send_subtitle_pick_peer,
+            when {
+                peers.isEmpty() -> R.string.send_subtitle_discovering
+                hasConnectablePeer -> R.string.send_subtitle_pick_peer
+                else -> R.string.send_subtitle_no_usable_route
+            },
         )
         updateEmptyPeerHintVisibility()
     }
@@ -247,11 +243,13 @@ internal class SendPeerPickerController(
     }
 
     private fun updateEmptyPeerHintVisibility() {
+        val onlyUnroutablePeers = peers.isNotEmpty() && peers.none { planFor(it).isConnectable }
         val show =
-            emptyPeerHintTimer.shouldShowHint(
-                nowMillis = System.currentTimeMillis(),
-                peerListEmpty = peers.isEmpty(),
-            )
+            (!emptyPeerHintTimer.isDismissed() && onlyUnroutablePeers) ||
+                emptyPeerHintTimer.shouldShowHint(
+                    nowMillis = System.currentTimeMillis(),
+                    peerListEmpty = peers.isEmpty(),
+                )
         binding.sendNetworkHint.visibility = if (show) View.VISIBLE else View.GONE
     }
 
@@ -274,18 +272,24 @@ internal class SendPeerPickerController(
             "<empty>"
         } else {
             peers.joinToString(";") { peer ->
+                val plan = planFor(peer)
                 val route =
-                    when (val preferredRoute = peer.preferredRoute()) {
-                        is NearbyPeerRoute.Lan -> "${preferredRoute.address.hostAddress}:${preferredRoute.port}"
-                        is NearbyPeerRoute.BluetoothClassic -> preferredRoute.macAddress
-                        is NearbyPeerRoute.BleL2cap -> "${preferredRoute.macAddress}:${preferredRoute.psm}"
-                        is NearbyPeerRoute.BleGatt -> preferredRoute.macAddress
-                        null -> "<none>"
+                    when (val action = plan.action) {
+                        is SendBootstrapPlan.Action.Direct ->
+                            when (val route = action.route) {
+                                is NearbyPeerRoute.Lan -> "${route.address.hostAddress}:${route.port}"
+                                is NearbyPeerRoute.BluetoothClassic -> route.macAddress
+                                is NearbyPeerRoute.BleL2cap -> "${route.macAddress}:${route.psm}"
+                                is NearbyPeerRoute.BleGatt -> route.macAddress
+                            }
+                        SendBootstrapPlan.Action.Unavailable -> "<none>"
                     }
                 "${peer.stableId}/${peer.endpointId ?: "<none>"}/$route/" +
                     "${peer.displayName().toSanitizedLogValue()}(${peer.displayNameSource()})"
             }
         }
+
+    private fun planFor(peer: NearbyPeer): SendBootstrapPlan = SendBootstrapPlan.resolve(peer = peer)
 
     private companion object {
         private const val BLE_TAG: String = "WvmgDiscovery"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -108,6 +108,20 @@
     <string name="send_done">Done</string>
     <string name="send_unsupported">This share could not be sent. The intent did not contain a file or text payload.</string>
 
+    <!--
+      Samsung BLE-GATT-only caveat (see docs/research/samsung-ble-gatt-cert-gate.md).
+      Samsung One UI rejects BLE GATT bootstrap from non-GMS senders at the
+      receiver-side per-peer Weave handler registration step (a Google-account-bound
+      sender_certificate lookup we cannot satisfy). Wi-Fi LAN works without that gate,
+      so we surface a confirmation dialog before letting the user wait through a
+      15s handshake timeout that is guaranteed to fail.
+    -->
+    <string name="send_samsung_ble_warning_title">Samsung devices need Wi-Fi</string>
+    <string name="send_samsung_ble_warning_body">%1$s is only reachable over Bluetooth right now. Samsung Quick Share rejects Bluetooth-only senders, so this attempt is very likely to time out after 15 seconds.\n\nConnect both devices to the same Wi-Fi network for a reliable transfer.</string>
+    <string name="send_samsung_ble_warning_open_wifi">Open Wi-Fi settings</string>
+    <string name="send_samsung_ble_warning_try_anyway">Try anyway</string>
+    <string name="send_samsung_ble_warning_cancel">Cancel</string>
+
     <!-- Payload summary templates. The %d arguments are item counts; %s is a formatted byte size. -->
     <string name="send_payload_text">Sharing text</string>
     <string name="send_payload_single_file">1 file</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -93,6 +93,7 @@
     <string name="send_activity_label">Send via Quick Share</string>
     <string name="send_subtitle_discovering">Looking for nearby devices…</string>
     <string name="send_subtitle_pick_peer">Tap a device to send.</string>
+    <string name="send_subtitle_no_usable_route">Nearby device found, but no supported transfer route is available yet.</string>
     <string name="send_empty_state">No devices nearby yet. Make sure the receiver has Quick Share open. Shared Wi-Fi is still the baseline path; if the devices are off-LAN, keep Bluetooth on for nearby bootstrap.</string>
 
     <!-- Same-Wi-Fi-network hint card (#85). Surfaced after a few seconds
@@ -100,7 +101,7 @@
          appeared. Condensed wording — the full explanation lives in
          the onboarding card. -->
     <string name="send_network_hint_title">Nearby discovery requirements</string>
-    <string name="send_network_hint_body">Shared Wi-Fi is still the baseline path. If the receiver is off-LAN, keep Bluetooth on so WVMG can try the nearby bootstrap path.</string>
+    <string name="send_network_hint_body">Shared Wi-Fi is still the baseline path. Some receivers can be named from BLE before they expose a supported transfer route; connect both devices to the same Wi-Fi network or keep Bluetooth available for supported bootstrap paths.</string>
     <string name="send_network_hint_dismiss">Got it</string>
     <string name="send_show_qr">Show QR</string>
     <string name="send_cancel">Cancel</string>

--- a/app/src/test/kotlin/io/github/kyujincho/wvmg/send/SendBootstrapPlanTest.kt
+++ b/app/src/test/kotlin/io/github/kyujincho/wvmg/send/SendBootstrapPlanTest.kt
@@ -132,6 +132,51 @@ class SendBootstrapPlanTest {
     }
 
     @Test
+    fun `Samsung peer reachable only via BLE GATT carries the Samsung caveat`() {
+        // Reproduces the empirical case the cert-gate research doc
+        // captures: a Samsung Galaxy with no Wi-Fi LAN exposure, only
+        // a BLE GATT route, will time out at 15s on the Weave
+        // handshake. The picker uses `samsungBleGattCaveat` to surface
+        // a "Wi-Fi recommended" subtitle and a confirmation dialog so
+        // the user understands why before they tap.
+        val peer =
+            peer(
+                bleAddress = "AA:BB:CC:DD:EE:FF",
+                blePsm = null,
+                bleVisible = true,
+            )
+
+        val plan = SendBootstrapPlan.resolve(peer = peer)
+
+        assertTrue(plan.isConnectable)
+        assertEquals(
+            NearbyPeerRoute.BleGatt("AA:BB:CC:DD:EE:FF"),
+            (plan.action as SendBootstrapPlan.Action.Direct).route,
+        )
+        assertTrue(plan.samsungBleGattCaveat)
+        assertTrue(plan.subtitle.contains("Wi-Fi recommended for Samsung"))
+    }
+
+    @Test
+    fun `Samsung peer reachable via Wi-Fi LAN does not carry the caveat`() {
+        // The cert-gate is BLE-GATT-only. When Wi-Fi LAN is available,
+        // the picker picks LAN and Samsung's Wi-Fi LAN acceptance path
+        // works without the cert lookup. No caveat needed.
+        val peer =
+            peer(
+                lanAddress = "192.168.1.20",
+                lanPort = 7654,
+                bleAddress = "AA:BB:CC:DD:EE:FF",
+                bleVisible = true,
+            )
+
+        val plan = SendBootstrapPlan.resolve(peer = peer)
+
+        assertFalse(plan.samsungBleGattCaveat)
+        assertFalse(plan.subtitle.contains("Samsung"))
+    }
+
+    @Test
     fun `peer without any route stays unavailable`() {
         val peer = peer()
 

--- a/app/src/test/kotlin/io/github/kyujincho/wvmg/send/SendBootstrapPlanTest.kt
+++ b/app/src/test/kotlin/io/github/kyujincho/wvmg/send/SendBootstrapPlanTest.kt
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.send
+
+import io.github.kyujincho.wvmg.discovery.NearbyPeer
+import io.github.kyujincho.wvmg.discovery.NearbyPeerRoute
+import io.github.kyujincho.wvmg.protocol.endpoint.DeviceType
+import io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.net.InetAddress
+
+class SendBootstrapPlanTest {
+    @Test
+    fun `Wi-Fi LAN route wins before BLE bootstrap routes`() {
+        val peer =
+            peer(
+                lanAddress = "192.168.1.20",
+                lanPort = 7654,
+                bluetoothMac = "11:22:33:44:55:66",
+                bleAddress = "AA:BB:CC:DD:EE:FF",
+                blePsm = 0x1234,
+            )
+
+        val plan = SendBootstrapPlan.resolve(peer = peer)
+
+        assertTrue(plan.isConnectable)
+        assertEquals(
+            NearbyPeerRoute.Lan(InetAddress.getByName("192.168.1.20"), 7654),
+            (plan.action as SendBootstrapPlan.Action.Direct).route,
+        )
+    }
+
+    @Test
+    fun `visible BLE peer stays unavailable when GATT is not connectable`() {
+        val peer =
+            peer(
+                bleAddress = "AA:BB:CC:DD:EE:FF",
+                blePsm = null,
+                bleVisible = true,
+                bleGattConnectable = false,
+            )
+
+        val plan = SendBootstrapPlan.resolve(peer = peer)
+
+        assertFalse(plan.isConnectable)
+        assertTrue(plan.failureReason!!.contains("no shared Wi-Fi LAN route"))
+        assertTrue(plan.failureReason!!.contains("receiver BLE advertisement has no L2CAP PSM"))
+        assertTrue(plan.failureReason!!.contains("receiver BLE GATT bootstrap is not verified"))
+    }
+
+    @Test
+    fun `verified visible BLE peer without PSM uses direct GATT bootstrap`() {
+        val peer =
+            peer(
+                bleAddress = "AA:BB:CC:DD:EE:FF",
+                blePsm = null,
+                bleVisible = true,
+            )
+
+        val plan = SendBootstrapPlan.resolve(peer = peer)
+
+        assertTrue(plan.isConnectable)
+        assertEquals(
+            NearbyPeerRoute.BleGatt("AA:BB:CC:DD:EE:FF"),
+            (plan.action as SendBootstrapPlan.Action.Direct).route,
+        )
+        assertTrue(plan.subtitle.contains("BLE GATT"))
+        assertTrue(plan.rejectedCandidates.contains("ble-l2cap=peer-psm-missing"))
+    }
+
+    @Test
+    fun `hidden BLE observation stays unavailable without verified bootstrap metadata`() {
+        val peer =
+            peer(
+                bleAddress = "AA:BB:CC:DD:EE:FF",
+                blePsm = null,
+                bleVisible = false,
+            )
+
+        val plan = SendBootstrapPlan.resolve(peer = peer)
+
+        assertFalse(plan.isConnectable)
+        assertTrue(plan.failureReason!!.contains("visible receiver"))
+        assertTrue(plan.rejectedCandidates.contains("ble-gatt=peer-hidden"))
+    }
+
+    @Test
+    fun `BLE GATT route wins before Bluetooth Classic when receiver is visible`() {
+        val peer =
+            peer(
+                bluetoothMac = "11:22:33:44:55:66",
+                bleAddress = "AA:BB:CC:DD:EE:FF",
+                blePsm = null,
+                bleVisible = true,
+            )
+
+        val plan = SendBootstrapPlan.resolve(peer = peer)
+
+        assertTrue(plan.isConnectable)
+        assertEquals(
+            NearbyPeerRoute.BleGatt("AA:BB:CC:DD:EE:FF"),
+            (plan.action as SendBootstrapPlan.Action.Direct).route,
+        )
+    }
+
+    @Test
+    fun `Bluetooth Classic is used when visible BLE GATT bootstrap is unverified`() {
+        val peer =
+            peer(
+                bluetoothMac = "11:22:33:44:55:66",
+                bleAddress = "AA:BB:CC:DD:EE:FF",
+                blePsm = null,
+                bleVisible = true,
+                bleGattConnectable = false,
+            )
+
+        val plan = SendBootstrapPlan.resolve(peer = peer)
+
+        assertTrue(plan.isConnectable)
+        assertEquals(
+            NearbyPeerRoute.BluetoothClassic("11:22:33:44:55:66"),
+            (plan.action as SendBootstrapPlan.Action.Direct).route,
+        )
+        assertTrue(plan.subtitle.contains("Bluetooth Classic"))
+        assertTrue(plan.rejectedCandidates.contains("ble-gatt=not-verified"))
+    }
+
+    @Test
+    fun `peer without any route stays unavailable`() {
+        val peer = peer()
+
+        val plan = SendBootstrapPlan.resolve(peer = peer)
+
+        assertFalse(plan.isConnectable)
+        assertTrue(plan.failureReason!!.contains("no shared Wi-Fi LAN route"))
+    }
+
+    @Suppress("LongParameterList")
+    private fun peer(
+        lanAddress: String? = null,
+        lanPort: Int = 7654,
+        bluetoothMac: String? = null,
+        bleAddress: String? = null,
+        blePsm: Int? = null,
+        bleVisible: Boolean? = null,
+        bleGattConnectable: Boolean = true,
+    ): NearbyPeer =
+        NearbyPeer(
+            stableId = "peer-1",
+            endpointId = "ABCD",
+            endpointInfo =
+                bleVisible?.let { visible ->
+                    EndpointInfo(
+                        version = 1,
+                        hidden = !visible,
+                        deviceType = DeviceType.PHONE,
+                        reserved = false,
+                        metadata = ByteArray(EndpointInfo.METADATA_LEN),
+                        deviceName = if (visible) "Galaxy S26 Ultra" else null,
+                    )
+                },
+            lanEndpoint =
+                lanAddress?.let {
+                    NearbyPeer.LanEndpoint(
+                        instanceNames = setOf("ABCD"),
+                        addresses = listOf(InetAddress.getByName(it)),
+                        port = lanPort,
+                    )
+                },
+            bluetoothEndpoint =
+                bluetoothMac?.let {
+                    NearbyPeer.BluetoothEndpoint(
+                        macAddress = it,
+                        advertisedName = "Nearby-$it",
+                    )
+                },
+            bleAdvertisement =
+                bleAddress?.let {
+                    NearbyPeer.BleAdvertisement(
+                        advertiserAddress = it,
+                        rssi = -42,
+                        l2capPsm = blePsm,
+                        gattConnectable = bleGattConnectable,
+                        displayName = "Galaxy S26 Ultra",
+                        displayNameSource = "fast-advertisement-endpoint-info",
+                    )
+                },
+        )
+}

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeFrames.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeFrames.kt
@@ -9,6 +9,8 @@ package io.github.kyujincho.wvmg.protocol.connection
 
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.BandwidthUpgradeNegotiationFrame
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.BandwidthUpgradeNegotiationFrame.UpgradePathInfo
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.MediumMetadata
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.MediumRole
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.V1Frame
 import com.google.protobuf.ByteString
@@ -75,6 +77,38 @@ public object BandwidthUpgradeFrames {
                 .setEventType(BandwidthUpgradeNegotiationFrame.EventType.UPGRADE_PATH_AVAILABLE)
                 .setUpgradePathInfo(info)
                 .build(),
+        )
+    }
+
+    /**
+     * Build `OfflineFrame{BANDWIDTH_UPGRADE_NEGOTIATION{
+     * event_type=UPGRADE_PATH_REQUEST, upgrade_path_info{
+     * upgrade_path_request{mediums=...}}}}`.
+     *
+     * Sent by a BLE/GATT sender after the encrypted channel is ready
+     * when the opening `ConnectionRequest.mediums` cannot safely include
+     * Wi-Fi Direct. The receiver remains the Nearby Connections server
+     * role and answers with `UPGRADE_PATH_AVAILABLE` if it can stand up
+     * one of the requested mediums.
+     */
+    public fun upgradePathRequest(requestedMediums: Set<Medium>): OfflineFrame {
+        val request =
+            UpgradePathInfo.UpgradePathRequest
+                .newBuilder()
+                .setMediumMetaData(defaultUpgradeRequestMetadata(requestedMediums))
+        requestedMediums
+            .map { it.toUpgradePathMedium() }
+            .sortedBy { it.number }
+            .forEach(request::addMediums)
+        return wrap(
+            BandwidthUpgradeNegotiationFrame
+                .newBuilder()
+                .setEventType(BandwidthUpgradeNegotiationFrame.EventType.UPGRADE_PATH_REQUEST)
+                .setUpgradePathInfo(
+                    UpgradePathInfo
+                        .newBuilder()
+                        .setUpgradePathRequest(request),
+                ).build(),
         )
     }
 
@@ -364,6 +398,30 @@ public object BandwidthUpgradeFrames {
     }
 
     /**
+     * Decode the medium set from an inbound `UPGRADE_PATH_REQUEST`.
+     * Returns `null` for any other frame shape.
+     */
+    @Suppress("ReturnCount")
+    public fun decodeUpgradePathRequestMediums(frame: OfflineFrame): Set<Medium>? {
+        if (!frame.hasV1() || frame.v1.type != V1Frame.FrameType.BANDWIDTH_UPGRADE_NEGOTIATION) {
+            return null
+        }
+        val negotiation = frame.v1.bandwidthUpgradeNegotiation
+        if (negotiation.eventType != BandwidthUpgradeNegotiationFrame.EventType.UPGRADE_PATH_REQUEST) {
+            return null
+        }
+        if (!negotiation.hasUpgradePathInfo() || !negotiation.upgradePathInfo.hasUpgradePathRequest()) {
+            return emptySet()
+        }
+        return negotiation
+            .upgradePathInfo
+            .upgradePathRequest
+            .mediumsList
+            .mapNotNull { Medium.fromUpgradePathMedium(it) }
+            .toSet()
+    }
+
+    /**
      * Parse a BLE-L2CAP-shaped `BluetoothCredentials` payload back into
      * [UpgradePathCredentials.BleL2cap]. Returns `null` when the proto
      * does not carry the `L2CAP:<psm>` discriminator (i.e. it really is
@@ -537,6 +595,23 @@ public object BandwidthUpgradeFrames {
         }
         return builder.build()
     }
+
+    private fun defaultUpgradeRequestMetadata(requestedMediums: Set<Medium>): MediumMetadata =
+        MediumMetadata
+            .newBuilder()
+            .also { builder ->
+                if (Medium.WIFI_DIRECT in requestedMediums) {
+                    builder.addSupportedWifiDirectAuthTypes(
+                        MediumMetadata.WifiDirectAuthType.WIFI_DIRECT_WITH_PASSWORD,
+                    )
+                    builder.setMediumRole(
+                        MediumRole
+                            .newBuilder()
+                            .setSupportWifiDirectGroupClient(true)
+                            .setSupportWifiDirectGroupOwner(true),
+                    )
+                }
+            }.build()
 
     /**
      * Serialize the publisher-side IPv6 + port pair into the byte layout

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeOrchestrator.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeOrchestrator.kt
@@ -248,8 +248,11 @@ internal object BandwidthUpgradeOrchestrator {
         closePriorChannelAfterUpgrade(oldChannel, consumedPeerSafe = true, logger = logger)
     }
 
-    suspend fun receiveOfferProbe(channel: SecureChannel): UpgradeOfferProbe =
-        withTimeoutOrNull(OFFER_WAIT_TIMEOUT_MILLIS) {
+    suspend fun receiveOfferProbe(
+        channel: SecureChannel,
+        timeoutMillis: Long = OFFER_WAIT_TIMEOUT_MILLIS,
+    ): UpgradeOfferProbe =
+        withTimeoutOrNull(timeoutMillis) {
             val frame = channel.receiveOfflineFrame()
             if (frame.isBandwidthUpgradeEvent(BandwidthUpgradeNegotiationFrame.EventType.UPGRADE_PATH_AVAILABLE)) {
                 UpgradeOfferProbe.Offer(frame)
@@ -625,7 +628,7 @@ internal object BandwidthUpgradeOrchestrator {
     }
 
     private const val UPGRADE_TIMEOUT_MILLIS: Long = 30_000L
-    private const val OFFER_WAIT_TIMEOUT_MILLIS: Long = 1_500L
+    internal const val OFFER_WAIT_TIMEOUT_MILLIS: Long = 1_500L
     private const val SERVER_PEER_SAFE_DRAIN_MILLIS: Long = 500L
     private const val PRIOR_CHANNEL_DISCONNECT_DRAIN_MILLIS: Long = 200L
     private const val DUAL_CHANNEL_DRAIN_IDLE_ATTEMPTS: Int = 25

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/InboundConnectionDriver.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/InboundConnectionDriver.kt
@@ -235,7 +235,17 @@ internal class InboundConnectionDriver(
         // immediately after connection success, before it processes our
         // bandwidth-upgrade offer. Drain one already-buffered frame so the
         // SecureMessage receive sequence remains aligned across the upgrade.
+        // BLE/GATT senders may also send UPGRADE_PATH_REQUEST here when
+        // their opening ConnectionRequest had to omit higher-bandwidth
+        // mediums for receiver compatibility; consume that request and use
+        // it as the upgrade candidate set instead of buffering it into the
+        // later sharing loop.
         val initialWireFrame = pollBufferedInitialWireFrame(channel)
+        val requestedUpgradeMediums =
+            initialWireFrame?.let(BandwidthUpgradeFrames::decodeUpgradePathRequestMediums)
+        if (requestedUpgradeMediums != null) {
+            logger("medium-upgrade: peer requested upgrade mediums=$requestedUpgradeMediums")
+        }
 
         // Step 7: as the Nearby Connections server role, offer the best
         // prepared upgrade medium before the Nearby Share payload
@@ -249,7 +259,7 @@ internal class InboundConnectionDriver(
                     oldChannel = channel,
                     currentMedium = transport.medium,
                     mediumRegistry = mediumRegistry,
-                    peerSupportedMediums = peerSupportedMediums,
+                    peerSupportedMediums = requestedUpgradeMediums ?: peerSupportedMediums,
                     peerEndpointId = initialFrame.v1.connectionRequest.endpointId,
                     logger = logger,
                 )
@@ -257,7 +267,9 @@ internal class InboundConnectionDriver(
         mutableActiveMedium.value = activeTransport.medium
         val initialWireFrames =
             buildList {
-                initialWireFrame?.let(::add)
+                if (requestedUpgradeMediums == null) {
+                    initialWireFrame?.let(::add)
+                }
                 addAll(activeTransport.bufferedFrames)
             }
 

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnection.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnection.kt
@@ -134,6 +134,16 @@ import java.security.SecureRandom
  * @param connectTimeoutMillis TCP connect timeout. Default 5 seconds —
  *   matches NearDrop's default and is generous enough for Wi-Fi LAN
  *   without making "host is down" cases linger.
+ * @param initialHandshakeTimeoutMillis Maximum time to wait for the
+ *   unencrypted ConnectionRequest / UKEY2 / ConnectionResponse leg
+ *   after the initial transport is open. Closing the transport on this
+ *   timeout prevents non-LAN virtual streams from leaving the sender UI
+ *   stuck in the pairing state.
+ * @param remoteAcceptanceTimeoutMillis Maximum time to wait after the
+ *   IntroductionFrame is sent for the receiver's encrypted
+ *   ConnectionResponseFrame. Stock receivers normally answer only after
+ *   the user accepts/rejects the consent UI; this bounds peers that keep
+ *   the secure channel alive but never surface that UI.
  * @param secureRandom Source of randomness for the UKEY2 keypair, the
  *   PairedKeyEncryption fill bytes, the SecureChannel IVs, and the
  *   per-frame `payload_id` choices. Tests inject a deterministic
@@ -157,6 +167,8 @@ public class OutboundConnection private constructor(
     private val endpointInfo: ByteArray = ByteArray(0),
     private val qrCodeHandshakeData: ByteArray? = null,
     private val connectTimeoutMillis: Int = DEFAULT_CONNECT_TIMEOUT_MILLIS,
+    private val initialHandshakeTimeoutMillis: Long = DEFAULT_INITIAL_HANDSHAKE_TIMEOUT_MILLIS,
+    private val remoteAcceptanceTimeoutMillis: Long = DEFAULT_REMOTE_ACCEPTANCE_TIMEOUT_MILLIS,
     private val secureRandom: SecureRandom = SecureRandom(),
     private val mediumRegistry: MediumRegistry = MediumRegistry.DefaultWifiLan,
     /**
@@ -176,6 +188,8 @@ public class OutboundConnection private constructor(
         endpointInfo: ByteArray = ByteArray(0),
         qrCodeHandshakeData: ByteArray? = null,
         connectTimeoutMillis: Int = DEFAULT_CONNECT_TIMEOUT_MILLIS,
+        initialHandshakeTimeoutMillis: Long = DEFAULT_INITIAL_HANDSHAKE_TIMEOUT_MILLIS,
+        remoteAcceptanceTimeoutMillis: Long = DEFAULT_REMOTE_ACCEPTANCE_TIMEOUT_MILLIS,
         secureRandom: SecureRandom = SecureRandom(),
         mediumRegistry: MediumRegistry = MediumRegistry.DefaultWifiLan,
         logger: (String) -> Unit = {},
@@ -187,6 +201,8 @@ public class OutboundConnection private constructor(
         endpointInfo = endpointInfo,
         qrCodeHandshakeData = qrCodeHandshakeData,
         connectTimeoutMillis = connectTimeoutMillis,
+        initialHandshakeTimeoutMillis = initialHandshakeTimeoutMillis,
+        remoteAcceptanceTimeoutMillis = remoteAcceptanceTimeoutMillis,
         secureRandom = secureRandom,
         mediumRegistry = mediumRegistry,
         logger = logger,
@@ -198,6 +214,8 @@ public class OutboundConnection private constructor(
         endpointInfo: ByteArray = ByteArray(0),
         qrCodeHandshakeData: ByteArray? = null,
         connectTimeoutMillis: Int = DEFAULT_CONNECT_TIMEOUT_MILLIS,
+        initialHandshakeTimeoutMillis: Long = DEFAULT_INITIAL_HANDSHAKE_TIMEOUT_MILLIS,
+        remoteAcceptanceTimeoutMillis: Long = DEFAULT_REMOTE_ACCEPTANCE_TIMEOUT_MILLIS,
         secureRandom: SecureRandom = SecureRandom(),
         mediumRegistry: MediumRegistry = MediumRegistry.DefaultWifiLan,
         logger: (String) -> Unit = {},
@@ -209,6 +227,8 @@ public class OutboundConnection private constructor(
         endpointInfo = endpointInfo,
         qrCodeHandshakeData = qrCodeHandshakeData,
         connectTimeoutMillis = connectTimeoutMillis,
+        initialHandshakeTimeoutMillis = initialHandshakeTimeoutMillis,
+        remoteAcceptanceTimeoutMillis = remoteAcceptanceTimeoutMillis,
         secureRandom = secureRandom,
         mediumRegistry = mediumRegistry,
         logger = logger,
@@ -285,6 +305,12 @@ public class OutboundConnection private constructor(
         require(usingLanSocket.xor(usingPreconnectedTransport)) {
             "OutboundConnection requires either targetAddress+port or transport"
         }
+        require(initialHandshakeTimeoutMillis > 0L) {
+            "initialHandshakeTimeoutMillis must be positive"
+        }
+        require(remoteAcceptanceTimeoutMillis > 0L) {
+            "remoteAcceptanceTimeoutMillis must be positive"
+        }
     }
 
     /**
@@ -352,6 +378,8 @@ public class OutboundConnection private constructor(
                 mediumRegistry = mediumRegistry,
                 onHandshakeComplete = ::markHandshakeComplete,
                 logger = logger,
+                initialHandshakeTimeoutMillis = initialHandshakeTimeoutMillis,
+                remoteAcceptanceTimeoutMillis = remoteAcceptanceTimeoutMillis,
             )
 
         return try {
@@ -542,6 +570,18 @@ public class OutboundConnection private constructor(
          * unreachable" failures within human attention span.
          */
         public const val DEFAULT_CONNECT_TIMEOUT_MILLIS: Int = 5000
+
+        /**
+         * Default timeout for the unencrypted ConnectionRequest/UKEY2/
+         * ConnectionResponse leg after the transport is open.
+         */
+        public const val DEFAULT_INITIAL_HANDSHAKE_TIMEOUT_MILLIS: Long = 15_000L
+
+        /**
+         * Default timeout for the encrypted receiver consent response
+         * after our IntroductionFrame has been sent.
+         */
+        public const val DEFAULT_REMOTE_ACCEPTANCE_TIMEOUT_MILLIS: Long = 30_000L
 
         /** Number of stack frames the diagnostic logger emits per failure. */
         private const val STACK_FRAMES_TO_LOG: Int = 8

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionDriver.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionDriver.kt
@@ -12,6 +12,7 @@ import io.github.kyujincho.wvmg.protocol.crypto.D2DKeyDerivation
 import io.github.kyujincho.wvmg.protocol.crypto.D2DRole
 import io.github.kyujincho.wvmg.protocol.crypto.pin.PinDerivation
 import io.github.kyujincho.wvmg.protocol.crypto.securemessage.SecureChannel
+import io.github.kyujincho.wvmg.protocol.medium.Medium
 import io.github.kyujincho.wvmg.protocol.medium.MediumRegistry
 import io.github.kyujincho.wvmg.protocol.payload.PayloadAssembler
 import io.github.kyujincho.wvmg.protocol.payload.PayloadEvent
@@ -30,16 +31,21 @@ import io.github.kyujincho.wvmg.protocol.transport.ConnectedTransport
 import io.github.kyujincho.wvmg.protocol.transport.EndOfFrameStream
 import io.github.kyujincho.wvmg.protocol.transport.FramedConnection
 import io.github.kyujincho.wvmg.protocol.ukey2.Ukey2Client
+import io.github.kyujincho.wvmg.protocol.ukey2.Ukey2HandshakeResult
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.selects.onTimeout
 import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.withTimeoutOrNull
 import java.security.SecureRandom
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Internal lifecycle driver for [OutboundConnection].
@@ -58,6 +64,7 @@ import java.security.SecureRandom
  * `select`s between that channel and [externalEvents].
  */
 @Suppress(
+    "LargeClass", // The driver intentionally keeps the full wire lifecycle in one state-owning type.
     "TooManyFunctions", // The lifecycle inherently has many phases; each is one function for readability.
     "LongParameterList", // Constructor takes the connection's collaborators verbatim.
 )
@@ -73,6 +80,10 @@ internal class OutboundConnectionDriver(
     private val mediumRegistry: MediumRegistry = MediumRegistry.DefaultWifiLan,
     private val onHandshakeComplete: () -> Unit = {},
     private val logger: (String) -> Unit = {},
+    private val initialHandshakeTimeoutMillis: Long =
+        OutboundConnection.DEFAULT_INITIAL_HANDSHAKE_TIMEOUT_MILLIS,
+    private val remoteAcceptanceTimeoutMillis: Long =
+        OutboundConnection.DEFAULT_REMOTE_ACCEPTANCE_TIMEOUT_MILLIS,
     /**
      * Wall-clock source for the rate estimator. Defaults to
      * [System.currentTimeMillis]; tests inject deterministic
@@ -125,7 +136,15 @@ internal class OutboundConnectionDriver(
         // provider this is functionally identical to the previous
         // hard-coded `[WIFI_LAN]` on the legacy LAN path.
         val advertisedMediums =
-            mediumRegistry.supportedMediumsForCurrentTransport(initialTransport.medium)
+            mediumRegistry
+                .supportedMediumsForCurrentTransport(initialTransport.medium)
+                .let { supportedMediums ->
+                    if (initialTransport.medium == Medium.BLE && Medium.BLE in supportedMediums) {
+                        linkedSetOf(Medium.BLE)
+                    } else {
+                        supportedMediums
+                    }
+                }
         logger("step 1: advertising mediums=$advertisedMediums")
         transport.sendFrame(
             OutboundFrames
@@ -137,9 +156,9 @@ internal class OutboundConnectionDriver(
         )
         logger("step 1: sent ConnectionRequest, awaiting Ukey2ServerInit")
 
-        // Step 2: UKEY2 client handshake (ClientInit, ServerInit, ClientFinish).
-        val handshake = Ukey2Client.performHandshake(transport, secureRandom)
-        logger("step 2: UKEY2 client handshake complete (dhs.size=${handshake.dhs.size})")
+        val (handshake, peerResponse) =
+            runInitialHandshakeWithTimeout(transport)
+                ?: return initialHandshakeTimedOut()
 
         // Step 3: send our unencrypted ConnectionResponse{ACCEPT}.
         //
@@ -149,14 +168,8 @@ internal class OutboundConnectionDriver(
         // if we read instead, both sides deadlock and the peer eventually
         // times out and closes (surfacing here as EndOfFrameStream right
         // after the UKEY2 handshake).
-        val responseBytes = OutboundFrames.connectionResponse().toByteArray()
-        logger("step 3: sending our ConnectionResponse, size=${responseBytes.size}")
-        transport.sendFrame(responseBytes)
-        logger("step 3: sent our ConnectionResponse{ACCEPT}")
 
         // Step 4: read receiver's unencrypted ConnectionResponse.
-        logger("step 4: awaiting peer ConnectionResponse...")
-        val peerResponse = readOfflineFrameUnencrypted(transport)
         val hasResp = peerResponse.v1.hasConnectionResponse()
         logger("step 4: received peer ConnectionResponse type=${peerResponse.v1.type} hasConnectionResponse=$hasResp")
         if (peerResponse.v1.hasConnectionResponse()) {
@@ -259,6 +272,68 @@ internal class OutboundConnectionDriver(
         runCatching { secureChannel?.close() }
         runCatching { framedConnection?.close() }
         runCatching { initialTransport.close() }
+    }
+
+    /**
+     * Run the pre-secure handshake under a wall-clock guard. Blocking
+     * reads inside [FramedConnection] do not wake up on coroutine
+     * cancellation alone; the timeout job closes the underlying
+     * transport first, which unblocks sockets and the BLE virtual
+     * streams used by non-LAN bootstrap paths.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun runInitialHandshakeWithTimeout(
+        transport: FramedConnection,
+    ): Pair<Ukey2HandshakeResult, OfflineFrame>? =
+        coroutineScope {
+            val timedOut = AtomicBoolean(false)
+            val timeoutJob =
+                launch {
+                    delay(initialHandshakeTimeoutMillis)
+                    timedOut.set(true)
+                    logger(
+                        "step 2: initial handshake timed out after " +
+                            "${initialHandshakeTimeoutMillis}ms; closing transport",
+                    )
+                    runCatching { transport.close() }
+                    runCatching { initialTransport.close() }
+                }
+            try {
+                val handshake = Ukey2Client.performHandshake(transport, secureRandom)
+
+                if (timedOut.get()) {
+                    null
+                } else {
+                    logger("step 2: UKEY2 client handshake complete (dhs.size=${handshake.dhs.size})")
+
+                    val responseBytes = OutboundFrames.connectionResponse().toByteArray()
+                    logger("step 3: sending our ConnectionResponse, size=${responseBytes.size}")
+                    transport.sendFrame(responseBytes)
+                    logger("step 3: sent our ConnectionResponse{ACCEPT}")
+
+                    logger("step 4: awaiting peer ConnectionResponse...")
+                    val peerResponse = readOfflineFrameUnencrypted(transport)
+                    if (timedOut.get()) {
+                        null
+                    } else {
+                        handshake to peerResponse
+                    }
+                }
+            } catch (e: Throwable) {
+                if (timedOut.get()) {
+                    null
+                } else {
+                    throw e
+                }
+            } finally {
+                timeoutJob.cancelAndJoin()
+            }
+        }
+
+    private fun initialHandshakeTimedOut(): OutboundResult.Failed {
+        val reason = "Initial handshake timed out after ${initialHandshakeTimeoutMillis}ms"
+        mutableState.value = OutboundConnectionState.Failed(reason)
+        return OutboundResult.Failed(reason)
     }
 
     /**
@@ -510,6 +585,7 @@ internal class OutboundConnectionDriver(
     /**
      * Dispatch loop — runs until a terminal state is reached.
      */
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Suppress("ReturnCount", "CyclomaticComplexMethod")
     private suspend fun dispatchLoop(
         channel: SecureChannel,
@@ -521,10 +597,21 @@ internal class OutboundConnectionDriver(
             ArrayDeque<OfflineFrame>().apply {
                 addAll(initialWireFrames)
             }
+        var remoteAcceptanceDeadlineMillis: Long? = null
         while (true) {
             // Terminal state? Resolve and return.
             if (fsm.state == OutboundSharingState.Disconnected) {
                 return terminalResultFromState()
+            }
+
+            remoteAcceptanceDeadlineMillis =
+                updateRemoteAcceptanceDeadline(
+                    fsm = fsm,
+                    currentDeadlineMillis = remoteAcceptanceDeadlineMillis,
+                )
+            val remoteAcceptanceRemainingMillis = remoteAcceptanceRemainingMillis(remoteAcceptanceDeadlineMillis)
+            if (remoteAcceptanceRemainingMillis == 0L) {
+                return remoteAcceptanceTimedOut()
             }
 
             val event: OutboundDriverEvent =
@@ -540,6 +627,11 @@ internal class OutboundConnectionDriver(
                                 is OutboundWireMessage.Frame -> OutboundDriverEvent.Wire(msg.frame)
                                 OutboundWireMessage.Closed -> OutboundDriverEvent.PeerClosed
                                 is OutboundWireMessage.Error -> OutboundDriverEvent.PumpError(msg.cause)
+                            }
+                        }
+                        remoteAcceptanceRemainingMillis?.let { remainingMillis ->
+                            onTimeout(remainingMillis) {
+                                OutboundDriverEvent.RemoteAcceptanceTimedOut
                             }
                         }
                     }
@@ -563,6 +655,7 @@ internal class OutboundConnectionDriver(
                 "Wire($v1Type)"
             }
             OutboundDriverEvent.PeerClosed -> "PeerClosed"
+            OutboundDriverEvent.RemoteAcceptanceTimedOut -> "RemoteAcceptanceTimedOut"
             is OutboundDriverEvent.PumpError ->
                 "PumpError(${event.cause::class.simpleName}: ${event.cause.message ?: "null"})"
         }
@@ -580,12 +673,38 @@ internal class OutboundConnectionDriver(
             }
             is OutboundDriverEvent.Wire -> handleInboundOfflineFrame(channel, fsm, event.frame)
             OutboundDriverEvent.PeerClosed -> handlePeerClosed()
+            OutboundDriverEvent.RemoteAcceptanceTimedOut -> remoteAcceptanceTimedOut()
             is OutboundDriverEvent.PumpError -> {
                 val reason = "Inbound pump error: ${event.cause::class.simpleName}: ${event.cause.message}"
                 mutableState.value = OutboundConnectionState.Failed(reason)
                 OutboundResult.Failed(reason)
             }
         }
+
+    private fun updateRemoteAcceptanceDeadline(
+        fsm: OutboundSharingFsm,
+        currentDeadlineMillis: Long?,
+    ): Long? =
+        when {
+            fsm.state != OutboundSharingState.SentIntroduction -> null
+            currentDeadlineMillis != null -> currentDeadlineMillis
+            else -> {
+                logger("fsm: awaiting receiver acceptance timeout=${remoteAcceptanceTimeoutMillis}ms")
+                nowMillisSource() + remoteAcceptanceTimeoutMillis
+            }
+        }
+
+    private fun remoteAcceptanceRemainingMillis(deadlineMillis: Long?): Long? =
+        deadlineMillis?.let { deadline ->
+            (deadline - nowMillisSource()).coerceAtLeast(0L)
+        }
+
+    private fun remoteAcceptanceTimedOut(): OutboundResult.Failed {
+        val reason = "Timed out waiting for receiver acceptance after ${remoteAcceptanceTimeoutMillis}ms"
+        logger("fsm: $reason")
+        mutableState.value = OutboundConnectionState.Failed(reason)
+        return OutboundResult.Failed(reason)
+    }
 
     /**
      * Handle one inbound `OfflineFrame` from the SecureChannel.

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionDriver.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionDriver.kt
@@ -5,6 +5,7 @@
  */
 package io.github.kyujincho.wvmg.protocol.connection
 
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.BandwidthUpgradeNegotiationFrame
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.V1Frame
 import com.google.protobuf.ByteString
@@ -119,6 +120,7 @@ internal class OutboundConnectionDriver(
      * [OutboundResult]; throws on coroutine cancellation (handled by
      * the caller).
      */
+    @Suppress("ReturnCount")
     suspend fun runLifecycle(): OutboundResult {
         mutableState.value = OutboundConnectionState.Handshaking
         logger(
@@ -127,24 +129,15 @@ internal class OutboundConnectionDriver(
         )
         val transport = FramedConnection(initialTransport).also { framedConnection = it }
 
-        // Step 1: send unencrypted ConnectionRequest. The mediums set
-        // is sourced from the registry's current-medium-aware view:
-        // WIFI_LAN only means "stay on the already-open LAN socket", so
-        // a Bluetooth/BLE bootstrap must not advertise it as an
-        // off-LAN upgrade option. Phase 4's per-medium adapters extend
-        // the set by registering against the registry; absent any extra
-        // provider this is functionally identical to the previous
-        // hard-coded `[WIFI_LAN]` on the legacy LAN path.
-        val advertisedMediums =
-            mediumRegistry
-                .supportedMediumsForCurrentTransport(initialTransport.medium)
-                .let { supportedMediums ->
-                    if (initialTransport.medium == Medium.BLE && Medium.BLE in supportedMediums) {
-                        linkedSetOf(Medium.BLE)
-                    } else {
-                        supportedMediums
-                    }
-                }
+        // Step 1: send unencrypted ConnectionRequest. BLE/GATT
+        // bootstraps still carry the legacy Wi-Fi LAN marker because
+        // stock Quick Share validates that shape before it dispatches
+        // the incoming connection. When a local Wi-Fi Direct provider
+        // is registered, advertise WFD in this opening request as well,
+        // then send a post-accept UPGRADE_PATH_REQUEST if the receiver
+        // does not proactively offer Wi-Fi Direct before payload
+        // streaming.
+        val advertisedMediums = advertisedMediumsForInitialTransport()
         logger("step 1: advertising mediums=$advertisedMediums")
         transport.sendFrame(
             OutboundFrames
@@ -206,7 +199,16 @@ internal class OutboundConnectionDriver(
         // adopt it before the Nearby Share payload negotiation begins.
         // Peers that stay on Wi-Fi LAN send the first sharing payload;
         // buffer that frame so the existing receive loop sees it.
-        val (activeChannel, initialWireFrames) = negotiateBandwidthUpgrade(channel)
+        val negotiated =
+            when (val negotiation = negotiateBandwidthUpgrade(channel)) {
+                is BandwidthNegotiation.Ready -> negotiation
+                is BandwidthNegotiation.Failed -> {
+                    logger("medium-upgrade: ${negotiation.reason}")
+                    runCatching { sendTerminalDisconnection(channel) }
+                    mutableState.value = OutboundConnectionState.Failed(negotiation.reason)
+                    return OutboundResult.Failed(negotiation.reason)
+                }
+            }
 
         // Step 8: build the OutboundSharingFsm with our IntroductionFrame.
         val introduction = buildIntroductionFrame(files)
@@ -217,7 +219,7 @@ internal class OutboundConnectionDriver(
         // Step 9: drive the FSM's initial PKE frame onto the wire,
         // optionally attaching qr_code_handshake_data.
         logger("step 8: sending initial PKE frame")
-        applyEffects(activeChannel, rewriteForQrIfNeeded(negotiationFsm.start()))
+        applyEffects(negotiated.channel, rewriteForQrIfNeeded(negotiationFsm.start()))
 
         // Mark the handshake as complete so a racing UI-side cancel()
         // takes the cooperative FSM path (CANCEL + DISCONNECTION on the
@@ -233,35 +235,78 @@ internal class OutboundConnectionDriver(
         // cancel() in that race would crash the peer with Broken pipe.
         onHandshakeComplete()
 
-        return runReceiveLoop(activeChannel, negotiationFsm, initialWireFrames)
+        return if (requiresWifiDirectUpgradeForBle() && negotiated.medium != Medium.WIFI_DIRECT) {
+            runBleWifiDirectReceiveLoop(
+                channel = negotiated.channel,
+                fsm = negotiationFsm,
+                initialWireFrames = negotiated.initialWireFrames,
+            )
+        } else {
+            runReceiveLoop(negotiated.channel, negotiationFsm, negotiated.initialWireFrames)
+        }
     }
 
-    private suspend fun negotiateBandwidthUpgrade(channel: SecureChannel): Pair<SecureChannel, List<OfflineFrame>> {
+    private fun advertisedMediumsForInitialTransport(): Set<Medium> {
+        val supportedMediums =
+            mediumRegistry.supportedMediumsForCurrentTransport(initialTransport.medium)
+        if (initialTransport.medium != Medium.BLE) return supportedMediums
+
+        return buildSet {
+            add(Medium.WIFI_LAN)
+            add(Medium.BLE)
+            if (Medium.WIFI_DIRECT in supportedMediums) {
+                add(Medium.WIFI_DIRECT)
+            }
+        }
+    }
+
+    private suspend fun negotiateBandwidthUpgrade(channel: SecureChannel): BandwidthNegotiation {
         val initialWireFrames = mutableListOf<OfflineFrame>()
-        val activeChannel =
-            when (val probe = BandwidthUpgradeOrchestrator.receiveOfferProbe(channel)) {
-                UpgradeOfferProbe.None -> channel
+        val requiresWifiDirect = requiresWifiDirectUpgradeForBle()
+        val activeTransport =
+            when (
+                val probe =
+                    BandwidthUpgradeOrchestrator.receiveOfferProbe(
+                        channel = channel,
+                        timeoutMillis =
+                            if (requiresWifiDirect) {
+                                BLE_WIFI_DIRECT_UPGRADE_TIMEOUT_MILLIS
+                            } else {
+                                BandwidthUpgradeOrchestrator.OFFER_WAIT_TIMEOUT_MILLIS
+                            },
+                    )
+            ) {
+                UpgradeOfferProbe.None -> ActiveTransportChannel(channel, initialTransport.medium)
                 is UpgradeOfferProbe.Other -> {
                     initialWireFrames += probe.frame
-                    channel
+                    ActiveTransportChannel(channel, initialTransport.medium)
                 }
                 is UpgradeOfferProbe.Offer -> {
-                    val activeTransport =
-                        BandwidthUpgradeOrchestrator
-                            .runClientUpgradeFromOffer(
-                                oldChannel = channel,
-                                currentMedium = initialTransport.medium,
-                                offer = probe.frame,
-                                mediumRegistry = mediumRegistry,
-                                endpointId = endpointId,
-                                logger = logger,
-                            )
-                    initialWireFrames += activeTransport.bufferedFrames
-                    activeTransport.channel.also { secureChannel = it }
+                    val transport =
+                        BandwidthUpgradeOrchestrator.runClientUpgradeFromOffer(
+                            oldChannel = channel,
+                            currentMedium = initialTransport.medium,
+                            offer = probe.frame,
+                            mediumRegistry = mediumRegistry,
+                            endpointId = endpointId,
+                            logger = logger,
+                        )
+                    if (requiresWifiDirect && transport.medium != Medium.WIFI_DIRECT) {
+                        return BandwidthNegotiation.Failed(
+                            "Wi-Fi Direct upgrade failed after BLE pairing; " +
+                                "stayed on ${transport.medium}",
+                        )
+                    }
+                    initialWireFrames += transport.bufferedFrames
+                    transport.also { secureChannel = it.channel }
                 }
             }
-        return activeChannel to initialWireFrames
+        return BandwidthNegotiation.Ready(activeTransport.channel, activeTransport.medium, initialWireFrames)
     }
+
+    private fun requiresWifiDirectUpgradeForBle(): Boolean =
+        initialTransport.medium == Medium.BLE &&
+            Medium.WIFI_DIRECT in mediumRegistry.supportedMediumsForCurrentTransport(initialTransport.medium)
 
     /**
      * Tear down all owned resources. Safe to call multiple times; each
@@ -450,7 +495,7 @@ internal class OutboundConnectionDriver(
                             "${SAFE_DISCONNECT_ACK_TIMEOUT_MS}ms",
                     )
                 }
-                result
+                publishCompletedIfNeeded(result)
             } finally {
                 // Cancel the KEEP_ALIVE ticker FIRST, before any socket
                 // close: the ticker spends almost all its life parked
@@ -504,6 +549,329 @@ internal class OutboundConnectionDriver(
                 logger("keep-alive: ticker stopped (${e::class.simpleName}: ${e.message ?: "null"})")
             },
         )
+    }
+
+    /**
+     * BLE/GATT sender path for stock Android receivers that advertise
+     * Wi-Fi Direct but do not auto-upgrade before the Nearby Share
+     * consent exchange. Keep the read side single-threaded here: the
+     * bandwidth-upgrade handshake needs to keep using the prior BLE
+     * channel, so the normal inbound pump must not be parked in a
+     * blocking read on that same channel when an offer arrives.
+     */
+    @Suppress("LongMethod", "CyclomaticComplexMethod", "NestedBlockDepth", "ReturnCount")
+    private suspend fun runBleWifiDirectReceiveLoop(
+        channel: SecureChannel,
+        fsm: OutboundSharingFsm,
+        initialWireFrames: List<OfflineFrame> = emptyList(),
+    ): OutboundResult {
+        var activeChannel = channel
+        var activeMedium = initialTransport.medium
+        val bufferedFrames =
+            ArrayDeque<OfflineFrame>().apply {
+                addAll(initialWireFrames)
+            }
+        var remoteAcceptanceDeadlineMillis: Long? = null
+        try {
+            while (true) {
+                if (fsm.state == OutboundSharingState.Disconnected) {
+                    return terminalResultFromState()
+                }
+
+                remoteAcceptanceDeadlineMillis =
+                    updateRemoteAcceptanceDeadline(
+                        fsm = fsm,
+                        currentDeadlineMillis = remoteAcceptanceDeadlineMillis,
+                    )
+                val remoteAcceptanceRemainingMillis = remoteAcceptanceRemainingMillis(remoteAcceptanceDeadlineMillis)
+                if (remoteAcceptanceRemainingMillis == 0L) {
+                    return remoteAcceptanceTimedOut()
+                }
+
+                val event =
+                    nextBleWifiDirectEvent(
+                        channel = activeChannel,
+                        bufferedFrames = bufferedFrames,
+                        remoteAcceptanceRemainingMillis = remoteAcceptanceRemainingMillis,
+                    )
+                logger("fsm: dispatch event=${describeDriverEvent(event)} fsmState=${fsm.state::class.simpleName}")
+
+                if (event is OutboundDriverEvent.Wire &&
+                    event.frame.isBandwidthUpgradeEvent(
+                        BandwidthUpgradeNegotiationFrame.EventType.UPGRADE_PATH_AVAILABLE,
+                    )
+                ) {
+                    val upgraded =
+                        adoptBleWifiDirectOffer(
+                            channel = activeChannel,
+                            currentMedium = activeMedium,
+                            offer = event.frame,
+                        )
+                    if (upgraded.medium != Medium.WIFI_DIRECT) {
+                        return failBleWifiDirect(
+                            "Wi-Fi Direct upgrade failed after BLE pairing; stayed on ${upgraded.medium}",
+                            activeChannel,
+                        )
+                    }
+                    activeChannel = upgraded.channel
+                    activeMedium = upgraded.medium
+                    bufferedFrames.addAll(upgraded.bufferedFrames)
+                    continue
+                }
+
+                when (val outcome = handleBleWifiDirectEvent(activeChannel, fsm, event)) {
+                    BleWifiDirectOutcome.Continue -> Unit
+                    is BleWifiDirectOutcome.Terminal -> {
+                        if (shouldDrainForSafeDisconnect(outcome.result)) {
+                            drainSafeDisconnectAckDirect(activeChannel)
+                        }
+                        return publishCompletedIfNeeded(outcome.result)
+                    }
+                    BleWifiDirectOutcome.ReadyToSendPayloads -> {
+                        val upgraded =
+                            ensureBleWifiDirectBeforePayloads(
+                                channel = activeChannel,
+                                currentMedium = activeMedium,
+                            )
+                        if (upgraded is PayloadChannelSelection.Failed) {
+                            return failBleWifiDirect(upgraded.reason, activeChannel)
+                        }
+                        val ready = upgraded as PayloadChannelSelection.Ready
+                        activeChannel = ready.channel
+                        activeMedium = ready.medium
+                        val result =
+                            coroutineScope {
+                                val keepAliveJob = launch { runKeepAliveTicker(activeChannel) }
+                                try {
+                                    val result = streamFilesAndComplete(activeChannel)
+                                    if (shouldDrainForSafeDisconnect(result)) {
+                                        drainSafeDisconnectAckDirect(activeChannel)
+                                    }
+                                    publishCompletedIfNeeded(result)
+                                } finally {
+                                    keepAliveJob.cancelAndJoin()
+                                }
+                            }
+                        return result
+                    }
+                }
+            }
+        } finally {
+            runCatching { activeChannel.close() }
+            runCatching { initialTransport.close() }
+        }
+    }
+
+    @Suppress("ReturnCount", "SwallowedException", "TooGenericExceptionCaught")
+    private suspend fun nextBleWifiDirectEvent(
+        channel: SecureChannel,
+        bufferedFrames: ArrayDeque<OfflineFrame>,
+        remoteAcceptanceRemainingMillis: Long?,
+    ): OutboundDriverEvent {
+        if (bufferedFrames.isNotEmpty()) {
+            return OutboundDriverEvent.Wire(bufferedFrames.removeFirst())
+        }
+        val deadlineMillis = remoteAcceptanceRemainingMillis?.let { nowMillisSource() + it }
+        while (true) {
+            externalEvents.tryReceive().getOrNull()?.let { return OutboundDriverEvent.External(it) }
+            if (channel.hasBufferedInput()) {
+                return try {
+                    OutboundDriverEvent.Wire(channel.receiveOfflineFrame())
+                } catch (e: EndOfFrameStream) {
+                    OutboundDriverEvent.PeerClosed
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    OutboundDriverEvent.PumpError(e)
+                }
+            }
+            if (deadlineMillis != null && nowMillisSource() >= deadlineMillis) {
+                return OutboundDriverEvent.RemoteAcceptanceTimedOut
+            }
+            delay(BLE_WIFI_DIRECT_POLL_DELAY_MILLIS)
+        }
+    }
+
+    private suspend fun handleBleWifiDirectEvent(
+        channel: SecureChannel,
+        fsm: OutboundSharingFsm,
+        event: OutboundDriverEvent,
+    ): BleWifiDirectOutcome =
+        when (event) {
+            is OutboundDriverEvent.External -> {
+                handleExternalEvent(channel, fsm, event.event)
+                BleWifiDirectOutcome.Continue
+            }
+            is OutboundDriverEvent.Wire -> handleBleWifiDirectInboundFrame(channel, fsm, event.frame)
+            OutboundDriverEvent.PeerClosed -> BleWifiDirectOutcome.Terminal(handlePeerClosed())
+            OutboundDriverEvent.RemoteAcceptanceTimedOut -> BleWifiDirectOutcome.Terminal(remoteAcceptanceTimedOut())
+            is OutboundDriverEvent.PumpError -> {
+                val reason = "Inbound pump error: ${event.cause::class.simpleName}: ${event.cause.message}"
+                mutableState.value = OutboundConnectionState.Failed(reason)
+                BleWifiDirectOutcome.Terminal(OutboundResult.Failed(reason))
+            }
+        }
+
+    @Suppress("ReturnCount")
+    private suspend fun handleBleWifiDirectInboundFrame(
+        channel: SecureChannel,
+        fsm: OutboundSharingFsm,
+        frame: OfflineFrame,
+    ): BleWifiDirectOutcome {
+        if (frame.isDisconnection()) {
+            return BleWifiDirectOutcome.Terminal(cancelFromPeer())
+        }
+        if (frame.hasV1() &&
+            frame.v1.type == V1Frame.FrameType.BANDWIDTH_UPGRADE_NEGOTIATION
+        ) {
+            logger(
+                "fsm: inbound BANDWIDTH_UPGRADE_NEGOTIATION event_type=" +
+                    frame.v1.bandwidthUpgradeNegotiation.eventType,
+            )
+            return BleWifiDirectOutcome.Continue
+        }
+        if (!frame.hasV1() || frame.v1.type != V1Frame.FrameType.PAYLOAD_TRANSFER) {
+            return BleWifiDirectOutcome.Continue
+        }
+        return when (val payloadEvent = inboundAssembler.onPayloadTransfer(frame.v1.payloadTransfer)) {
+            is PayloadEvent.BytesComplete -> handleBleWifiDirectBytesComplete(channel, fsm, payloadEvent)
+            is PayloadEvent.FileComplete,
+            is PayloadEvent.Progress,
+            is PayloadEvent.Ignored,
+            -> BleWifiDirectOutcome.Continue
+        }
+    }
+
+    private suspend fun handleBleWifiDirectBytesComplete(
+        channel: SecureChannel,
+        fsm: OutboundSharingFsm,
+        event: PayloadEvent.BytesComplete,
+    ): BleWifiDirectOutcome {
+        val sharingFrame = SharingFrames.parse(event.data)
+        logger("fsm: rx SharingFrame type=${sharingFrame.v1.type}")
+        val effects = fsm.onEvent(SharingFsmEvent.FrameReceived(sharingFrame))
+        applyEffects(channel, effects)
+        return if (effects.any { it is SharingFsmEffect.ReadyToSendPayloads }) {
+            BleWifiDirectOutcome.ReadyToSendPayloads
+        } else {
+            BleWifiDirectOutcome.Continue
+        }
+    }
+
+    private suspend fun ensureBleWifiDirectBeforePayloads(
+        channel: SecureChannel,
+        currentMedium: Medium,
+    ): PayloadChannelSelection {
+        if (currentMedium == Medium.WIFI_DIRECT) {
+            return PayloadChannelSelection.Ready(channel, currentMedium)
+        }
+        channel.sendOfflineFrame(
+            BandwidthUpgradeFrames.upgradePathRequest(setOf(Medium.WIFI_DIRECT)),
+        )
+        logger("medium-upgrade: requested receiver Wi-Fi Direct upgrade before streaming payloads")
+        logger("medium-upgrade: waiting for receiver Wi-Fi Direct offer before streaming payloads")
+        return when (val probe = pollBleWifiDirectOffer(channel, BLE_WIFI_DIRECT_UPGRADE_TIMEOUT_MILLIS)) {
+            UpgradeOfferProbe.None ->
+                PayloadChannelSelection.Failed("Wi-Fi Direct upgrade was not offered before payload streaming")
+            is UpgradeOfferProbe.Other ->
+                PayloadChannelSelection.Failed(
+                    "Wi-Fi Direct upgrade was required before payload streaming, " +
+                        "but peer sent ${probe.frame.describeFrameType()} first",
+                )
+            is UpgradeOfferProbe.Offer -> {
+                val upgraded =
+                    adoptBleWifiDirectOffer(
+                        channel = channel,
+                        currentMedium = currentMedium,
+                        offer = probe.frame,
+                    )
+                if (upgraded.medium == Medium.WIFI_DIRECT) {
+                    PayloadChannelSelection.Ready(upgraded.channel, upgraded.medium)
+                } else {
+                    PayloadChannelSelection.Failed(
+                        "Wi-Fi Direct upgrade failed before payload streaming; stayed on ${upgraded.medium}",
+                    )
+                }
+            }
+        }
+    }
+
+    @Suppress("ReturnCount")
+    private suspend fun pollBleWifiDirectOffer(
+        channel: SecureChannel,
+        timeoutMillis: Long,
+    ): UpgradeOfferProbe {
+        val deadlineMillis = nowMillisSource() + timeoutMillis
+        while (nowMillisSource() < deadlineMillis) {
+            if (channel.hasBufferedInput()) {
+                val frame = channel.receiveOfflineFrame()
+                when {
+                    frame.isBandwidthUpgradeEvent(
+                        BandwidthUpgradeNegotiationFrame.EventType.UPGRADE_PATH_AVAILABLE,
+                    ) -> return UpgradeOfferProbe.Offer(frame)
+                    frame.hasV1() && frame.v1.type == V1Frame.FrameType.KEEP_ALIVE -> {
+                        logger("medium-upgrade: ignoring KEEP_ALIVE while waiting for Wi-Fi Direct offer")
+                    }
+                    else -> return UpgradeOfferProbe.Other(frame)
+                }
+            }
+            delay(BLE_WIFI_DIRECT_POLL_DELAY_MILLIS)
+        }
+        return UpgradeOfferProbe.None
+    }
+
+    private suspend fun adoptBleWifiDirectOffer(
+        channel: SecureChannel,
+        currentMedium: Medium,
+        offer: OfflineFrame,
+    ): ActiveTransportChannel {
+        val upgraded =
+            BandwidthUpgradeOrchestrator.runClientUpgradeFromOffer(
+                oldChannel = channel,
+                currentMedium = currentMedium,
+                offer = offer,
+                mediumRegistry = mediumRegistry,
+                endpointId = endpointId,
+                logger = logger,
+            )
+        secureChannel = upgraded.channel
+        return upgraded
+    }
+
+    private suspend fun failBleWifiDirect(
+        reason: String,
+        channel: SecureChannel,
+    ): OutboundResult.Failed {
+        logger("medium-upgrade: $reason")
+        mutableState.value = OutboundConnectionState.Failed(reason)
+        runCatching { sendTerminalDisconnection(channel) }
+        return OutboundResult.Failed(reason)
+    }
+
+    private suspend fun drainSafeDisconnectAckDirect(channel: SecureChannel) {
+        val acked =
+            withTimeoutOrNull(SAFE_DISCONNECT_ACK_TIMEOUT_MS) {
+                while (true) {
+                    if (channel.hasBufferedInput()) {
+                        val frame = channel.receiveOfflineFrame()
+                        if (frame.hasV1() && frame.v1.type == V1Frame.FrameType.DISCONNECTION) {
+                            logger(
+                                "fsm: safe-disconnect peer Disconnection ack=" +
+                                    frame.v1.disconnection.ackSafeToDisconnect,
+                            )
+                            return@withTimeoutOrNull true
+                        }
+                    }
+                    delay(BLE_WIFI_DIRECT_POLL_DELAY_MILLIS)
+                }
+                false
+            } == true
+        if (!acked) {
+            logger(
+                "fsm: safe-disconnect drain timed out after " +
+                    "${SAFE_DISCONNECT_ACK_TIMEOUT_MS}ms",
+            )
+        }
     }
 
     /**
@@ -846,8 +1214,14 @@ internal class OutboundConnectionDriver(
         // All files streamed. Emit Disconnection and complete.
         logger("fsm: all files streamed, sending Disconnection")
         runCatching { sendTerminalDisconnection(channel) }
-        mutableState.value = OutboundConnectionState.Completed
         return OutboundResult.Completed
+    }
+
+    private fun publishCompletedIfNeeded(result: OutboundResult): OutboundResult {
+        if (result == OutboundResult.Completed) {
+            mutableState.value = OutboundConnectionState.Completed
+        }
+        return result
     }
 
     /**
@@ -1134,17 +1508,71 @@ internal class OutboundConnectionDriver(
         channel.sendOfflineFrame(OfflineFrames.disconnection(requestSafeToDisconnect = true))
     }
 
+    private fun OfflineFrame.describeFrameType(): String =
+        if (hasV1()) {
+            when (v1.type) {
+                V1Frame.FrameType.BANDWIDTH_UPGRADE_NEGOTIATION ->
+                    "${v1.type}(${v1.bandwidthUpgradeNegotiation.eventType})"
+                V1Frame.FrameType.BANDWIDTH_UPGRADE_RETRY ->
+                    "${v1.type}(request=${v1.bandwidthUpgradeRetry.isRequest})"
+                else -> v1.type.toString()
+            }
+        } else {
+            "NO_V1"
+        }
+
+    private fun OfflineFrame.isBandwidthUpgradeEvent(expected: BandwidthUpgradeNegotiationFrame.EventType): Boolean =
+        hasV1() &&
+            v1.type == V1Frame.FrameType.BANDWIDTH_UPGRADE_NEGOTIATION &&
+            v1.bandwidthUpgradeNegotiation.eventType == expected
+
     private companion object {
+        private const val BLE_WIFI_DIRECT_UPGRADE_TIMEOUT_MILLIS: Long = 12_000L
+        private const val BLE_WIFI_DIRECT_POLL_DELAY_MILLIS: Long = 25L
+
         /**
          * Maximum time the orchestrator waits for the peer's
          * `DisconnectionFrame{ack_safe_to_disconnect=true}` (or peer
          * FIN) after sending its own request. 1500 ms covers Samsung
-         * One UI 8.0.5's observed drain time for an 87 KiB single-chunk
-         * file (~14 ms socket-to-FIN on a clean network plus headroom);
-         * larger payloads dominate over this timeout because the
-         * receiver only acks after writing all pending payloads to
-         * disk.
+         * One UI 8.0.5's observed drain time for small payloads, plus
+         * headroom for stock Quick Share builds that do not send an ack
+         * before their receive UI leaves "Preparing..."; larger payloads
+         * dominate over this timeout because the receiver only acks after
+         * writing all pending payloads to disk.
          */
-        const val SAFE_DISCONNECT_ACK_TIMEOUT_MS: Long = 1500L
+        const val SAFE_DISCONNECT_ACK_TIMEOUT_MS: Long = 5_000L
+    }
+
+    private sealed interface BandwidthNegotiation {
+        data class Ready(
+            val channel: SecureChannel,
+            val medium: Medium,
+            val initialWireFrames: List<OfflineFrame>,
+        ) : BandwidthNegotiation
+
+        data class Failed(
+            val reason: String,
+        ) : BandwidthNegotiation
+    }
+
+    private sealed interface BleWifiDirectOutcome {
+        data object Continue : BleWifiDirectOutcome
+
+        data object ReadyToSendPayloads : BleWifiDirectOutcome
+
+        data class Terminal(
+            val result: OutboundResult,
+        ) : BleWifiDirectOutcome
+    }
+
+    private sealed interface PayloadChannelSelection {
+        data class Ready(
+            val channel: SecureChannel,
+            val medium: Medium,
+        ) : PayloadChannelSelection
+
+        data class Failed(
+            val reason: String,
+        ) : PayloadChannelSelection
     }
 }

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionEvents.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionEvents.kt
@@ -17,7 +17,8 @@ import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.Offl
  *  2. External user-supplied events
  *     ([OutboundExternalEvent.UserCancel]) arriving on
  *     [OutboundConnection.cancel], wrapped here as [External].
- *  3. The peer closing the TCP half-channel cleanly ([PeerClosed]) or
+ *  3. Driver-owned timers such as [RemoteAcceptanceTimedOut].
+ *  4. The peer closing the TCP half-channel cleanly ([PeerClosed]) or
  *     an unexpected pump-side I/O failure ([PumpError]).
  *
  * Hoisted to its own file so [OutboundConnectionDriver] can stay under
@@ -36,6 +37,9 @@ internal sealed interface OutboundDriverEvent {
 
     /** The peer closed the TCP connection cleanly. */
     object PeerClosed : OutboundDriverEvent
+
+    /** The receiver did not answer the IntroductionFrame in time. */
+    object RemoteAcceptanceTimedOut : OutboundDriverEvent
 
     /** The inbound pump terminated due to an unexpected error. */
     data class PumpError(

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundFrames.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundFrames.kt
@@ -7,6 +7,8 @@ package io.github.kyujincho.wvmg.protocol.connection
 
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.ConnectionRequestFrame
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.ConnectionResponseFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.ConnectionsDevice
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.EndpointType
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.MediumMetadata
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OsInfo
@@ -61,14 +63,11 @@ internal object OutboundFrames {
         // Match NearDrop's ConnectionRequestFrame shape. Stock Quick Share
         // closes the socket immediately if these fields are absent — only
         // endpoint_id and endpoint_info is not enough on Android 14+:
-        //   * mediums = [WIFI_LAN, ...] tells the receiver which transports
-        //     this device can negotiate up to. WIFI_LAN is mandatory because
-        //     it IS the discovery medium for every Quick Share connection
-        //     today; absence of any medium hits a validation in Nearby
-        //     Connections that rejects the request. Phase 4 (#48–#54) adds
-        //     the BANDWIDTH_UPGRADE_NEGOTIATION machinery that lets us
-        //     advertise more than just WIFI_LAN here — the orchestrator
-        //     populates this set from the MediumRegistry's supportedMediums().
+        //   * mediums tells the receiver which transports this device can
+        //     negotiate up to. The default keeps the historical LAN-only
+        //     shape, while off-LAN bootstraps pass their exact medium set so
+        //     a BLE GATT + Wi-Fi Direct handoff does not silently advertise
+        //     Wi-Fi LAN as an available upgrade path.
         //   * keep_alive_interval / timeout are read by the receiver to
         //     decide its own KEEP_ALIVE cadence. We advertise 10 s / 10 min
         //     — PROTOCOL.md documents stock Android emitting KEEP_ALIVE
@@ -79,13 +78,10 @@ internal object OutboundFrames {
         //     empty string keeps modern peers happy and gives legacy peers
         //     a defined value to read.
         //
-        // Always include WIFI_LAN even if the caller forgot — it is the
-        // current connection's medium. Sort the proto-side enum values so
-        // the wire encoding is deterministic for tests and for KAT-style
-        // regression detection.
-        val withWifiLan = supportedMediums + Medium.WIFI_LAN
+        // Sort the proto-side enum values so the wire encoding is
+        // deterministic for tests and for KAT-style regression detection.
         val mediumProtoValues =
-            withWifiLan
+            supportedMediums
                 .map { it.toConnectionRequestMedium() }
                 .sortedBy { it.number }
         val builder =
@@ -95,9 +91,16 @@ internal object OutboundFrames {
                 .setEndpointName("")
                 .setEndpointInfo(ByteString.copyFrom(endpointInfo))
                 .setNonce(nonce)
-                .setMediumMetadata(defaultMediumMetadata())
+                .setMediumMetadata(defaultMediumMetadata(supportedMediums))
                 .setKeepAliveIntervalMillis(KEEP_ALIVE_INTERVAL_MILLIS)
                 .setKeepAliveTimeoutMillis(KEEP_ALIVE_TIMEOUT_MILLIS)
+                .setConnectionsDevice(
+                    ConnectionsDevice
+                        .newBuilder()
+                        .setEndpointId(endpointId)
+                        .setEndpointType(EndpointType.CONNECTIONS_ENDPOINT)
+                        .setEndpointInfo(ByteString.copyFrom(endpointInfo)),
+                )
         for (m in mediumProtoValues) builder.addMediums(m)
         val request = builder.build()
         return OfflineFrame
@@ -147,14 +150,20 @@ internal object OutboundFrames {
      * here keeps the field-shape compatible without introducing
      * `android.*` dependencies into `:core-protocol`.
      */
-    private fun defaultMediumMetadata(): MediumMetadata =
+    private fun defaultMediumMetadata(supportedMediums: Set<Medium>): MediumMetadata =
         MediumMetadata
             .newBuilder()
             .setSupports5Ghz(false)
             .setSupports6Ghz(false)
             .setMobileRadio(false)
             .setApFrequency(-1)
-            .build()
+            .also { builder ->
+                if (Medium.WIFI_DIRECT in supportedMediums) {
+                    builder.addSupportedWifiDirectAuthTypes(
+                        MediumMetadata.WifiDirectAuthType.WIFI_DIRECT_WITH_PASSWORD,
+                    )
+                }
+            }.build()
 
     /** Legacy `status` field value for "STATUS_OK". 0 in the proto enum. */
     private const val STATUS_OK: Int = 0

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/BleAdvertisementHeader.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/BleAdvertisementHeader.kt
@@ -3,9 +3,12 @@
  *
  * Licensed under the Apache License, Version 2.0.
  */
-@file:Suppress("ReturnCount")
+@file:Suppress("MagicNumber", "ReturnCount")
 
 package io.github.kyujincho.wvmg.protocol.endpoint
+
+import java.security.MessageDigest
+import java.security.SecureRandom
 
 /**
  * Nearby BLE v2 GATT advertisement header.
@@ -70,6 +73,7 @@ public data class BleAdvertisementHeader(
         private const val NUM_SLOTS_MASK: Int = 0x0F
         private const val MAX_PSM: Int = 0xFFFF
         private const val UNSIGNED_BYTE_MASK: Int = 0xFF
+        private const val DUMMY_SERVICE_ID_LEN: Int = 128
 
         /**
          * Parses either the stock base64-url encoded service-data header or
@@ -111,6 +115,84 @@ public data class BleAdvertisementHeader(
             )
         }
 
+        /**
+         * Encodes a stock Nearby BLE v2 GATT advertisement header for a single
+         * hosted advertisement slot.
+         *
+         * Stock Nearby inserts a random dummy service id into the bloom filter
+         * before the real service id so the header does not trivially reveal
+         * the exact service set. Its advertisement hash is chained from the
+         * dummy bytes and the hosted GATT advertisement body; scanners use it
+         * to decide whether the remote GATT slots need to be re-read.
+         */
+        @JvmStatic
+        @JvmOverloads
+        public fun encodeSingleSlot(
+            serviceId: String,
+            gattAdvertisement: ByteArray,
+            psm: Int = 0,
+            supportsExtendedAdvertisement: Boolean = false,
+            dummyServiceId: ByteArray = randomDummyServiceId(),
+        ): ByteArray {
+            require(psm in 0..MAX_PSM) { "psm must fit in uint16, got $psm" }
+            require(dummyServiceId.isNotEmpty()) { "dummyServiceId must not be empty" }
+            require(serviceId.isNotEmpty()) { "serviceId must not be empty" }
+
+            val bloomFilter =
+                ServiceIdBloomFilter().apply {
+                    add(dummyServiceId)
+                    add(serviceId.toByteArray(Charsets.UTF_8))
+                }
+            val advertisementHash =
+                advertisementHash(
+                    advertisementHash(dummyServiceId) + gattAdvertisement,
+                )
+
+            return encodeRaw(
+                supportsExtendedAdvertisement = supportsExtendedAdvertisement,
+                numSlots = 1,
+                serviceIdBloomFilter = bloomFilter.toByteArray(),
+                advertisementHash = advertisementHash,
+                psm = psm,
+            )
+        }
+
+        @JvmStatic
+        public fun advertisementHash(bytes: ByteArray): ByteArray =
+            MessageDigest
+                .getInstance("SHA-256")
+                .digest(bytes)
+                .copyOf(ADVERTISEMENT_HASH_LEN)
+
+        private fun encodeRaw(
+            supportsExtendedAdvertisement: Boolean,
+            numSlots: Int,
+            serviceIdBloomFilter: ByteArray,
+            advertisementHash: ByteArray,
+            psm: Int,
+        ): ByteArray {
+            require(numSlots in 0..NUM_SLOTS_MASK) { "numSlots must fit in 4 bits, got $numSlots" }
+            require(serviceIdBloomFilter.size == SERVICE_ID_BLOOM_FILTER_LEN) {
+                "serviceIdBloomFilter must be $SERVICE_ID_BLOOM_FILTER_LEN bytes"
+            }
+            require(advertisementHash.size == ADVERTISEMENT_HASH_LEN) {
+                "advertisementHash must be $ADVERTISEMENT_HASH_LEN bytes"
+            }
+            val out = ByteArray(HEADER_WITH_PSM_LEN)
+            out[0] =
+                (
+                    (VERSION shl VERSION_SHIFT) or
+                        (if (supportsExtendedAdvertisement) EXTENDED_ADVERTISEMENT_MASK else 0) or
+                        numSlots
+                ).toByte()
+            serviceIdBloomFilter.copyInto(out, destinationOffset = 1)
+            advertisementHash.copyInto(out, destinationOffset = 1 + SERVICE_ID_BLOOM_FILTER_LEN)
+            val psmOffset = 1 + SERVICE_ID_BLOOM_FILTER_LEN + ADVERTISEMENT_HASH_LEN
+            out[psmOffset] = ((psm ushr Byte.SIZE_BITS) and UNSIGNED_BYTE_MASK).toByte()
+            out[psmOffset + 1] = (psm and UNSIGNED_BYTE_MASK).toByte()
+            return out
+        }
+
         private fun decodeHeaderBytes(serviceData: ByteArray): ByteArray? {
             if (serviceData.size == MIN_HEADER_LEN || serviceData.size == HEADER_WITH_PSM_LEN) {
                 return serviceData
@@ -121,5 +203,135 @@ public data class BleAdvertisementHeader(
                     ?: return null
             return Base64Url.decode(encoded)
         }
+
+        private fun randomDummyServiceId(): ByteArray = ByteArray(DUMMY_SERVICE_ID_LEN).also(SecureRandom()::nextBytes)
+    }
+}
+
+private class ServiceIdBloomFilter {
+    private val bits: BooleanArray =
+        BooleanArray(BleAdvertisementHeader.SERVICE_ID_BLOOM_FILTER_LEN * Byte.SIZE_BITS)
+
+    fun add(bytes: ByteArray) {
+        val (hash1, hash2) =
+            murmurHash3X64Low64(bytes).let { low64 ->
+                (low64 and LOWER_32_BITS).toInt() to ((low64 ushr Int.SIZE_BITS) and LOWER_32_BITS).toInt()
+            }
+        for (i in 1..HASH_REPETITIONS) {
+            var combinedHash = hash1 + i * hash2
+            if (combinedHash < 0) {
+                combinedHash = combinedHash.inv()
+            }
+            bits[combinedHash % bits.size] = true
+        }
+    }
+
+    fun toByteArray(): ByteArray {
+        val out = ByteArray(BleAdvertisementHeader.SERVICE_ID_BLOOM_FILTER_LEN)
+        for (byteIndex in out.indices) {
+            var value = 0
+            for (bitIndex in 0 until Byte.SIZE_BITS) {
+                if (bits[byteIndex * Byte.SIZE_BITS + bitIndex]) {
+                    value = value or (1 shl bitIndex)
+                }
+            }
+            out[byteIndex] = value.toByte()
+        }
+        return out
+    }
+
+    private fun murmurHash3X64Low64(bytes: ByteArray): Long {
+        var h1 = 0L
+        var h2 = 0L
+        val blockEnd = bytes.size and -16
+        var offset = 0
+        while (offset < blockEnd) {
+            var k1 = bytes.readLittleEndianLong(offset)
+            var k2 = bytes.readLittleEndianLong(offset + Long.SIZE_BYTES)
+
+            k1 *= C1
+            k1 = java.lang.Long.rotateLeft(k1, 31)
+            k1 *= C2
+            h1 = h1 xor k1
+
+            h1 = java.lang.Long.rotateLeft(h1, 27)
+            h1 += h2
+            h1 = h1 * 5 + H1_ADD
+
+            k2 *= C2
+            k2 = java.lang.Long.rotateLeft(k2, 33)
+            k2 *= C1
+            h2 = h2 xor k2
+
+            h2 = java.lang.Long.rotateLeft(h2, 31)
+            h2 += h1
+            h2 = h2 * 5 + H2_ADD
+
+            offset += 16
+        }
+
+        var k1 = 0L
+        var k2 = 0L
+        val tail = bytes.size - blockEnd
+        for (i in 0 until minOf(tail, Long.SIZE_BYTES)) {
+            k1 = k1 or ((bytes[blockEnd + i].toLong() and LOWER_8_BITS) shl (Byte.SIZE_BITS * i))
+        }
+        for (i in Long.SIZE_BYTES until tail) {
+            k2 = k2 or ((bytes[blockEnd + i].toLong() and LOWER_8_BITS) shl (Byte.SIZE_BITS * (i - Long.SIZE_BYTES)))
+        }
+        if (tail > Long.SIZE_BYTES) {
+            k2 *= C2
+            k2 = java.lang.Long.rotateLeft(k2, 33)
+            k2 *= C1
+            h2 = h2 xor k2
+        }
+        if (tail > 0) {
+            k1 *= C1
+            k1 = java.lang.Long.rotateLeft(k1, 31)
+            k1 *= C2
+            h1 = h1 xor k1
+        }
+
+        h1 = h1 xor bytes.size.toLong()
+        h2 = h2 xor bytes.size.toLong()
+
+        h1 += h2
+        h2 += h1
+
+        h1 = fmix64(h1)
+        h2 = fmix64(h2)
+
+        h1 += h2
+        return h1
+    }
+
+    private fun ByteArray.readLittleEndianLong(offset: Int): Long {
+        var value = 0L
+        for (i in 0 until Long.SIZE_BYTES) {
+            value = value or ((this[offset + i].toLong() and LOWER_8_BITS) shl (Byte.SIZE_BITS * i))
+        }
+        return value
+    }
+
+    private fun fmix64(input: Long): Long {
+        var k = input
+        k = k xor (k ushr 33)
+        k *= FMIX1
+        k = k xor (k ushr 33)
+        k *= FMIX2
+        k = k xor (k ushr 33)
+        return k
+    }
+
+    private companion object {
+        private const val HASH_REPETITIONS: Int = 5
+        private const val LOWER_8_BITS: Long = 0xFFL
+        private const val LOWER_32_BITS: Long = 0xFFFF_FFFFL
+        private const val C1: Long = -8663945395140668459L
+        private const val C2: Long = 5545529020109919103L
+        private const val H1_ADD: Long = 1390208809L
+        private const val H2_ADD: Long = 944331445L
+        private const val FMIX1: Long = -49064778989728563L
+        private const val FMIX2: Long = -4265267296055464877L
     }
 }

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/BleServiceData.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/BleServiceData.kt
@@ -102,6 +102,12 @@ public object BleServiceData {
     /** BLE v2 frame type used by stock Nearby for fast advertisements. */
     public const val FRAME_TYPE_FAST_ADVERTISEMENT: Int = 0x4A
 
+    /**
+     * BLE v2 fast-advertisement frame type with the Nearby "second profile"
+     * bit set.
+     */
+    public const val FRAME_TYPE_SECOND_PROFILE_FAST_ADVERTISEMENT: Int = 0x4B
+
     /** Length of the BLE v2 frame type + frame-length prefix. */
     public const val FRAME_HEADER_LEN: Int = 2
 
@@ -251,6 +257,7 @@ public object BleServiceData {
         endpointInfo: EndpointInfo,
         version: Int = DEFAULT_VERSION,
         pcp: Int = DEFAULT_PCP,
+        secondProfile: Boolean = false,
     ): ByteArray {
         val body = encode(endpointId, endpointInfo, version, pcp)
         require(body.size <= MAX_FRAME_BODY_LEN) {
@@ -258,7 +265,12 @@ public object BleServiceData {
         }
         val deviceToken = deriveDeviceToken(body)
         val out = ByteArray(FRAME_HEADER_LEN + body.size + DEVICE_TOKEN_LEN)
-        out[0] = FRAME_TYPE_FAST_ADVERTISEMENT.toByte()
+        out[0] =
+            if (secondProfile) {
+                FRAME_TYPE_SECOND_PROFILE_FAST_ADVERTISEMENT.toByte()
+            } else {
+                FRAME_TYPE_FAST_ADVERTISEMENT.toByte()
+            }
         out[1] = body.size.toByte()
         body.copyInto(out, destinationOffset = FRAME_HEADER_LEN)
         deviceToken.copyInto(out, destinationOffset = FRAME_HEADER_LEN + body.size)
@@ -284,9 +296,10 @@ public object BleServiceData {
         psm: Int,
         version: Int = DEFAULT_VERSION,
         pcp: Int = DEFAULT_PCP,
+        secondProfile: Boolean = false,
     ): ByteArray {
         require(psm in 1..MAX_PSM) { "psm must fit in uint16 and be non-zero, got $psm" }
-        val framed = encodeFramed(endpointId, endpointInfo, version, pcp)
+        val framed = encodeFramed(endpointId, endpointInfo, version, pcp, secondProfile)
         val out = ByteArray(framed.size + EXTRA_FIELDS_MASK_LEN + PSM_LEN)
         framed.copyInto(out)
         out[framed.size] = EXTRA_FIELD_PSM_MASK.toByte()
@@ -306,6 +319,7 @@ public object BleServiceData {
         psm: Int,
         version: Int = DEFAULT_VERSION,
         pcp: Int = DEFAULT_PCP,
+        secondProfile: Boolean = false,
     ): ByteArray =
         encodeFramedWithPsm(
             endpointId = asciiEndpointId(endpointId),
@@ -313,6 +327,7 @@ public object BleServiceData {
             psm = psm,
             version = version,
             pcp = pcp,
+            secondProfile = secondProfile,
         )
 
     /**
@@ -325,12 +340,14 @@ public object BleServiceData {
         endpointInfo: EndpointInfo,
         version: Int = DEFAULT_VERSION,
         pcp: Int = DEFAULT_PCP,
+        secondProfile: Boolean = false,
     ): ByteArray =
         encodeFramed(
             endpointId = asciiEndpointId(endpointId),
             endpointInfo = endpointInfo,
             version = version,
             pcp = pcp,
+            secondProfile = secondProfile,
         )
 
     /**
@@ -433,7 +450,7 @@ public object BleServiceData {
     @Suppress("ReturnCount")
     private fun unwrapFrame(bytes: ByteArray): ByteArray? {
         if (bytes.size < FRAME_HEADER_LEN) return null
-        if ((bytes[0].toInt() and UNSIGNED_BYTE_MASK) != FRAME_TYPE_FAST_ADVERTISEMENT) return null
+        if (!isFastFrameType(bytes[0].toInt() and UNSIGNED_BYTE_MASK)) return null
         val len = bytes[1].toInt() and UNSIGNED_BYTE_MASK
         if (FRAME_HEADER_LEN + len > bytes.size) return null
         return bytes.copyOfRange(FRAME_HEADER_LEN, FRAME_HEADER_LEN + len)
@@ -442,12 +459,16 @@ public object BleServiceData {
     @Suppress("ReturnCount")
     private fun extraFieldsOffset(bytes: ByteArray): Int? {
         if (bytes.size < FRAME_HEADER_LEN) return null
-        if ((bytes[0].toInt() and UNSIGNED_BYTE_MASK) != FRAME_TYPE_FAST_ADVERTISEMENT) return null
+        if (!isFastFrameType(bytes[0].toInt() and UNSIGNED_BYTE_MASK)) return null
         val len = bytes[1].toInt() and UNSIGNED_BYTE_MASK
         val offset = FRAME_HEADER_LEN + len + DEVICE_TOKEN_LEN
         if (offset > bytes.size) return null
         return offset
     }
+
+    private fun isFastFrameType(value: Int): Boolean =
+        value == FRAME_TYPE_FAST_ADVERTISEMENT ||
+            value == FRAME_TYPE_SECOND_PROFILE_FAST_ADVERTISEMENT
 
     private fun asciiEndpointId(endpointId: String): ByteArray {
         // String.toByteArray(US_ASCII) silently substitutes '?' for any

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/BleServiceData.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/BleServiceData.kt
@@ -108,6 +108,9 @@ public object BleServiceData {
     /** Length of the trailing Nearby Mediums device token. */
     public const val DEVICE_TOKEN_LEN: Int = 2
 
+    /** Length of the service-id hash prefix in regular BLE advertisements. */
+    public const val SERVICE_ID_HASH_LEN: Int = 3
+
     /** One-byte extra-field mask appended by stock Nearby extended BLE advertisements. */
     public const val EXTRA_FIELDS_MASK_LEN: Int = 1
 
@@ -128,6 +131,13 @@ public object BleServiceData {
 
     /** Total fixed overhead before the EndpointInfo bytes. */
     public const val FIXED_HEADER_LEN: Int = HEADER_LEN + ENDPOINT_ID_LEN + ENDPOINT_INFO_LEN_BYTES
+
+    /** Total fixed overhead before EndpointInfo in the regular non-fast body. */
+    public const val REGULAR_FIXED_HEADER_LEN: Int =
+        HEADER_LEN + SERVICE_ID_HASH_LEN + ENDPOINT_ID_LEN + ENDPOINT_INFO_LEN_BYTES
+
+    /** Bluetooth MAC bytes carried after EndpointInfo in regular BLE advertisements. */
+    public const val BLUETOOTH_MAC_LEN: Int = 6
 
     /**
      * Default protocol version stock Quick Share emits in the high
@@ -353,9 +363,9 @@ public object BleServiceData {
     @JvmStatic
     public fun parse(bytes: ByteArray): Parsed? {
         unwrapFrame(bytes)?.let { framed ->
-            return parseBody(framed)
+            return parseFastBody(framed) ?: parseRegularBody(framed)
         }
-        return parseBody(bytes)
+        return parseFastBody(bytes) ?: parseRegularBody(bytes)
     }
 
     /**
@@ -376,7 +386,7 @@ public object BleServiceData {
     }
 
     @Suppress("ReturnCount")
-    private fun parseBody(bytes: ByteArray): Parsed? {
+    private fun parseFastBody(bytes: ByteArray): Parsed? {
         if (bytes.size < FIXED_HEADER_LEN) return null
         val header = bytes[0].toInt() and UNSIGNED_BYTE_MASK
         val version = (header ushr VERSION_SHIFT) and VERSION_MASK
@@ -385,6 +395,32 @@ public object BleServiceData {
         val len = bytes[HEADER_LEN + ENDPOINT_ID_LEN].toInt() and UNSIGNED_BYTE_MASK
         if (FIXED_HEADER_LEN + len > bytes.size) return null
         val infoBytes = bytes.copyOfRange(FIXED_HEADER_LEN, FIXED_HEADER_LEN + len)
+        val info = EndpointInfo.parse(infoBytes) ?: return null
+        return Parsed(
+            version = version,
+            pcp = pcp,
+            endpointId = endpointId,
+            endpointInfo = info,
+        )
+    }
+
+    @Suppress("ReturnCount")
+    private fun parseRegularBody(bytes: ByteArray): Parsed? {
+        if (bytes.size < REGULAR_FIXED_HEADER_LEN + BLUETOOTH_MAC_LEN) return null
+        val header = bytes[0].toInt() and UNSIGNED_BYTE_MASK
+        val version = (header ushr VERSION_SHIFT) and VERSION_MASK
+        val pcp = header and PCP_MASK
+
+        var offset = HEADER_LEN
+        val serviceIdHash = bytes.copyOfRange(offset, offset + SERVICE_ID_HASH_LEN)
+        offset += SERVICE_ID_HASH_LEN
+        if (!serviceIdHash.contentEquals(NearbyServiceId.hashPrefix)) return null
+
+        val endpointId = bytes.copyOfRange(offset, offset + ENDPOINT_ID_LEN)
+        offset += ENDPOINT_ID_LEN
+        val len = bytes[offset++].toInt() and UNSIGNED_BYTE_MASK
+        if (offset + len + BLUETOOTH_MAC_LEN > bytes.size) return null
+        val infoBytes = bytes.copyOfRange(offset, offset + len)
         val info = EndpointInfo.parse(infoBytes) ?: return null
         return Parsed(
             version = version,

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/sharing/InboundSharingFsm.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/sharing/InboundSharingFsm.kt
@@ -219,6 +219,14 @@ public class InboundSharingFsm(
             return protocolError("non-frame event in ReceivedPairedKeyResult: ${event::class.simpleName}")
         }
         val frame = event.frame
+        if (frame.v1.type == SharingFrameType.RESPONSE) {
+            // On One UI 8.x the sender's local acceptance can race with
+            // INTRODUCTION after the channel moves from BLE to Wi-Fi
+            // Direct. Treat it the same as the documented
+            // INTRODUCTION-then-RESPONSE ordering below: non-terminal
+            // accept/unknown is only the sender declaring readiness.
+            return handlePreemptiveConnectionResponse(frame)
+        }
         if (frame.v1.type != SharingFrameType.INTRODUCTION) {
             return protocolError("expected INTRODUCTION, got ${frame.v1.type}")
         }
@@ -254,13 +262,7 @@ public class InboundSharingFsm(
             //    TIMED_OUT: treat as a peer-side cancel — the sender has
             //    already abandoned the transfer, so our consent UI is
             //    moot.
-            val status = event.frame.v1.connectionResponse.status
-            return when (status) {
-                ConnectionResponseStatus.ACCEPT,
-                ConnectionResponseStatus.UNKNOWN,
-                -> emptyList()
-                else -> handlePeerCancel()
-            }
+            return handlePreemptiveConnectionResponse(event.frame)
         }
         if (event !is SharingFsmEvent.UserConsent) {
             // The peer is not supposed to push a frame at us while we are
@@ -345,6 +347,16 @@ public class InboundSharingFsm(
     private fun handlePeerCancel(): List<SharingFsmEffect> {
         state = InboundSharingState.Disconnected
         return listOf(SharingFsmEffect.Cancelled)
+    }
+
+    private fun handlePreemptiveConnectionResponse(frame: SharingFrame): List<SharingFsmEffect> {
+        val status = frame.v1.connectionResponse.status
+        return when (status) {
+            ConnectionResponseStatus.ACCEPT,
+            ConnectionResponseStatus.UNKNOWN,
+            -> emptyList()
+            else -> handlePeerCancel()
+        }
     }
 
     private fun protocolError(reason: String): List<SharingFsmEffect> {

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/sharing/SharingFsmState.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/sharing/SharingFsmState.kt
@@ -46,6 +46,8 @@ package io.github.kyujincho.wvmg.protocol.sharing
  *
  *   ReceivedPairedKeyResult
  *     +-- Frame{INTRODUCTION}               ->  WaitingForUserConsent      (emit IntroductionReceived)
+ *     +-- Frame{RESPONSE, status=ACCEPT|UNKNOWN}
+ *                                            ->  ReceivedPairedKeyResult    (ignore sender pre-consent)
  *     ... (CANCEL / ProtocolError as above)
  *
  *   WaitingForUserConsent

--- a/core-protocol/src/main/proto/offline_wire_formats.proto
+++ b/core-protocol/src/main/proto/offline_wire_formats.proto
@@ -457,6 +457,16 @@ message AutoReconnectFrame {
 }
 
 message MediumMetadata {
+  // Should always match
+  // cs/symbol:location.nearby.proto.connections.WifiDirectAuthType
+  enum WifiDirectAuthType {
+    WIFI_DIRECT_TYPE_UNKNOWN = 0;
+    // WifiDirect type that uses ssid/password for authentication.
+    WIFI_DIRECT_WITH_PASSWORD = 1;
+    // WifiDirect type that uses service_name/pin for authentication.
+    WIFI_DIRECT_WITH_PIN = 2;
+  }
+
   // True if local device supports 5GHz.
   optional bool supports_5_ghz = 1;
   // WiFi LAN BSSID, in the form of a six-byte MAC address: XX:XX:XX:XX:XX:XX
@@ -483,6 +493,9 @@ message MediumMetadata {
   optional WifiHotspotStaUsableChannels wifi_hotspot_sta_usable_channels = 11;
   // The supported medium roles.
   optional MediumRole medium_role = 12;
+  // The supported WifiDirect auth types.
+  repeated WifiDirectAuthType supported_wifi_direct_auth_types = 13
+      [packed = true];
 }
 
 // Available channels on the local device.

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeFramesTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeFramesTest.kt
@@ -8,6 +8,7 @@ package io.github.kyujincho.wvmg.protocol.connection
 import com.google.common.truth.Truth.assertThat
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.BandwidthUpgradeNegotiationFrame
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.BandwidthUpgradeNegotiationFrame.UpgradePathInfo
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.MediumMetadata
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.V1Frame
 import io.github.kyujincho.wvmg.protocol.medium.Medium
@@ -49,6 +50,21 @@ class BandwidthUpgradeFramesTest {
         assertThat(parsed.upgradePathInfo.supportsClientIntroductionAck).isTrue()
         assertThat(parsed.upgradePathInfo.medium.number).isEqualTo(Medium.WIFI_DIRECT.wireNumber)
         assertThat(parsed.upgradePathInfo.hasWifiLanSocket()).isFalse()
+    }
+
+    @Test
+    fun `upgradePathRequest carries requested Wi-Fi Direct medium and role metadata`() {
+        val frame = BandwidthUpgradeFrames.upgradePathRequest(setOf(Medium.WIFI_DIRECT))
+        val parsed = parse(frame)
+        val request = parsed.upgradePathInfo.upgradePathRequest
+
+        assertThat(parsed.eventType).isEqualTo(BandwidthUpgradeNegotiationFrame.EventType.UPGRADE_PATH_REQUEST)
+        assertThat(request.mediumsList.map { it.number }).containsExactly(Medium.WIFI_DIRECT.wireNumber)
+        assertThat(request.mediumMetaData.supportedWifiDirectAuthTypesList)
+            .containsExactly(MediumMetadata.WifiDirectAuthType.WIFI_DIRECT_WITH_PASSWORD)
+        assertThat(request.mediumMetaData.mediumRole.supportWifiDirectGroupClient).isTrue()
+        assertThat(BandwidthUpgradeFrames.decodeUpgradePathRequestMediums(frame))
+            .containsExactly(Medium.WIFI_DIRECT)
     }
 
     @Test

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/ConnectionRequestMediumsTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/ConnectionRequestMediumsTest.kt
@@ -7,6 +7,8 @@ package io.github.kyujincho.wvmg.protocol.connection
 
 import com.google.common.truth.Truth.assertThat
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.ConnectionRequestFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.EndpointType
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.MediumMetadata
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame
 import io.github.kyujincho.wvmg.protocol.medium.Medium
 import org.junit.jupiter.api.Test
@@ -18,9 +20,10 @@ import org.junit.jupiter.api.Test
  *   1. Default behaviour (no mediums passed) advertises Wi-Fi LAN
  *      only — functionally identical to the project's pre-Phase-4
  *      hard-coded shape and to NearDrop.
- *   2. Multiple mediums survive the wire round-trip and Wi-Fi LAN is
- *      always present (it IS the discovery medium today; absence
- *      breaks Android 14+ Nearby Connections validation).
+ *   2. Multiple mediums survive the wire round-trip without hidden
+ *      expansion. Callers that own an off-LAN bootstrap must be able to
+ *      choose whether the legacy Wi-Fi LAN capability marker belongs in
+ *      that request shape.
  */
 class ConnectionRequestMediumsTest {
     @Test
@@ -48,11 +51,7 @@ class ConnectionRequestMediumsTest {
     }
 
     @Test
-    fun `Wi-Fi LAN is always implicitly present`() {
-        // Even a caller that forgets WIFI_LAN must end up advertising
-        // it because it IS the discovery medium for the current
-        // socket — Android 14+ Nearby Connections rejects absence of
-        // it as malformed.
+    fun `caller supplied off-LAN mediums can omit Wi-Fi LAN`() {
         val frame =
             OutboundFrames.connectionRequest(
                 endpointId = "ABCD",
@@ -60,8 +59,7 @@ class ConnectionRequestMediumsTest {
                 supportedMediums = setOf(Medium.BLUETOOTH),
             )
         val numbers = parseRequest(frame).mediumsList.map { it.number }.toSet()
-        assertThat(numbers).contains(Medium.WIFI_LAN.wireNumber)
-        assertThat(numbers).contains(Medium.BLUETOOTH.wireNumber)
+        assertThat(numbers).containsExactly(Medium.BLUETOOTH.wireNumber)
     }
 
     @Test
@@ -78,19 +76,39 @@ class ConnectionRequestMediumsTest {
     }
 
     @Test
-    fun `keep_alive fields and endpoint_id survive the change`() {
+    fun `keep_alive fields endpoint_id and connections_device survive the change`() {
         // Sanity: pinning the mediums field must not have regressed
-        // the four other fields ConnectionRequestFrame is expected to
+        // the other fields ConnectionRequestFrame is expected to
         // populate (One UI 8.0.5 silent-FIN guards live here).
-        val frame = OutboundFrames.connectionRequest("XYZW", ByteArray(0))
+        val endpointInfo = byteArrayOf(0x01, 0x02, 0x03)
+        val frame = OutboundFrames.connectionRequest("XYZW", endpointInfo)
         val req = parseRequest(frame)
         assertThat(req.endpointId).isEqualTo("XYZW")
         assertThat(req.endpointName).isEqualTo("")
+        assertThat(req.endpointInfo.toByteArray()).isEqualTo(endpointInfo)
         assertThat(req.keepAliveIntervalMillis).isEqualTo(10_000)
         assertThat(req.keepAliveTimeoutMillis).isEqualTo(600_000)
         assertThat(req.hasNonce()).isTrue()
         assertThat(req.hasMediumMetadata()).isTrue()
         assertThat(req.mediumMetadata.apFrequency).isEqualTo(-1)
+        assertThat(req.hasConnectionsDevice()).isTrue()
+        assertThat(req.connectionsDevice.endpointId).isEqualTo("XYZW")
+        assertThat(req.connectionsDevice.endpointType).isEqualTo(EndpointType.CONNECTIONS_ENDPOINT)
+        assertThat(req.connectionsDevice.endpointInfo.toByteArray()).isEqualTo(endpointInfo)
+    }
+
+    @Test
+    fun `Wi-Fi Direct requests advertise password auth support without opening role`() {
+        val frame =
+            OutboundFrames.connectionRequest(
+                endpointId = "ABCD",
+                endpointInfo = ByteArray(0),
+                supportedMediums = setOf(Medium.WIFI_DIRECT, Medium.BLE),
+            )
+        val metadata = parseRequest(frame).mediumMetadata
+        assertThat(metadata.supportedWifiDirectAuthTypesList)
+            .containsExactly(MediumMetadata.WifiDirectAuthType.WIFI_DIRECT_WITH_PASSWORD)
+        assertThat(metadata.hasMediumRole()).isFalse()
     }
 
     @Test

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionTest.kt
@@ -6,6 +6,8 @@
 package io.github.kyujincho.wvmg.protocol.connection
 
 import com.google.common.truth.Truth.assertThat
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.MediumMetadata
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.PayloadTransferFrame.PayloadHeader
 import io.github.kyujincho.wvmg.protocol.medium.Medium
 import io.github.kyujincho.wvmg.protocol.medium.MediumLadder
@@ -15,6 +17,7 @@ import io.github.kyujincho.wvmg.protocol.medium.UpgradePathCredentials
 import io.github.kyujincho.wvmg.protocol.medium.UpgradedTransport
 import io.github.kyujincho.wvmg.protocol.payload.FileDestinationFactory
 import io.github.kyujincho.wvmg.protocol.transport.ConnectedTransport
+import io.github.kyujincho.wvmg.protocol.transport.FramedConnection
 import io.github.kyujincho.wvmg.protocol.transport.asConnectedTransport
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -63,6 +66,7 @@ import java.util.concurrent.TimeUnit
  *    → Completed) including a non-empty PIN.
  */
 @Timeout(value = 30, unit = TimeUnit.SECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+@Suppress("LargeClass")
 class OutboundConnectionTest {
     private lateinit var serverSocket: ServerSocket
     private val openedSockets: MutableList<Socket> = mutableListOf()
@@ -220,6 +224,12 @@ class OutboundConnectionTest {
             listener.close()
             return client to server
         }
+    }
+
+    private class SupportedProvider(
+        override val medium: Medium,
+    ) : MediumProvider {
+        override fun isSupported(): Boolean = true
     }
 
     /** Build a [FileSource] backed by an in-memory byte array. */
@@ -497,6 +507,141 @@ class OutboundConnectionTest {
                     assertThat(outbound.state.value).isEqualTo(OutboundConnectionState.Completed)
                 } finally {
                     upgradePair.close()
+                }
+            }
+        }
+
+    @Test
+    fun `preconnected BLE bootstrap upgrades to Wi-Fi Direct from initial medium advertisement`() =
+        runBlocking {
+            withTimeout(WALLCLOCK_TIMEOUT_MS) {
+                val (client, server) = connectedSocketPair()
+                val factory = InMemoryFactory()
+                val directUpgradePair = LoopbackUpgradePair(Medium.WIFI_DIRECT)
+                val hotspotUpgradePair = LoopbackUpgradePair(Medium.WIFI_HOTSPOT)
+                val ladder =
+                    MediumLadder(
+                        listOf(
+                            Medium.WIFI_HOTSPOT,
+                            Medium.WIFI_DIRECT,
+                            Medium.WIFI_LAN,
+                            Medium.BLE,
+                        ),
+                    )
+                val outbound =
+                    OutboundConnection(
+                        transport = client.asConnectedTransport(Medium.BLE),
+                        secureRandom = SecureRandom("outbound-ble-bootstrap-direct".toByteArray()),
+                        mediumRegistry =
+                            MediumRegistry(
+                                providers =
+                                    listOf(
+                                        MediumRegistry.DefaultWifiLan.providerFor(Medium.WIFI_LAN)!!,
+                                        hotspotUpgradePair.clientProvider,
+                                        directUpgradePair.clientProvider,
+                                        SupportedProvider(Medium.BLE),
+                                        SupportedProvider(Medium.BLE_L2CAP),
+                                    ),
+                                ladder = ladder,
+                            ),
+                    )
+
+                val fileBytes = ByteArray(1024) { (it and 0x7F).toByte() }
+                val payloadId = 0x5154L
+                val files = listOf(bytesSource("ble-bootstrap-direct.bin", fileBytes, payloadId))
+
+                try {
+                    coroutineScope {
+                        val outboundJob = async { outbound.run(files) }
+                        val inbound =
+                            InboundConnection(
+                                transport = server.asConnectedTransport(Medium.BLE),
+                                secureRandom = SecureRandom("inbound-ble-bootstrap-direct".toByteArray()),
+                                mediumRegistry =
+                                    MediumRegistry(
+                                        providers =
+                                            listOf(
+                                                MediumRegistry.DefaultWifiLan.providerFor(Medium.WIFI_LAN)!!,
+                                                hotspotUpgradePair.serverProvider,
+                                                directUpgradePair.serverProvider,
+                                                SupportedProvider(Medium.BLE),
+                                                SupportedProvider(Medium.BLE_L2CAP),
+                                            ),
+                                        ladder = ladder,
+                                    ),
+                            )
+
+                        launch {
+                            inbound.state.first { it is InboundConnectionState.WaitingForUserConsent }
+                            inbound.submitUserConsent(accepted = true)
+                        }
+
+                        val inboundResult = inbound.run(factory)
+                        val outboundResult = outboundJob.await()
+
+                        assertThat(outboundResult).isEqualTo(OutboundResult.Completed)
+                        assertThat(inboundResult).isInstanceOf(InboundResult.Completed::class.java)
+                        assertThat(inbound.activeMedium.value).isEqualTo(Medium.WIFI_DIRECT)
+                    }
+
+                    assertThat(factory.output[payloadId]?.toByteArray()).isEqualTo(fileBytes)
+                    assertThat(outbound.state.value).isEqualTo(OutboundConnectionState.Completed)
+                } finally {
+                    directUpgradePair.close()
+                    hotspotUpgradePair.close()
+                }
+            }
+        }
+
+    @Test
+    fun `preconnected BLE bootstrap request advertises LAN marker BLE and Wi-Fi Direct`() =
+        runBlocking {
+            withTimeout(WALLCLOCK_TIMEOUT_MS) {
+                val (client, server) = connectedSocketPair()
+                val directUpgradePair = LoopbackUpgradePair(Medium.WIFI_DIRECT)
+                val outbound =
+                    OutboundConnection(
+                        transport = client.asConnectedTransport(Medium.BLE),
+                        secureRandom = SecureRandom("outbound-ble-bootstrap-request".toByteArray()),
+                        mediumRegistry =
+                            MediumRegistry(
+                                providers =
+                                    listOf(
+                                        MediumRegistry.DefaultWifiLan.providerFor(Medium.WIFI_LAN)!!,
+                                        directUpgradePair.clientProvider,
+                                        SupportedProvider(Medium.BLE),
+                                    ),
+                                ladder = MediumLadder(listOf(Medium.WIFI_DIRECT, Medium.WIFI_LAN, Medium.BLE)),
+                            ),
+                        initialHandshakeTimeoutMillis = SHORT_INITIAL_HANDSHAKE_TIMEOUT_MS,
+                    )
+                val wire = FramedConnection(server.asConnectedTransport(Medium.BLE))
+
+                try {
+                    coroutineScope {
+                        val outboundJob = async { outbound.run(emptyList()) }
+                        val request =
+                            OfflineFrame
+                                .parseFrom(wire.receiveFrame())
+                                .v1
+                                .connectionRequest
+
+                        assertThat(request.mediumsList.map { it.number })
+                            .containsExactly(
+                                Medium.BLE.wireNumber,
+                                Medium.WIFI_LAN.wireNumber,
+                                Medium.WIFI_DIRECT.wireNumber,
+                            ).inOrder()
+                        assertThat(request.mediumMetadata.supportedWifiDirectAuthTypesList)
+                            .containsExactly(MediumMetadata.WifiDirectAuthType.WIFI_DIRECT_WITH_PASSWORD)
+                        assertThat(request.mediumMetadata.hasMediumRole()).isFalse()
+
+                        wire.close()
+                        assertThat(outboundJob.await()).isInstanceOf(OutboundResult.Failed::class.java)
+                    }
+                } finally {
+                    runCatching { wire.close() }
+                    directUpgradePair.close()
                 }
             }
         }

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionTest.kt
@@ -14,6 +14,7 @@ import io.github.kyujincho.wvmg.protocol.medium.MediumRegistry
 import io.github.kyujincho.wvmg.protocol.medium.UpgradePathCredentials
 import io.github.kyujincho.wvmg.protocol.medium.UpgradedTransport
 import io.github.kyujincho.wvmg.protocol.payload.FileDestinationFactory
+import io.github.kyujincho.wvmg.protocol.transport.ConnectedTransport
 import io.github.kyujincho.wvmg.protocol.transport.asConnectedTransport
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -27,6 +28,8 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
 import java.net.InetAddress
 import java.net.ServerSocket
 import java.net.Socket
@@ -234,6 +237,47 @@ class OutboundConnectionTest {
             payloadId = payloadId,
             open = { Channels.newChannel(ByteArrayInputStream(bytes)) as ReadableByteChannel },
         )
+
+    private class CloseAwareBlockingInputStream : InputStream() {
+        private val lock = Object()
+        private var closed: Boolean = false
+
+        override fun read(): Int {
+            synchronized(lock) {
+                while (!closed) {
+                    lock.wait()
+                }
+            }
+            return -1
+        }
+
+        override fun read(
+            b: ByteArray,
+            off: Int,
+            len: Int,
+        ): Int = read()
+
+        override fun close() {
+            synchronized(lock) {
+                closed = true
+                lock.notifyAll()
+            }
+        }
+    }
+
+    private class HangingConnectedTransport : ConnectedTransport {
+        override val medium: Medium = Medium.BLE
+        override val inputStream: CloseAwareBlockingInputStream = CloseAwareBlockingInputStream()
+        override val outputStream: ByteArrayOutputStream = ByteArrayOutputStream()
+        var closed: Boolean = false
+            private set
+
+        override fun close() {
+            closed = true
+            inputStream.close()
+            outputStream.close()
+        }
+    }
 
     @Test
     fun `accept path - file payload completes through full lifecycle`() =
@@ -776,6 +820,30 @@ class OutboundConnectionTest {
         }
 
     @Test
+    fun `initial handshake timeout closes a silent preconnected transport`() =
+        runBlocking {
+            withTimeout(WALLCLOCK_TIMEOUT_MS) {
+                val transport = HangingConnectedTransport()
+                val logs = mutableListOf<String>()
+                val outbound =
+                    OutboundConnection(
+                        transport = transport,
+                        initialHandshakeTimeoutMillis = SHORT_INITIAL_HANDSHAKE_TIMEOUT_MS,
+                        secureRandom = SecureRandom("outbound-initial-timeout".toByteArray()),
+                        logger = logs::add,
+                    )
+
+                val result = outbound.run(emptyList())
+                val failedState = outbound.state.value as OutboundConnectionState.Failed
+
+                assertThat(result).isInstanceOf(OutboundResult.Failed::class.java)
+                assertThat(failedState.reason).contains("Initial handshake timed out")
+                assertThat(transport.closed).isTrue()
+                assertThat(logs.any { it.contains("initial handshake timed out") }).isTrue()
+            }
+        }
+
+    @Test
     fun `double run throws IllegalStateException`() =
         runBlocking {
             withTimeout(WALLCLOCK_TIMEOUT_MS) {
@@ -837,6 +905,8 @@ class OutboundConnectionTest {
         // 1.5 MiB scenario is still expected to complete in a couple seconds
         // on a modern dev machine.
         private const val LONG_WALLCLOCK_TIMEOUT_MS: Long = 60_000L
+
+        private const val SHORT_INITIAL_HANDSHAKE_TIMEOUT_MS: Long = 50L
 
         private val MediumLadderForBluetoothFirst: MediumLadder =
             MediumLadder(listOf(Medium.BLUETOOTH, Medium.WIFI_LAN))

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/BleAdvertisementHeaderTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/BleAdvertisementHeaderTest.kt
@@ -7,6 +7,7 @@ package io.github.kyujincho.wvmg.protocol.endpoint
 
 import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.Test
+import java.security.MessageDigest
 
 class BleAdvertisementHeaderTest {
     @Test
@@ -71,4 +72,46 @@ class BleAdvertisementHeaderTest {
 
         assertThat(BleAdvertisementHeader.parse(fast)).isNull()
     }
+
+    @Test
+    fun `encode writes stock single-slot GATT header with PSM`() {
+        val info =
+            EndpointInfo(
+                version = 1,
+                hidden = false,
+                deviceType = DeviceType.PHONE,
+                reserved = false,
+                metadata = ByteArray(EndpointInfo.METADATA_LEN) { it.toByte() },
+                deviceName = "Galaxy",
+            )
+        val gattAdvertisement =
+            BleAdvertisement.encodeGattAdvertisement(
+                endpointId = "RINE".toByteArray(Charsets.US_ASCII),
+                endpointInfo = info,
+                psm = 0x1234,
+            )
+        val dummyServiceId = ByteArray(128)
+
+        val bytes =
+            BleAdvertisementHeader.encodeSingleSlot(
+                serviceId = NearbyServiceId.VALUE,
+                gattAdvertisement = gattAdvertisement,
+                psm = 0x1234,
+                dummyServiceId = dummyServiceId,
+            )
+
+        val parsed = BleAdvertisementHeader.parse(bytes)
+        assertThat(parsed).isNotNull()
+        assertThat(parsed!!.version).isEqualTo(2)
+        assertThat(parsed.supportsExtendedAdvertisement).isFalse()
+        assertThat(parsed.numSlots).isEqualTo(1)
+        assertThat(parsed.psm).isEqualTo(0x1234)
+        assertThat(parsed.serviceIdBloomFilter)
+            .isEqualTo(byteArrayOf(0x64, 0x00, 0x08, 0x14, 0x02, 0x08, 0x00, 0x03, 0x00, 0x00))
+
+        val expectedHash = sha256First4(sha256First4(dummyServiceId) + gattAdvertisement)
+        assertThat(parsed.advertisementHash).isEqualTo(expectedHash)
+    }
+
+    private fun sha256First4(bytes: ByteArray): ByteArray = MessageDigest.getInstance("SHA-256").digest(bytes).copyOf(4)
 }

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/BleAdvertisementTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/BleAdvertisementTest.kt
@@ -47,6 +47,20 @@ class BleAdvertisementTest {
         assertThat(BleServiceData.parse(parsed.data)?.endpointInfo).isEqualTo(info)
     }
 
+    @Test
+    fun `parse exposes second-profile fast advertisement wrapper`() {
+        val info = endpointInfo("Pixel")
+        val bytes = BleServiceData.encodeFramed("ABCD", info, secondProfile = true)
+
+        val parsed = BleAdvertisement.parse(bytes)
+
+        assertThat(parsed).isNotNull()
+        assertThat(parsed!!.fastAdvertisement).isTrue()
+        assertThat(parsed.secondProfile).isTrue()
+        assertThat(parsed.serviceIdHash).isNull()
+        assertThat(BleServiceData.parse(parsed.data)?.endpointInfo).isEqualTo(info)
+    }
+
     private fun endpointInfo(name: String): EndpointInfo =
         EndpointInfo(
             version = 1,

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/BleServiceDataTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/BleServiceDataTest.kt
@@ -102,6 +102,27 @@ class BleServiceDataTest {
     }
 
     @Test
+    fun `parse accepts regular non-fast BLE advertisement body`() {
+        val info =
+            EndpointInfo(
+                version = 1,
+                hidden = false,
+                deviceType = DeviceType.PHONE,
+                reserved = false,
+                metadata = ByteArray(EndpointInfo.METADATA_LEN) { it.toByte() },
+                deviceName = "Kyujin's S26 Ultra",
+            )
+        val payload = regularBleBody("LPPM", info)
+        val parsed = BleServiceData.parse(payload)
+
+        assertThat(parsed).isNotNull()
+        assertThat(String(parsed!!.endpointId, Charsets.US_ASCII)).isEqualTo("LPPM")
+        assertThat(parsed.version).isEqualTo(BleServiceData.DEFAULT_VERSION)
+        assertThat(parsed.pcp).isEqualTo(BleServiceData.DEFAULT_PCP)
+        assertThat(parsed.endpointInfo).isEqualTo(info)
+    }
+
+    @Test
     fun `encodeFramed wraps the fast-advertisement body like stock Nearby`() {
         val info = hiddenPhoneEndpointInfo()
         val payload = BleServiceData.encodeFramed("Wvmg", info)
@@ -304,6 +325,38 @@ class BleServiceDataTest {
             metadata = ByteArray(EndpointInfo.METADATA_LEN) { 0x00 },
             deviceName = null,
         )
+
+    private fun regularBleBody(
+        endpointId: String,
+        endpointInfo: EndpointInfo,
+    ): ByteArray {
+        val infoBytes = endpointInfo.serialize()
+        val payload =
+            ByteArray(
+                BleServiceData.REGULAR_FIXED_HEADER_LEN +
+                    infoBytes.size +
+                    BleServiceData.BLUETOOTH_MAC_LEN +
+                    2,
+            )
+        var offset = 0
+        payload[offset++] =
+            BleServiceData.packVersionPcp(BleServiceData.DEFAULT_VERSION, BleServiceData.DEFAULT_PCP)
+        NearbyServiceId.hashPrefix.copyInto(payload, destinationOffset = offset)
+        offset += BleServiceData.SERVICE_ID_HASH_LEN
+        endpointId.toByteArray(Charsets.US_ASCII).copyInto(payload, destinationOffset = offset)
+        offset += BleServiceData.ENDPOINT_ID_LEN
+        payload[offset++] = infoBytes.size.toByte()
+        infoBytes.copyInto(payload, destinationOffset = offset)
+        offset += infoBytes.size
+        byteArrayOf(0x70, 0x4E, 0xE0.toByte(), 0x12, 0xDE.toByte(), 0x3A).copyInto(
+            payload,
+            destinationOffset = offset,
+        )
+        offset += BleServiceData.BLUETOOTH_MAC_LEN
+        payload[offset++] = 0x00
+        payload[offset] = 0x01
+        return payload
+    }
 
     private fun sha256FirstTwo(bytes: ByteArray): ByteArray =
         MessageDigest

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/BleServiceDataTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/BleServiceDataTest.kt
@@ -153,6 +153,17 @@ class BleServiceDataTest {
     }
 
     @Test
+    fun `encodeFramed can set the second-profile bit`() {
+        val info = hiddenPhoneEndpointInfo()
+        val payload = BleServiceData.encodeFramed("Wvmg", info, secondProfile = true)
+
+        assertThat(payload).hasLength(27)
+        assertThat(payload[0].toInt() and 0xFF)
+            .isEqualTo(BleServiceData.FRAME_TYPE_SECOND_PROFILE_FAST_ADVERTISEMENT)
+        assertThat(BleServiceData.parse(payload)?.endpointInfo).isEqualTo(info)
+    }
+
+    @Test
     fun `encodeFramedWithPsm rejects invalid PSM values`() {
         val info = hiddenPhoneEndpointInfo()
         assertThrows<IllegalArgumentException> {

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/sharing/InboundSharingFsmTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/sharing/InboundSharingFsmTest.kt
@@ -255,6 +255,64 @@ class InboundSharingFsmTest {
     // alive; regressing any of these breaks Galaxy → WVMG sends.
 
     @Test
+    fun `preemptive RESPONSE ACCEPT before INTRODUCTION is ignored until introduction arrives`() {
+        val fsm = driveToReceivedPairedKeyResult()
+
+        val responseEffects =
+            fsm.onEvent(
+                SharingFsmEvent.FrameReceived(
+                    SharingFrames.connectionResponse(ConnectionResponseStatus.ACCEPT),
+                ),
+            )
+
+        assertThat(responseEffects).isEmpty()
+        assertThat(fsm.state).isEqualTo(InboundSharingState.ReceivedPairedKeyResult)
+
+        val intro = IntroductionFrame.newBuilder().build()
+        val introEffects =
+            fsm.onEvent(
+                SharingFsmEvent.FrameReceived(
+                    SharingFrames.introduction(intro),
+                ),
+            )
+
+        assertThat(introEffects).hasSize(1)
+        assertThat(introEffects[0]).isInstanceOf(SharingFsmEffect.IntroductionReceived::class.java)
+        assertThat(fsm.state).isEqualTo(InboundSharingState.WaitingForUserConsent)
+    }
+
+    @Test
+    fun `preemptive RESPONSE UNKNOWN before INTRODUCTION is ignored`() {
+        val fsm = driveToReceivedPairedKeyResult()
+
+        val effects =
+            fsm.onEvent(
+                SharingFsmEvent.FrameReceived(
+                    SharingFrames.connectionResponse(ConnectionResponseStatus.UNKNOWN),
+                ),
+            )
+
+        assertThat(effects).isEmpty()
+        assertThat(fsm.state).isEqualTo(InboundSharingState.ReceivedPairedKeyResult)
+    }
+
+    @Test
+    fun `preemptive RESPONSE REJECT before INTRODUCTION is treated as peer cancel`() {
+        val fsm = driveToReceivedPairedKeyResult()
+
+        val effects =
+            fsm.onEvent(
+                SharingFsmEvent.FrameReceived(
+                    SharingFrames.connectionResponse(ConnectionResponseStatus.REJECT),
+                ),
+            )
+
+        assertThat(effects).hasSize(1)
+        assertThat(effects[0]).isInstanceOf(SharingFsmEffect.Cancelled::class.java)
+        assertThat(fsm.state).isEqualTo(InboundSharingState.Disconnected)
+    }
+
+    @Test
     fun `preemptive RESPONSE ACCEPT in WaitingForUserConsent is ignored`() {
         // Samsung's stock Quick Share sends RESPONSE(status=ACCEPT) to
         // the receiver right after INTRODUCTION — the sender treats the
@@ -432,16 +490,24 @@ class InboundSharingFsmTest {
      * starts in [InboundSharingState.WaitingForUserConsent].
      */
     private fun driveToWaitingForUserConsent(): InboundSharingFsm {
-        val fsm = newFsm()
-        fsm.start()
-        fsm.onEvent(SharingFsmEvent.FrameReceived(SharingFrames.pairedKeyEncryption()))
-        fsm.onEvent(SharingFsmEvent.FrameReceived(SharingFrames.pairedKeyResult()))
+        val fsm = driveToReceivedPairedKeyResult()
         fsm.onEvent(
             SharingFsmEvent.FrameReceived(
                 SharingFrames.introduction(IntroductionFrame.newBuilder().build()),
             ),
         )
         check(fsm.state == InboundSharingState.WaitingForUserConsent) {
+            "fixture state setup failed: ${fsm.state}"
+        }
+        return fsm
+    }
+
+    private fun driveToReceivedPairedKeyResult(): InboundSharingFsm {
+        val fsm = newFsm()
+        fsm.start()
+        fsm.onEvent(SharingFsmEvent.FrameReceived(SharingFrames.pairedKeyEncryption()))
+        fsm.onEvent(SharingFsmEvent.FrameReceived(SharingFrames.pairedKeyResult()))
+        check(fsm.state == InboundSharingState.ReceivedPairedKeyResult) {
             "fixture state setup failed: ${fsm.state}"
         }
         return fsm

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/NearbyPeer.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/NearbyPeer.kt
@@ -54,10 +54,12 @@ public data class NearbyPeer(
      *
      * LAN remains first priority to preserve the pre-#137 behaviour when
      * a peer is already reachable by mDNS + TCP. BLE L2CAP is the preferred
-     * off-LAN bootstrap path when the receiver advertises a PSM. BLE GATT is
-     * the stock off-LAN fallback when the receiver exposes only a GATT-backed
-     * advertisement header; Bluetooth Classic remains only a last fallback for
-     * peers that still expose it.
+     * off-LAN bootstrap path when the receiver advertises a PSM. A visible
+     * BLE receiver without a PSM is only a GATT bootstrap candidate after
+     * the GATT advertisement-slot probe verifies the service; header-only,
+     * hidden, and raw scan-result-only BLE observations remain discovery
+     * metadata until another route confirms a transport. Bluetooth Classic
+     * remains only a last fallback for peers that still expose it.
      */
     public fun preferredRoute(): NearbyPeerRoute? {
         val lan = lanEndpoint
@@ -74,7 +76,7 @@ public data class NearbyPeer(
         if (bleAddress != null && l2capPsm != null) {
             return NearbyPeerRoute.BleL2cap(macAddress = bleAddress, psm = l2capPsm)
         }
-        if (bleAddress != null && ble.gattConnectable) {
+        if (bleAddress != null && ble.gattConnectable && endpointInfo?.hidden == false) {
             return NearbyPeerRoute.BleGatt(macAddress = bleAddress)
         }
         val bluetooth = bluetoothEndpoint
@@ -91,7 +93,7 @@ public data class NearbyPeer(
         val bleName = bleAdvertisement?.displayName.toDisplayNameOrNull()
         if (bleName != null) return bleName
         if (!endpointId.isNullOrBlank()) return "Quick Share device ($endpointId)"
-        if (bleAdvertisement?.gattConnectable == true) return "Quick Share BLE device"
+        if (bleAdvertisement != null) return "Quick Share BLE device"
         return stableId
     }
 
@@ -109,7 +111,7 @@ public data class NearbyPeer(
             bleName != null ->
                 bleAdvertisement?.displayNameSource ?: "ble-metadata"
             !endpointId.isNullOrBlank() -> "endpoint-id"
-            bleAdvertisement?.gattConnectable == true -> "ble-gatt-fallback"
+            bleAdvertisement != null -> "ble-advertisement"
             else -> "stable-id"
         }
     }

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/NearbyPeerDiscovery.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/NearbyPeerDiscovery.kt
@@ -166,10 +166,13 @@ private class PeerAggregator {
         state.endpointId = state.endpointId ?: observation.endpointId
         observation.endpointId?.let { endpointIdIndex[it] = state.stableId }
         state.endpointInfo = chooseEndpointInfo(state.endpointInfo, observation.endpointInfo)
+        if (state.bleAddress != observation.advertiserAddress) {
+            state.bleGattConnectable = false
+        }
         state.bleAddress = observation.advertiserAddress
         state.bleRssi = observation.rssi
         state.bleL2capPsm = observation.l2capPsm
-        state.bleGattConnectable = observation.gattConnectable
+        state.bleGattConnectable = state.bleGattConnectable || observation.gattConnectable
         observation.displayName?.toDisplayNameOrNull()?.let { displayName ->
             state.bleDisplayName = displayName
             state.bleDisplayNameSource = observation.displayNameSource?.logLabel

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/SamsungQuickShareHeuristic.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/SamsungQuickShareHeuristic.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.discovery
+
+/**
+ * Best-effort identifier for "this is a Samsung One UI device on the
+ * other end" — used to gate the BLE GATT bootstrap UX caveat surfaced
+ * by the send picker.
+ *
+ * **Why this exists.** Samsung One UI's Quick Share receiver enforces a
+ * Google-account-bound `SenderCertificate` lookup before it registers a
+ * per-peer Weave handler on its `0xFEF3` GATT server. WVMG cannot
+ * satisfy that check without GMS internals, so writes to the Weave
+ * write characteristic always come back rejected with
+ * `BluetoothGattException: No handler registered for characteristic …`
+ * and the bootstrap stalls at the 15-second handshake timeout. See
+ * `docs/research/samsung-ble-gatt-cert-gate.md` for the GMS
+ * decompilation details.
+ *
+ * The block is **only** in the BLE GATT path. Wi-Fi LAN works fine
+ * against Samsung. So when a peer is Samsung-class **and** the only
+ * available bootstrap is BLE GATT, the picker should warn the user and
+ * point them to Wi-Fi rather than letting them sit through a doomed
+ * 15 s handshake.
+ *
+ * **Detection strategy.** We can't read the BLE pulse to identify the
+ * vendor reliably (the FastInitiation payload format is the same for
+ * every Quick Share peer). The next-best signal is the receiver-side
+ * device name we resolve from `EndpointInfo.deviceName` or the BLE
+ * fast-advertisement slot 0. Samsung's defaults follow predictable
+ * model-name patterns, and even after user customization the model
+ * suffix usually survives (`"Kyujin's S26 Ultra"`, `"Family Z Fold5"`,
+ * etc.).
+ *
+ * Patterns we match (case-insensitive, word-boundary aware):
+ *
+ * | Family            | Pattern marker                             |
+ * |-------------------|--------------------------------------------|
+ * | Galaxy umbrella   | the literal substring `galaxy`             |
+ * | Foldables         | `z fold`, `z flip` (any digit)             |
+ * | S series          | `s20`–`s29` ± `+`/`fe`/`ultra`/`plus`      |
+ * | Note series       | `note 10`, `note 20`                       |
+ * | A series          | `a10`–`a89` (Galaxy A line)                |
+ * | M series          | `m10`–`m59` (Galaxy M line)                |
+ * | F series          | `f20`–`f69` (Galaxy F line)                |
+ * | Tab S series      | `tab s` followed by a digit                |
+ *
+ * Patterns chosen so non-Samsung devices that happen to share a
+ * letter+number shape (`Pixel 8`, `OnePlus 10 Pro`, `Xperia 1 V`,
+ * `vivo X300 Ultra`) do not trigger. False positives bias toward
+ * "warn unnecessarily, user clicks Try Anyway" rather than "let them
+ * burn 15 seconds on a guaranteed timeout"; false negatives bias
+ * toward "Samsung peer with an unusual name doesn't get the warning,
+ * user burns 15 seconds." Both failure modes are recoverable.
+ *
+ * This is intentionally a conservative heuristic, not a vendor
+ * fingerprint. If Samsung ever loosens the cert gate (or another
+ * vendor adopts the same restriction), update the pattern set rather
+ * than the surrounding picker logic.
+ */
+public object SamsungQuickShareHeuristic {
+    /**
+     * @return `true` iff [peer]'s resolved display name suggests a
+     *   Samsung Galaxy device. `false` for unknown/unnamed peers.
+     */
+    public fun isLikelySamsungReceiver(peer: NearbyPeer): Boolean {
+        // Prefer the EndpointInfo-derived name (post-mDNS resolve, full
+        // device name) over the BLE fast-advertisement name (which can
+        // be truncated to fit the advertising PDU). Both are available
+        // by the time the picker calls into us, so use either.
+        val endpointName = peer.endpointInfo?.deviceName
+        val bleName = peer.bleAdvertisement?.displayName
+        return matches(endpointName) || matches(bleName)
+    }
+
+    /** Same matcher as [isLikelySamsungReceiver] but on a raw name string. Useful in tests. */
+    public fun matchesDeviceName(name: String?): Boolean = matches(name)
+
+    private fun matches(rawName: String?): Boolean {
+        val name = rawName?.lowercase()?.trim().orEmpty()
+        if (name.isEmpty()) return false
+        return SAMSUNG_PATTERNS.any { pattern -> pattern.containsMatchIn(name) }
+    }
+
+    /**
+     * Compiled patterns. Each pattern is anchored to a word boundary
+     * (or the equivalent lookaround) so that, e.g., `"a25"` is matched
+     * inside `"Galaxy A25"` but not inside `"OnePlus 10a25-something"`.
+     *
+     * Kept as a single-source-of-truth list so adding/tweaking a model
+     * family is a one-line change.
+     */
+    private val SAMSUNG_PATTERNS: List<Regex> =
+        listOf(
+            Regex("""\bgalaxy\b"""),
+            Regex("""\bz\s?fold\s?\d*\b"""),
+            Regex("""\bz\s?flip\s?\d*\b"""),
+            // Galaxy S20..S29 (with optional +/FE/Ultra/Plus suffix).
+            Regex("""\bs2\d(\+|\s?fe|\s?ultra|\s?plus)?\b"""),
+            // Galaxy Note 10 / Note 20 (active models in the field).
+            Regex("""\bnote\s?(10|20)\b"""),
+            // Galaxy A10..A89 — A-series budget/mid-tier line.
+            Regex("""\ba[1-8]\d\b"""),
+            // Galaxy M10..M59 — emerging-market M-series.
+            Regex("""\bm[1-5]\d\b"""),
+            // Galaxy F20..F69 — India-only F-series.
+            Regex("""\bf[2-6]\d\b"""),
+            // Galaxy Tab S* (tablets — same Quick Share gate).
+            Regex("""\btab\s?s\d+\b"""),
+        )
+}

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleAdvertisePayload.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleAdvertisePayload.kt
@@ -5,23 +5,55 @@
  */
 package io.github.kyujincho.wvmg.discovery.ble
 
+import java.security.MessageDigest
 import java.security.SecureRandom
 
 /**
- * Composes the 24-byte BLE service-data payload that the sender broadcasts
- * to wake nearby Quick Share receivers (#32).
+ * Composes the BLE service-data payload that the sender broadcasts on the
+ * Quick Share `0xFE2C` FastInitiation service UUID to wake nearby
+ * receivers (#32).
  *
- * Wire format (per
- * [PROTOCOL.md](https://github.com/grishka/NearDrop/blob/master/PROTOCOL.md)):
+ * Wire format (per `google/nearby`'s
+ * `sharing/internal/api/fast_init_ble_beacon.h` and Chromium's
+ * `chrome/browser/nearby_sharing/fast_initiation/fast_initiation_advertiser.cc`):
  *
  * ```text
- *   fc 12 8e 01 42 00 00 00 00 00 00 00 00 00 || rand10
- *   |---------------- 14 fixed bytes ----------------|  |--10--|
+ *   fc 12 8e VV PP UU AA AA AA AA AA AA AA AA SS HH HH HH HH HH HH HH HH
+ *   |---- model id ---|        |--- uwb addr (8) ---| salt |---- secret_id_hash ----|
+ *                  metadata  uwb_meta
+ *                  byte 3
  * ```
  *
- * The 14-byte prefix is a literal Quick Share magic. The trailing 10 bytes
- * are session-scoped randomness — receivers use them to debounce
- * advertisements from a single sender across short BLE airtime windows.
+ * - `fc 12 8e` — `kFastInitModelId`, the magic bytes for Quick Share.
+ * - `VV` (byte 3) — packed metadata. Bitfield layout (high → low):
+ *   `version (3 bits) << 5 | type (3 bits) << 2 | uwb_supported (1 bit) << 1
+ *   | sender_cert_supported (1 bit)`.
+ *   Stock GMS senders that have an active share intent emit `version=0`,
+ *   `type=kNotify=0`, `uwb=0`, `sender_cert=0` → byte = `0x00`. Earlier
+ *   NearDrop captures (and prior versions of this file) had `0x01`, which
+ *   sets the deprecated/reinterpreted `sender_cert_supported` bit and
+ *   causes Samsung One UI to mis-classify the pulse as `type=SILENT` (see
+ *   `Detected fast init state changed: type=SILENT` in Galaxy logcat),
+ *   which in turn prevents Samsung's GMS from registering the per-peer
+ *   Weave-byte handler on its `0xFEF3` GATT server. Fix: emit `0x00`.
+ * - `PP` (byte 4) — `metadata[1]`, the unsigned negation of the adjusted Tx
+ *   power. `kAdjustedTxPower = -66 dBm` so the wire byte is `-(-66) = 66 = 0x42`.
+ * - `UU` (byte 5) — `uwb_metadata`. Zero when we do not advertise UWB.
+ * - `AA × 8` (bytes 6..13) — `uwb_address`. Zero unless UWB is in play.
+ * - `SS` (byte 14) — per-share-session salt so receivers can dedupe pulses.
+ * - `HH × 8` (bytes 15..22) — `secret_id_hash`. Truncated SHA-256 over the
+ *   sender's `endpointId`. Samsung GMS treats an all-zero hash as "no real
+ *   share intent" and demotes the pulse to `type=SILENT` regardless of the
+ *   metadata-byte type bits. A stable non-zero hash is the trigger that
+ *   makes the receiver's `shouldAcceptSocketHandler` return true and wire
+ *   the per-characteristic Weave handler so subsequent ATT writes to
+ *   `00000100-0004-1000-8000-001a11000101` are actually delivered to the
+ *   GMS application layer (instead of throwing
+ *   `BluetoothGattException: No handler registered for characteristic …`).
+ *
+ * Total payload = 14 fixed bytes + 1 salt + 8 hash = 23 bytes, comfortably
+ * inside the legacy 31-byte advertising-PDU budget alongside the 16-bit
+ * service-data AD wrapper.
  *
  * This object is pure-JVM (no `android.*` imports) so it is exhaustively
  * unit-testable. The Android-side advertiser ([BleAdvertiser]) consumes it
@@ -46,31 +78,39 @@ public object BleAdvertisePayload {
     public const val SERVICE_UUID_128: String = "0000fe2c-0000-1000-8000-00805f9b34fb"
 
     /**
-     * Total size of the service-data payload in bytes (14 fixed prefix +
-     * 10 random suffix). This must fit alongside the service-UUID field
-     * inside the legacy 31-byte advertising-PDU budget.
+     * Length of the 14-byte fixed prefix (model id + metadata + uwb stub).
+     * The first 14 bytes are constant for every share session; only the
+     * trailing 9 bytes (1 salt + 8 hash) carry per-session entropy.
      */
-    public const val PAYLOAD_LEN: Int = 24
+    public const val PREFIX_LEN: Int = 14
 
-    /** Length of the randomness tail. */
-    public const val RANDOM_LEN: Int = 10
+    /** Length of the per-share-session salt byte. */
+    public const val SALT_LEN: Int = 1
 
-    /**
-     * Length of the fixed Quick Share prefix that precedes the randomness.
-     */
-    public const val PREFIX_LEN: Int = PAYLOAD_LEN - RANDOM_LEN // 14
+    /** Length of the truncated SHA-256 secret-id-hash. */
+    public const val SECRET_ID_HASH_LEN: Int = 8
+
+    /** Total dynamic tail = salt + hash = 9 bytes. */
+    public const val DYNAMIC_TAIL_LEN: Int = SALT_LEN + SECRET_ID_HASH_LEN
+
+    /** Total service-data payload size = 14 fixed + 9 dynamic = 23 bytes. */
+    public const val PAYLOAD_LEN: Int = PREFIX_LEN + DYNAMIC_TAIL_LEN
 
     /**
      * The 14-byte literal prefix mandated by the protocol. Exposed as a
      * defensive copy via [prefixBytes] so callers cannot mutate the
      * canonical bytes.
+     *
+     * Byte 3 = `0x00` packs `version=0, type=kNotify (0), uwb=0,
+     * sender_cert=0`. **Do not change to `0x01`** — see the kdoc above for
+     * the Samsung-One-UI-classifies-as-SILENT regression that introduces.
      */
     private val PREFIX: ByteArray =
         byteArrayOf(
             0xFC.toByte(),
             0x12.toByte(),
             0x8E.toByte(),
-            0x01.toByte(),
+            0x00.toByte(),
             0x42.toByte(),
             0x00.toByte(),
             0x00.toByte(),
@@ -87,39 +127,60 @@ public object BleAdvertisePayload {
     public fun prefixBytes(): ByteArray = PREFIX.copyOf()
 
     /**
-     * Build a fresh 24-byte payload. The prefix is the canonical Quick
-     * Share magic; the trailing 10 bytes are drawn from [random].
+     * Build a fresh 23-byte payload bound to [endpointId]. The trailing
+     * 8-byte `secret_id_hash` is the truncated SHA-256 of `endpointId`'s
+     * UTF-8 bytes — any non-zero hash is sufficient for stock GMS
+     * receivers to classify the pulse as `type=NORMAL` (kNotify with
+     * intent) and wire their per-peer Weave handler. The single salt byte
+     * preceding the hash is drawn from [random] and lets receivers
+     * dedupe rapid back-to-back broadcasts within the same share session.
      *
-     * @param random source of the 10 trailing bytes. Defaults to a fresh
-     *   [SecureRandom]; tests may inject a deterministic [java.util.Random]
-     *   subclass to assert against fixed bytes.
+     * @param endpointId the sender's 4-byte ASCII slug (the same value
+     *   that appears in the OfflineFrame `ConnectionRequestFrame.endpoint_id`
+     *   and in our mDNS instance-name slug). Must be non-empty.
+     * @param random source of the salt byte. Defaults to a fresh
+     *   [SecureRandom]; tests inject deterministic [java.util.Random].
      */
     @JvmOverloads
-    public fun build(random: java.util.Random = SecureRandom()): ByteArray {
+    public fun build(
+        endpointId: String,
+        random: java.util.Random = SecureRandom(),
+    ): ByteArray {
+        require(endpointId.isNotEmpty()) { "endpointId must not be empty" }
         val out = ByteArray(PAYLOAD_LEN)
         System.arraycopy(PREFIX, 0, out, 0, PREFIX_LEN)
-        val tail = ByteArray(RANDOM_LEN)
-        random.nextBytes(tail)
-        System.arraycopy(tail, 0, out, PREFIX_LEN, RANDOM_LEN)
+        val saltBuf = ByteArray(SALT_LEN)
+        random.nextBytes(saltBuf)
+        out[PREFIX_LEN] = saltBuf[0]
+        val hash =
+            MessageDigest
+                .getInstance("SHA-256")
+                .digest(endpointId.toByteArray(Charsets.UTF_8))
+                .copyOf(SECRET_ID_HASH_LEN)
+        System.arraycopy(hash, 0, out, PREFIX_LEN + SALT_LEN, SECRET_ID_HASH_LEN)
         return out
     }
 
     /**
-     * Build a payload with the supplied 10-byte randomness tail. Useful
-     * in tests and in scenarios where the caller needs the same random
-     * suffix to be reused (e.g. when re-emitting after a Bluetooth restart
-     * within the same share session).
+     * Build a payload with the supplied salt byte and `secret_id_hash`.
+     * Useful in tests and in scenarios where the caller needs reproducible
+     * bytes (e.g. when re-emitting after a Bluetooth restart within the
+     * same share session and the salt should stay stable).
      *
-     * @throws IllegalArgumentException if [randomTail] is not exactly
-     *   [RANDOM_LEN] bytes long.
+     * @throws IllegalArgumentException if [secretIdHash] is not exactly
+     *   [SECRET_ID_HASH_LEN] bytes long.
      */
-    public fun buildWith(randomTail: ByteArray): ByteArray {
-        require(randomTail.size == RANDOM_LEN) {
-            "randomTail must be exactly $RANDOM_LEN bytes, got ${randomTail.size}"
+    public fun buildWith(
+        salt: Byte,
+        secretIdHash: ByteArray,
+    ): ByteArray {
+        require(secretIdHash.size == SECRET_ID_HASH_LEN) {
+            "secretIdHash must be exactly $SECRET_ID_HASH_LEN bytes, got ${secretIdHash.size}"
         }
         val out = ByteArray(PAYLOAD_LEN)
         System.arraycopy(PREFIX, 0, out, 0, PREFIX_LEN)
-        System.arraycopy(randomTail, 0, out, PREFIX_LEN, RANDOM_LEN)
+        out[PREFIX_LEN] = salt
+        System.arraycopy(secretIdHash, 0, out, PREFIX_LEN + SALT_LEN, SECRET_ID_HASH_LEN)
         return out
     }
 }

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleAdvertiser.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleAdvertiser.kt
@@ -80,11 +80,17 @@ public class BleAdvertiser internal constructor(
 
     /**
      * Production constructor. Wires up the Android `BluetoothManager` and
-     * a fresh [SecureRandom] for the payload's random tail.
+     * a fresh [SecureRandom] for the payload's random salt byte.
+     *
+     * @param endpointId the sender's 4-byte ASCII slug. The pulse's
+     *   `secret_id_hash` is the truncated SHA-256 of this value, which is
+     *   what stock GMS receivers (notably Samsung One UI) inspect to
+     *   classify the pulse as `type=NORMAL` and wire their per-peer Weave
+     *   handler. Must be non-empty.
      */
-    public constructor(context: Context) : this(
+    public constructor(context: Context, endpointId: String) : this(
         provider = DefaultAdvertiserProvider(context.applicationContext),
-        payloadFactory = { BleAdvertisePayload.build(SecureRandom()) },
+        payloadFactory = { BleAdvertisePayload.build(endpointId, SecureRandom()) },
         now = System::currentTimeMillis,
     )
 
@@ -211,16 +217,23 @@ public class BleAdvertiser internal constructor(
      *   * `LOW_LATENCY` mode — receivers should see us within ~100ms.
      *   * `TX_POWER_HIGH` — best chance of a wake-up across a typical
      *     room.
-     *   * `connectable = false` — we never accept GATT connections; this
-     *     keeps the advertising-PDU budget free for the 24-byte service
-     *     data and tells the platform not to allocate a connection window.
+     *   * `connectable = true` — stock Quick Share senders advertise as
+     *     connectable, and Samsung One UI 8.x receivers appear to gate
+     *     their per-peer Weave handler registration on this bit (a
+     *     non-connectable pulse is treated as a passive scan / discovery
+     *     beacon, not a real share-intent peer). We do not actually host
+     *     a GATT server on the sender side, so any connection attempt
+     *     from a receiver will be NACKed at the application layer — but
+     *     the connectable bit on the wire is a strong "real peer" signal
+     *     that, paired with the `secret_id_hash` in the service data,
+     *     unblocks the receiver-side handler registration path.
      */
     private fun buildSettings(): AdvertiseSettings =
         AdvertiseSettings
             .Builder()
             .setAdvertiseMode(AdvertiseSettings.ADVERTISE_MODE_LOW_LATENCY)
             .setTxPowerLevel(AdvertiseSettings.ADVERTISE_TX_POWER_HIGH)
-            .setConnectable(false)
+            .setConnectable(true)
             .build()
 
     /**

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleFastAdvertisementScanner.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleFastAdvertisementScanner.kt
@@ -25,6 +25,7 @@ import android.os.SystemClock
 import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.core.content.ContextCompat
+import io.github.kyujincho.wvmg.protocol.endpoint.BleAdvertisement
 import io.github.kyujincho.wvmg.protocol.endpoint.BleAdvertisementHeader
 import io.github.kyujincho.wvmg.protocol.endpoint.BleServiceData
 import io.github.kyujincho.wvmg.protocol.endpoint.DctAdvertisement
@@ -53,11 +54,14 @@ public class BleFastAdvertisementScanner(
             val gattReadSucceeded = ConcurrentHashMap.newKeySet<String>()
 
             fun scheduleGattAdvertisementRead(
-                header: BleAdvertisementHeader,
                 advertiserAddress: String,
                 rssi: Int?,
+                slotCount: Int,
+                advertisementKey: String,
+                fallbackPsm: Int? = null,
+                fallbackObservation: Observation? = null,
             ) {
-                val key = "$advertiserAddress:${header.advertisementHash.toHex()}:${header.numSlots}"
+                val key = "$advertiserAddress:$advertisementKey:$slotCount"
                 if (key in gattReadSucceeded) return
                 if (!gattReadInFlight.add(key)) return
                 val now = SystemClock.elapsedRealtime()
@@ -69,23 +73,45 @@ public class BleFastAdvertisementScanner(
                 gattReadAttempts[key] = now
                 launch {
                     try {
-                        val slotAdvertisements =
+                        val readResult =
                             gattAdvertisementReader.read(
                                 macAddress = advertiserAddress,
-                                slotCount = header.numSlots,
+                                slotCount = slotCount,
                             )
+                        val slotAdvertisements = readResult.slotAdvertisements
+                        if (readResult.socketServiceAvailable && slotAdvertisements.isEmpty()) {
+                            fallbackObservation?.let { observation ->
+                                val verifiedObservation =
+                                    observation.copy(
+                                        l2capPsm = observation.l2capPsm ?: fallbackPsm,
+                                        gattConnectable = true,
+                                    )
+                                Log.w(
+                                    TAG,
+                                    "BLE GATT socket service verified endpointId=${verifiedObservation.endpointId} " +
+                                        "address=$advertiserAddress rssi=$rssi " +
+                                        "psm=${verifiedObservation.l2capPsm} " +
+                                        "name=${verifiedObservation.displayName ?: "<none>"} " +
+                                        "nameSource=${verifiedObservation.displayNameSource?.logLabel ?: "<none>"}",
+                                )
+                                trySend(verifiedObservation).isSuccess
+                            }
+                        }
                         if (slotAdvertisements.isNotEmpty()) {
+                            gattReadSucceeded.add(key)
+                        } else if (readResult.socketServiceAvailable) {
                             gattReadSucceeded.add(key)
                         }
                         slotAdvertisements.forEach { slot ->
                             val slotDisplayName = slot.endpointInfo.deviceName.toDisplayNameOrNull()
                             val slotDisplayNameSource =
                                 slotDisplayName?.let { DisplayNameSource.GATT_SLOT_ENDPOINT_INFO }
+                            val slotL2capPsm = slot.l2capPsm ?: fallbackPsm
                             Log.w(
                                 TAG,
                                 "BLE GATT slot advertisement observed endpointId=${slot.endpointId} " +
                                     "address=$advertiserAddress rssi=$rssi " +
-                                    "psm=${slot.l2capPsm ?: header.psm.takeIf { it > 0 }} " +
+                                    "psm=$slotL2capPsm " +
                                     "name=${slotDisplayName ?: "<none>"} " +
                                     "nameSource=${slotDisplayNameSource?.logLabel ?: "<none>"}",
                             )
@@ -95,7 +121,7 @@ public class BleFastAdvertisementScanner(
                                     endpointInfo = slot.endpointInfo,
                                     advertiserAddress = advertiserAddress,
                                     rssi = rssi,
-                                    l2capPsm = slot.l2capPsm ?: header.psm.takeIf { it > 0 },
+                                    l2capPsm = slotL2capPsm,
                                     gattConnectable = true,
                                     displayName = slotDisplayName,
                                     displayNameSource = slotDisplayNameSource,
@@ -184,7 +210,7 @@ public class BleFastAdvertisementScanner(
 
     @Suppress("CyclomaticComplexMethod", "NestedBlockDepth", "LongMethod")
     private fun ScanResult.toObservation(
-        scheduleGattAdvertisementRead: (BleAdvertisementHeader, String, Int?) -> Unit,
+        scheduleGattAdvertisementRead: (String, Int?, Int, String, Int?, Observation?) -> Unit,
     ): Observation? {
         val scanRecord: ScanRecord =
             scanRecord ?: run {
@@ -193,7 +219,7 @@ public class BleFastAdvertisementScanner(
             }
         val fastData = scanRecord.getServiceData(SERVICE_UUID)
         val dctData = scanRecord.getServiceData(DCT_SERVICE_UUID)
-        val gattConnectable = isGattConnectable()
+        val scanResultConnectable = isGattConnectable()
         if (fastData == null && dctData == null) {
             Log.w(
                 TAG,
@@ -205,10 +231,18 @@ public class BleFastAdvertisementScanner(
         val localDisplayName = scanRecord.displayNameCandidate()
         val fastObservation =
             fastData?.let { serviceData ->
-                BleAdvertisementHeader.parse(serviceData)?.let { header ->
+                val advertisementHeader = BleAdvertisementHeader.parse(serviceData)
+                advertisementHeader?.let { header ->
                     device?.address?.let { address ->
-                        if (gattConnectable) {
-                            scheduleGattAdvertisementRead(header, address, rssi)
+                        if (scanResultConnectable && !header.supportsExtendedAdvertisement) {
+                            scheduleGattAdvertisementRead(
+                                address,
+                                rssi,
+                                header.numSlots,
+                                header.advertisementHash.toHex(),
+                                header.psm.takeIf { it > 0 },
+                                null,
+                            )
                         }
                     }
                 }
@@ -216,16 +250,18 @@ public class BleFastAdvertisementScanner(
                     serviceData = serviceData,
                     advertiserAddress = device?.address,
                     rssi = rssi,
-                    gattConnectable = gattConnectable,
+                    gattConnectable = scanResultConnectable,
                     fallbackDisplayName = localDisplayName?.value,
                     fallbackDisplayNameSource = localDisplayName?.source,
                 ).also { observation ->
                     if (observation == null) {
-                        Log.w(
-                            TAG,
-                            "BLE fast-advertisement parse failed address=${device?.address} " +
-                                "rssi=$rssi bytes=${serviceData.toHex()}",
-                        )
+                        if (advertisementHeader?.supportsExtendedAdvertisement != true) {
+                            Log.w(
+                                TAG,
+                                "BLE fast-advertisement parse failed address=${device?.address} " +
+                                    "rssi=$rssi bytes=${serviceData.toHex()}",
+                            )
+                        }
                     } else {
                         Log.w(
                             TAG,
@@ -236,6 +272,16 @@ public class BleFastAdvertisementScanner(
                                 "nameSource=${observation.displayNameSource?.logLabel ?: "<none>"} " +
                                 "bytes=${serviceData.toHex()}",
                         )
+                        if (scanResultConnectable && observation.requiresGattVerification()) {
+                            scheduleGattAdvertisementRead(
+                                requireNotNull(observation.advertiserAddress),
+                                observation.rssi,
+                                DEFAULT_GATT_SLOT_READ_COUNT,
+                                serviceData.contentKey(),
+                                null,
+                                observation,
+                            )
+                        }
                     }
                 }
             }
@@ -245,7 +291,7 @@ public class BleFastAdvertisementScanner(
                     serviceData = serviceData,
                     advertiserAddress = device?.address,
                     rssi = rssi,
-                    gattConnectable = gattConnectable,
+                    gattConnectable = scanResultConnectable,
                     fallbackDisplayName = localDisplayName?.value,
                     fallbackDisplayNameSource = localDisplayName?.source,
                 ).also { observation ->
@@ -265,6 +311,16 @@ public class BleFastAdvertisementScanner(
                                 "nameSource=${observation.displayNameSource?.logLabel ?: "<none>"} " +
                                 "bytes=${serviceData.toHex()}",
                         )
+                        if (scanResultConnectable && observation.requiresGattVerification()) {
+                            scheduleGattAdvertisementRead(
+                                requireNotNull(observation.advertiserAddress),
+                                observation.rssi,
+                                DEFAULT_GATT_SLOT_READ_COUNT,
+                                serviceData.contentKey(),
+                                null,
+                                observation,
+                            )
+                        }
                     }
                 }
             }
@@ -317,12 +373,20 @@ public class BleFastAdvertisementScanner(
                 .build(),
         )
 
-    private fun buildSettings(): ScanSettings =
-        ScanSettings
-            .Builder()
-            .setScanMode(ScanSettings.SCAN_MODE_BALANCED)
-            .setReportDelay(0)
-            .build()
+    private fun buildSettings(): ScanSettings {
+        val builder =
+            ScanSettings
+                .Builder()
+                .setScanMode(ScanSettings.SCAN_MODE_BALANCED)
+                .setReportDelay(0)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            // Stock Nearby publishes the full identity as extended advertising data
+            // when possible, keeping the legacy GATT header only as a fallback.
+            builder.setLegacy(false)
+            builder.setPhy(ScanSettings.PHY_LE_ALL_SUPPORTED)
+        }
+        return builder.build()
+    }
 
     private fun ScanResult.isGattConnectable(): Boolean =
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -333,6 +397,7 @@ public class BleFastAdvertisementScanner(
 
     public companion object {
         private const val TAG: String = "WvmgBleFastScan"
+        private const val DEFAULT_GATT_SLOT_READ_COUNT: Int = 1
         private const val GATT_READ_RETRY_MILLIS: Long = 5_000L
         private val SERVICE_UUID: ParcelUuid
             get() = ParcelUuid.fromString(BleServiceData.SERVICE_UUID_128_STRING)
@@ -350,31 +415,136 @@ public class BleFastAdvertisementScanner(
             fallbackDisplayNameSource: DisplayNameSource? = null,
         ): Observation? {
             val fallbackName = fallbackDisplayName.toDisplayNameOrNull()
-            BleAdvertisementHeader.parse(serviceData)?.let { header ->
-                val l2capPsm = header.psm.takeIf { it > 0 }
-                return Observation(
-                    endpointId = null,
-                    endpointInfo = null,
-                    advertiserAddress = advertiserAddress,
-                    rssi = rssi,
-                    l2capPsm = l2capPsm,
-                    gattConnectable = gattConnectable && advertiserAddress != null,
-                    displayName = fallbackName,
-                    displayNameSource = fallbackName?.let { fallbackDisplayNameSource },
-                )
-            }
+            return parseLegacyGattHeader(
+                serviceData = serviceData,
+                advertiserAddress = advertiserAddress,
+                rssi = rssi,
+                gattConnectable = gattConnectable,
+                fallbackDisplayName = fallbackName,
+                fallbackDisplayNameSource = fallbackDisplayNameSource,
+            ) ?: BleAdvertisement
+                .parse(serviceData)
+                ?.let { advertisement ->
+                    parseNearbyBleAdvertisement(
+                        advertisement = advertisement,
+                        advertiserAddress = advertiserAddress,
+                        rssi = rssi,
+                        gattConnectable = gattConnectable,
+                        fallbackDisplayName = fallbackName,
+                        fallbackDisplayNameSource = fallbackDisplayNameSource,
+                    )
+                } ?: parseFramedFastServiceData(
+                serviceData = serviceData,
+                advertiserAddress = advertiserAddress,
+                rssi = rssi,
+                gattConnectable = gattConnectable,
+                fallbackDisplayName = fallbackName,
+                fallbackDisplayNameSource = fallbackDisplayNameSource,
+            )
+        }
+
+        private fun parseLegacyGattHeader(
+            serviceData: ByteArray,
+            advertiserAddress: String?,
+            rssi: Int?,
+            gattConnectable: Boolean,
+            fallbackDisplayName: String?,
+            fallbackDisplayNameSource: DisplayNameSource?,
+        ): Observation? {
+            val header = BleAdvertisementHeader.parse(serviceData) ?: return null
+            if (header.supportsExtendedAdvertisement) return null
+            val l2capPsm = header.psm.takeIf { it > 0 }
+            return Observation(
+                endpointId = null,
+                endpointInfo = null,
+                advertiserAddress = advertiserAddress,
+                rssi = rssi,
+                l2capPsm = l2capPsm,
+                gattConnectable = gattConnectable && advertiserAddress != null && l2capPsm != null,
+                displayName = fallbackDisplayName,
+                displayNameSource = fallbackDisplayName?.let { fallbackDisplayNameSource },
+            )
+        }
+
+        private fun parseFramedFastServiceData(
+            serviceData: ByteArray,
+            advertiserAddress: String?,
+            rssi: Int?,
+            gattConnectable: Boolean,
+            fallbackDisplayName: String?,
+            fallbackDisplayNameSource: DisplayNameSource?,
+        ): Observation? {
             val parsed = BleServiceData.parse(serviceData) ?: return null
             val endpointId = String(parsed.endpointId, Charsets.US_ASCII)
             val l2capPsm = BleServiceData.parsePsmExtraField(serviceData)?.takeIf { it > 0 }
             val endpointName = parsed.endpointInfo.deviceName.toDisplayNameOrNull()
-            val displayName = endpointName ?: fallbackName
+            val displayName = endpointName ?: fallbackDisplayName
             return Observation(
                 endpointId = endpointId,
                 endpointInfo = parsed.endpointInfo,
                 advertiserAddress = advertiserAddress,
                 rssi = rssi,
                 l2capPsm = l2capPsm,
-                gattConnectable = gattConnectable && advertiserAddress != null,
+                gattConnectable = gattConnectable && advertiserAddress != null && l2capPsm != null,
+                displayName = displayName,
+                displayNameSource =
+                    when {
+                        endpointName != null -> DisplayNameSource.FAST_ADVERTISEMENT_ENDPOINT_INFO
+                        displayName != null -> fallbackDisplayNameSource
+                        else -> null
+                    },
+            )
+        }
+
+        private fun parseNearbyBleAdvertisement(
+            advertisement: BleAdvertisement.Parsed,
+            advertiserAddress: String?,
+            rssi: Int?,
+            gattConnectable: Boolean,
+            fallbackDisplayName: String?,
+            fallbackDisplayNameSource: DisplayNameSource?,
+        ): Observation? {
+            val serviceData =
+                when {
+                    advertisement.fastAdvertisement -> advertisement.data
+                    advertisement.serviceIdHash?.contentEquals(NearbyServiceId.hashPrefix) == true ->
+                        advertisement.data
+
+                    else -> return null
+                }
+            return parseNearbyBleAdvertisementBody(
+                serviceData = serviceData,
+                psm = advertisement.psm,
+                advertiserAddress = advertiserAddress,
+                rssi = rssi,
+                gattConnectable = gattConnectable,
+                fallbackDisplayName = fallbackDisplayName,
+                fallbackDisplayNameSource = fallbackDisplayNameSource,
+            )
+        }
+
+        @Suppress("LongParameterList")
+        private fun parseNearbyBleAdvertisementBody(
+            serviceData: ByteArray,
+            psm: Int,
+            advertiserAddress: String?,
+            rssi: Int?,
+            gattConnectable: Boolean,
+            fallbackDisplayName: String?,
+            fallbackDisplayNameSource: DisplayNameSource?,
+        ): Observation? {
+            val parsed = BleServiceData.parse(serviceData) ?: return null
+            val endpointId = String(parsed.endpointId, Charsets.US_ASCII)
+            val endpointName = parsed.endpointInfo.deviceName.toDisplayNameOrNull()
+            val displayName = endpointName ?: fallbackDisplayName
+            val l2capPsm = psm.takeIf { it > 0 }
+            return Observation(
+                endpointId = endpointId,
+                endpointInfo = parsed.endpointInfo,
+                advertiserAddress = advertiserAddress,
+                rssi = rssi,
+                l2capPsm = l2capPsm,
+                gattConnectable = gattConnectable && advertiserAddress != null && l2capPsm != null,
                 displayName = displayName,
                 displayNameSource =
                     when {
@@ -407,7 +577,7 @@ public class BleFastAdvertisementScanner(
                 advertiserAddress = advertiserAddress,
                 rssi = rssi,
                 l2capPsm = l2capPsm,
-                gattConnectable = gattConnectable && advertiserAddress != null,
+                gattConnectable = gattConnectable && advertiserAddress != null && l2capPsm != null,
                 displayName = displayName,
                 displayNameSource =
                     when {
@@ -432,6 +602,12 @@ public class BleFastAdvertisementScanner(
     }
 }
 
+private fun BleFastAdvertisementScanner.Observation.requiresGattVerification(): Boolean =
+    advertiserAddress != null &&
+        l2capPsm == null &&
+        endpointInfo?.hidden == false &&
+        !gattConnectable
+
 private fun DctAdvertisement.Parsed.toEndpointInfo(): EndpointInfo =
     EndpointInfo(
         version = 1,
@@ -443,6 +619,8 @@ private fun DctAdvertisement.Parsed.toEndpointInfo(): EndpointInfo =
     )
 
 private fun ByteArray.toHex(): String = joinToString("") { "%02x".format(it) }
+
+private fun ByteArray.contentKey(): String = "$size:${contentHashCode().toString(radix = 16)}"
 
 private data class DisplayNameCandidate(
     val value: String,

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleGattAdvertisementReader.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleGattAdvertisementReader.kt
@@ -33,8 +33,8 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 
 /**
- * Reads Nearby BLE v2 GATT advertisement slots referenced by a `0x55`
- * advertisement header.
+ * Probes Nearby BLE v2 GATT bootstrap service and reads any
+ * advertisement slots referenced by a `0x55` advertisement header.
  */
 internal class BleGattAdvertisementReader(
     private val context: Context,
@@ -43,21 +43,22 @@ internal class BleGattAdvertisementReader(
     suspend fun read(
         macAddress: String,
         slotCount: Int,
-    ): List<SlotAdvertisement> =
+    ): ReadResult =
         withContext(dispatcher) {
-            if (!isAvailable() || slotCount <= 0) return@withContext emptyList()
+            if (!isAvailable()) return@withContext ReadResult.Empty
             val adapter =
                 context
                     .applicationContext
                     .getSystemService(BluetoothManager::class.java)
                     ?.adapter
-                    ?: return@withContext emptyList()
+                    ?: return@withContext ReadResult.Empty
+            cancelDiscoveryBeforeGattConnect(adapter, macAddress)
             val device =
                 try {
                     adapter.getRemoteDevice(macAddress)
                 } catch (badAddress: IllegalArgumentException) {
                     Log.w(TAG, "invalid BLE GATT advertisement address=$macAddress", badAddress)
-                    return@withContext emptyList()
+                    return@withContext ReadResult.Empty
                 }
             val callback = Callback(slotCount.coerceAtMost(MAX_SLOT_COUNT))
             val gatt =
@@ -66,15 +67,34 @@ internal class BleGattAdvertisementReader(
                     false,
                     callback,
                     BluetoothDevice.TRANSPORT_LE,
-                ) ?: return@withContext emptyList()
+                ) ?: return@withContext ReadResult.Empty
             callback.attach(gatt)
             try {
-                withTimeoutOrNull(READ_TIMEOUT_MILLIS) { callback.result.await() }.orEmpty()
+                val result = withTimeoutOrNull(READ_TIMEOUT_MILLIS) { callback.result.await() }
+                if (result == null) {
+                    Log.w(TAG, "slot-read timed out address=$macAddress slots=$slotCount")
+                    ReadResult.Empty
+                } else {
+                    result
+                }
             } finally {
                 runCatching { gatt.disconnect() }
                 runCatching { gatt.close() }
             }
         }
+
+    private fun cancelDiscoveryBeforeGattConnect(
+        adapter: android.bluetooth.BluetoothAdapter,
+        macAddress: String,
+    ) {
+        if (!adapter.isDiscovering) return
+        val cancelled =
+            runCatching { adapter.cancelDiscovery() }
+                .onFailure { e ->
+                    Log.w(TAG, "slot-read cancelDiscovery failed address=$macAddress", e)
+                }.getOrDefault(false)
+        Log.i(TAG, "slot-read cancelDiscovery before GATT connect address=$macAddress cancelled=$cancelled")
+    }
 
     private fun isAvailable(): Boolean {
         val appContext = context.applicationContext
@@ -95,11 +115,12 @@ internal class BleGattAdvertisementReader(
     private class Callback(
         private val slotCount: Int,
     ) : BluetoothGattCallback() {
-        val result = CompletableDeferred<List<SlotAdvertisement>>()
+        val result = CompletableDeferred<ReadResult>()
         private val rawSlots = mutableListOf<ByteArray>()
         private var gatt: BluetoothGatt? = null
         private var slots: List<BluetoothGattCharacteristic> = emptyList()
         private var nextSlotIndex: Int = 0
+        private var socketServiceAvailable: Boolean = false
 
         fun attach(gatt: BluetoothGatt) {
             this.gatt = gatt
@@ -112,7 +133,10 @@ internal class BleGattAdvertisementReader(
         ) {
             Log.i(TAG, "slot-read state status=$status newState=$newState device=${gatt.device.safeAddress()}")
             if (status == BluetoothGatt.GATT_SUCCESS && newState == BluetoothProfile.STATE_CONNECTED) {
-                if (!gatt.discoverServices()) complete()
+                if (!gatt.discoverServices()) {
+                    Log.w(TAG, "slot-read discoverServices returned false device=${gatt.device.safeAddress()}")
+                    complete()
+                }
             } else {
                 complete()
             }
@@ -129,15 +153,30 @@ internal class BleGattAdvertisementReader(
             }
             val service = gatt.getService(BleGattInitialControlServer.SERVICE_UUID)
             if (service == null) {
-                Log.w(TAG, "slot-read service missing")
+                Log.w(
+                    TAG,
+                    "slot-read service missing services=${gatt.describeServices()}",
+                )
                 complete()
                 return
             }
+            socketServiceAvailable =
+                service.getCharacteristic(BleGattInitialControlServer.TO_PERIPHERAL_UUID) != null &&
+                service.getCharacteristic(BleGattInitialControlServer.FROM_PERIPHERAL_UUID) != null
+            val characteristicUuids =
+                service.characteristics.joinToString(",") { characteristic ->
+                    characteristic.uuid.toString()
+                }
             slots =
                 (0 until slotCount)
                     .mapNotNull { slot ->
                         service.getCharacteristic(BleGattInitialControlServer.advertisementSlotUuid(slot))
                     }
+            Log.i(
+                TAG,
+                "slot-read service discovered socket=$socketServiceAvailable " +
+                    "slots=${slots.size}/$slotCount chars=$characteristicUuids",
+            )
             readNextSlot()
         }
 
@@ -188,7 +227,12 @@ internal class BleGattAdvertisementReader(
 
         private fun complete() {
             if (!result.isCompleted) {
-                result.complete(rawSlots.mapNotNull(::parseSlotAdvertisement))
+                result.complete(
+                    ReadResult(
+                        socketServiceAvailable = socketServiceAvailable,
+                        slotAdvertisements = rawSlots.mapNotNull(::parseSlotAdvertisement),
+                    ),
+                )
             }
         }
 
@@ -223,6 +267,19 @@ internal class BleGattAdvertisementReader(
         val l2capPsm: Int?,
     )
 
+    data class ReadResult(
+        val socketServiceAvailable: Boolean,
+        val slotAdvertisements: List<SlotAdvertisement>,
+    ) {
+        companion object {
+            val Empty: ReadResult =
+                ReadResult(
+                    socketServiceAvailable = false,
+                    slotAdvertisements = emptyList(),
+                )
+        }
+    }
+
     private companion object {
         private const val TAG: String = "WvmgBleFastScan"
         private const val MAX_SLOT_COUNT: Int = 16
@@ -231,5 +288,11 @@ internal class BleGattAdvertisementReader(
 }
 
 private fun BluetoothDevice.safeAddress(): String = runCatching { address }.getOrNull() ?: "<unknown>"
+
+private fun BluetoothGatt.describeServices(): String =
+    services.joinToString(",") { service ->
+        val characteristics = service.characteristics.joinToString("|") { it.uuid.toString() }
+        "${service.uuid}[$characteristics]"
+    }
 
 private fun ByteArray.firstByteHex(): String = firstOrNull()?.let { "%02x".format(it) } ?: "--"

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareAdvertiser.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareAdvertiser.kt
@@ -23,6 +23,8 @@ import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.annotation.RequiresPermission
 import androidx.core.content.ContextCompat
+import io.github.kyujincho.wvmg.protocol.endpoint.BleAdvertisement
+import io.github.kyujincho.wvmg.protocol.endpoint.BleAdvertisementHeader
 import io.github.kyujincho.wvmg.protocol.endpoint.BleServiceData
 import io.github.kyujincho.wvmg.protocol.endpoint.DctAdvertisement
 import io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo
@@ -632,7 +634,23 @@ public object DefaultPayloadFactory : PayloadFactory {
     override fun build(
         endpointId: ByteArray,
         endpointInfo: EndpointInfo,
-    ): ByteArray = BleServiceData.encodeFramed(endpointId, endpointInfo.compactForFastAdvertisement())
+    ): ByteArray {
+        val psm = BleDctPsmHolder.currentPsm
+        if (psm != null && psm != DctAdvertisement.DEFAULT_PSM) {
+            val gattAdvertisement =
+                BleAdvertisement.encodeGattAdvertisement(
+                    endpointId = endpointId,
+                    endpointInfo = endpointInfo,
+                    psm = psm,
+                )
+            return BleAdvertisementHeader.encodeSingleSlot(
+                serviceId = NearbyServiceId.VALUE,
+                gattAdvertisement = gattAdvertisement,
+                psm = psm,
+            )
+        }
+        return BleServiceData.encodeFramed(endpointId, endpointInfo.compactForFastAdvertisement())
+    }
 
     private fun EndpointInfo.compactForFastAdvertisement(): EndpointInfo =
         EndpointInfo(
@@ -779,20 +797,11 @@ internal class AndroidBleAdvertiserGate(
                 mode = mode,
             )
         val callback =
-            if (visibleRegistration == null) {
-                val settings = BleQuickShareAdvertiser.buildSettings(mode)
-                val data = BleQuickShareAdvertiser.buildAdvertiseData()
-                val scanResponse = BleQuickShareAdvertiser.buildScanResponseData(serviceData)
-                AdvertiseCallbackImpl(label = "advertise").also { primaryCallback ->
-                    advertiser.startAdvertising(settings, data, scanResponse, primaryCallback)
-                }
-            } else {
-                Log.w(
-                    BleQuickShareAdvertiser.TAG,
-                    "advertise: hidden legacy 0xFEF3 suppressed while visible extended set is active",
-                )
-                null
-            }
+            startHiddenLegacyAdvertising(
+                advertiser = advertiser,
+                serviceData = serviceData,
+                mode = mode,
+            )
         val dctRegistration =
             startDctAdvertisingIfAvailable(
                 advertiser = advertiser,
@@ -801,6 +810,55 @@ internal class AndroidBleAdvertiserGate(
                 mode = mode,
             )
         return Registration(advertiser, callback, visibleRegistration, dctRegistration)
+    }
+
+    @RequiresPermission(Manifest.permission.BLUETOOTH_ADVERTISE)
+    private fun startHiddenLegacyAdvertising(
+        advertiser: BluetoothLeAdvertiser,
+        serviceData: ByteArray,
+        mode: Int,
+    ): AdvertiseCallbackImpl? {
+        val settings = BleQuickShareAdvertiser.buildSettings(mode)
+        val (data, scanResponse, placement) =
+            if (serviceData.fitsPrimaryLegacyAdvertisement()) {
+                Triple(BleQuickShareAdvertiser.buildScanResponseData(serviceData), null, "primary")
+            } else {
+                Triple(
+                    BleQuickShareAdvertiser.buildAdvertiseData(),
+                    BleQuickShareAdvertiser.buildScanResponseData(serviceData),
+                    "scan-response",
+                )
+            }
+        return try {
+            AdvertiseCallbackImpl(label = "advertise").also { primaryCallback ->
+                advertiser.startAdvertising(settings, data, scanResponse, primaryCallback)
+                Log.w(
+                    BleQuickShareAdvertiser.TAG,
+                    "advertise: submitted legacy $placement bytes=${serviceData.size} " +
+                        "uuid=${BleServiceData.SERVICE_UUID_128_STRING}",
+                )
+            }
+        } catch (e: SecurityException) {
+            logHiddenLegacyStartFailure(e)
+            null
+        } catch (e: IllegalArgumentException) {
+            logHiddenLegacyStartFailure(e)
+            null
+        } catch (e: IllegalStateException) {
+            logHiddenLegacyStartFailure(e)
+            null
+        }
+    }
+
+    private fun ByteArray.fitsPrimaryLegacyAdvertisement(): Boolean =
+        size + SERVICE_DATA_AD_OVERHEAD_BYTES + FLAGS_AD_OVERHEAD_BYTES <= LEGACY_ADVERTISING_DATA_BYTES
+
+    private fun logHiddenLegacyStartFailure(e: RuntimeException) {
+        Log.w(
+            BleQuickShareAdvertiser.TAG,
+            "advertise: hidden legacy startAdvertising failed; continuing with secondary advertisements",
+            e,
+        )
     }
 
     @Suppress("ReturnCount")
@@ -1135,6 +1193,7 @@ internal class AndroidBleAdvertiserGate(
     }
 
     private companion object {
+        private const val FLAGS_AD_OVERHEAD_BYTES: Int = 3
         private const val SERVICE_DATA_AD_OVERHEAD_BYTES: Int = 4
         private const val LEGACY_ADVERTISING_DATA_BYTES: Int = 31
     }

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareAdvertiser.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareAdvertiser.kt
@@ -23,7 +23,6 @@ import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.annotation.RequiresPermission
 import androidx.core.content.ContextCompat
-import io.github.kyujincho.wvmg.protocol.endpoint.BleAdvertisement
 import io.github.kyujincho.wvmg.protocol.endpoint.BleAdvertisementHeader
 import io.github.kyujincho.wvmg.protocol.endpoint.BleServiceData
 import io.github.kyujincho.wvmg.protocol.endpoint.DctAdvertisement
@@ -48,23 +47,22 @@ import java.util.concurrent.atomic.AtomicReference
  *
  * ### Wire format
  *
- * The service-data payload is built by [BleServiceData.encodeFramed] in
- * `:core-protocol` (pure-JVM, KAT-tested). The shape captured from a
- * Galaxy peer's broadcast is:
+ * The primary service-data payload is built as a BLE v2 GATT
+ * advertisement header in `:core-protocol` (pure-JVM, KAT-tested). Stock
+ * senders read the actual receiver identity from slot zero on the
+ * connectable GATT service before opening the same GATT socket. The slot
+ * value has the raw fast-body shape that Samsung GMS logs after a
+ * successful slot read:
  *
  * ```text
- * [ frameType(0x4a) | inner_len | versPCP | endpoint_id(4 ASCII) |
- *   endpoint_info_len | EndpointInfo(N) | device_token(2) ]
+ * [ versPCP | endpoint_id(4 ASCII) | endpoint_info_len |
+ *   EndpointInfo(N) ]
  * ```
  *
- * For our hidden, version=1, PHONE EndpointInfo the inner payload is
- * **23 bytes** and the stock BLE v2 framed service-data value is
- * **27 bytes**, which fits alongside the 16-bit service-data AD header
- * inside the legacy 31-byte advertising-PDU budget without needing
- * extended advertising. The receiver's mDNS path may carry a visible
- * name-bearing EndpointInfo for stock picker compatibility; the BLE
- * payload factory intentionally emits this compact hidden form so the
- * fast advertisement remains legal on legacy Android BLE advertisers.
+ * The compact header fits inside the legacy 31-byte scan-response budget
+ * while letting the GATT slot carry a visible name-bearing [EndpointInfo].
+ * This keeps the production receiver on the verified GATT socket path and
+ * avoids publishing an LE CoC PSM that One UI can prefer over GATT.
  *
  * WVMG also submits a second legacy DCT advertisement on `0xFC73`. Stock
  * Nearby uses DCT as the compact visible identity path: it carries a short
@@ -129,9 +127,9 @@ import java.util.concurrent.atomic.AtomicReference
  * @param gate platform-advertiser abstraction; tests inject a fake.
  * @param permissionChecker checks `BLUETOOTH_ADVERTISE` at start time;
  *   defaults to a [ContextCompat]-backed implementation in production.
- * @param payloadFactory builds the compact framed service-data payload from
- *   the supplied [EndpointInfo] and the latest endpoint_id. Defaults to
- *   [BleServiceData.encode] over a hidden, no-name copy of the identity.
+ * @param payloadFactory builds the compact GATT advertisement header from
+ *   the supplied [EndpointInfo] and the latest endpoint_id. The hosted slot
+ *   carries the same visible identity that the GATT server exposes.
  * @param visiblePayloadFactory optionally builds an Android O+ extended
  *   `0xFEF3` payload carrying the visible [EndpointInfo]. This is the BLE-only
  *   path Samsung ShareLive was observed to promote into the share sheet when
@@ -615,8 +613,8 @@ internal class AndroidAdvertisePermissionChecker(
 }
 
 /**
- * Builder for the compact framed service-data payload. The default implementation
- * delegates to [BleServiceData.encodeFramed] in `:core-protocol`; tests can
+ * Builder for the compact primary service-data payload. The default implementation
+ * emits a BLE v2 GATT advertisement header in `:core-protocol`; tests can
  * substitute a fake to drive specific failure paths.
  */
 public fun interface PayloadFactory {
@@ -635,33 +633,18 @@ public object DefaultPayloadFactory : PayloadFactory {
         endpointId: ByteArray,
         endpointInfo: EndpointInfo,
     ): ByteArray {
-        val psm = BleDctPsmHolder.currentPsm
-        if (psm != null && psm != DctAdvertisement.DEFAULT_PSM) {
-            val gattAdvertisement =
-                BleAdvertisement.encodeGattAdvertisement(
-                    endpointId = endpointId,
-                    endpointInfo = endpointInfo,
-                    psm = psm,
-                )
-            return BleAdvertisementHeader.encodeSingleSlot(
-                serviceId = NearbyServiceId.VALUE,
-                gattAdvertisement = gattAdvertisement,
-                psm = psm,
-            )
-        }
-        return BleServiceData.encodeFramed(endpointId, endpointInfo.compactForFastAdvertisement())
+        val gattAdvertisement = buildSlotPayload(endpointId, endpointInfo)
+        return BleAdvertisementHeader.encodeSingleSlot(
+            serviceId = NearbyServiceId.VALUE,
+            gattAdvertisement = gattAdvertisement,
+            psm = 0,
+        )
     }
 
-    private fun EndpointInfo.compactForFastAdvertisement(): EndpointInfo =
-        EndpointInfo(
-            version = version,
-            hidden = true,
-            deviceType = deviceType,
-            reserved = reserved,
-            metadata = metadata.copyOf(),
-            deviceName = null,
-            tlvRecords = emptyList(),
-        )
+    internal fun buildSlotPayload(
+        endpointId: ByteArray,
+        endpointInfo: EndpointInfo,
+    ): ByteArray = BleServiceData.encode(endpointId, endpointInfo)
 }
 
 /** Optional payload builder for secondary extended advertisements. */

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareAdvertiser.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareAdvertiser.kt
@@ -638,14 +638,22 @@ public object DefaultPayloadFactory : PayloadFactory {
             serviceId = NearbyServiceId.VALUE,
             gattAdvertisement = gattAdvertisement,
             psm = 0,
+            supportsExtendedAdvertisement = endpointInfo.supportsVisibleExtendedAdvertisement(),
         )
     }
 
     internal fun buildSlotPayload(
         endpointId: ByteArray,
         endpointInfo: EndpointInfo,
-    ): ByteArray = BleServiceData.encode(endpointId, endpointInfo)
+    ): ByteArray =
+        BleServiceData.encodeFramed(
+            endpointId = endpointId,
+            endpointInfo = endpointInfo,
+            secondProfile = true,
+        )
 }
+
+private fun EndpointInfo.supportsVisibleExtendedAdvertisement(): Boolean = !hidden && !deviceName.isNullOrBlank()
 
 /** Optional payload builder for secondary extended advertisements. */
 public fun interface OptionalPayloadFactory {
@@ -669,9 +677,18 @@ public object DefaultVisiblePayloadFactory : OptionalPayloadFactory {
         if (endpointInfo.hidden || endpointInfo.deviceName == null) return null
         val psm = BleDctPsmHolder.currentPsm
         return if (psm != null && psm != DctAdvertisement.DEFAULT_PSM) {
-            BleServiceData.encodeFramedWithPsm(endpointId, endpointInfo, psm)
+            BleServiceData.encodeFramedWithPsm(
+                endpointId = endpointId,
+                endpointInfo = endpointInfo,
+                psm = psm,
+                secondProfile = true,
+            )
         } else {
-            BleServiceData.encodeFramed(endpointId, endpointInfo)
+            BleServiceData.encodeFramed(
+                endpointId = endpointId,
+                endpointInfo = endpointInfo,
+                secondProfile = true,
+            )
         }
     }
 }

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BleGattInitialControlClient.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BleGattInitialControlClient.kt
@@ -459,6 +459,7 @@ private class BleGattClientTransport(
         runCatching { input.close() }
         val openGatt = gatt
         gatt = null
+        writeQueue.clear()
         runCatching { openGatt?.disconnect() }
         runCatching { openGatt?.close() }
         onClose(this)
@@ -604,6 +605,10 @@ private class BleGattClientTransport(
         weaveConnected = true
         Log.w(TAG, "Weave connected raw Nearby stream packetSize=$negotiatedPacketSize device=${device.safeAddress()}")
         sendWeaveMessage(NearbyBleSocketFrames.encodeIntroductionPacket())
+        // Samsung's GMS raw Nearby handler expects the first app payload
+        // immediately after the socket-introduction packet. Waiting after
+        // the intro write leaves the BLE Weave stream open, but the
+        // ConnectionRequestFrame is never dispatched to Nearby Connections.
         if (!ready.isCompleted) ready.complete(true)
     }
 
@@ -666,8 +671,21 @@ private class BleGattClientTransport(
 
     private fun sendSocketServiceBytes(bytes: ByteArray) {
         if (bytes.isEmpty()) return
+        // Log.w (not Log.i) here is the Funtouch OS / vivo workaround from PR #144:
+        // Funtouch filters Log.i for non-system apps, leaving us blind to the
+        // outbound write path during BLE GATT bootstrap diagnostics. Log.w
+        // also lands in `getExternalFilesDir(null)/wvmg-outbound.log` via
+        // OutboundConnection's logger so on-device logs survive a logcat
+        // flush. The function split (sendSocketServiceBytes vs.
+        // sendSocketServiceMessage) is from PR #146, where new callers send
+        // already-prefixed socket payloads and want the inner helper without
+        // the extra logging.
         Log.w(TAG, "BLE GATT service write bytes=${bytes.size} preview=${bytes.previewHex()}")
-        sendWeaveMessage(NearbyServiceId.hashPrefix + bytes)
+        sendSocketServiceMessage(bytes)
+    }
+
+    private fun sendSocketServiceMessage(payload: ByteArray) {
+        sendWeaveMessage(NearbyServiceId.hashPrefix + payload)
     }
 
     @Synchronized
@@ -693,7 +711,14 @@ private class BleGattClientTransport(
 
     private fun enqueueWriteLocked(packet: ByteArray) {
         if (closed) return
-        Log.w(TAG, "enqueue write len=${packet.size} header=${packet.firstByteHex()} device=${device.safeAddress()}")
+        // Log.w (not Log.i): same Funtouch OS / vivo workaround as
+        // sendSocketServiceBytes above — Log.i is filtered by Funtouch
+        // for non-system apps, leaving us blind to the per-packet
+        // enqueue path during BLE GATT bootstrap diagnostics.
+        Log.w(
+            TAG,
+            "enqueue write len=${packet.size} header=${packet.firstByteHex()} device=${device.safeAddress()}",
+        )
         writeQueue.add(packet)
         drainWritesLocked()
     }

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BleGattInitialControlClient.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BleGattInitialControlClient.kt
@@ -27,6 +27,8 @@ import android.bluetooth.BluetoothProfile
 import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.core.content.ContextCompat
@@ -69,7 +71,7 @@ public class BleGattInitialControlClient internal constructor(
     public suspend fun connect(macAddress: String): ConnectedTransport? =
         withContext(dispatcher) {
             if (!isAvailable()) {
-                Log.i(TAG, "BLE GATT initial connect unavailable")
+                Log.w(TAG, "BLE GATT initial connect unavailable")
                 return@withContext null
             }
             val adapter =
@@ -101,7 +103,7 @@ public class BleGattInitialControlClient internal constructor(
                 transport.close()
                 return@withContext null
             }
-            Log.i(TAG, "BLE GATT initial connect ready mac=$macAddress")
+            Log.w(TAG, "BLE GATT initial connect ready mac=$macAddress")
             transport
         }
 
@@ -143,10 +145,14 @@ private class BleGattClientTransport(
     private val writeQueue: ArrayDeque<ByteArray> = ArrayDeque()
     private val incomingMessage = ArrayList<Byte>()
 
+    private val mainHandler = Handler(Looper.getMainLooper())
+
     private var gatt: BluetoothGatt? = null
     private var toPeripheral: BluetoothGattCharacteristic? = null
     private var fromPeripheral: BluetoothGattCharacteristic? = null
     private var serviceDiscoveryStarted: Boolean = false
+    private var slotCharacteristics: List<BluetoothGattCharacteristic> = emptyList()
+    private var slotReadIndex: Int = 0
     private var writeInFlight: Boolean = false
     private var mtuPayloadSize: Int = WeaveFrames.DEFAULT_ATT_PAYLOAD_SIZE
     private var negotiatedPacketSize: Int = WeaveFrames.MIN_PACKET_SIZE
@@ -185,14 +191,35 @@ private class BleGattClientTransport(
         }
 
     fun start(): Boolean {
+        val phyMask = BluetoothDevice.PHY_LE_2M_MASK or BluetoothDevice.PHY_LE_1M_MASK
         val opened =
             device.connectGatt(
                 context,
                 false,
                 this,
                 BluetoothDevice.TRANSPORT_LE,
+                phyMask,
+                mainHandler,
             )
         gatt = opened
+        // Force a GATT cache refresh as soon as the connection is
+        // available. Android's BLE stack caches discovered services
+        // per-MAC across connections; if a previous bootstrap to the
+        // same MAC populated the cache with stale handles (e.g. before
+        // Samsung published the slot characteristics), our subsequent
+        // service discovery will reuse those handles and the
+        // characteristic-handle that Samsung's `gchu` is keyed on may
+        // not match anymore — which would manifest as `No handler
+        // registered for characteristic …` even though the UUIDs all
+        // match. The `BluetoothGatt.refresh()` method is hidden but
+        // accessible via reflection.
+        if (opened != null) {
+            runCatching {
+                val refresh = BluetoothGatt::class.java.getMethod("refresh")
+                val ok = refresh.invoke(opened) as? Boolean
+                Log.w(TAG, "BluetoothGatt.refresh() invoked result=$ok")
+            }.onFailure { Log.w(TAG, "refresh() reflection failed", it) }
+        }
         return opened != null
     }
 
@@ -203,13 +230,42 @@ private class BleGattClientTransport(
         status: Int,
         newState: Int,
     ) {
-        Log.i(TAG, "gatt state device=${device.safeAddress()} status=$status newState=$newState")
+        Log.w(TAG, "gatt state device=${device.safeAddress()} status=$status newState=$newState")
         if (status != BluetoothGatt.GATT_SUCCESS || newState != BluetoothProfile.STATE_CONNECTED) {
             close()
             return
         }
-        val requested = gatt.requestMtu(REQUESTED_MTU)
-        if (!requested) discoverServicesOnce(gatt)
+        // Stock Quick Share receivers (notably Samsung One UI 8.x on
+        // Galaxy S22/S26 firmware) register their per-characteristic
+        // GATT handlers (`00000100-…-0101` / `…-0102`) lazily after the
+        // GATT connection comes up — typically ~1.5 s after
+        // `onServerConnectionState(connected=true)` on Samsung. If we
+        // start the MTU exchange / CCCD write / Weave CONNECTION_REQUEST
+        // immediately, our writes land on the wire before the handler
+        // is registered and Samsung logs
+        // `No handler registered for characteristic 00000100-…-0101`
+        // and silently drops them; the remote ATT layer still ACKs the
+        // write so our local stack reports success but Samsung's app
+        // never sees the bytes, and the Weave CONNECTION_CONFIRM never
+        // comes back. Hold the next step on a 1.5 s grace window so
+        // Samsung has enough time to wire its handler and accept the
+        // ATT writes when they finally arrive.
+        // Keep the connection in CONNECTION_PRIORITY_HIGH (interval=6)
+        // for the entire bootstrap. Without this, Samsung downgrades to
+        // interval=24 (~30 ms) right after the initial activity burst,
+        // which seems to coincide with the per-peer Weave handler not
+        // being wired in `gchk`. Stock GMS centrals stay in HIGH for
+        // the duration of the Weave + multiplex + Nearby ConnectionRequest
+        // exchange and only drop priority once they switch to the
+        // upgraded medium.
+        runCatching { gatt.requestConnectionPriority(BluetoothGatt.CONNECTION_PRIORITY_HIGH) }
+            .onFailure { Log.w(TAG, "requestConnectionPriority(HIGH) threw", it) }
+        mainHandler.postDelayed({
+            if (closed) return@postDelayed
+            Log.w(TAG, "post-connect grace expired; requesting MTU device=${device.safeAddress()}")
+            val requested = gatt.requestMtu(REQUESTED_MTU)
+            if (!requested) discoverServicesOnce(gatt)
+        }, POST_CONNECT_DELAY_MILLIS)
     }
 
     override fun onMtuChanged(
@@ -217,7 +273,7 @@ private class BleGattClientTransport(
         mtu: Int,
         status: Int,
     ) {
-        Log.i(TAG, "mtu changed mtu=$mtu status=$status device=${device.safeAddress()}")
+        Log.w(TAG, "mtu changed mtu=$mtu status=$status device=${device.safeAddress()}")
         if (status == BluetoothGatt.GATT_SUCCESS) {
             mtuPayloadSize = (mtu - GATT_ATT_HEADER_BYTES).coerceAtLeast(WeaveFrames.DEFAULT_ATT_PAYLOAD_SIZE)
         }
@@ -233,12 +289,69 @@ private class BleGattClientTransport(
             close()
             return
         }
-        val service = gatt.getService(BleGattInitialControlServer.SERVICE_UUID)
-        if (service == null || !bindCharacteristics(service)) {
-            Log.w(TAG, "BLE GATT bootstrap service missing required characteristics")
+        // Dump every advertised service + characteristic so we can spot
+        // peer-side variations in the Weave UUID family. Samsung GMS
+        // sometimes exposes non-standard write/notify pairs alongside
+        // the canonical 00000100-…-0101 / -0102, and our writes silently
+        // fail with `No handler registered` if we picked the wrong pair.
+        for (s in gatt.services) {
+            val charDump =
+                s.characteristics.joinToString(",") { c ->
+                    "${c.uuid}(props=${c.properties})"
+                }
+            Log.w(TAG, "gatt service ${s.uuid} chars=[$charDump]")
+        }
+        if (!bindWeaveAndSlotsAcrossServices(gatt)) {
+            Log.w(TAG, "BLE GATT bootstrap missing Weave write/notify characteristics")
             close()
             return
         }
+        // Stock Quick Share centrals read the receiver's
+        // `0xFEF3` advertisement-slot characteristics
+        // (`00000000-0000-3000-8000-00000000000{0..4}`) BEFORE writing
+        // anything to the Weave write characteristic. On Samsung One UI
+        // 8.x this read sequence is what triggers the receiver-side
+        // GMS to register the per-peer Weave handler — without it our
+        // first CCCD/CONNECTION_REQUEST writes get
+        // `gchu.onCharacteristicWriteRequest → No handler registered`
+        // even though pulse classification is type=NOTIFY and the
+        // peer is in EVERYONE-visibility mode. Drain the slot reads
+        // in sequence, then proceed to CCCD subscribe + Weave
+        // CONNECTION_REQUEST in `onAllSlotsRead`.
+        if (slotCharacteristics.isEmpty()) {
+            Log.w(TAG, "no advertisement slot characteristics found; subscribing immediately")
+            subscribeAndConnect(gatt)
+            return
+        }
+        slotReadIndex = 0
+        readNextSlot(gatt)
+    }
+
+    private fun readNextSlot(gatt: BluetoothGatt) {
+        val slot = slotCharacteristics.getOrNull(slotReadIndex)
+        if (slot == null) {
+            Log.w(TAG, "all advertisement slots read; waiting before CCCD subscribe")
+            // Hold another grace window before CCCD: stock GMS receivers
+            // may take additional time after the slot reads to wire the
+            // per-peer Weave write handler in `gchi`. Without this
+            // second grace, our CCCD/CONNECTION_REQUEST writes still
+            // race the registration and get dropped with `No handler
+            // registered for characteristic …-0101`.
+            mainHandler.postDelayed({
+                if (closed) return@postDelayed
+                Log.w(TAG, "post-slot grace expired; subscribing CCCD")
+                subscribeAndConnect(gatt)
+            }, POST_SLOT_DELAY_MILLIS)
+            return
+        }
+        Log.w(TAG, "reading advertisement slot[$slotReadIndex] uuid=${slot.uuid}")
+        if (!gatt.readCharacteristic(slot)) {
+            Log.w(TAG, "readCharacteristic returned false for slot[$slotReadIndex]; skipping rest")
+            subscribeAndConnect(gatt)
+        }
+    }
+
+    private fun subscribeAndConnect(gatt: BluetoothGatt) {
         val outgoing = fromPeripheral ?: return close()
         if (!gatt.setCharacteristicNotification(outgoing, true)) {
             Log.w(TAG, "setCharacteristicNotification returned false")
@@ -256,6 +369,39 @@ private class BleGattClientTransport(
             Log.w(TAG, "write notification descriptor returned false")
             close()
         }
+    }
+
+    @Deprecated("Android calls this overload before API 33")
+    override fun onCharacteristicRead(
+        gatt: BluetoothGatt,
+        characteristic: BluetoothGattCharacteristic,
+        status: Int,
+    ) {
+        handleSlotRead(gatt, characteristic, characteristic.value ?: ByteArray(0), status)
+    }
+
+    override fun onCharacteristicRead(
+        gatt: BluetoothGatt,
+        characteristic: BluetoothGattCharacteristic,
+        value: ByteArray,
+        status: Int,
+    ) {
+        handleSlotRead(gatt, characteristic, value, status)
+    }
+
+    private fun handleSlotRead(
+        gatt: BluetoothGatt,
+        characteristic: BluetoothGattCharacteristic,
+        value: ByteArray,
+        status: Int,
+    ) {
+        Log.w(
+            TAG,
+            "slot read uuid=${characteristic.uuid} status=$status " +
+                "len=${value.size} preview=${value.previewHex()}",
+        )
+        slotReadIndex++
+        readNextSlot(gatt)
     }
 
     override fun onDescriptorWrite(
@@ -283,7 +429,7 @@ private class BleGattClientTransport(
                 close()
                 return
             }
-            Log.i(TAG, "characteristic write complete device=${device.safeAddress()}")
+            Log.w(TAG, "characteristic write complete device=${device.safeAddress()}")
             drainWritesLocked()
         }
     }
@@ -327,10 +473,45 @@ private class BleGattClientTransport(
         }
     }
 
-    private fun bindCharacteristics(service: BluetoothGattService): Boolean {
-        toPeripheral = service.getCharacteristic(BleGattInitialControlServer.TO_PERIPHERAL_UUID)
-        fromPeripheral = service.getCharacteristic(BleGattInitialControlServer.FROM_PERIPHERAL_UUID)
+    /**
+     * Stock Quick Share peripherals (Samsung One UI included) expose
+     * **two** services on `0xFEF3`: one carrying the Weave write/notify
+     * pair (`00000100-0004-1000-8000-001a11000101`/`-0102`) and a
+     * separate "advertisement slot" service carrying read-only
+     * characteristics under `00000000-0000-3000-8000-00000000000{0..4}`.
+     * `BluetoothGatt.getService(uuid)` only returns the first match, so
+     * iterate every service the peer published and pick the one that
+     * actually has the Weave UUIDs as Weave, then collect any other
+     * service's read-only chars as slots.
+     */
+    private fun bindWeaveAndSlotsAcrossServices(gatt: BluetoothGatt): Boolean {
+        val slots = mutableListOf<BluetoothGattCharacteristic>()
+        gatt.services
+            .filter { it.uuid == BleGattInitialControlServer.SERVICE_UUID }
+            .forEach { service -> bindServiceShape(service, slots) }
+        slotCharacteristics = slots
+        Log.w(TAG, "bound Weave chars=${toPeripheral != null}/${fromPeripheral != null} slots=${slots.size}")
         return toPeripheral != null && fromPeripheral != null
+    }
+
+    private fun bindServiceShape(
+        service: BluetoothGattService,
+        slots: MutableList<BluetoothGattCharacteristic>,
+    ) {
+        val toPer = service.getCharacteristic(BleGattInitialControlServer.TO_PERIPHERAL_UUID)
+        val fromPer = service.getCharacteristic(BleGattInitialControlServer.FROM_PERIPHERAL_UUID)
+        if (toPer != null && fromPer != null && toPeripheral == null) {
+            toPeripheral = toPer
+            fromPeripheral = fromPer
+            return
+        }
+        // Slot 0 (`00000000-0000-3000-8000-000000000000`) is the
+        // EndpointInfo slot every Quick Share peripheral populates.
+        // Slots 1-4 are present but typically empty. Stock GMS
+        // centrals appear to only read the populated slots; reading
+        // empty ones might confuse Samsung's per-peer state tracking.
+        val slot0 = service.getCharacteristic(SLOT_0_UUID)
+        if (slot0 != null) slots += slot0
     }
 
     private fun cccdValueFor(characteristic: BluetoothGattCharacteristic): ByteArray =
@@ -354,12 +535,52 @@ private class BleGattClientTransport(
             ),
         )
         sendPacketCounter = (sendPacketCounter + 1) % WeaveFrames.MAX_PACKET_COUNTER
+        // Stock Quick Share receivers (Samsung One UI 8.x) register
+        // their per-characteristic GATT handlers reactively when the
+        // first ATT write lands. The first 1-3 writes always fail
+        // silently from the receiver's app point of view (the BLE link
+        // ACKs them, but `gchu.onCharacteristicWriteRequest` throws
+        // `No handler registered for characteristic 00000100-…-0101`),
+        // and the receiver only registers the
+        // `BlockingQueueStream with size 10` after parsing one of these
+        // failed writes. By that time our CONNECTION_REQUEST is already
+        // lost and we sit waiting for a CONNECTION_CONFIRM that will
+        // never come. Schedule a retry so a second CONNECTION_REQUEST
+        // lands on the now-registered handler. We re-enqueue up to
+        // [WEAVE_REQUEST_MAX_RETRIES] times, gated on
+        // `weaveConnected`; the receive callback aborts the retry as
+        // soon as the real CONNECTION_CONFIRM lands.
+        scheduleWeaveConnectionRequestRetryLocked(attempt = 1)
+    }
+
+    private fun scheduleWeaveConnectionRequestRetryLocked(attempt: Int) {
+        if (attempt > WEAVE_REQUEST_MAX_RETRIES) return
+        mainHandler.postDelayed({
+            synchronized(this) {
+                if (closed || weaveConnected) return@synchronized
+                Log.w(
+                    TAG,
+                    "no Weave CONNECTION_CONFIRM after attempt=$attempt; " +
+                        "resending CONNECTION_REQUEST device=${device.safeAddress()}",
+                )
+                enqueueWriteLocked(
+                    WeaveFrames.connectionRequest(
+                        packetCounter = sendPacketCounter,
+                        minVersion = WeaveFrames.VERSION,
+                        maxVersion = WeaveFrames.VERSION,
+                        maxPacketSize = negotiatedPacketSize,
+                    ),
+                )
+                sendPacketCounter = (sendPacketCounter + 1) % WeaveFrames.MAX_PACKET_COUNTER
+                scheduleWeaveConnectionRequestRetryLocked(attempt + 1)
+            }
+        }, WEAVE_REQUEST_RETRY_DELAY_MILLIS)
     }
 
     @Synchronized
     private fun handleNotification(packetBytes: ByteArray) {
         if (closed) return
-        Log.i(TAG, "notification len=${packetBytes.size} header=${packetBytes.firstByteHex()}")
+        Log.w(TAG, "notification len=${packetBytes.size} header=${packetBytes.firstByteHex()}")
         when (val packet = WeaveFrames.parse(packetBytes)) {
             is WeavePacket.ConnectionConfirm -> handleConnectionConfirm(packet)
             is WeavePacket.Data -> handleDataPacket(packet)
@@ -381,7 +602,7 @@ private class BleGattClientTransport(
                 ?.coerceAtMost(WeaveFrames.MAX_PACKET_SIZE)
                 ?: WeaveFrames.MIN_PACKET_SIZE
         weaveConnected = true
-        Log.i(TAG, "Weave connected raw Nearby stream packetSize=$negotiatedPacketSize device=${device.safeAddress()}")
+        Log.w(TAG, "Weave connected raw Nearby stream packetSize=$negotiatedPacketSize device=${device.safeAddress()}")
         sendWeaveMessage(NearbyBleSocketFrames.encodeIntroductionPacket())
         if (!ready.isCompleted) ready.complete(true)
     }
@@ -425,10 +646,10 @@ private class BleGattClientTransport(
         }
         when (control.type) {
             BleFramesProto.SocketControlFrame.ControlFrameType.PACKET_ACKNOWLEDGEMENT -> {
-                Log.i(TAG, "BLE GATT packet ack size=${control.packetAcknowledgement.receivedSize}")
+                Log.w(TAG, "BLE GATT packet ack size=${control.packetAcknowledgement.receivedSize}")
             }
             BleFramesProto.SocketControlFrame.ControlFrameType.DISCONNECTION -> close()
-            else -> Log.i(TAG, "BLE GATT control frame type=${control.type}")
+            else -> Log.w(TAG, "BLE GATT control frame type=${control.type}")
         }
     }
 
@@ -445,7 +666,7 @@ private class BleGattClientTransport(
 
     private fun sendSocketServiceBytes(bytes: ByteArray) {
         if (bytes.isEmpty()) return
-        Log.i(TAG, "BLE GATT service write bytes=${bytes.size} preview=${bytes.previewHex()}")
+        Log.w(TAG, "BLE GATT service write bytes=${bytes.size} preview=${bytes.previewHex()}")
         sendWeaveMessage(NearbyServiceId.hashPrefix + bytes)
     }
 
@@ -472,7 +693,7 @@ private class BleGattClientTransport(
 
     private fun enqueueWriteLocked(packet: ByteArray) {
         if (closed) return
-        Log.i(TAG, "enqueue write len=${packet.size} header=${packet.firstByteHex()} device=${device.safeAddress()}")
+        Log.w(TAG, "enqueue write len=${packet.size} header=${packet.firstByteHex()} device=${device.safeAddress()}")
         writeQueue.add(packet)
         drainWritesLocked()
     }
@@ -502,9 +723,15 @@ private class BleGattClientTransport(
         private const val GATT_ATT_HEADER_BYTES: Int = 3
         private const val INPUT_PIPE_SIZE: Int = 1024 * 1024
         private const val SERVICE_ID_HASH_LEN: Int = 3
+        private const val POST_CONNECT_DELAY_MILLIS: Long = 600L
+        private const val POST_SLOT_DELAY_MILLIS: Long = 300L
+        private const val WEAVE_REQUEST_RETRY_DELAY_MILLIS: Long = 1000L
+        private const val WEAVE_REQUEST_MAX_RETRIES: Int = 10
         private val CONTROL_PACKET_PREFIX: ByteArray = ByteArray(SERVICE_ID_HASH_LEN)
         private val CLIENT_CHARACTERISTIC_CONFIG_UUID: UUID =
             UUID.fromString("00002902-0000-1000-8000-00805f9b34fb")
+        private val SLOT_0_UUID: UUID =
+            UUID.fromString("00000000-0000-3000-8000-000000000000")
     }
 }
 

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BleGattInitialControlClient.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BleGattInitialControlClient.kt
@@ -97,7 +97,7 @@ public class BleGattInitialControlClient internal constructor(
             }
             val ready = transport.awaitReady(CONNECTION_READY_TIMEOUT_MILLIS)
             if (!ready) {
-                Log.w(TAG, "BLE GATT initial connect timed out waiting for multiplex accept")
+                Log.w(TAG, "BLE GATT initial connect timed out waiting for socket ready")
                 transport.close()
                 return@withContext null
             }
@@ -283,6 +283,7 @@ private class BleGattClientTransport(
                 close()
                 return
             }
+            Log.i(TAG, "characteristic write complete device=${device.safeAddress()}")
             drainWritesLocked()
         }
     }
@@ -423,7 +424,9 @@ private class BleGattClientTransport(
             return
         }
         when (control.type) {
-            BleFramesProto.SocketControlFrame.ControlFrameType.PACKET_ACKNOWLEDGEMENT -> Unit
+            BleFramesProto.SocketControlFrame.ControlFrameType.PACKET_ACKNOWLEDGEMENT -> {
+                Log.i(TAG, "BLE GATT packet ack size=${control.packetAcknowledgement.receivedSize}")
+            }
             BleFramesProto.SocketControlFrame.ControlFrameType.DISCONNECTION -> close()
             else -> Log.i(TAG, "BLE GATT control frame type=${control.type}")
         }
@@ -442,6 +445,7 @@ private class BleGattClientTransport(
 
     private fun sendSocketServiceBytes(bytes: ByteArray) {
         if (bytes.isEmpty()) return
+        Log.i(TAG, "BLE GATT service write bytes=${bytes.size} preview=${bytes.previewHex()}")
         sendWeaveMessage(NearbyServiceId.hashPrefix + bytes)
     }
 
@@ -480,6 +484,11 @@ private class BleGattClientTransport(
         val outgoing = toPeripheral ?: return close()
         outgoing.writeType = writeTypeFor(outgoing)
         outgoing.value = packet
+        Log.i(
+            TAG,
+            "write characteristic len=${packet.size} header=${packet.firstByteHex()} " +
+                "type=${outgoing.writeType} properties=${outgoing.properties} device=${device.safeAddress()}",
+        )
         writeInFlight = openGatt.writeCharacteristic(outgoing)
         if (!writeInFlight) {
             Log.w(TAG, "writeCharacteristic returned false")
@@ -500,10 +509,10 @@ private class BleGattClientTransport(
 }
 
 private fun writeTypeFor(characteristic: BluetoothGattCharacteristic): Int =
-    if ((characteristic.properties and BluetoothGattCharacteristic.PROPERTY_WRITE) != 0) {
-        BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT
-    } else {
+    if ((characteristic.properties and BluetoothGattCharacteristic.PROPERTY_WRITE_NO_RESPONSE) != 0) {
         BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE
+    } else {
+        BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT
     }
 
 private fun ArrayList<Byte>.toByteArray(): ByteArray {
@@ -517,3 +526,5 @@ private fun BluetoothDevice.safeAddress(): String = runCatching { address }.getO
 private fun ByteArray.toHex(): String = joinToString("") { "%02x".format(it) }
 
 private fun ByteArray.firstByteHex(): String = firstOrNull()?.let { "%02x".format(it) } ?: "--"
+
+private fun ByteArray.previewHex(limit: Int = 16): String = copyOfRange(0, size.coerceAtMost(limit)).toHex()

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BleGattInitialControlServer.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BleGattInitialControlServer.kt
@@ -27,6 +27,7 @@ import androidx.annotation.RequiresPermission
 import androidx.core.content.ContextCompat
 import com.google.location.nearby.mediums.proto.BleFramesProto
 import com.google.location.nearby.mediums.proto.MultiplexFramesProto
+import io.github.kyujincho.wvmg.discovery.ble.BleDctPsmHolder
 import io.github.kyujincho.wvmg.protocol.endpoint.BleAdvertisement
 import io.github.kyujincho.wvmg.protocol.endpoint.BleServiceData
 import io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo
@@ -328,8 +329,9 @@ public class BleGattInitialControlServer(
                 endpointInfo: EndpointInfo,
                 endpointId: ByteArray,
             ): List<BluetoothGattCharacteristic> {
+                val psm = BleDctPsmHolder.currentPsm ?: 0
                 val visibleAdvertisement =
-                    runCatching { BleAdvertisement.encodeGattAdvertisement(endpointId, endpointInfo) }
+                    runCatching { BleAdvertisement.encodeGattAdvertisement(endpointId, endpointInfo, psm = psm) }
                         .getOrDefault(ByteArray(0))
 
                 return (0 until GATT_ADVERTISEMENT_SLOT_COUNT).map { slot ->

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BleGattInitialControlServer.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BleGattInitialControlServer.kt
@@ -27,8 +27,6 @@ import androidx.annotation.RequiresPermission
 import androidx.core.content.ContextCompat
 import com.google.location.nearby.mediums.proto.BleFramesProto
 import com.google.location.nearby.mediums.proto.MultiplexFramesProto
-import io.github.kyujincho.wvmg.discovery.ble.BleDctPsmHolder
-import io.github.kyujincho.wvmg.protocol.endpoint.BleAdvertisement
 import io.github.kyujincho.wvmg.protocol.endpoint.BleServiceData
 import io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo
 import io.github.kyujincho.wvmg.protocol.endpoint.NearbyServiceId
@@ -248,13 +246,18 @@ public class BleGattInitialControlServer(
                 "write descriptor=${descriptor.uuid} char=${descriptor.characteristic?.uuid} " +
                     "value=${value.toHex()} offset=$offset device=${device.safeAddress()}",
             )
-            val enablesNotifications =
-                value.contentEquals(BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE) ||
-                    value.contentEquals(BluetoothGattDescriptor.ENABLE_INDICATION_VALUE)
+            val subscriptionMode =
+                when {
+                    value.contentEquals(BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE) ->
+                        GattSubscriptionMode.NOTIFICATION
+                    value.contentEquals(BluetoothGattDescriptor.ENABLE_INDICATION_VALUE) ->
+                        GattSubscriptionMode.INDICATION
+                    else -> GattSubscriptionMode.DISABLED
+                }
             if (descriptor.uuid == CLIENT_CHARACTERISTIC_CONFIG_UUID &&
                 descriptor.characteristic?.uuid == FROM_PERIPHERAL_UUID
             ) {
-                sessionFor(device).setSubscribed(enablesNotifications)
+                sessionFor(device).setSubscription(subscriptionMode)
             }
             if (responseNeeded) {
                 server?.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, null)
@@ -298,20 +301,11 @@ public class BleGattInitialControlServer(
                         SERVICE_UUID,
                         BluetoothGattService.SERVICE_TYPE_PRIMARY,
                     )
-                val toPeripheral =
-                    BluetoothGattCharacteristic(
-                        TO_PERIPHERAL_UUID,
-                        BluetoothGattCharacteristic.PROPERTY_WRITE or
-                            BluetoothGattCharacteristic.PROPERTY_WRITE_NO_RESPONSE,
-                        BluetoothGattCharacteristic.PERMISSION_WRITE,
-                    )
                 val fromPeripheral =
                     BluetoothGattCharacteristic(
                         FROM_PERIPHERAL_UUID,
-                        BluetoothGattCharacteristic.PROPERTY_READ or
-                            BluetoothGattCharacteristic.PROPERTY_NOTIFY or
-                            BluetoothGattCharacteristic.PROPERTY_INDICATE,
-                        BluetoothGattCharacteristic.PERMISSION_READ,
+                        BluetoothGattCharacteristic.PROPERTY_INDICATE,
+                        0,
                     )
                 fromPeripheral.addDescriptor(
                     BluetoothGattDescriptor(
@@ -319,8 +313,14 @@ public class BleGattInitialControlServer(
                         BluetoothGattDescriptor.PERMISSION_READ or BluetoothGattDescriptor.PERMISSION_WRITE,
                     ),
                 )
-                service.addCharacteristic(toPeripheral)
+                val toPeripheral =
+                    BluetoothGattCharacteristic(
+                        TO_PERIPHERAL_UUID,
+                        BluetoothGattCharacteristic.PROPERTY_WRITE,
+                        BluetoothGattCharacteristic.PERMISSION_WRITE,
+                    )
                 service.addCharacteristic(fromPeripheral)
+                service.addCharacteristic(toPeripheral)
                 buildAdvertisementSlots(endpointInfo, endpointId).forEach(service::addCharacteristic)
                 return service
             }
@@ -329,9 +329,11 @@ public class BleGattInitialControlServer(
                 endpointInfo: EndpointInfo,
                 endpointId: ByteArray,
             ): List<BluetoothGattCharacteristic> {
-                val psm = BleDctPsmHolder.currentPsm ?: 0
+                // Stock GMS expects GATT slots to host the raw Nearby BLE
+                // advertisement body (0x23 + endpoint_id + EndpointInfo),
+                // not the heavier non-fast wrapper used by some scanners.
                 val visibleAdvertisement =
-                    runCatching { BleAdvertisement.encodeGattAdvertisement(endpointId, endpointInfo, psm = psm) }
+                    runCatching { BleServiceData.encode(endpointId, endpointInfo) }
                         .getOrDefault(ByteArray(0))
 
                 return (0 until GATT_ADVERTISEMENT_SLOT_COUNT).map { slot ->
@@ -388,6 +390,7 @@ private class BleWeaveGattSession(
         )
     private val incomingMessage = ArrayList<Byte>()
     private var subscribed: Boolean = false
+    private var subscriptionMode: GattSubscriptionMode = GattSubscriptionMode.DISABLED
     private var sending: Boolean = false
     private var introReceived: Boolean = false
     private var mtuPayloadSize: Int = WeaveFrames.DEFAULT_ATT_PAYLOAD_SIZE
@@ -396,9 +399,13 @@ private class BleWeaveGattSession(
     private var closed: Boolean = false
 
     @Synchronized
-    fun setSubscribed(enabled: Boolean) {
-        subscribed = enabled
-        Log.i(BleGattInitialControlServer.TAG, "subscription enabled=$enabled device=${device.safeAddress()}")
+    fun setSubscription(mode: GattSubscriptionMode) {
+        subscriptionMode = mode
+        subscribed = mode != GattSubscriptionMode.DISABLED
+        Log.i(
+            BleGattInitialControlServer.TAG,
+            "subscription mode=$mode enabled=$subscribed device=${device.safeAddress()}",
+        )
         drainNotificationsLocked()
     }
 
@@ -558,17 +565,19 @@ private class BleWeaveGattSession(
     private fun drainNotificationsLocked() {
         if (!subscribed || sending || closed) return
         val packet = if (notificationQueue.isEmpty()) return else notificationQueue.removeFirst()
+        val confirm = subscriptionMode == GattSubscriptionMode.INDICATION
         Log.i(
             BleGattInitialControlServer.TAG,
-            "send notification len=${packet.size} header=${packet.firstByteHex()} device=${device.safeAddress()}",
+            "send notification len=${packet.size} header=${packet.firstByteHex()} " +
+                "confirm=$confirm device=${device.safeAddress()}",
         )
         outgoingCharacteristic.value = packet
         sending =
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                server.notifyCharacteristicChanged(device, outgoingCharacteristic, false, packet) ==
+                server.notifyCharacteristicChanged(device, outgoingCharacteristic, confirm, packet) ==
                     android.bluetooth.BluetoothStatusCodes.SUCCESS
             } else {
-                server.notifyCharacteristicChanged(device, outgoingCharacteristic, false)
+                server.notifyCharacteristicChanged(device, outgoingCharacteristic, confirm)
             }
         if (!sending) {
             Log.w(BleGattInitialControlServer.TAG, "notifyCharacteristicChanged returned false")
@@ -578,6 +587,12 @@ private class BleWeaveGattSession(
     private companion object {
         private const val GATT_ATT_HEADER_BYTES: Int = 3
     }
+}
+
+private enum class GattSubscriptionMode {
+    DISABLED,
+    NOTIFICATION,
+    INDICATION,
 }
 
 internal class BleMultiplexBridge(

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BleGattInitialControlServer.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BleGattInitialControlServer.kt
@@ -43,6 +43,8 @@ import java.io.PipedOutputStream
 import java.util.ArrayDeque
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 
 /**
@@ -89,9 +91,10 @@ public class BleGattInitialControlServer(
                         return false
                     }
             callback.attach(server)
-            if (!server.addService(callback.service)) {
-                Log.w(TAG, "BluetoothGattServer.addService failed")
+            if (!callback.startAddingServices() || !callback.awaitServicesReady()) {
+                runCatching { server.clearServices() }
                 server.close()
+                callback.close()
                 return false
             }
             val state = ActiveState(server = server, callback = callback)
@@ -100,7 +103,7 @@ public class BleGattInitialControlServer(
                 callback.close()
                 return true
             }
-            Log.i(TAG, "BLE GATT bootstrap active service=$SERVICE_UUID")
+            Log.i(TAG, "BLE GATT bootstrap active services=${callback.services.joinToString { it.uuid.toString() }}")
             true
         }
 
@@ -145,21 +148,40 @@ public class BleGattInitialControlServer(
         endpointId: ByteArray,
         private val acceptTransport: (ConnectedTransport) -> Unit,
     ) : BluetoothGattServerCallback() {
-        val service: BluetoothGattService = buildService(endpointInfo, endpointId)
+        val services: List<BluetoothGattService> =
+            buildServices(
+                endpointInfo = endpointInfo,
+                endpointId = endpointId,
+            )
 
         private val sessions: ConcurrentHashMap<String, BleWeaveGattSession> = ConcurrentHashMap()
         private val fromPeripheral: BluetoothGattCharacteristic =
-            requireNotNull(service.getCharacteristic(FROM_PERIPHERAL_UUID))
+            requireNotNull(services.firstNotNullOfOrNull { it.getCharacteristic(FROM_PERIPHERAL_UUID) })
         private var server: BluetoothGattServer? = null
+        private val serviceAddLock: Any = Any()
+        private val serviceAddLatch: CountDownLatch = CountDownLatch(services.size)
+        private var nextServiceIndex: Int = 0
+        private var serviceAddFailed: Boolean = false
 
         fun attach(server: BluetoothGattServer) {
             this.server = server
+        }
+
+        fun startAddingServices(): Boolean = addNextService()
+
+        fun awaitServicesReady(): Boolean {
+            val ready = serviceAddLatch.await(SERVICE_ADD_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
+            if (!ready) {
+                Log.w(TAG, "timed out adding BLE GATT services")
+            }
+            return ready && !serviceAddFailed
         }
 
         fun close() {
             sessions.values.forEach { it.close() }
             sessions.clear()
             server = null
+            markServiceAddFailed()
         }
 
         override fun onConnectionStateChange(
@@ -180,6 +202,12 @@ public class BleGattInitialControlServer(
             service: BluetoothGattService,
         ) {
             Log.i(TAG, "service added status=$status uuid=${service.uuid}")
+            if (status != BluetoothGatt.GATT_SUCCESS) {
+                markServiceAddFailed()
+                return
+            }
+            serviceAddLatch.countDown()
+            addNextService()
         }
 
         override fun onCharacteristicReadRequest(
@@ -264,6 +292,40 @@ public class BleGattInitialControlServer(
             }
         }
 
+        override fun onDescriptorReadRequest(
+            device: BluetoothDevice,
+            requestId: Int,
+            offset: Int,
+            descriptor: BluetoothGattDescriptor,
+        ) {
+            Log.i(
+                TAG,
+                "read descriptor=${descriptor.uuid} char=${descriptor.characteristic?.uuid} " +
+                    "offset=$offset device=${device.safeAddress()}",
+            )
+            val value =
+                if (descriptor.uuid == CLIENT_CHARACTERISTIC_CONFIG_UUID &&
+                    descriptor.characteristic?.uuid == FROM_PERIPHERAL_UUID
+                ) {
+                    sessionFor(device).cccdValue()
+                } else {
+                    ByteArray(0)
+                }
+            val response =
+                if (offset in 0..value.size) {
+                    value.copyOfRange(offset, value.size)
+                } else {
+                    ByteArray(0)
+                }
+            server?.sendResponse(
+                device,
+                requestId,
+                if (offset in 0..value.size) BluetoothGatt.GATT_SUCCESS else BluetoothGatt.GATT_INVALID_OFFSET,
+                offset,
+                response,
+            )
+        }
+
         override fun onMtuChanged(
             device: BluetoothDevice,
             mtu: Int,
@@ -291,60 +353,45 @@ public class BleGattInitialControlServer(
             }
         }
 
-        private companion object {
-            private fun buildService(
-                endpointInfo: EndpointInfo,
-                endpointId: ByteArray,
-            ): BluetoothGattService {
-                val service =
-                    BluetoothGattService(
-                        SERVICE_UUID,
-                        BluetoothGattService.SERVICE_TYPE_PRIMARY,
-                    )
-                val fromPeripheral =
-                    BluetoothGattCharacteristic(
-                        FROM_PERIPHERAL_UUID,
-                        BluetoothGattCharacteristic.PROPERTY_INDICATE,
-                        0,
-                    )
-                fromPeripheral.addDescriptor(
-                    BluetoothGattDescriptor(
-                        CLIENT_CHARACTERISTIC_CONFIG_UUID,
-                        BluetoothGattDescriptor.PERMISSION_READ or BluetoothGattDescriptor.PERMISSION_WRITE,
-                    ),
-                )
-                val toPeripheral =
-                    BluetoothGattCharacteristic(
-                        TO_PERIPHERAL_UUID,
-                        BluetoothGattCharacteristic.PROPERTY_WRITE,
-                        BluetoothGattCharacteristic.PERMISSION_WRITE,
-                    )
-                service.addCharacteristic(fromPeripheral)
-                service.addCharacteristic(toPeripheral)
-                buildAdvertisementSlots(endpointInfo, endpointId).forEach(service::addCharacteristic)
-                return service
-            }
-
-            private fun buildAdvertisementSlots(
-                endpointInfo: EndpointInfo,
-                endpointId: ByteArray,
-            ): List<BluetoothGattCharacteristic> {
-                // Stock GMS expects GATT slots to host the raw Nearby BLE
-                // advertisement body (0x23 + endpoint_id + EndpointInfo),
-                // not the heavier non-fast wrapper used by some scanners.
-                val visibleAdvertisement =
-                    runCatching { BleServiceData.encode(endpointId, endpointInfo) }
-                        .getOrDefault(ByteArray(0))
-
-                return (0 until GATT_ADVERTISEMENT_SLOT_COUNT).map { slot ->
-                    BluetoothGattCharacteristic(
-                        advertisementSlotUuid(slot),
-                        BluetoothGattCharacteristic.PROPERTY_READ,
-                        BluetoothGattCharacteristic.PERMISSION_READ,
-                    ).apply {
-                        value = if (slot == 0) visibleAdvertisement else ByteArray(0)
+        private fun addNextService(): Boolean {
+            val gattServer = server
+            val service =
+                synchronized(serviceAddLock) {
+                    if (serviceAddFailed || nextServiceIndex >= services.size) {
+                        null
+                    } else {
+                        services[nextServiceIndex++]
                     }
                 }
+
+            val accepted =
+                if (gattServer == null) {
+                    false
+                } else if (service == null) {
+                    true
+                } else {
+                    // Android's BluetoothGattServer keeps one mPendingService internally.
+                    // Queue services from onServiceAdded so descriptor handles are copied
+                    // back onto the right local service before the next add starts.
+                    gattServer.addService(service).also { serviceAccepted ->
+                        if (!serviceAccepted) {
+                            Log.w(TAG, "BluetoothGattServer.addService failed uuid=${service.uuid}")
+                            markServiceAddFailed()
+                        }
+                    }
+                }
+            if (gattServer == null) {
+                markServiceAddFailed()
+            }
+            return accepted
+        }
+
+        private fun markServiceAddFailed() {
+            synchronized(serviceAddLock) {
+                serviceAddFailed = true
+            }
+            while (serviceAddLatch.count > 0) {
+                serviceAddLatch.countDown()
             }
         }
     }
@@ -354,6 +401,10 @@ public class BleGattInitialControlServer(
 
         /** Copresence / Nearby BLE socket service UUID. */
         public val SERVICE_UUID: UUID = UUID.fromString(BleServiceData.SERVICE_UUID_128_STRING)
+
+        /** Nearby BLE second-profile socket service UUID used when GMS owns the first profile. */
+        public val SECOND_PROFILE_SERVICE_UUID: UUID =
+            UUID.fromString("0000fef3-0004-1000-8000-001a11000100")
 
         /** Central writes Weave packets here. */
         public val TO_PERIPHERAL_UUID: UUID = UUID.fromString("00000100-0004-1000-8000-001a11000101")
@@ -368,9 +419,134 @@ public class BleGattInitialControlServer(
             UUID.fromString("00002902-0000-1000-8000-00805f9b34fb")
 
         private const val GATT_ADVERTISEMENT_SLOT_COUNT: Int = 16
+        private const val SERVICE_ADD_TIMEOUT_MILLIS: Long = 2_000L
+
+        internal data class GattServiceSpec(
+            val uuid: UUID,
+            val characteristics: List<GattCharacteristicSpec>,
+        )
+
+        internal data class GattCharacteristicSpec(
+            val uuid: UUID,
+            val properties: Int,
+            val permissions: Int,
+            val descriptors: List<GattDescriptorSpec> = emptyList(),
+            val value: ByteArray = ByteArray(0),
+        )
+
+        internal data class GattDescriptorSpec(
+            val uuid: UUID,
+            val permissions: Int,
+        )
+
+        internal fun buildServiceSpecs(
+            endpointInfo: EndpointInfo,
+            endpointId: ByteArray,
+        ): List<GattServiceSpec> {
+            val advertisementService = buildAdvertisementServiceSpec(endpointInfo, endpointId)
+            val socketService = buildSocketServiceSpec()
+            return listOf(advertisementService, socketService)
+        }
+
+        internal fun buildServices(
+            endpointInfo: EndpointInfo,
+            endpointId: ByteArray,
+        ): List<BluetoothGattService> = buildServiceSpecs(endpointInfo, endpointId).map { it.toBluetoothGattService() }
 
         internal fun advertisementSlotUuid(slot: Int): UUID =
             UUID.fromString("00000000-0000-3000-8000-${slot.toString(radix = 16).padStart(12, '0')}")
+
+        private fun buildAdvertisementServiceSpec(
+            endpointInfo: EndpointInfo,
+            endpointId: ByteArray,
+        ): GattServiceSpec =
+            GattServiceSpec(
+                uuid = SERVICE_UUID,
+                characteristics = buildAdvertisementSlots(endpointInfo, endpointId),
+            )
+
+        private fun buildSocketServiceSpec(): GattServiceSpec {
+            val fromPeripheral =
+                GattCharacteristicSpec(
+                    uuid = FROM_PERIPHERAL_UUID,
+                    properties = BluetoothGattCharacteristic.PROPERTY_INDICATE,
+                    permissions = 0,
+                    descriptors =
+                        listOf(
+                            GattDescriptorSpec(
+                                uuid = CLIENT_CHARACTERISTIC_CONFIG_UUID,
+                                permissions =
+                                    BluetoothGattDescriptor.PERMISSION_READ or
+                                        BluetoothGattDescriptor.PERMISSION_WRITE,
+                            ),
+                        ),
+                )
+            val toPeripheral =
+                GattCharacteristicSpec(
+                    uuid = TO_PERIPHERAL_UUID,
+                    properties = BluetoothGattCharacteristic.PROPERTY_WRITE,
+                    permissions = BluetoothGattCharacteristic.PERMISSION_WRITE,
+                )
+            return GattServiceSpec(
+                uuid = SECOND_PROFILE_SERVICE_UUID,
+                characteristics = listOf(fromPeripheral, toPeripheral),
+            )
+        }
+
+        private fun buildAdvertisementSlots(
+            endpointInfo: EndpointInfo,
+            endpointId: ByteArray,
+        ): List<GattCharacteristicSpec> {
+            // WVMG runs beside Google Play services on Android. GMS may
+            // already own the first 0xFEF3 GATT socket profile, so the
+            // regular service is read-only and advertises the second-profile
+            // bit. Stock senders can still fetch the endpoint from the normal
+            // slot path, then open the socket on the isolated second profile.
+            val visibleAdvertisement =
+                runCatching {
+                    BleServiceData.encodeFramed(
+                        endpointId = endpointId,
+                        endpointInfo = endpointInfo,
+                        secondProfile = true,
+                    )
+                }.getOrDefault(ByteArray(0))
+
+            return (0 until GATT_ADVERTISEMENT_SLOT_COUNT).map { slot ->
+                GattCharacteristicSpec(
+                    uuid = advertisementSlotUuid(slot),
+                    properties = BluetoothGattCharacteristic.PROPERTY_READ,
+                    permissions = BluetoothGattCharacteristic.PERMISSION_READ,
+                    value = if (slot == 0) visibleAdvertisement else ByteArray(0),
+                )
+            }
+        }
+
+        private fun GattServiceSpec.toBluetoothGattService(): BluetoothGattService {
+            val spec = this
+            return BluetoothGattService(
+                uuid,
+                BluetoothGattService.SERVICE_TYPE_PRIMARY,
+            ).apply {
+                spec.characteristics.forEach { addCharacteristic(it.toBluetoothGattCharacteristic()) }
+            }
+        }
+
+        private fun GattCharacteristicSpec.toBluetoothGattCharacteristic(): BluetoothGattCharacteristic =
+            BluetoothGattCharacteristic(
+                uuid,
+                properties,
+                permissions,
+            ).also { characteristic ->
+                characteristic.value = value
+                descriptors.forEach { descriptor ->
+                    characteristic.addDescriptor(
+                        BluetoothGattDescriptor(
+                            descriptor.uuid,
+                            descriptor.permissions,
+                        ),
+                    )
+                }
+            }
     }
 }
 
@@ -408,6 +584,14 @@ private class BleWeaveGattSession(
         )
         drainNotificationsLocked()
     }
+
+    @Synchronized
+    fun cccdValue(): ByteArray =
+        when (subscriptionMode) {
+            GattSubscriptionMode.NOTIFICATION -> BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
+            GattSubscriptionMode.INDICATION -> BluetoothGattDescriptor.ENABLE_INDICATION_VALUE
+            GattSubscriptionMode.DISABLED -> BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE
+        }
 
     @Synchronized
     fun setMtu(mtu: Int) {

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/medium/WifiDirectGroupController.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/medium/WifiDirectGroupController.kt
@@ -26,7 +26,9 @@ import androidx.annotation.RequiresPermission
 import androidx.core.content.ContextCompat
 import io.github.kyujincho.wvmg.protocol.medium.UpgradePathCredentials
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import java.io.Closeable
 import java.io.IOException
@@ -125,9 +127,10 @@ internal class WifiDirectGroupController(
         channel: WifiP2pManager.Channel,
         requested: RequestedWifiDirectCredentials,
     ): Boolean {
+        primeP2pChannel(channel)
         removeExistingGroupBeforeServerCreate(channel)
         val createOk =
-            awaitActionListener { listener ->
+            awaitActionListener("createGroup") { listener ->
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                     manager.createGroup(channel, requested.toConfig(), listener)
                 } else {
@@ -140,9 +143,28 @@ internal class WifiDirectGroupController(
         return createOk
     }
 
+    @RequiresPermission(Manifest.permission.NEARBY_WIFI_DEVICES)
+    private suspend fun primeP2pChannel(channel: WifiP2pManager.Channel) {
+        val stateChanged = registerStateChangedReceiver()
+        try {
+            val discoverStarted =
+                awaitActionListener("discoverPeers") { listener ->
+                    manager.discoverPeers(channel, listener)
+                }
+            if (discoverStarted) {
+                stateChanged.awaitEnabledOrTimeout(P2P_ENABLE_TIMEOUT_MS)
+            } else {
+                Log.w(TAG, "WifiP2pManager.discoverPeers failed while priming P2P channel")
+            }
+        } finally {
+            stateChanged.unregister()
+            stopPeerDiscoveryQuietly(channel)
+        }
+    }
+
     private suspend fun removeExistingGroupBeforeServerCreate(channel: WifiP2pManager.Channel) {
         val removedExisting =
-            awaitActionListener { listener ->
+            awaitActionListener("removeGroup") { listener ->
                 manager.removeGroup(channel, listener)
             }
         if (removedExisting) {
@@ -284,10 +306,16 @@ internal class WifiDirectGroupController(
                 cancelConnectQuietly(channel)
             }
 
-        if (!WifiDirectCredentialShape.isValidNetworkName(credentials.ssid) ||
-            !WifiDirectCredentialShape.isValidPassphrase(credentials.passphrase)
-        ) {
-            Log.w(TAG, "Wi-Fi Direct credentials from peer are malformed; declining upgrade")
+        val validNetworkName = WifiDirectCredentialShape.isValidNetworkName(credentials.ssid)
+        val validPassphrase = WifiDirectCredentialShape.isValidPassphrase(credentials.passphrase)
+        if (!validNetworkName || !validPassphrase) {
+            Log.w(
+                TAG,
+                "Wi-Fi Direct credentials from peer are malformed; " +
+                    "ssid=${credentials.ssid} ssidLength=${credentials.ssid.length} " +
+                    "passphraseLength=${credentials.passphrase.length} port=${credentials.port}; " +
+                    "declining upgrade",
+            )
             teardown.close()
             return null
         }
@@ -311,7 +339,7 @@ internal class WifiDirectGroupController(
                     wps.setup = WpsInfo.PBC
                 }
         val connectOk =
-            awaitActionListener { listener ->
+            awaitActionListener("connect") { listener ->
                 manager.connect(channel, config, listener)
             }
         if (!connectOk) {
@@ -340,9 +368,7 @@ internal class WifiDirectGroupController(
             }
         val socket =
             try {
-                Socket().also { s ->
-                    s.connect(java.net.InetSocketAddress(address, credentials.port), SOCKET_CONNECT_TIMEOUT_MS)
-                }
+                connectSocketToGroupOwner(address, credentials.port)
             } catch (e: IOException) {
                 Log.w(TAG, "TCP connect to Wi-Fi Direct group owner failed", e)
                 teardown.close()
@@ -350,6 +376,19 @@ internal class WifiDirectGroupController(
             }
         return WifiDirectTransport(socket = socket, teardown = teardown)
     }
+
+    private suspend fun connectSocketToGroupOwner(
+        address: InetAddress,
+        port: Int,
+    ): Socket =
+        withContext(Dispatchers.IO) {
+            Socket().also { socket ->
+                socket.connect(
+                    java.net.InetSocketAddress(address, port),
+                    SOCKET_CONNECT_TIMEOUT_MS,
+                )
+            }
+        }
 
     /**
      * Result of [createGroupAsServer]. The framework hands [credentials]
@@ -366,16 +405,20 @@ internal class WifiDirectGroupController(
     // suspend-able primitives so the call sites read top-to-bottom.
     // -----------------------------------------------------------------
 
-    private suspend fun awaitActionListener(call: (WifiP2pManager.ActionListener) -> Unit): Boolean {
+    private suspend fun awaitActionListener(
+        label: String,
+        call: (WifiP2pManager.ActionListener) -> Unit,
+    ): Boolean {
         val deferred = CompletableDeferred<Boolean>()
         val listener =
             object : WifiP2pManager.ActionListener {
                 override fun onSuccess() {
+                    Log.w(TAG, "WifiP2pManager.$label onSuccess")
                     deferred.complete(true)
                 }
 
                 override fun onFailure(reason: Int) {
-                    Log.w(TAG, "WifiP2pManager.ActionListener.onFailure reason=$reason")
+                    Log.w(TAG, "WifiP2pManager.$label onFailure reason=$reason")
                     deferred.complete(false)
                 }
             }
@@ -384,7 +427,7 @@ internal class WifiDirectGroupController(
         } catch (
             @Suppress("TooGenericExceptionCaught") t: Throwable,
         ) {
-            Log.w(TAG, "WifiP2pManager call threw before listener invocation", t)
+            Log.w(TAG, "WifiP2pManager.$label threw before listener invocation", t)
             deferred.complete(false)
         }
         return deferred.await()
@@ -442,6 +485,27 @@ internal class WifiDirectGroupController(
         }
     }
 
+    private fun stopPeerDiscoveryQuietly(channel: WifiP2pManager.Channel) {
+        try {
+            manager.stopPeerDiscovery(
+                channel,
+                object : WifiP2pManager.ActionListener {
+                    override fun onSuccess() {
+                        Log.w(TAG, "WifiP2pManager.stopPeerDiscovery onSuccess")
+                    }
+
+                    override fun onFailure(reason: Int) {
+                        Log.w(TAG, "WifiP2pManager.stopPeerDiscovery reason=$reason")
+                    }
+                },
+            )
+        } catch (
+            @Suppress("TooGenericExceptionCaught") t: Throwable,
+        ) {
+            Log.w(TAG, "WifiP2pManager.stopPeerDiscovery threw during P2P prime", t)
+        }
+    }
+
     private fun registerConnectionChangedReceiver(): ConnectionChangedReceiver {
         val receiver = ConnectionChangedReceiver()
         val filter = IntentFilter(WifiP2pManager.WIFI_P2P_CONNECTION_CHANGED_ACTION)
@@ -462,6 +526,25 @@ internal class WifiDirectGroupController(
             @Suppress("TooGenericExceptionCaught") t: Throwable,
         ) {
             Log.w(TAG, "Failed to register P2P connection-changed receiver", t)
+        }
+        receiver.context = context
+        return receiver
+    }
+
+    private fun registerStateChangedReceiver(): StateChangedReceiver {
+        val receiver = StateChangedReceiver()
+        val filter = IntentFilter(WifiP2pManager.WIFI_P2P_STATE_CHANGED_ACTION)
+        try {
+            ContextCompat.registerReceiver(
+                context,
+                receiver,
+                filter,
+                ContextCompat.RECEIVER_NOT_EXPORTED,
+            )
+        } catch (
+            @Suppress("TooGenericExceptionCaught") t: Throwable,
+        ) {
+            Log.w(TAG, "Failed to register P2P state-changed receiver", t)
         }
         receiver.context = context
         return receiver
@@ -532,6 +615,50 @@ internal class WifiDirectGroupController(
         }
     }
 
+    private class StateChangedReceiver : BroadcastReceiver() {
+        var context: Context? = null
+        private val unregistered = AtomicReference(false)
+        private val enabled = CompletableDeferred<Unit>()
+
+        override fun onReceive(
+            context: Context?,
+            intent: Intent?,
+        ) {
+            if (intent?.action != WifiP2pManager.WIFI_P2P_STATE_CHANGED_ACTION) return
+            val state =
+                intent.getIntExtra(
+                    WifiP2pManager.EXTRA_WIFI_STATE,
+                    WifiP2pManager.WIFI_P2P_STATE_DISABLED,
+                )
+            Log.w(TAG, "WIFI_P2P_STATE_CHANGED state=$state")
+            if (state == WifiP2pManager.WIFI_P2P_STATE_ENABLED && !enabled.isCompleted) {
+                enabled.complete(Unit)
+            }
+        }
+
+        suspend fun awaitEnabledOrTimeout(timeoutMillis: Long) {
+            try {
+                withTimeout(timeoutMillis) {
+                    enabled.await()
+                }
+            } catch (_: TimeoutCancellationException) {
+                Log.w(TAG, "Wi-Fi Direct state enable wait timed out after ${timeoutMillis}ms")
+            }
+        }
+
+        fun unregister() {
+            if (!unregistered.compareAndSet(false, true)) return
+            val ctx = context ?: return
+            try {
+                ctx.unregisterReceiver(this)
+            } catch (
+                @Suppress("TooGenericExceptionCaught") t: IllegalArgumentException,
+            ) {
+                Log.d(TAG, "P2P state-changed receiver not registered at unregister time", t)
+            }
+        }
+    }
+
     private fun closeable(action: () -> Unit): Closeable {
         val closed = AtomicReference(false)
         return Closeable {
@@ -553,6 +680,9 @@ internal class WifiDirectGroupController(
         /** Wait at most this long for the WIFI_P2P_CONNECTION_CHANGED broadcast. */
         const val GROUP_FORMATION_TIMEOUT_MS: Long = 30_000
 
+        /** Short preflight wait for OEMs that lazily enable P2P after discoverPeers. */
+        const val P2P_ENABLE_TIMEOUT_MS: Long = 2_000
+
         /** Sender-side equivalent of [GROUP_FORMATION_TIMEOUT_MS]. */
         const val CONNECT_TIMEOUT_MS: Long = 30_000
 
@@ -563,10 +693,11 @@ internal class WifiDirectGroupController(
 
 internal object WifiDirectCredentialShape {
     private val random = SecureRandom()
-    private val networkNameRegex = Regex("^DIRECT-[A-Za-z0-9]{2}-[A-Za-z0-9_-]+$")
+    private val networkNameRegex = Regex("^DIRECT-[A-Za-z0-9]{2}[A-Za-z0-9_-]*$")
     private const val NETWORK_NAME_RANDOM_CHARS = 2
     private const val NETWORK_NAME_SUFFIX = "WVMG"
     private const val NETWORK_NAME_SESSION_CHARS = 6
+    private const val NETWORK_NAME_MAX_LENGTH = 32
     private const val PASSPHRASE_LENGTH = 16
     private const val PASSPHRASE_MIN_LENGTH = 8
     private const val PASSPHRASE_MAX_LENGTH = 63
@@ -578,7 +709,8 @@ internal object WifiDirectCredentialShape {
 
     fun generatePassphrase(): String = randomToken(PASSPHRASE_LENGTH)
 
-    fun isValidNetworkName(value: String): Boolean = networkNameRegex.matches(value)
+    fun isValidNetworkName(value: String): Boolean =
+        value.length <= NETWORK_NAME_MAX_LENGTH && networkNameRegex.matches(value)
 
     fun isValidPassphrase(value: String): Boolean =
         value.length in PASSPHRASE_MIN_LENGTH..PASSPHRASE_MAX_LENGTH &&

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/NearbyPeerDiscoveryTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/NearbyPeerDiscoveryTest.kt
@@ -225,7 +225,144 @@ class NearbyPeerDiscoveryTest {
         }
 
     @Test
-    fun `BLE GATT advertisement is connectable without Classic or L2CAP`() =
+    fun `verified visible BLE GATT advertisement without PSM is connectable over GATT`() =
+        runTest {
+            val lanEvents = MutableSharedFlow<DiscoveryEvent>()
+            val bleEvents = MutableSharedFlow<BleFastAdvertisementScanner.Observation>()
+            val bluetoothEvents = MutableSharedFlow<BluetoothClassicPeerScanner.Observation>()
+            val discovery =
+                NearbyPeerDiscovery.forTesting(
+                    lanEvents = lanEvents,
+                    bleEvents = bleEvents,
+                    bluetoothEvents = bluetoothEvents,
+                )
+            val seen = mutableListOf<NearbyPeerEvent>()
+            val collector =
+                backgroundScope.launch {
+                    discovery.browse().collect { seen += it }
+                }
+            runCurrent()
+
+            val endpointInfo = endpointInfo(name = "Galaxy")
+            bleEvents.emit(
+                BleFastAdvertisementScanner.Observation(
+                    endpointId = "RINE",
+                    endpointInfo = endpointInfo,
+                    advertiserAddress = "77:88:99:AA:BB:CC",
+                    rssi = -47,
+                    l2capPsm = null,
+                    gattConnectable = true,
+                ),
+            )
+            runCurrent()
+
+            val resolved = seen.filterIsInstance<NearbyPeerEvent.Resolved>().last().peer
+            assertThat(resolved.isConnectable).isTrue()
+            assertThat(resolved.candidateMediums).containsExactly(Medium.BLE)
+            assertThat(resolved.preferredRoute()).isEqualTo(
+                NearbyPeerRoute.BleGatt(
+                    macAddress = "77:88:99:AA:BB:CC",
+                ),
+            )
+
+            collector.cancel()
+        }
+
+    @Test
+    fun `visible BLE advertisement without PSM waits for GATT verification`() =
+        runTest {
+            val lanEvents = MutableSharedFlow<DiscoveryEvent>()
+            val bleEvents = MutableSharedFlow<BleFastAdvertisementScanner.Observation>()
+            val bluetoothEvents = MutableSharedFlow<BluetoothClassicPeerScanner.Observation>()
+            val discovery =
+                NearbyPeerDiscovery.forTesting(
+                    lanEvents = lanEvents,
+                    bleEvents = bleEvents,
+                    bluetoothEvents = bluetoothEvents,
+                )
+            val seen = mutableListOf<NearbyPeerEvent>()
+            val collector =
+                backgroundScope.launch {
+                    discovery.browse().collect { seen += it }
+                }
+            runCurrent()
+
+            val endpointInfo = endpointInfo(name = "Galaxy")
+            bleEvents.emit(
+                BleFastAdvertisementScanner.Observation(
+                    endpointId = "RINE",
+                    endpointInfo = endpointInfo,
+                    advertiserAddress = "77:88:99:AA:BB:CC",
+                    rssi = -47,
+                    l2capPsm = null,
+                    gattConnectable = false,
+                ),
+            )
+            runCurrent()
+
+            val resolved = seen.filterIsInstance<NearbyPeerEvent.Resolved>().last().peer
+            assertThat(resolved.isConnectable).isFalse()
+            assertThat(resolved.candidateMediums).containsExactly(Medium.BLE)
+            assertThat(resolved.preferredRoute()).isNull()
+
+            collector.cancel()
+        }
+
+    @Test
+    fun `verified BLE GATT route is kept across later raw scan observations`() =
+        runTest {
+            val lanEvents = MutableSharedFlow<DiscoveryEvent>()
+            val bleEvents = MutableSharedFlow<BleFastAdvertisementScanner.Observation>()
+            val bluetoothEvents = MutableSharedFlow<BluetoothClassicPeerScanner.Observation>()
+            val discovery =
+                NearbyPeerDiscovery.forTesting(
+                    lanEvents = lanEvents,
+                    bleEvents = bleEvents,
+                    bluetoothEvents = bluetoothEvents,
+                )
+            val seen = mutableListOf<NearbyPeerEvent>()
+            val collector =
+                backgroundScope.launch {
+                    discovery.browse().collect { seen += it }
+                }
+            runCurrent()
+
+            val endpointInfo = endpointInfo(name = "Galaxy")
+            bleEvents.emit(
+                BleFastAdvertisementScanner.Observation(
+                    endpointId = "RINE",
+                    endpointInfo = endpointInfo,
+                    advertiserAddress = "77:88:99:AA:BB:CC",
+                    rssi = -47,
+                    l2capPsm = null,
+                    gattConnectable = true,
+                ),
+            )
+            bleEvents.emit(
+                BleFastAdvertisementScanner.Observation(
+                    endpointId = "RINE",
+                    endpointInfo = endpointInfo,
+                    advertiserAddress = "77:88:99:AA:BB:CC",
+                    rssi = -48,
+                    l2capPsm = null,
+                    gattConnectable = false,
+                ),
+            )
+            runCurrent()
+
+            val resolved = seen.filterIsInstance<NearbyPeerEvent.Resolved>().last().peer
+            assertThat(resolved.isConnectable).isTrue()
+            assertThat(resolved.preferredRoute()).isEqualTo(
+                NearbyPeerRoute.BleGatt(
+                    macAddress = "77:88:99:AA:BB:CC",
+                ),
+            )
+
+            collector.cancel()
+        }
+
+    @Test
+    fun `BLE advertisement without Classic or L2CAP is observation-only`() =
         runTest {
             val lanEvents = MutableSharedFlow<DiscoveryEvent>()
             val bleEvents = MutableSharedFlow<BleFastAdvertisementScanner.Observation>()
@@ -256,13 +393,11 @@ class NearbyPeerDiscoveryTest {
             runCurrent()
 
             val resolved = seen.filterIsInstance<NearbyPeerEvent.Resolved>().last().peer
-            assertThat(resolved.isConnectable).isTrue()
+            assertThat(resolved.isConnectable).isFalse()
             assertThat(resolved.candidateMediums).containsExactly(Medium.BLE)
             assertThat(resolved.displayName()).isEqualTo("Quick Share BLE device")
-            assertThat(resolved.displayNameSource()).isEqualTo("ble-gatt-fallback")
-            assertThat(resolved.preferredRoute()).isEqualTo(
-                NearbyPeerRoute.BleGatt(macAddress = "28:1B:3E:BA:B1:1B"),
-            )
+            assertThat(resolved.displayNameSource()).isEqualTo("ble-advertisement")
+            assertThat(resolved.preferredRoute()).isNull()
 
             collector.cancel()
         }
@@ -305,9 +440,8 @@ class NearbyPeerDiscoveryTest {
             assertThat(resolved.displayName()).isEqualTo("Galaxy S26")
             assertThat(resolved.displayNameSource()).isEqualTo("ble-local-name")
             assertThat(resolved.bleAdvertisement?.displayName).isEqualTo("Galaxy S26")
-            assertThat(resolved.preferredRoute()).isEqualTo(
-                NearbyPeerRoute.BleGatt(macAddress = "28:1B:3E:BA:B1:1B"),
-            )
+            assertThat(resolved.isConnectable).isFalse()
+            assertThat(resolved.preferredRoute()).isNull()
 
             collector.cancel()
         }
@@ -346,6 +480,8 @@ class NearbyPeerDiscoveryTest {
             val resolved = seen.filterIsInstance<NearbyPeerEvent.Resolved>().last().peer
             assertThat(resolved.displayName()).isEqualTo("Quick Share device (RINE)")
             assertThat(resolved.displayNameSource()).isEqualTo("endpoint-id")
+            assertThat(resolved.isConnectable).isFalse()
+            assertThat(resolved.preferredRoute()).isNull()
 
             collector.cancel()
         }

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/SamsungQuickShareHeuristicTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/SamsungQuickShareHeuristicTest.kt
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package io.github.kyujincho.wvmg.discovery
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Pattern-set regression tests for [SamsungQuickShareHeuristic]. Lock
+ * in the cases that motivated the heuristic in the first place
+ * (empirically observed Samsung device names) and the non-Samsung
+ * names that must not false-positive (Pixel, OnePlus, Sony, Xiaomi,
+ * vivo).
+ */
+class SamsungQuickShareHeuristicTest {
+    @Test
+    fun `S26 Ultra with user prefix is matched`() {
+        // Real device name observed during the BLE GATT cert-gate
+        // research session — the user customized the friendly name but
+        // kept the model suffix.
+        assertThat(SamsungQuickShareHeuristic.matchesDeviceName("Kyujin's S26 Ultra")).isTrue()
+    }
+
+    @Test
+    fun `Galaxy umbrella brand matches regardless of model suffix`() {
+        listOf(
+            "Galaxy S22",
+            "Galaxy A54",
+            "Galaxy",
+            "GALAXY S25 PLUS",
+            "My Galaxy device",
+        ).forEach { name ->
+            assertThat(SamsungQuickShareHeuristic.matchesDeviceName(name)).isTrue()
+        }
+    }
+
+    @Test
+    fun `Galaxy embedded inside another word does not match (word boundary)`() {
+        // The token must be `\b`-bounded so we don't false-positive on
+        // arbitrary substrings — e.g., a third-party app or device
+        // whose model name happens to contain the literal letters
+        // "galaxy" without being a Galaxy device shouldn't trigger
+        // the warning. Names like "GalaxyTab Android Phone" still
+        // match (whitespace is a word boundary), but "MyGalaxyDevice"
+        // (no boundary on either side) does not.
+        assertThat(SamsungQuickShareHeuristic.matchesDeviceName("MyGalaxyDevice")).isFalse()
+    }
+
+    @Test
+    fun `S series spans S20 through S29 with optional suffixes`() {
+        listOf(
+            "S20",
+            "S21",
+            "S22 Ultra",
+            "S23+",
+            "S24 FE",
+            "S25 Plus",
+            "S26 Ultra",
+            "S29",
+        ).forEach { name ->
+            assertThat(SamsungQuickShareHeuristic.matchesDeviceName(name)).isTrue()
+        }
+    }
+
+    @Test
+    fun `Note 10 and Note 20 series match`() {
+        assertThat(SamsungQuickShareHeuristic.matchesDeviceName("Galaxy Note 10")).isTrue()
+        assertThat(SamsungQuickShareHeuristic.matchesDeviceName("Note20 Ultra")).isTrue()
+    }
+
+    @Test
+    fun `Z Fold and Z Flip match with and without trailing digit`() {
+        listOf("Z Fold", "Z Fold5", "Z Fold 7", "ZFold6", "Z Flip", "Z Flip4").forEach { name ->
+            assertThat(SamsungQuickShareHeuristic.matchesDeviceName(name)).isTrue()
+        }
+    }
+
+    @Test
+    fun `A series and M series and F series match`() {
+        assertThat(SamsungQuickShareHeuristic.matchesDeviceName("A54")).isTrue()
+        assertThat(SamsungQuickShareHeuristic.matchesDeviceName("M53")).isTrue()
+        assertThat(SamsungQuickShareHeuristic.matchesDeviceName("F62")).isTrue()
+    }
+
+    @Test
+    fun `Tab S tablets match`() {
+        assertThat(SamsungQuickShareHeuristic.matchesDeviceName("Tab S9")).isTrue()
+        assertThat(SamsungQuickShareHeuristic.matchesDeviceName("Galaxy Tab S8 Ultra")).isTrue()
+    }
+
+    @Test
+    fun `non-Samsung Android devices do not match`() {
+        // These are the realistic peers a WVMG user would see and we
+        // would burn 15 s on if we false-positive'd: Google Pixel,
+        // OnePlus, Sony Xperia, Xiaomi, vivo, Huawei.
+        listOf(
+            "Pixel 8",
+            "Pixel 7a",
+            "Pixel Fold",
+            "OnePlus 12",
+            "OnePlus 10 Pro",
+            "Xperia 1 V",
+            "Xperia 5 IV",
+            "Xiaomi 14",
+            "Xiaomi 13T",
+            "Redmi Note 12",
+            "vivo X300 Ultra",
+            "vivo Y200",
+            "iQOO 12",
+            "Huawei P60",
+            "Mate 60",
+            "Oppo Find X7",
+        ).forEach { name ->
+            assertThat(SamsungQuickShareHeuristic.matchesDeviceName(name)).isFalse()
+        }
+    }
+
+    @Test
+    fun `null and blank names do not match`() {
+        assertThat(SamsungQuickShareHeuristic.matchesDeviceName(null)).isFalse()
+        assertThat(SamsungQuickShareHeuristic.matchesDeviceName("")).isFalse()
+        assertThat(SamsungQuickShareHeuristic.matchesDeviceName("   ")).isFalse()
+    }
+
+    @Test
+    fun `matching is case-insensitive`() {
+        assertThat(SamsungQuickShareHeuristic.matchesDeviceName("galaxy s26 ultra")).isTrue()
+        assertThat(SamsungQuickShareHeuristic.matchesDeviceName("GALAXY S26 ULTRA")).isTrue()
+    }
+
+    @Test
+    fun `Redmi Note (Xiaomi) does not match Note pattern thanks to anchoring`() {
+        // Important non-trivial false-positive guard: Xiaomi's "Redmi
+        // Note 12" / "Note 13" share the literal token "Note" with
+        // Galaxy Note. The Samsung Note pattern only matches
+        // "Note 10" or "Note 20" (the active Galaxy Note models),
+        // which Xiaomi's Note line never used.
+        assertThat(SamsungQuickShareHeuristic.matchesDeviceName("Redmi Note 12")).isFalse()
+        assertThat(SamsungQuickShareHeuristic.matchesDeviceName("Redmi Note 13 Pro")).isFalse()
+    }
+}

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleAdvertisePayloadTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleAdvertisePayloadTest.kt
@@ -8,39 +8,69 @@ package io.github.kyujincho.wvmg.discovery.ble
 import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.security.MessageDigest
 import java.util.Random
 
 /**
- * Bit-exact tests for the Quick Share BLE service-data payload
- * composition (#32, PROTOCOL.md).
+ * Bit-exact tests for the Quick Share BLE FastInitiation service-data
+ * payload (#32, #145).
  *
  * The wire format is fixed at:
  *
  * ```text
- *   fc 12 8e 01 42 00 00 00 00 00 00 00 00 00 || rand10
+ *   fc 12 8e 00 42 00 00 00 00 00 00 00 00 00 || salt(1) || hash(8)
+ *   |---------- 14-byte fixed prefix ----------|   per-session salt + secret_id_hash
  * ```
  *
- * If any of these assertions fail in CI, stock Quick Share / NearDrop
- * receivers will silently ignore our advertisement — these tests are
- * the regression net.
+ * Byte 3 = `0x00` packs `version=0, type=kNotify (0), uwb=0,
+ * sender_cert=0`. **Drift here breaks Samsung One UI**: a non-zero byte 3
+ * (e.g. the legacy `0x01` we shipped before fixing #145) is interpreted
+ * by stock GMS as `type=SILENT`, which causes the receiver to skip
+ * registering its per-peer Weave handler — every subsequent ATT write to
+ * `00000100-…-0101` then throws
+ * `BluetoothGattException: No handler registered for characteristic …`
+ * and the BLE GATT bootstrap stalls at the Weave handshake.
+ *
+ * The trailing 8-byte `secret_id_hash` (truncated SHA-256 of the
+ * sender's `endpointId`) is the second half of the same gate: an
+ * all-zero hash also demotes the pulse to `type=SILENT` regardless of
+ * byte 3. These tests are the regression net for both fields.
  */
 class BleAdvertisePayloadTest {
+    private val sampleEndpointId = "abcd"
+
     @Test
-    fun `payload length matches the protocol-mandated 24 bytes`() {
-        val payload = BleAdvertisePayload.build(deterministicRandom(seed = 1L))
+    fun `payload length matches the protocol-mandated 23 bytes`() {
+        val payload = BleAdvertisePayload.build(sampleEndpointId, deterministicRandom(seed = 1L))
         assertThat(payload).hasLength(BleAdvertisePayload.PAYLOAD_LEN)
-        assertThat(payload).hasLength(24)
+        assertThat(payload).hasLength(23)
     }
 
     @Test
-    fun `prefix is the canonical Quick Share magic`() {
-        // Spec: fc 12 8e 01 42 00 00 00 00 00 00 00 00 00 (14 bytes).
+    fun `payload structural lengths are 14 + 1 + 8`() {
+        // Defensive: surface-area drift in the constants is the cheapest
+        // place to catch a bad refactor before it ships.
+        assertThat(BleAdvertisePayload.PREFIX_LEN).isEqualTo(14)
+        assertThat(BleAdvertisePayload.SALT_LEN).isEqualTo(1)
+        assertThat(BleAdvertisePayload.SECRET_ID_HASH_LEN).isEqualTo(8)
+        assertThat(BleAdvertisePayload.DYNAMIC_TAIL_LEN).isEqualTo(9)
+        assertThat(BleAdvertisePayload.PAYLOAD_LEN).isEqualTo(
+            BleAdvertisePayload.PREFIX_LEN + BleAdvertisePayload.DYNAMIC_TAIL_LEN,
+        )
+    }
+
+    @Test
+    fun `prefix is the canonical Quick Share FastInitiation magic`() {
+        // Spec: fc 12 8e 00 42 00 00 00 00 00 00 00 00 00.
+        // Byte 3 = 0x00 packs version=0, type=kNotify, no flags.
+        // Empirically: 0x00 → Galaxy classifies as NOTIFY; 0x01 → SILENT;
+        // 0x20 (version=1) → Galaxy stops detecting the pulse entirely.
         val expected =
             byteArrayOf(
                 0xFC.toByte(),
                 0x12.toByte(),
                 0x8E.toByte(),
-                0x01.toByte(),
+                0x00.toByte(),
                 0x42.toByte(),
                 0x00.toByte(),
                 0x00.toByte(),
@@ -56,6 +86,11 @@ class BleAdvertisePayloadTest {
     }
 
     @Test
+    fun `metadata byte three is zero for kNotify classification`() {
+        assertThat(BleAdvertisePayload.prefixBytes()[3]).isEqualTo(0x00.toByte())
+    }
+
+    @Test
     fun `prefixBytes returns a defensive copy`() {
         val first = BleAdvertisePayload.prefixBytes()
         first[0] = 0x00
@@ -66,16 +101,16 @@ class BleAdvertisePayloadTest {
 
     @Test
     fun `build copies the prefix verbatim into the first 14 bytes`() {
-        val payload = BleAdvertisePayload.build(deterministicRandom(seed = 42L))
+        val payload = BleAdvertisePayload.build(sampleEndpointId, deterministicRandom(seed = 42L))
         val head = payload.copyOfRange(0, BleAdvertisePayload.PREFIX_LEN)
         assertThat(head).isEqualTo(BleAdvertisePayload.prefixBytes())
     }
 
     @Test
-    fun `build draws exactly 10 bytes of randomness from the supplied source`() {
-        // Random.nextBytes is the only entropy call — using a counting
-        // wrapper lets us assert on the byte count even with a tiny
-        // deterministic seed.
+    fun `build draws exactly one byte of salt entropy from the supplied source`() {
+        // Random.nextBytes is the only entropy call into the supplied
+        // [Random]. SHA-256 over the endpointId is deterministic so the
+        // entropy budget is just the salt byte.
         var calls = 0
         var bytesRead = 0
         val counting =
@@ -86,47 +121,86 @@ class BleAdvertisePayloadTest {
                     super.nextBytes(bytes)
                 }
             }
-        BleAdvertisePayload.build(counting)
+        BleAdvertisePayload.build(sampleEndpointId, counting)
         assertThat(calls).isEqualTo(1)
-        assertThat(bytesRead).isEqualTo(BleAdvertisePayload.RANDOM_LEN)
+        assertThat(bytesRead).isEqualTo(BleAdvertisePayload.SALT_LEN)
     }
 
     @Test
-    fun `successive build calls produce different randomness tails`() {
-        // Pull two payloads from a SecureRandom-equivalent source and
-        // assert the random tails differ. A 10-byte collision under a
-        // uniform RNG is ~2^-80, well below any flake threshold.
-        val first = BleAdvertisePayload.build(Random(1L))
-        val second = BleAdvertisePayload.build(Random(2L))
-        val firstTail = first.copyOfRange(BleAdvertisePayload.PREFIX_LEN, first.size)
-        val secondTail = second.copyOfRange(BleAdvertisePayload.PREFIX_LEN, second.size)
-        assertThat(firstTail).isNotEqualTo(secondTail)
+    fun `secret id hash is the truncated sha-256 of the endpoint id`() {
+        // Pin the hash derivation so a refactor that changes the input
+        // encoding (e.g. drops UTF-8) is caught immediately.
+        val payload = BleAdvertisePayload.build(sampleEndpointId, deterministicRandom(seed = 7L))
+        val hashStart = BleAdvertisePayload.PREFIX_LEN + BleAdvertisePayload.SALT_LEN
+        val actualHash = payload.copyOfRange(hashStart, hashStart + BleAdvertisePayload.SECRET_ID_HASH_LEN)
+        val expectedHash =
+            MessageDigest
+                .getInstance("SHA-256")
+                .digest(sampleEndpointId.toByteArray(Charsets.UTF_8))
+                .copyOf(BleAdvertisePayload.SECRET_ID_HASH_LEN)
+        assertThat(actualHash).isEqualTo(expectedHash)
     }
 
     @Test
-    fun `buildWith places the supplied tail after the prefix`() {
-        val tail = ByteArray(BleAdvertisePayload.RANDOM_LEN) { (0xA0 + it).toByte() }
-        val payload = BleAdvertisePayload.buildWith(tail)
+    fun `secret id hash is non-zero for any non-empty endpoint id`() {
+        // The all-zero secret_id_hash failure mode is the exact signal
+        // Samsung uses to demote the pulse to type=SILENT. Lock in that
+        // every realistic endpointId produces a non-zero hash.
+        val payload = BleAdvertisePayload.build(sampleEndpointId, deterministicRandom(seed = 0L))
+        val hashStart = BleAdvertisePayload.PREFIX_LEN + BleAdvertisePayload.SALT_LEN
+        val hash = payload.copyOfRange(hashStart, hashStart + BleAdvertisePayload.SECRET_ID_HASH_LEN)
+        assertThat(hash.any { it != 0.toByte() }).isTrue()
+    }
+
+    @Test
+    fun `build with the same endpoint id and different salts differs only in the salt byte`() {
+        val first = BleAdvertisePayload.build(sampleEndpointId, Random(1L))
+        val second = BleAdvertisePayload.build(sampleEndpointId, Random(2L))
+        // Prefix and hash are identical (same endpointId, deterministic SHA-256).
+        assertThat(first.copyOfRange(0, BleAdvertisePayload.PREFIX_LEN))
+            .isEqualTo(second.copyOfRange(0, BleAdvertisePayload.PREFIX_LEN))
+        val hashStart = BleAdvertisePayload.PREFIX_LEN + BleAdvertisePayload.SALT_LEN
+        assertThat(first.copyOfRange(hashStart, hashStart + BleAdvertisePayload.SECRET_ID_HASH_LEN))
+            .isEqualTo(second.copyOfRange(hashStart, hashStart + BleAdvertisePayload.SECRET_ID_HASH_LEN))
+        // Salt byte differs (1-byte collision under a uniform RNG is 1/256;
+        // the deterministic seeds we picked yield distinct salt bytes).
+        assertThat(first[BleAdvertisePayload.PREFIX_LEN])
+            .isNotEqualTo(second[BleAdvertisePayload.PREFIX_LEN])
+    }
+
+    @Test
+    fun `build rejects an empty endpoint id`() {
+        assertThrows<IllegalArgumentException> {
+            BleAdvertisePayload.build("", deterministicRandom(seed = 0L))
+        }
+    }
+
+    @Test
+    fun `buildWith places salt at byte 14 and hash at bytes 15-22`() {
+        val hash = ByteArray(BleAdvertisePayload.SECRET_ID_HASH_LEN) { (0xA0 + it).toByte() }
+        val payload = BleAdvertisePayload.buildWith(salt = 0x77.toByte(), secretIdHash = hash)
         assertThat(payload).hasLength(BleAdvertisePayload.PAYLOAD_LEN)
         assertThat(payload.copyOfRange(0, BleAdvertisePayload.PREFIX_LEN))
             .isEqualTo(BleAdvertisePayload.prefixBytes())
-        assertThat(payload.copyOfRange(BleAdvertisePayload.PREFIX_LEN, payload.size))
-            .isEqualTo(tail)
+        assertThat(payload[BleAdvertisePayload.PREFIX_LEN]).isEqualTo(0x77.toByte())
+        val hashStart = BleAdvertisePayload.PREFIX_LEN + BleAdvertisePayload.SALT_LEN
+        assertThat(payload.copyOfRange(hashStart, hashStart + BleAdvertisePayload.SECRET_ID_HASH_LEN))
+            .isEqualTo(hash)
     }
 
     @Test
-    fun `buildWith rejects a tail of the wrong length`() {
+    fun `buildWith rejects a hash of the wrong length`() {
         // Too short.
         assertThrows<IllegalArgumentException> {
-            BleAdvertisePayload.buildWith(ByteArray(BleAdvertisePayload.RANDOM_LEN - 1))
+            BleAdvertisePayload.buildWith(0x00, ByteArray(BleAdvertisePayload.SECRET_ID_HASH_LEN - 1))
         }
         // Too long.
         assertThrows<IllegalArgumentException> {
-            BleAdvertisePayload.buildWith(ByteArray(BleAdvertisePayload.RANDOM_LEN + 1))
+            BleAdvertisePayload.buildWith(0x00, ByteArray(BleAdvertisePayload.SECRET_ID_HASH_LEN + 1))
         }
         // Empty.
         assertThrows<IllegalArgumentException> {
-            BleAdvertisePayload.buildWith(ByteArray(0))
+            BleAdvertisePayload.buildWith(0x00, ByteArray(0))
         }
     }
 

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleFastAdvertisementScannerTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleFastAdvertisementScannerTest.kt
@@ -46,27 +46,29 @@ class BleFastAdvertisementScannerTest {
     }
 
     @Test
-    fun `GATT advertisement header becomes a connectable BLE observation`() {
-        val rawHeader =
-            byteArrayOf(
-                0x55,
-                0x20,
-                0x14,
-                0x01,
-                0x10,
-                0x02,
-                0x00,
-                0x00,
-                0x03,
-                0x00,
-                0x0a,
-                0x3c,
-                0x56,
-                0xee.toByte(),
-                0x2c,
-                0x00,
-                0x00,
+    fun `extended regular advertisement decodes endpoint info and PSM`() {
+        val info = endpointInfo("Galaxy")
+        val payload = regularAdvertisementServiceData("RINE", info, psm = 0x1234)
+
+        val observed =
+            BleFastAdvertisementScanner.parseFastServiceData(
+                serviceData = payload,
+                advertiserAddress = "77:88:99:AA:BB:CC",
+                rssi = -47,
             )
+
+        assertThat(observed).isNotNull()
+        assertThat(observed!!.endpointId).isEqualTo("RINE")
+        assertThat(observed.endpointInfo).isEqualTo(info)
+        assertThat(observed.l2capPsm).isEqualTo(0x1234)
+        assertThat(observed.displayName).isEqualTo("Galaxy")
+        assertThat(observed.displayNameSource)
+            .isEqualTo(BleFastAdvertisementScanner.DisplayNameSource.FAST_ADVERTISEMENT_ENDPOINT_INFO)
+    }
+
+    @Test
+    fun `GATT advertisement header is observation-only before slot verification`() {
+        val rawHeader = legacyGattHeaderRawBytes()
 
         val observed =
             BleFastAdvertisementScanner.parseFastServiceData(
@@ -82,7 +84,7 @@ class BleFastAdvertisementScannerTest {
         assertThat(observed.advertiserAddress).isEqualTo("28:1B:3E:BA:B1:1B")
         assertThat(observed.rssi).isEqualTo(-41)
         assertThat(observed.l2capPsm).isNull()
-        assertThat(observed.gattConnectable).isTrue()
+        assertThat(observed.gattConnectable).isFalse()
         assertThat(observed.displayName).isNull()
         assertThat(observed.displayNameSource).isNull()
     }
@@ -91,7 +93,7 @@ class BleFastAdvertisementScannerTest {
     fun `GATT advertisement header keeps BLE local name fallback`() {
         val observed =
             BleFastAdvertisementScanner.parseFastServiceData(
-                serviceData = "VSAUARACAAADAAo8Vu4sAAA".toByteArray(Charsets.US_ASCII),
+                serviceData = legacyGattHeaderServiceData(),
                 advertiserAddress = "28:1B:3E:BA:B1:1B",
                 rssi = -41,
                 fallbackDisplayName = " Galaxy S26 ",
@@ -101,16 +103,29 @@ class BleFastAdvertisementScannerTest {
         assertThat(observed).isNotNull()
         assertThat(observed!!.endpointId).isNull()
         assertThat(observed.endpointInfo).isNull()
+        assertThat(observed.gattConnectable).isFalse()
         assertThat(observed.displayName).isEqualTo("Galaxy S26")
         assertThat(observed.displayNameSource)
             .isEqualTo(BleFastAdvertisementScanner.DisplayNameSource.BLE_LOCAL_NAME)
     }
 
     @Test
-    fun `GATT advertisement header preserves non-connectable scan result`() {
+    fun `extended-capable GATT header waits for regular advertisement bytes`() {
         val observed =
             BleFastAdvertisementScanner.parseFastServiceData(
                 serviceData = "VSAUARACAAADAAo8Vu4sAAA".toByteArray(Charsets.US_ASCII),
+                advertiserAddress = "28:1B:3E:BA:B1:1B",
+                rssi = -41,
+            )
+
+        assertThat(observed).isNull()
+    }
+
+    @Test
+    fun `GATT advertisement header preserves non-connectable scan result`() {
+        val observed =
+            BleFastAdvertisementScanner.parseFastServiceData(
+                serviceData = legacyGattHeaderServiceData(),
                 advertiserAddress = "28:1B:3E:BA:B1:1B",
                 rssi = -41,
                 gattConnectable = false,
@@ -182,4 +197,95 @@ class BleFastAdvertisementScannerTest {
             metadata = ByteArray(EndpointInfo.METADATA_LEN) { it.toByte() },
             deviceName = name,
         )
+
+    private fun legacyGattHeaderServiceData(): ByteArray =
+        Base64Url.encode(legacyGattHeaderRawBytes()).toByteArray(Charsets.US_ASCII)
+
+    private fun legacyGattHeaderRawBytes(): ByteArray =
+        byteArrayOf(
+            0x45,
+            0x20,
+            0x14,
+            0x01,
+            0x10,
+            0x02,
+            0x00,
+            0x00,
+            0x03,
+            0x00,
+            0x0a,
+            0x3c,
+            0x56,
+            0xee.toByte(),
+            0x2c,
+            0x00,
+            0x00,
+        )
+
+    private fun regularAdvertisementServiceData(
+        endpointId: String,
+        endpointInfo: EndpointInfo,
+        psm: Int,
+    ): ByteArray {
+        val body = regularBleBody(endpointId, endpointInfo)
+        val out =
+            ByteArray(
+                1 +
+                    NearbyServiceId.hashPrefix.size +
+                    4 +
+                    body.size +
+                    BleServiceData.DEVICE_TOKEN_LEN +
+                    BleServiceData.EXTRA_FIELDS_MASK_LEN +
+                    BleServiceData.PSM_LEN,
+            )
+        var offset = 0
+        out[offset++] = 0x48
+        NearbyServiceId.hashPrefix.copyInto(out, destinationOffset = offset)
+        offset += NearbyServiceId.hashPrefix.size
+        out[offset++] = ((body.size ushr 24) and 0xFF).toByte()
+        out[offset++] = ((body.size ushr 16) and 0xFF).toByte()
+        out[offset++] = ((body.size ushr 8) and 0xFF).toByte()
+        out[offset++] = (body.size and 0xFF).toByte()
+        body.copyInto(out, destinationOffset = offset)
+        offset += body.size
+        offset += BleServiceData.DEVICE_TOKEN_LEN
+        out[offset++] = BleServiceData.EXTRA_FIELD_PSM_MASK.toByte()
+        out[offset++] = ((psm ushr 8) and 0xFF).toByte()
+        out[offset] = (psm and 0xFF).toByte()
+        return out
+    }
+
+    private fun regularBleBody(
+        endpointId: String,
+        endpointInfo: EndpointInfo,
+    ): ByteArray {
+        val infoBytes = endpointInfo.serialize()
+        val out =
+            ByteArray(
+                1 +
+                    NearbyServiceId.hashPrefix.size +
+                    BleServiceData.ENDPOINT_ID_LEN +
+                    1 +
+                    infoBytes.size +
+                    BleServiceData.BLUETOOTH_MAC_LEN +
+                    2,
+            )
+        var offset = 0
+        out[offset++] = ((BleServiceData.DEFAULT_VERSION shl 5) or BleServiceData.DEFAULT_PCP).toByte()
+        NearbyServiceId.hashPrefix.copyInto(out, destinationOffset = offset)
+        offset += NearbyServiceId.hashPrefix.size
+        endpointId.toByteArray(Charsets.US_ASCII).copyInto(out, destinationOffset = offset)
+        offset += BleServiceData.ENDPOINT_ID_LEN
+        out[offset++] = infoBytes.size.toByte()
+        infoBytes.copyInto(out, destinationOffset = offset)
+        offset += infoBytes.size
+        byteArrayOf(0x70, 0x4E, 0xE0.toByte(), 0x12, 0xDE.toByte(), 0x3A).copyInto(
+            out,
+            destinationOffset = offset,
+        )
+        offset += BleServiceData.BLUETOOTH_MAC_LEN
+        out[offset++] = 0x00
+        out[offset] = 0x01
+        return out
+    }
 }

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareAdvertiserTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareAdvertiserTest.kt
@@ -7,6 +7,7 @@ package io.github.kyujincho.wvmg.discovery.ble
 
 import android.bluetooth.le.AdvertiseSettings
 import com.google.common.truth.Truth.assertThat
+import io.github.kyujincho.wvmg.protocol.endpoint.BleAdvertisement
 import io.github.kyujincho.wvmg.protocol.endpoint.BleAdvertisementHeader
 import io.github.kyujincho.wvmg.protocol.endpoint.BleServiceData
 import io.github.kyujincho.wvmg.protocol.endpoint.DctAdvertisement
@@ -97,6 +98,9 @@ class BleQuickShareAdvertiserTest {
         assertThat(BleServiceData.parse(payload)).isNull()
 
         val slotPayload = DefaultPayloadFactory.buildSlotPayload(endpointId("Wvmg"), info)
+        val slotAdvertisement = BleAdvertisement.parse(slotPayload)
+        assertThat(slotAdvertisement).isNotNull()
+        assertThat(slotAdvertisement!!.secondProfile).isTrue()
         val slot = BleServiceData.parse(slotPayload)
         assertThat(slot).isNotNull()
         assertThat(String(slot!!.endpointId, Charsets.US_ASCII)).isEqualTo("Wvmg")
@@ -132,6 +136,7 @@ class BleQuickShareAdvertiserTest {
         assertThat(header).isNotNull()
         assertThat(header!!.numSlots).isEqualTo(1)
         assertThat(header.psm).isEqualTo(0)
+        assertThat(header.supportsExtendedAdvertisement).isTrue()
         assertThat(BleServiceData.parse(payload)).isNull()
 
         assertThat(dctPayload).isNotNull()
@@ -141,7 +146,8 @@ class BleQuickShareAdvertiserTest {
         assertThat(dct.psm).isEqualTo(DctAdvertisement.DEFAULT_PSM)
 
         assertThat(visiblePayload).isNotNull()
-        val visibleInfo = BleServiceData.parse(visiblePayload!!)!!.endpointInfo
+        assertThat(BleAdvertisement.parse(visiblePayload!!)!!.secondProfile).isTrue()
+        val visibleInfo = BleServiceData.parse(visiblePayload)!!.endpointInfo
         assertThat(visibleInfo.hidden).isFalse()
         assertThat(visibleInfo.deviceName).isEqualTo("WhenVivoMeetsGoogle")
         assertThat(BleServiceData.parsePsmExtraField(visiblePayload)).isNull()
@@ -167,6 +173,7 @@ class BleQuickShareAdvertiserTest {
             assertThat(header).isNotNull()
             assertThat(header!!.psm).isEqualTo(0)
             assertThat(header.numSlots).isEqualTo(1)
+            assertThat(header.supportsExtendedAdvertisement).isTrue()
             val dct = DctAdvertisement.parse(call.dctPayload!!)!!
             assertThat(dct.psm).isEqualTo(0x1234)
             assertThat(BleServiceData.parsePsmExtraField(call.visiblePayload!!)).isEqualTo(0x1234)

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareAdvertiserTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareAdvertiserTest.kt
@@ -70,7 +70,7 @@ class BleQuickShareAdvertiserTest {
     }
 
     @Test
-    fun `start submits the canonical fast-advertisement payload`() {
+    fun `start submits a GATT advertisement header payload`() {
         val gate = RecordingGate(failOnStart = false)
         val advertiser =
             BleQuickShareAdvertiser.forTesting(
@@ -89,24 +89,22 @@ class BleQuickShareAdvertiserTest {
         assertThat(mode).isEqualTo(AdvertiseSettings.ADVERTISE_MODE_BALANCED)
         assertThat(gate.startCalls.last().dctPayload).isNull()
 
-        // The service data is the stock BLE v2 frame wrapper followed
-        // by the canonical 0x23 (version=1, PCP=3) inner body.
-        val expectedPayloadSize =
-            BleServiceData.FRAME_HEADER_LEN +
-                BleServiceData.FIXED_HEADER_LEN +
-                info.serialize().size +
-                BleServiceData.DEVICE_TOKEN_LEN
-        assertThat(payload).hasLength(expectedPayloadSize)
-        assertThat(payload[0].toInt() and 0xFF).isEqualTo(BleServiceData.FRAME_TYPE_FAST_ADVERTISEMENT)
-        assertThat(payload[1].toInt() and 0xFF).isEqualTo(BleServiceData.FIXED_HEADER_LEN + info.serialize().size)
-        assertThat(payload[2].toInt() and 0xFF).isEqualTo(0x23)
-        assertThat(payload.copyOfRange(3, 7)).isEqualTo(endpointId("Wvmg"))
-        assertThat(payload[7].toInt() and 0xFF).isEqualTo(0x11)
-        assertThat(payload[8].toInt() and 0xFF).isEqualTo(0x32)
+        val header = BleAdvertisementHeader.parse(payload)
+        assertThat(header).isNotNull()
+        assertThat(header!!.numSlots).isEqualTo(1)
+        assertThat(header.psm).isEqualTo(0)
+        assertThat(header.supportsExtendedAdvertisement).isFalse()
+        assertThat(BleServiceData.parse(payload)).isNull()
+
+        val slotPayload = DefaultPayloadFactory.buildSlotPayload(endpointId("Wvmg"), info)
+        val slot = BleServiceData.parse(slotPayload)
+        assertThat(slot).isNotNull()
+        assertThat(String(slot!!.endpointId, Charsets.US_ASCII)).isEqualTo("Wvmg")
+        assertThat(slot.endpointInfo).isEqualTo(info)
     }
 
     @Test
-    fun `start compacts visible EndpointInfo to hidden BLE payload`() {
+    fun `start exposes visible EndpointInfo through GATT header and extended payload`() {
         val gate = RecordingGate(failOnStart = false)
         val advertiser =
             BleQuickShareAdvertiser.forTesting(
@@ -130,12 +128,11 @@ class BleQuickShareAdvertiserTest {
         val payload = call.payload
         val dctPayload = call.dctPayload
         val visiblePayload = call.visiblePayload
-        assertThat(payload).hasLength(27)
-        val parsedInfo = BleServiceData.parse(payload)!!.endpointInfo
-        assertThat(parsedInfo.hidden).isTrue()
-        assertThat(parsedInfo.deviceName).isNull()
-        assertThat(parsedInfo.deviceType).isEqualTo(info.deviceType)
-        assertThat(parsedInfo.metadata).isEqualTo(info.metadata)
+        val header = BleAdvertisementHeader.parse(payload)
+        assertThat(header).isNotNull()
+        assertThat(header!!.numSlots).isEqualTo(1)
+        assertThat(header.psm).isEqualTo(0)
+        assertThat(BleServiceData.parse(payload)).isNull()
 
         assertThat(dctPayload).isNotNull()
         val dct = DctAdvertisement.parse(dctPayload!!)!!
@@ -168,7 +165,7 @@ class BleQuickShareAdvertiserTest {
             val call = gate.startCalls.single()
             val header = BleAdvertisementHeader.parse(call.payload)
             assertThat(header).isNotNull()
-            assertThat(header!!.psm).isEqualTo(0x1234)
+            assertThat(header!!.psm).isEqualTo(0)
             assertThat(header.numSlots).isEqualTo(1)
             val dct = DctAdvertisement.parse(call.dctPayload!!)!!
             assertThat(dct.psm).isEqualTo(0x1234)
@@ -209,9 +206,10 @@ class BleQuickShareAdvertiserTest {
         assertThat(gate.firstRegistration?.closed).isTrue()
         assertThat(gate.lastRegistration?.closed).isFalse()
 
-        // Bytes 3..6 of the latest payload reflect the second endpoint_id.
+        // Header bytes include a random dummy service id; identity drift is
+        // covered by the replacement count and by the GATT-slot encoder tests.
         val (payload, _) = gate.startCalls.last()
-        assertThat(payload.copyOfRange(3, 7)).isEqualTo(endpointId("BBBB"))
+        assertThat(BleAdvertisementHeader.parse(payload)).isNotNull()
     }
 
     @Test

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareAdvertiserTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareAdvertiserTest.kt
@@ -7,6 +7,7 @@ package io.github.kyujincho.wvmg.discovery.ble
 
 import android.bluetooth.le.AdvertiseSettings
 import com.google.common.truth.Truth.assertThat
+import io.github.kyujincho.wvmg.protocol.endpoint.BleAdvertisementHeader
 import io.github.kyujincho.wvmg.protocol.endpoint.BleServiceData
 import io.github.kyujincho.wvmg.protocol.endpoint.DctAdvertisement
 import io.github.kyujincho.wvmg.protocol.endpoint.DeviceType
@@ -165,6 +166,10 @@ class BleQuickShareAdvertiserTest {
 
             assertThat(started).isTrue()
             val call = gate.startCalls.single()
+            val header = BleAdvertisementHeader.parse(call.payload)
+            assertThat(header).isNotNull()
+            assertThat(header!!.psm).isEqualTo(0x1234)
+            assertThat(header.numSlots).isEqualTo(1)
             val dct = DctAdvertisement.parse(call.dctPayload!!)!!
             assertThat(dct.psm).isEqualTo(0x1234)
             assertThat(BleServiceData.parsePsmExtraField(call.visiblePayload!!)).isEqualTo(0x1234)

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BleGattInitialControlServerTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BleGattInitialControlServerTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+
+package io.github.kyujincho.wvmg.discovery.bootstrap
+
+import com.google.common.truth.Truth.assertThat
+import io.github.kyujincho.wvmg.protocol.endpoint.BleServiceData
+import io.github.kyujincho.wvmg.protocol.endpoint.DeviceType
+import io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo
+import org.junit.Test
+import java.nio.charset.StandardCharsets
+
+class BleGattInitialControlServerTest {
+    @Test
+    fun `regular service UUID stays the GATT advertisement slot host`() {
+        assertThat(BleGattInitialControlServer.SERVICE_UUID.toString())
+            .isEqualTo(BleServiceData.SERVICE_UUID_128_STRING)
+    }
+
+    @Test
+    fun `second-profile service UUID matches stock Nearby socket lookup`() {
+        assertThat(BleGattInitialControlServer.SECOND_PROFILE_SERVICE_UUID.toString())
+            .isEqualTo("0000fef3-0004-1000-8000-001a11000100")
+    }
+
+    @Test
+    fun `regular slot service points stock sender at second-profile socket`() {
+        val serviceSpecs =
+            BleGattInitialControlServer.buildServiceSpecs(
+                endpointInfo = sampleEndpointInfo(),
+                endpointId = "P0ZK".toByteArray(StandardCharsets.US_ASCII),
+            )
+
+        assertThat(serviceSpecs.map { it.uuid })
+            .containsExactly(
+                BleGattInitialControlServer.SERVICE_UUID,
+                BleGattInitialControlServer.SECOND_PROFILE_SERVICE_UUID,
+            ).inOrder()
+
+        val advertisementService = serviceSpecs[0]
+        val socketService = serviceSpecs[1]
+
+        assertThat(advertisementService.characteristicUuids())
+            .contains(BleGattInitialControlServer.GATT_SLOT_0_UUID)
+        assertThat(advertisementService.characteristicUuids())
+            .doesNotContain(BleGattInitialControlServer.FROM_PERIPHERAL_UUID)
+        assertThat(advertisementService.characteristicUuids())
+            .doesNotContain(BleGattInitialControlServer.TO_PERIPHERAL_UUID)
+
+        assertThat(socketService.characteristicUuids())
+            .doesNotContain(BleGattInitialControlServer.GATT_SLOT_0_UUID)
+        assertThat(socketService.characteristicUuids())
+            .contains(BleGattInitialControlServer.FROM_PERIPHERAL_UUID)
+        assertThat(socketService.characteristicUuids())
+            .contains(BleGattInitialControlServer.TO_PERIPHERAL_UUID)
+
+        val slotValue =
+            requireNotNull(
+                advertisementService.characteristics.firstOrNull {
+                    it.uuid == BleGattInitialControlServer.GATT_SLOT_0_UUID
+                },
+            ).value
+        assertThat(slotValue)
+            .isNotNull()
+        assertThat(slotValue[0].toInt() and 0xFF)
+            .isEqualTo(BleServiceData.FRAME_TYPE_SECOND_PROFILE_FAST_ADVERTISEMENT)
+    }
+
+    private fun BleGattInitialControlServer.Companion.GattServiceSpec.characteristicUuids() =
+        characteristics.map { it.uuid }
+
+    private fun sampleEndpointInfo(): EndpointInfo =
+        EndpointInfo(
+            version = 1,
+            hidden = false,
+            deviceType = DeviceType.PHONE,
+            reserved = false,
+            metadata = ByteArray(EndpointInfo.METADATA_LEN) { index -> index.toByte() },
+            deviceName = "WhenVivoMeetsGoogle",
+        )
+}

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/medium/WifiDirectMediumProviderTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/medium/WifiDirectMediumProviderTest.kt
@@ -152,6 +152,7 @@ class WifiDirectMediumProviderTest {
         assertThat(
             WifiDirectCredentialShape.isValidNetworkName("DIRECT-O3-Kyujin's vivo X300 Ult"),
         ).isFalse()
+        assertThat(WifiDirectCredentialShape.isValidNetworkName("DIRECT-14F768FDC")).isTrue()
         assertThat(WifiDirectCredentialShape.isValidNetworkName("DIRECT-ab-WVMG")).isTrue()
     }
 

--- a/docs/research/samsung-ble-gatt-cert-gate.md
+++ b/docs/research/samsung-ble-gatt-cert-gate.md
@@ -1,0 +1,297 @@
+# Samsung One UI BLE GATT bootstrap — sender-certificate gate
+
+**Document type:** Reverse-engineering analysis / interop limitation note
+**Subject:** Samsung One UI 8.x Quick Share BLE GATT acceptance gate (per-peer Weave handler registration)
+**Status:** GMS APK decompilation + on-device empirical verification (16+ test rounds against Galaxy S26 Ultra running stock Quick Share / `com.samsung.android.app.sharelive`)
+**GMS version analyzed:** `com.google.android.gms@261731035@26.17.31 (260400-906420463)`
+**Companion code:** `discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BleGattInitialControlClient.kt`, `discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleAdvertisePayload.kt`
+**Last verified:** 2026-05-03
+**Audience:** Future contributors who would otherwise re-walk this loop trying to make WVMG's BLE GATT bootstrap reach a stock Samsung receiver.
+
+> **TL;DR.** WVMG (or any non-GMS app) cannot complete a BLE GATT bootstrap into Samsung One UI's Quick Share receiver. The block is a Google-account-bound `SenderCertificate` lookup that gates per-peer Weave handler registration on the receiver. Without a certificate that Samsung's GMS already has in its `nearby_sharing_sender_certificate_book_*` files, every ATT write to characteristic `00000100-0004-1000-8000-001A11000101` is rejected with `BluetoothGattException: No handler registered for characteristic …`. The gate is cryptographic, not behavioral; protocol-level workarounds do not exist. The same finding is what `rquickshare`/`NearDrop` ran into and bailed on. Samsung is reachable from WVMG via Wi-Fi LAN (mDNS) without this restriction; that is the supported path.
+
+---
+
+## 1. Symptom
+
+Sender (WVMG on a non-Samsung Android, e.g., vivo X300) detects a stock Galaxy S26 receiver by its BLE FastInitiation pulse on `0xFE2C`, picks a `route=ble-gatt` bootstrap, opens a GATT connection to the FEF3 service, and is rejected at the Weave layer. Concretely (timestamps from a single representative Round 16 capture):
+
+```
+[vivo  ] 01:02:29.385 enqueue write len=7 header=80           (Weave CONNECTION_REQUEST)
+[vivo  ] 01:02:29.413 characteristic write complete            (link-layer ACK)
+[vivo  ] 01:02:29.414 notification len=5 header=81             (Weave CONFIRM-shaped response)
+[vivo  ] 01:02:29.445 enqueue write len=15 header=1c           (NearbyConnections introduction)
+[vivo  ] 01:02:29.464 BLE GATT service write bytes=78          (ConnectionRequestFrame part 1)
+[vivo  ] 01:02:29.469 enqueue write len=144 header=3c          (ConnectionRequestFrame part 2)
+[vivo  ] 01:02:44.467 step 2: initial handshake timed out after 15000ms
+
+[Galaxy] 01:02:30.063 gchm: Could not write descriptor 00002902-… on characteristic 00000100-…-0102 …
+                      BluetoothGattException: No handler registered for characteristic 00000100-…-0102.
+                          at gchi.a (29)
+                          at gchk.c (26)
+                          at gchu.onDescriptorWriteRequest (9)
+                          at djpp.onDescriptorWriteRequest (68)
+[Galaxy] 01:02:30.093 gchm: Could not write characteristic 00000100-…-0101 …
+                      BluetoothGattException: No handler registered for characteristic 00000100-…-0101.
+                          at gchi.a (29)
+                          at gchk.b (15)
+                          at gchu.onCharacteristicWriteRequest (9)
+                          at djpp.onCharacteristicWriteRequest (68)
+[Galaxy] 01:02:30.151 gchm: Could not write characteristic 00000100-…-0101 …  (4 more, one per write)
+[Galaxy] 01:02:30.182 gchm: Could not write characteristic 00000100-…-0101 …
+[Galaxy] 01:02:30.215 gchm: Could not write characteristic 00000100-…-0101 …
+[Galaxy] 01:02:46.204 NearbyMediums: Weave socket onDisconnected callback is called, finish socket cleanup.
+```
+
+The error pattern is **bit-identical across rounds, peers, MACs, pulse contents, and timing tweaks** — the unmistakable signature of a deny-by-default ACL rather than a race or framing mistake.
+
+---
+
+## 2. The CONFIRM-shaped notification is not a sign of progress
+
+`vivo` receives a 5-byte notification with header `0x81` ≈ 30 ms after writing CONNECTION_REQUEST. This decodes cleanly as Weave `CONNECTION_CONFIRM` v1 with `packetSize=509`. It is not, in fact, the Samsung GMS Weave-handshake handler responding to us:
+
+- Round 18 ablation: skip the CCCD ATT write (still call `setCharacteristicNotification(true)` so BlueDroid forwards) and re-issue the CONNECTION_REQUEST. The CONFIRM-shaped notification **disappears entirely**, and our request retries fire 10× with no response. So the "CONFIRM" is contingent on the CCCD ATT write.
+- Galaxy's gchm log shows the CCCD write itself being rejected with `No handler registered for characteristic 00000100-…-0102.` at the same instant the "CONFIRM" arrives at vivo.
+- The `gchu.onDescriptorWriteRequest` rejection happens after gchu has already returned `GATT_SUCCESS` at the link layer (Android's `BluetoothGattServer$1` dispatches the success response synchronously before the gchk handler runs), so vivo's stack sees the descriptor write as successful and proceeds.
+
+Working hypothesis: the `0x81 00 01 01 fd` indication is generated by a lower BlueDroid layer (or by Galaxy's Quick Share advertisement-slot server's wildcard handler reflexively echoing handshake state), not by an app-layer Weave handler. It is structural noise that decodes as a real CONFIRM by coincidence of the framing. The receiver-side per-peer dispatcher remains unregistered.
+
+This is important because it explains why early rounds appeared to be "almost working" (we got CONFIRM, set `weaveConnected=true`, sent the introduction packet, then timed out at the next step). Subsequent writes were always going to be rejected — we just didn't notice the rejection because GMS doesn't propagate it to the link layer.
+
+---
+
+## 3. The gate, mechanically (GMS decompilation)
+
+GMS's BLE GATT server stack on the receiver side is structured as follows (obfuscated names, classes11.dex unless noted):
+
+```
+djpq            singleton GATT-server multiplexer.
+                Owns the single BluetoothGattServer instance and dispatches
+                onCharacteristicWriteRequest / onDescriptorWriteRequest
+                etc. across all registered BluetoothGattServerCallback
+                instances based on UUID filtering.
+
+djpp            djpq's BluetoothGattServerCallback implementation.
+                Loops over djpq.e (registered callbacks) and routes to
+                each callback whose hffc-set in djpq.f covers the target
+                UUID (or to every callback if the registration was
+                wildcard, hffcVar == null).
+
+gchm            per-server wrapper. Holds:
+                - g (gchc):   handler registry (service UUID → gchb)
+                - h (gcht):   the actual BluetoothGattServer
+                - i (Map):    peer device → gchi instance
+                - d (gchk):   the BluetoothGattServerCallback for this
+                              gchm; registered with djpq.
+
+gchu            BluetoothGattServerCallback that just delegates to a
+                gchv (gchk in practice).
+
+gchk extends gchv     dispatch logic. On peer connect:
+                gchk.d() → gchm.i.put(peer, new gchi(gchm, peer, gchm.g))
+                On characteristic write:
+                gchk.b() → gchi gchi = gchm.a(peer);
+                          gchn handler = gchi.a(characteristic);  ← THROWS
+                          handler.dispatch(...)
+
+gchi            per-peer state. Built from gchm.g.a (a Map<UUID, gchb>)
+                merged into a single Map<BluetoothGattCharacteristic, gchn>
+                in gchi.g. The throw site:
+
+                public final gchn a(BluetoothGattCharacteristic c)
+                        throws BluetoothGattException {
+                    gchn h = (gchn) this.g.get(c);
+                    if (h != null) return h;
+                    throw new BluetoothGattException(
+                        "No handler registered for characteristic " + c.getUuid(),
+                        6);
+                }
+```
+
+There are **two `gchm` instances** on the wire that matter for Quick Share, registered with djpq independently:
+
+1. **Slot / advertisement GATT server** — created in `dozb` via `doxx.a()`. Its `gchc.a` map registers handlers only for the slot characteristics `00000000-0000-3000-8000-00000000000{0..4}`. It is registered with djpq as a **wildcard** (`hffcVar = null`), so djpq routes *every* incoming UUID's events to it (because `djpq.h` falls back to `djpq.m`, the master union of FEF3 + Weave + slot UUIDs). This server is what holds slot 0 (the receiver's own EndpointInfo, served when a sender does an initial GATT-read to verify identity).
+
+2. **Weave GATT server (BleServerSocket)** — created in `doza.a()` via `dpba(…, hdix, …)`. Its `hdix` instance has the actual handlers for `00000100-…-0101` (write) / `00000100-…-0102` (notify) and dispatches to `hdix.b()`. It is registered with djpq for the FEF3 service + Weave char UUIDs.
+
+When a sender (us) writes to `0x0101`, djpp routes the event to **both** registered callbacks (slot-server wildcard + Weave server). The Weave server, *if running*, would handle it correctly — `hdix.b()` checks `this.d.equals(uuid)` (Weave WRITE char), looks up `hdiv` (the per-device Weave session), and dispatches the bytes onto its Executor for Weave parsing. The slot server has no handler for `0x0101` and throws.
+
+**The actual gate is therefore: is the Weave server (`doza`/`dpba`) running for our peer?** The answer in our test runs is *no* — and that's the entire phenomenon. The throw we see is the slot-server's wildcard handler going through the motions in the absence of the Weave server.
+
+---
+
+## 4. Why the Weave server isn't started for our peer
+
+`dozb.aa(serviceId, dkgkVar)` is the public method to *start accepting BLE GATT incoming connections* for a given service id. It calls `dozb.ab` which creates the `doza` MediumOperation, registers it with `dpde`, and stores `(serviceId, dkgkVar)` in `dozb.K`. `doza.a()` is what actually:
+
+```java
+hdix hdixVar = new hdix(uuidE, uuid, uuid2, new gchv());
+djpqVarB.h(context, hdixVar.c, /* hffc UUIDs or null */);  // register with djpq
+gcht gchtVarA = gcht.a(djpqVarB.a());                     // wrap the BluetoothGattServer
+…
+new doyz(this, dpbaVar).start();                          // accept loop
+```
+
+If `dozb.aa(...)` is never called for the service ID our pulse advertises, the Weave server never starts, `hdix.c` is never registered with djpq, and no `gchi.g` entry will ever exist for `0x0101` for our peer.
+
+`dozb.aa` is invoked by the upper-layer NearbyConnections / NearbySharing receiver flow when a discovery target is decided to be acceptable for incoming BLE GATT bootstrap. The decision predicate is what we care about. From the on-device GMS log on Galaxy after our pulse stops:
+
+```
+NearbySharing: Detected fast init state changed: version=0, type=NOTIFY, state=LOST.
+NearbySharing: isFastInitSilent is false.
+NearbySharing: 'listSenderCertificates' succeeded for parent: users/me/devices/VEBNNCULWW, count = 6.
+NearbySharing: Saved sender certificates to file
+   nearby_sharing_sender_certificate_book_from_self_share.
+NearbySharing: Saved sender certificates to file
+   nearby_sharing_sender_certificate_book_from_all_contacts.
+NearbySharing: Saved sender certificates to file
+   nearby_sharing_sender_certificate_book_from_selected_contacts.
+NearbySharing: 'listSenderCertificates' succeeded for parent: users/me/devices/VEBNNCULWW, count = 6.
+```
+
+Galaxy maintains a database of 6 `SenderCertificate` instances synced from Google's `nearbysharing-pa.googleapis.com` backend. The lookup key Galaxy uses to match an incoming pulse to one of these certs is the BLE FastInitiation `secret_id_hash` (bytes 15..22 of our pulse — the truncated SHA-256 of the cert's id). Galaxy classifies our pulse as `version=0, type=NOTIFY` (good — we got past the SILENT filter via `BleAdvertisePayload`'s byte-3 = `0x00` and non-zero hash), runs `secret_id_hash` against the cert book, **fails to match anything**, and never invokes `dozb.aa` for our peer. Hence: no Weave server, no `gchi` handler, deny-by-default at `gchi.a`.
+
+This is consistent with every rounds-of-attempts observation — the rejection pattern doesn't change with stable identity, write order, CCCD timing, MTU, connection priority, PHY, or retries, because none of those touch the cert lookup.
+
+---
+
+## 5. The certificate model
+
+```
+┌────────────────────────────────────┐         nearbysharing-pa.googleapis.com
+│  Device A (signed in to acct@…)    │   gRPC  location.nearby.sharing.v1.NearbySharingService
+│  GMS:                              │  ────►  - UpdateDevice
+│   gen keypair → KeyStore (TEE)     │  ◄────  - ListPublicCertificates
+│   upload public cert (id, pubkey)  │         - ListSenderCertificates
+│                                    │         - RegisterReceiver
+└────────────────────────────────────┘         OAuth scope:
+                                                 https://www.googleapis.com/auth/nearbysharing-pa
+                                                 https://www.googleapis.com/auth/nearbypresence-pa
+
+┌────────────────────────────────────┐
+│  Device B (same acct or contact)   │   syncs A's cert into one of:
+│  GMS:                              │     nearby_sharing_sender_certificate_book_from_self_share
+│   ListSenderCertificates           │     nearby_sharing_sender_certificate_book_from_all_contacts
+│                                    │     nearby_sharing_sender_certificate_book_from_selected_contacts
+└────────────────────────────────────┘
+
+When A sends to B:
+  A's BLE pulse:
+     secret_id_hash = SHA256(A.cert.id)[:8]   (bytes 15..22 of the 23-byte FastInit payload)
+
+  B detects pulse, looks up secret_id_hash in its three cert books.
+  ┌─ no match ─► (Samsung path) dozb.aa never called → no Weave server → 
+  │              gchi.a throws "No handler registered" on every ATT write
+  └─ match ────► dozb.aa(serviceId, callback) called → Weave server starts →
+                 hdix registered → gchi.g has 0x0101 → writes dispatched →
+                 PairedKeyEncryption signed with cert's private key (KeyStore alias) →
+                 NearbyConnections handshake → file transfer
+```
+
+The cert id hash is what the pulse advertises; the cert's *private key* is also load-bearing — the receiver expects the sender to sign a `PairedKeyEncryptionFrame` with it during the Sharing.Nearby handshake. Spoofing only the hash gets you past the BLE GATT acceptance gate but stalls at PairedKeyEncryption.
+
+---
+
+## 6. The gate is not bypassable from a third-party app
+
+We considered five paths and ruled each out:
+
+### 6.1 Same Google account on both devices (self-share) — extract from local GMS
+- Cert files live under `/data/data/com.google.android.gms/files/nearby/sharing/…` (private to GMS uid).
+- Reading them requires root.
+- Even with root, the cert's private key is in Android KeyStore under a GMS-uid-bound alias; on Tensor / StrongBox-backed devices the key material lives in the TEE and **cannot be exported even with root**. The KeyStore APIs let you *use* the key only if you're running as the gms uid.
+- Outcome: spoofable hash, unreachable private key. Gets us past `gchi.a` but dies at PairedKeyEncryption.
+
+### 6.2 Be in the user's Google Contacts — same as above
+Mechanically identical: contact's GMS uploads, B's GMS syncs, WVMG would need *contact's* cert id + private key. Same dead-end.
+
+### 6.3 Reverse-engineer Google's Nearby Sharing API and call it from WVMG
+- gRPC service: `nearbysharing-pa.googleapis.com` (`location.nearby.sharing.v1.NearbySharingService`)
+- Companion service for presence/contacts: `nearbypresence-pa.googleapis.com` (`location.nearby.presence.v1.NearbyPresenceService`)
+- OAuth scopes:
+  - `https://www.googleapis.com/auth/nearbysharing-pa`
+  - `https://www.googleapis.com/auth/nearbypresence-pa`
+- Methods we'd need: `UpdateDevice` (register WVMG's device under user's account), `RegisterReceiver`, `ListSenderCertificates`, plus our own keypair generation and cert upload.
+- **The OAuth scopes are first-party-restricted.** `AccountManager.getAuthToken(account, "oauth2:https://…/nearbysharing-pa", …)` from a non-Google-signed app returns `INVALID_SCOPE` / consent denied. The whitelist is an internal Google list of GMS + a handful of OEM partner apps; there is no public application form.
+- Outcome: cleanest design, completely closed off in practice.
+
+### 6.4 Bind to GMS as a service via signature-restricted permission
+- The relevant permission is `com.google.android.gms.permission.ACCESS_NEARBY_SHARE_API` declared in GMS's manifest with `protectionLevel="signature"`.
+- Only apps signed with Google's platform signature can hold it. WVMG cannot.
+- Outcome: closed.
+
+### 6.5 Delegate to GMS Quick Share via `Intent.ACTION_SEND` / `com.google.android.gms.SHARE_NEARBY`
+- The Quick Share entry point is `com.google.android.gms/.nearby.sharing.main.MainActivity` and its trampoline `…/.nearby.sharing.migration.TransparentTrampolineActivity`. Both accept `SEND` / `SEND_MULTIPLE` / `SHARE_NEARBY` / `nearby.sharing.UNIFIED` / `nearby.QUICK_SHARE` / `nearby.SEND_FOLDER`.
+- On Pixel and Galaxy these activities are enabled by GMS's Chimera loader at runtime.
+- **On vivo X300 (and most non-Google-partner Android) the activities are declared but `enabled=false` and Chimera never enables them.** We confirmed:
+  ```
+  $ adb -s vivo am start -a com.google.android.gms.SHARE_NEARBY -t image/* …
+  Error: Activity not started, unable to resolve Intent
+
+  $ adb -s vivo pm enable com.google.android.gms/.nearby.sharing.main.MainActivity
+  SecurityException: Shell cannot change component state …
+  ```
+  `pm query-activities -a android.intent.action.SEND -t image/*` on vivo returns 56 hits, **none** of them Quick Share. The system share sheet has nothing to offer.
+- Outcome: cannot delegate to GMS Quick Share on vivo because GMS never installs/enables the UI on this device class.
+
+This is a Google-side gatekeeping decision (Chimera config), not something WVMG can route around at app level.
+
+---
+
+## 7. What rounds 1–18 actually ruled out
+
+For the record so this loop doesn't get re-walked:
+
+| Round | Lever | Outcome |
+|------:|---|---|
+| 1–9 | various delays between connect/MTU/discoverServices/CCCD/CONNECTION_REQUEST (0–2 s grids) | no change in rejection |
+| 10 | `requestConnectionPriority(HIGH)` | no change |
+| 11 | `PHY_LE_2M_MASK` on `connectGatt` | no change |
+| 12 | skip CCCD subscribe entirely | breaks: no CONFIRM-shaped notification at all (proves CONFIRM is contingent on CCCD attempt, not on app-layer success) |
+| 13 | `device.createBond()` before discoverServices | bond fails with "incorrect PIN" (Just-Works pairing mismatch); even when bond is active, gate doesn't open |
+| 14 | spin up sender-side GATT server hosting our own FEF3 + slot 0 with our EndpointInfo | Galaxy connects to our server but does not read or write — confirming Galaxy isn't waiting on us to expose anything |
+| 15 | byte 3 = `0x20` (Weave version=1) | Galaxy stops detecting the pulse entirely (worse) |
+| 16 | extend Weave CONNECTION_REQUEST retries from 3×700 ms to 10×1000 ms | retry timer never fires because we falsely set `weaveConnected=true` from the phantom CONFIRM |
+| 17 | stable `endpointId` across runs (SharedPreferences-backed); same secret_id_hash on every attempt | no change — gate is not "has-this-hash-been-seen-recently" |
+| 18 | no CCCD ATT write at all (only `setCharacteristicNotification(true)`); resend CONNECTION_REQUEST 10× | no CONFIRM, all attempts time out, peer sees nothing useful (proves CCCD is necessary plumbing but not sufficient) |
+
+The only rounds that *materially changed* something on Galaxy's side were:
+- byte-3 fix (`0x01` → `0x00`): pulse classification flips from `SILENT` to `NOTIFY` (necessary precondition; not sufficient)
+- non-zero `secret_id_hash`: same precondition flip (necessary; not sufficient)
+
+Both of those are kept in `BleAdvertisePayload`. They are real interop wins that benefit non-Samsung peers too.
+
+---
+
+## 8. What actually works against Samsung today
+
+| Direction | Wi-Fi LAN (mDNS) | BLE GATT |
+|---|---|---|
+| Galaxy → WVMG (vivo as receiver) | ✅ works | ✅ works (WVMG accepts any peer; cert-gate is a Samsung-receiver thing, not on us) |
+| WVMG (vivo) → Galaxy | ✅ works (Galaxy's Wi-Fi LAN acceptance path doesn't enforce the cert gate; mDNS-discovered peers complete the Sharing.Nearby handshake without certificate match) | ❌ blocked by §3–§4 above |
+
+So for the user's sending-from-non-Samsung-to-Samsung case, **Wi-Fi LAN is the supported route**. WVMG's existing implementation handles it. No additional certificate or GMS dependency is required.
+
+---
+
+## 9. Recommended product behavior
+
+In WVMG's peer picker, when a Samsung-class peer (`bleName` containing "Galaxy" / `endpointInfo.deviceName.startsWith("Kyujin's …")`-style markers, or simply: "this peer was discovered via BLE pulse but doesn't have a Wi-Fi LAN route") shows up:
+
+1. **Try Wi-Fi LAN first.** If available, use it.
+2. **If only BLE-GATT route is available** and the peer is Samsung-class, **don't claim BLE GATT will work**. Either:
+   - Greyed-out / "unavailable" with a hint: *"Samsung Quick Share requires Wi-Fi. Connect both devices to the same Wi-Fi network."* + a `Settings.ACTION_WIFI_SETTINGS` deeplink, or
+   - Allow the user to attempt BLE GATT (for the rare future world where Samsung loosens this), but with a clear disclaimer that it likely won't complete.
+3. If the BLE-GATT bootstrap is attempted and the receiver's first ATT write window elapses without a real CONNECTION_CONFIRM (i.e., no Weave data frame arrives in the next ~5 s after the phantom CONFIRM), **demote the BLE-GATT route and rebroadcast the picker** rather than waiting the full Sharing.Nearby handshake timeout.
+
+The current implementation in `discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BleGattInitialControlClient.kt` correctly **stops trying to bootstrap into Samsung once the handshake times out**, but it does so only after 15 s — long enough for users to assume the app is broken. The mitigation above is a UX patch on top of an architectural reality: BLE GATT to Samsung just doesn't work for non-GMS senders, and the right answer is to tell the user, not to keep retrying.
+
+---
+
+## 10. Cross-references
+
+- `BleAdvertisePayload.kt` — the 23-byte FastInitiation pulse format with the byte-3 fix and `secret_id_hash`. Kdoc on that file documents *why* each byte matters (which Samsung empirics it preserves).
+- `BleGattInitialControlClient.kt` — the central-side BLE GATT bootstrap (writes Weave CONNECTION_REQUEST, expects CONFIRM). The `WEAVE_REQUEST_MAX_RETRIES` and post-connect / post-slot grace constants are residue from rounds 1–18 trying to find a timing window; they're harmless for Pixel and the rare working Samsung-edge cases, but they do not help against the Samsung cert gate. Documented in this file for context.
+- `BleGattInitialControlServer.kt` — the receiver-side server. WVMG **does not** enforce a cert gate on incoming peers; this is intentional — WVMG-as-receiver wants to accept anyone, including Samsung senders that *do* have a valid cert chain in their own GMS.
+- `rquickshare`'s README explicitly bails on Samsung BLE GATT with the note "Samsung did something shady". `NearDrop` has no Samsung BLE GATT story. Both projects independently arrived at the same wall via different routes; this document captures *exactly which wall*, so the next contributor doesn't have to.

--- a/docs/testing/interop-stock-quick-share-android.md
+++ b/docs/testing/interop-stock-quick-share-android.md
@@ -148,16 +148,17 @@ discover and start the session without relying on same-LAN mDNS.
       and confirm **Bluetooth is on**.
 - [ ] On the **WVMG device**: open the system share sheet for the file
       under test and route into `SendActivity`.
-- [ ] Wait for the peer row to appear in the picker. If the row appears
-      but is disabled, record that as a partial discovery result and
-      capture the discovery log before continuing.
-- [ ] Capture `adb logcat -s WvmgOutbound WvmgBtScan WvmgBleFastScan`
+- [ ] Wait for the peer row to appear in the picker. A BLE-only stock
+      receiver with no L2CAP PSM should stay disabled until WVMG verifies
+      the Nearby GATT socket service, then surface as a direct
+      `BLE GATT <mac>` route.
+- [ ] Capture `adb logcat -s WvmgOutbound WvmgBtScan WvmgBleFastScan WvmgBleGattClient`
       while the picker is open. Record the discovery surfaces reported
       in the `picked target:` line's `mediums=[...]` field.
 - [ ] Select the peer row and record the initial control route from the
-      same `picked target:` line. For the off-LAN bootstrap path it
-      should show `route=bluetooth=<mac>` unless the devices happen to
-      regain LAN reachability.
+      same `picked target:` line. For the stock BLE-only bootstrap path it
+      should show `route=ble-gatt=<mac>` and
+      `bootstrap={selected=ble-gatt rejected=[wifi-lan=missing, ble-l2cap=peer-psm-missing]}`.
 - [ ] Confirm the 4-digit PIN matches on both devices.
 - [ ] Wait for the transfer to complete and verify the received file's
       SHA-256 hash on the peer.
@@ -166,6 +167,39 @@ discover and start the session without relying on same-LAN mDNS.
       and any `medium-upgrade:` lines in `WvmgOutbound`.
 - [ ] Immediately rerun the same peer pair on a **shared LAN** and
       confirm the regression path still chooses `route=lan=<ip>:<port>`.
+
+#### BLE-only / no-shared-LAN sender repro (#143)
+
+Use this focused checklist when the stock receiver is visible only
+through BLE advertisements and does not expose a direct LAN or peer-PSM
+route.
+
+- [ ] Connect two adb devices and export serials:
+      `export VIVO_SERIAL=<wvmg-sender-serial>`
+      `export STOCK_SERIAL=<stock-receiver-serial>`
+- [ ] Confirm the devices do **not** share a usable LAN route:
+      `adb -s "$VIVO_SERIAL" shell ip route`
+      `adb -s "$STOCK_SERIAL" shell ip route`
+- [ ] Open the stock Quick Share receive UI on the receiver and keep it
+      visible.
+- [ ] Start `adb -s "$VIVO_SERIAL" logcat -c` and then capture:
+      `adb -s "$VIVO_SERIAL" logcat -s WvmgOutbound WvmgDiscovery WvmgBleFastScan WvmgBleGattClient WvmgBleL2cap`
+- [ ] Launch WVMG's send flow on the vivo and wait for the receiver row.
+      The discovery log should first show an observation-only BLE peer,
+      then either `slot-read service discovered socket=true ...` or
+      `BLE GATT socket service verified ...` once the stock receiver's
+      Nearby GATT socket service is confirmed.
+- [ ] Tap the receiver row. Record:
+      `picked target: ... route=ble-gatt=<mac> ... bootstrap={selected=ble-gatt ...}`
+- [ ] Confirm WVMG then logs `BLE GATT initial connect ready`, followed by
+      `step 1: initial transport open medium=BLE` and
+      `step 2: UKEY2 client handshake complete`.
+- [ ] Verify there is **no** `ConnectionRequest` / UKEY2 hang on a
+      dead header-only path. Header-only BLE/GATT observations must stay
+      disabled unless the slot probe yields an advertisement or verifies
+      the socket service for a visible receiver.
+- [ ] Continue through PIN confirmation and verify the received file hash
+      on the stock receiver.
 
 ### Legacy fallback: QR-code path
 

--- a/docs/testing/interop-stock-quick-share-android.md
+++ b/docs/testing/interop-stock-quick-share-android.md
@@ -14,9 +14,12 @@ the [Phase 1 epic](https://github.com/kyujin-cho/WhenVivoMeetsGoogle/issues/1).
 > Issue #137 adds a sender-side non-LAN bootstrap path: WVMG can now
 > discover stock peers through Bluetooth-adjacent discovery surfaces and
 > start the initial control channel without requiring the same Wi-Fi LAN.
+> Issue #145 adds the reciprocal receiver path for stock Samsung senders:
+> WVMG can be discovered through the stock Quick Share picker, accept the
+> initial BLE GATT socket, and hand the transfer off to Wi-Fi Direct.
 > Shared-LAN mDNS is still the baseline regression path, and stock sender
-> -> WVMG receiver regression should still be exercised on a shared LAN
-> unless a future issue changes the receiver-side bootstrap story.
+> -> WVMG receiver regression should now be exercised both on a shared
+> LAN and on the BLE GATT -> Wi-Fi Direct path when hardware supports it.
 
 ---
 
@@ -49,6 +52,11 @@ Two network topologies matter now:
 - [ ] Both devices have **Wi-Fi turned on**.
 - [ ] For the **off-LAN sender** cells, both devices also have
       **Bluetooth turned on**.
+- [ ] For the **stock sender -> WVMG receiver BLE GATT** cells, Bluetooth
+      is on for discovery/bootstrap, and Wi-Fi Direct is available on
+      both devices for the bandwidth upgrade. The sender's infrastructure
+      Wi-Fi may be off; the transfer should still complete after the
+      Wi-Fi Direct handoff.
 - [ ] Location permission is granted to Google Play Services on the
       stock device (Quick Share requires it for Wi-Fi scans).
 
@@ -110,7 +118,7 @@ Every cell in the matrix must be exercised once per RC build.
 | 3 | WVMG -> Samsung  | Samsung | Shared-LAN picker / mDNS regression      | Everyone                   |        |
 | 4 | WVMG -> Samsung  | Samsung | Off-LAN sender bootstrap (#137)          | Everyone                   |        |
 | 5 | Pixel -> WVMG    | Pixel   | Pixel device picker                      | n/a (sender side picks us) |        |
-| 6 | Samsung -> WVMG  | Samsung | Samsung Quick Share UI                   | n/a                        |        |
+| 6 | Samsung -> WVMG  | Samsung | Samsung Quick Share UI / BLE GATT -> Wi-Fi Direct | n/a                        |        |
 
 For each cell, run **both** a small file (≤ 1 MB, e.g. a JPEG) and a
 large file (≥ 200 MB, e.g. a video). The large-file run is what catches
@@ -167,6 +175,56 @@ discover and start the session without relying on same-LAN mDNS.
       and any `medium-upgrade:` lines in `WvmgOutbound`.
 - [ ] Immediately rerun the same peer pair on a **shared LAN** and
       confirm the regression path still chooses `route=lan=<ip>:<port>`.
+
+### Test 5 / Test 6: Receive file from a stock Android phone
+
+Use this checklist for the stock sender -> WVMG receiver path. It covers
+the shared-LAN regression and the BLE GATT -> Wi-Fi Direct receiver path.
+
+- [ ] Install the WVMG debug APK on the receiver and start the receiver
+      foreground service. If the install stalls on vivo for more than 5 s,
+      clear the vendor Security Care consent prompt and continue.
+- [ ] Open WVMG on the receiver and enable **Always Visible**.
+- [ ] Capture receiver logs:
+      `adb logcat -s WvmgBleGatt WvmgBleAdv WvmgMdnsGate WvmgDiscovery WvmgReceive WvmgInbound WvmgWifiDirect`
+- [ ] Capture Samsung sender logs:
+      `adb logcat -s NearbySharing ShareLive NearbyConnections NearbyMediums BtGatt BluetoothGatt WifiP2pService WifiDirectController`
+- [ ] On the stock sender, share a small file through the Samsung Quick
+      Share UI and select the WVMG row.
+- [ ] Confirm the BLE GATT bootstrap reaches WVMG. Receiver logs should
+      show a CCCD write on `00000100-0004-1000-8000-001a11000102`, a
+      write on `00000100-0004-1000-8000-001a11000101`, and
+      `BLE socket introduction accepted`.
+- [ ] Confirm the transfer upgrades to Wi-Fi Direct. Receiver logs should
+      show `WifiP2pManager.createGroup onSuccess`, a `Wi-Fi Direct group
+      ready` line, `medium-upgrade: server offering WIFI_DIRECT`, and
+      `medium-upgrade: server completed WIFI_DIRECT`.
+- [ ] On the sender, confirm the channel changes from encrypted BLE to
+      encrypted Wi-Fi Direct, then the Quick Share UI reports **Sent**.
+- [ ] On the receiver, accept consent, wait for `Completed`, and verify
+      the received file's SHA-256 hash matches the sender source.
+
+#### Validated BLE GATT -> Wi-Fi Direct receiver result (#145)
+
+2026-05-02 actual-device run:
+
+- **Sender:** Galaxy S26 Ultra (`SM-S948N`) using Samsung ShareLive /
+  stock Quick Share.
+- **Receiver:** vivo X300 Ultra (`V2547A`) running WVMG debug.
+- **Topology:** Galaxy Wi-Fi disabled, Bluetooth on; receiver formed the
+  Wi-Fi Direct group after BLE GATT bootstrap.
+- **Receiver evidence:** WVMG published the regular `0xFEF3` slot service
+  and the Nearby second-profile socket service
+  `0000fef3-0004-1000-8000-001a11000100`; Samsung wrote the socket CCCD
+  and TO-peripheral characteristic, WVMG logged
+  `BLE socket using raw Nearby stream`, then completed `WIFI_DIRECT`.
+- **Sender evidence:** Samsung logged a successful connection to
+  `DIRECT-pX-WVMG-PlRuIQ` and replaced the endpoint channel from
+  `ENCRYPTED_BLE` to `ENCRYPTED_WIFI_DIRECT`; ShareLive reported `Sent`.
+- **Payload evidence:** `issue-145-galaxy-to-vivo-repro.txt` was written
+  to `/sdcard/Download/WVMG/` with 52 bytes and SHA-256
+  `95e6c8f9462c24715a79e956b92956d7ce4f0677a0f8cf37284ce1a145e8e648`,
+  matching the Galaxy source file.
 
 #### BLE-only / no-shared-LAN sender repro (#143)
 

--- a/docs/testing/medium-wifi-direct.md
+++ b/docs/testing/medium-wifi-direct.md
@@ -187,3 +187,11 @@ adb logcat -s WvmgOutbound | grep -E 'UPGRADE_FAILURE|UpgradeAborted'
   this is not an issue in practice; if you see missed broadcasts on a
   vivo device, double-check the receiver lifecycle isn't tied to an
   activity.
+* **vivo X300 Ultra / Funtouch OS** may leave Wi-Fi Direct in a disabled
+  state until a peer-discovery operation primes the P2P stack. The
+  receiver path now calls `discoverPeers`, waits briefly for
+  `WIFI_P2P_STATE_CHANGED state=2`, stops discovery, removes any stale
+  group, and only then calls `createGroup`. In a successful Galaxy ->
+  vivo BLE GATT handoff, `WvmgWifiDirect` should show
+  `discoverPeers onSuccess`, `stopPeerDiscovery onSuccess`, and
+  `createGroup onSuccess` before the group-ready line.

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/MdnsAdvertisementGate.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/MdnsAdvertisementGate.kt
@@ -118,6 +118,9 @@ public class MdnsAdvertisementGate(
     @Volatile
     private var debounceJob: Job? = null
 
+    @Volatile
+    private var bleAdvertising: Boolean = false
+
     /**
      * Serialises [apply] across the three child collectors so a racing
      * BLE/override/QR transition cannot interleave the
@@ -233,6 +236,11 @@ public class MdnsAdvertisementGate(
             // "should publish" half of the gate.
             debounceJob?.cancel()
             debounceJob = null
+            // Bring up BLE before the potentially slow mDNS path. Some
+            // vivo builds stall inside NsdManager registration; the
+            // receiver still needs to be BLE GATT connectible while that
+            // platform callback is pending.
+            startBleSafely(decision)
             if (!session.isAdvertising) {
                 try {
                     session.publishAdvertisement()
@@ -245,11 +253,6 @@ public class MdnsAdvertisementGate(
                     Log.w(TAG, "publish: failed (decision=$decision)", t)
                 }
             }
-            // Symmetric BLE advertise — start in lock-step with the
-            // mDNS publish. The broadcaster is itself idempotent, so
-            // re-issuing start() while it is already advertising is a
-            // no-op on the platform.
-            startBleSafely(decision)
             return
         }
 
@@ -260,7 +263,10 @@ public class MdnsAdvertisementGate(
         // the returning `if (shouldPublish)` block above push the
         // function past detekt's default of 2; suppressed inline since
         // the alternative (nested if/else) would be harder to read.
-        if (!session.isAdvertising) return
+        if (!session.isAdvertising) {
+            stopBleSafely(reason = "idle with no mDNS advertisement")
+            return
+        }
         if (debounceJob?.isActive == true) return
         debounceJob =
             scope.launch {
@@ -296,6 +302,7 @@ public class MdnsAdvertisementGate(
         try {
             val started = bleBroadcaster.start()
             if (started) {
+                bleAdvertising = true
                 Log.w(TAG, "publish: BLE pulse advertise started (decision=$decision)")
             } else {
                 Log.w(TAG, "publish: BLE pulse advertise unavailable (decision=$decision)")
@@ -312,8 +319,10 @@ public class MdnsAdvertisementGate(
      */
     @Suppress("TooGenericExceptionCaught")
     private fun stopBleSafely(reason: String) {
+        if (!bleAdvertising) return
         try {
             bleBroadcaster.stop()
+            bleAdvertising = false
             Log.w(TAG, "unpublish: BLE pulse advertise stopped ($reason)")
         } catch (t: Throwable) {
             Log.w(TAG, "unpublish: BLE pulse advertise stop threw ($reason)", t)

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverForegroundService.kt
@@ -28,7 +28,6 @@ import io.github.kyujincho.wvmg.discovery.Discovery
 import io.github.kyujincho.wvmg.discovery.ble.BleQuickShareAdvertiser
 import io.github.kyujincho.wvmg.discovery.ble.BleQuickShareScanner
 import io.github.kyujincho.wvmg.discovery.bootstrap.BleGattInitialControlServer
-import io.github.kyujincho.wvmg.discovery.bootstrap.BleL2capInitialControlServer
 import io.github.kyujincho.wvmg.discovery.medium.MediumRegistries
 import io.github.kyujincho.wvmg.protocol.endpoint.BleServiceData
 import io.github.kyujincho.wvmg.protocol.endpoint.DctAdvertisement
@@ -835,9 +834,10 @@ public class ReceiverForegroundService : Service() {
                     mediumRegistry = MediumRegistries.defaultForContext(context.applicationContext),
                     initialControlServers =
                         listOf(
-                            BleL2capInitialControlServer(
-                                context = context.applicationContext,
-                            ),
+                            // Keep the production receiver bootstrap GATT-only for now.
+                            // Advertising an LE CoC PSM makes One UI prefer L2CAP over
+                            // the verified GATT socket path and fail before protocol
+                            // consent reaches the app.
                             BleGattInitialControlServer(
                                 context = context.applicationContext,
                                 endpointIdProvider = { BleEndpointIdHolder.bytesFor(identity) },

--- a/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverSession.kt
+++ b/service-android/src/main/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverSession.kt
@@ -336,12 +336,29 @@ public class ReceiverSession(
 
     private val advertiseLock: Any = Any()
 
+    @Suppress("TooGenericExceptionCaught")
     private fun publishAdvertisementLocked(
         tcpServer: TcpReceiverServer,
         port: Int,
     ) {
-        advertiseHandle = advertiser.advertise(endpointInfo, port)
-        ReceiverAdvertisementStateHolder.setAdvertising(true)
+        // Bring up BLE GATT / other initial-control listeners before
+        // the mDNS registration call. Some Android builds can leave
+        // NsdManager registration pending for a long time; the
+        // receiver should still be connectible over BLE GATT while
+        // that platform callback is pending.
+        startInitialControlServersLocked(tcpServer)
+        try {
+            advertiseHandle = advertiser.advertise(endpointInfo, port)
+            ReceiverAdvertisementStateHolder.setAdvertising(true)
+        } catch (t: Throwable) {
+            advertiseHandle = null
+            stopInitialControlServersLocked()
+            ReceiverAdvertisementStateHolder.setAdvertising(false)
+            throw t
+        }
+    }
+
+    private fun startInitialControlServersLocked(tcpServer: TcpReceiverServer) {
         for (initialControlServer in initialControlServers) {
             if (initialControlServer.isActive) continue
             runCatching {

--- a/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/MdnsAdvertisementGateTest.kt
+++ b/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/MdnsAdvertisementGateTest.kt
@@ -527,6 +527,37 @@ class MdnsAdvertisementGateTest {
             session.stop()
         }
 
+    @Test
+    fun `BLE broadcaster starts even when mDNS publish fails`() =
+        runTest {
+            val session = startedGatedSession(advertiser = ThrowingAdvertiser())
+            val ble = MutableStateFlow<ScanActivity>(ScanActivity.Idle)
+            val override = MutableStateFlow(true)
+            val qr = MutableStateFlow(false)
+            val broadcaster = RecordingBleBroadcaster()
+
+            val gate =
+                MdnsAdvertisementGate(
+                    session = session,
+                    bleActivity = ble,
+                    alwaysVisibleOverride = override,
+                    qrSessionActive = qr,
+                    bleBroadcaster = broadcaster,
+                )
+            gate.start(this)
+            advanceUntilIdle()
+
+            assertThat(session.isAdvertising).isFalse()
+            assertThat(broadcaster.startCount).isAtLeast(1)
+
+            override.value = false
+            advanceUntilIdle()
+            assertThat(broadcaster.stopCount).isEqualTo(1)
+
+            gate.stop()
+            session.stop()
+        }
+
     // --------------------------------------------------------------
     // Helpers
     // --------------------------------------------------------------
@@ -536,7 +567,7 @@ class MdnsAdvertisementGateTest {
      * start it (so the TCP listener binds), and return it ready for the
      * gate to drive publish/unpublish against.
      */
-    private fun startedGatedSession(advertiser: RecordingAdvertiser): ReceiverSession {
+    private fun startedGatedSession(advertiser: DiscoveryAdvertiser): ReceiverSession {
         val session =
             ReceiverSession(
                 tcpServerFactory =
@@ -599,6 +630,13 @@ class MdnsAdvertisementGateTest {
             calls += Call(endpointInfo, port, handle)
             return handle
         }
+    }
+
+    private class ThrowingAdvertiser : DiscoveryAdvertiser {
+        override fun advertise(
+            endpointInfo: EndpointInfo,
+            port: Int,
+        ): AdvertiseHandle = error("synthetic mDNS publish failure")
     }
 
     /**

--- a/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverSessionTest.kt
+++ b/service-android/src/test/kotlin/io/github/kyujincho/wvmg/service/receiver/ReceiverSessionTest.kt
@@ -325,6 +325,72 @@ class ReceiverSessionTest {
         }
 
     @Test
+    fun `gated publish starts initial control servers before mDNS advertise`() =
+        runBlocking {
+            val order = mutableListOf<String>()
+            val advertiser =
+                object : DiscoveryAdvertiser {
+                    override fun advertise(
+                        endpointInfo: EndpointInfo,
+                        port: Int,
+                    ): AdvertiseHandle {
+                        order += "mdns"
+                        return FakeAdvertiseHandle(port = port)
+                    }
+                }
+            val initialControlServer =
+                object : RecordingInitialControlServer() {
+                    override fun start(
+                        endpointInfo: EndpointInfo,
+                        acceptTransport: (ConnectedTransport) -> Unit,
+                    ): Boolean {
+                        order += "initial-control"
+                        return super.start(endpointInfo, acceptTransport)
+                    }
+                }
+            val session =
+                makeSession(
+                    advertiser = advertiser,
+                    advertiseGated = true,
+                    initialControlServers = listOf(initialControlServer),
+                )
+
+            session.start()
+            session.publishAdvertisement()
+
+            assertThat(order).containsExactly("initial-control", "mdns").inOrder()
+
+            session.stop()
+        }
+
+    @Test
+    fun `gated publish rolls back initial control servers when mDNS advertise fails`() =
+        runBlocking {
+            val initialControlServer = RecordingInitialControlServer()
+            val session =
+                makeSession(
+                    advertiser =
+                        object : DiscoveryAdvertiser {
+                            override fun advertise(
+                                endpointInfo: EndpointInfo,
+                                port: Int,
+                            ): AdvertiseHandle = error("synthetic mDNS publish failure")
+                        },
+                    advertiseGated = true,
+                    initialControlServers = listOf(initialControlServer),
+                )
+
+            session.start()
+
+            assertThrows<IllegalStateException> { session.publishAdvertisement() }
+            assertThat(session.isAdvertising).isFalse()
+            assertThat(initialControlServer.stopCount).isEqualTo(1)
+            assertThat(initialControlServer.isActive).isFalse()
+
+            session.stop()
+        }
+
+    @Test
     fun `initial control transports are injected into active connection flow`() =
         runBlocking {
             val initialControlServer = RecordingInitialControlServer()
@@ -504,7 +570,7 @@ class ReceiverSessionTest {
         }
     }
 
-    private class RecordingInitialControlServer : InitialControlServer {
+    private open class RecordingInitialControlServer : InitialControlServer {
         data class StartCall(
             val endpointInfo: EndpointInfo,
         )


### PR DESCRIPTION
## Summary
- Parse stock BLE advertisement bodies and verify the Nearby GATT socket service before enabling no-PSM BLE peers.
- Route visible BLE-only stock receivers through the BLE GATT initial-control client while keeping observation-only rows disabled with explicit diagnostics.
- Add sender bootstrap planning, handshake/acceptance timeouts, regression coverage, and the BLE-only no-LAN interop checklist.

Fixes #143

## Verification
- ./gradlew :core-protocol:test :discovery-android:testDebugUnitTest --tests 'io.github.kyujincho.wvmg.discovery.ble.BleFastAdvertisementScannerTest' --tests 'io.github.kyujincho.wvmg.discovery.NearbyPeerDiscoveryTest' :app:testDebugUnitTest --tests 'io.github.kyujincho.wvmg.send.SendBootstrapPlanTest' staticAnalysis :app:assembleDebug\n- ./gradlew check\n- Actual devices, 2026-05-01: vivo X300 Ultra -> Galaxy S26 Ultra off-LAN transfer selected `route=ble-gatt=3F:DE:01:35:25:C9`, opened `medium=BLE`, completed UKEY2, and sent `issue-143-ble-gatt.txt`.\n- SHA-256 matched on sender and receiver: `d7c9a4f1bd321b6223f91255138650d1e3b930ec4d5e62141c3cba0f0ff25671`.\n- Receiver saved the file at `/sdcard/Download/Quick Share/issue-143-ble-gatt.txt` with size 40 bytes.