### PR TITLE
fix: complete Galaxy to vivo BLE GATT handoff

### DIFF
--- a/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendActivity.kt
+++ b/app/src/main/kotlin/io/github/kyujincho/wvmg/send/SendActivity.kt
@@ -285,8 +285,12 @@ public class SendActivity : AppCompatActivity() {
         val targetSnapshot = peerPickerController.formatPeerSnapshot(peer, chosenRoute)
         Log.e(OUTBOUND_TAG, "picked target: $targetSnapshot")
         appendOutboundLog("picked target: $targetSnapshot")
-        // Stop discovery once we've made our pick.
+        // Stop discovery and the wake-up pulse once we've made our pick.
+        // BLE GATT bootstrap reuses the Bluetooth controller immediately;
+        // leaving the pulse active during the dial adds avoidable role
+        // churn on stock Quick Share receivers.
         peerPickerController.suspendPicker()
+        peerPickerController.stopBleAdvertise()
 
         // Hide the picker chrome.
         binding.sendPeerList.isVisible = false
@@ -362,9 +366,9 @@ public class SendActivity : AppCompatActivity() {
                 binding.sendStatusMessage.text = peerPickerController.peerSubtitle(peer)
             }
             OutboundConnectionState.Handshaking -> {
-                // TCP socket is up — the BLE wake-up pulse has done its
-                // job, stop broadcasting (#32 acceptance: stops as soon
-                // as the TCP connection to a recipient is established).
+                // The transport is up. The wake-up pulse is already
+                // stopped on selection; keep this idempotent call for any
+                // older path that reaches Handshaking without a picker tap.
                 peerPickerController.stopBleAdvertise()
                 binding.sendStatusPhase.setText(R.string.send_phase_handshaking)
                 binding.sendPin.visibility = View.GONE

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeFrames.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeFrames.kt
@@ -9,6 +9,8 @@ package io.github.kyujincho.wvmg.protocol.connection
 
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.BandwidthUpgradeNegotiationFrame
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.BandwidthUpgradeNegotiationFrame.UpgradePathInfo
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.MediumMetadata
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.MediumRole
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.V1Frame
 import com.google.protobuf.ByteString
@@ -75,6 +77,38 @@ public object BandwidthUpgradeFrames {
                 .setEventType(BandwidthUpgradeNegotiationFrame.EventType.UPGRADE_PATH_AVAILABLE)
                 .setUpgradePathInfo(info)
                 .build(),
+        )
+    }
+
+    /**
+     * Build `OfflineFrame{BANDWIDTH_UPGRADE_NEGOTIATION{
+     * event_type=UPGRADE_PATH_REQUEST, upgrade_path_info{
+     * upgrade_path_request{mediums=...}}}}`.
+     *
+     * Sent by a BLE/GATT sender after the encrypted channel is ready
+     * when the opening `ConnectionRequest.mediums` cannot safely include
+     * Wi-Fi Direct. The receiver remains the Nearby Connections server
+     * role and answers with `UPGRADE_PATH_AVAILABLE` if it can stand up
+     * one of the requested mediums.
+     */
+    public fun upgradePathRequest(requestedMediums: Set<Medium>): OfflineFrame {
+        val request =
+            UpgradePathInfo.UpgradePathRequest
+                .newBuilder()
+                .setMediumMetaData(defaultUpgradeRequestMetadata(requestedMediums))
+        requestedMediums
+            .map { it.toUpgradePathMedium() }
+            .sortedBy { it.number }
+            .forEach(request::addMediums)
+        return wrap(
+            BandwidthUpgradeNegotiationFrame
+                .newBuilder()
+                .setEventType(BandwidthUpgradeNegotiationFrame.EventType.UPGRADE_PATH_REQUEST)
+                .setUpgradePathInfo(
+                    UpgradePathInfo
+                        .newBuilder()
+                        .setUpgradePathRequest(request),
+                ).build(),
         )
     }
 
@@ -364,6 +398,30 @@ public object BandwidthUpgradeFrames {
     }
 
     /**
+     * Decode the medium set from an inbound `UPGRADE_PATH_REQUEST`.
+     * Returns `null` for any other frame shape.
+     */
+    @Suppress("ReturnCount")
+    public fun decodeUpgradePathRequestMediums(frame: OfflineFrame): Set<Medium>? {
+        if (!frame.hasV1() || frame.v1.type != V1Frame.FrameType.BANDWIDTH_UPGRADE_NEGOTIATION) {
+            return null
+        }
+        val negotiation = frame.v1.bandwidthUpgradeNegotiation
+        if (negotiation.eventType != BandwidthUpgradeNegotiationFrame.EventType.UPGRADE_PATH_REQUEST) {
+            return null
+        }
+        if (!negotiation.hasUpgradePathInfo() || !negotiation.upgradePathInfo.hasUpgradePathRequest()) {
+            return emptySet()
+        }
+        return negotiation
+            .upgradePathInfo
+            .upgradePathRequest
+            .mediumsList
+            .mapNotNull { Medium.fromUpgradePathMedium(it) }
+            .toSet()
+    }
+
+    /**
      * Parse a BLE-L2CAP-shaped `BluetoothCredentials` payload back into
      * [UpgradePathCredentials.BleL2cap]. Returns `null` when the proto
      * does not carry the `L2CAP:<psm>` discriminator (i.e. it really is
@@ -537,6 +595,23 @@ public object BandwidthUpgradeFrames {
         }
         return builder.build()
     }
+
+    private fun defaultUpgradeRequestMetadata(requestedMediums: Set<Medium>): MediumMetadata =
+        MediumMetadata
+            .newBuilder()
+            .also { builder ->
+                if (Medium.WIFI_DIRECT in requestedMediums) {
+                    builder.addSupportedWifiDirectAuthTypes(
+                        MediumMetadata.WifiDirectAuthType.WIFI_DIRECT_WITH_PASSWORD,
+                    )
+                    builder.setMediumRole(
+                        MediumRole
+                            .newBuilder()
+                            .setSupportWifiDirectGroupClient(true)
+                            .setSupportWifiDirectGroupOwner(true),
+                    )
+                }
+            }.build()
 
     /**
      * Serialize the publisher-side IPv6 + port pair into the byte layout

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeOrchestrator.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeOrchestrator.kt
@@ -248,8 +248,11 @@ internal object BandwidthUpgradeOrchestrator {
         closePriorChannelAfterUpgrade(oldChannel, consumedPeerSafe = true, logger = logger)
     }
 
-    suspend fun receiveOfferProbe(channel: SecureChannel): UpgradeOfferProbe =
-        withTimeoutOrNull(OFFER_WAIT_TIMEOUT_MILLIS) {
+    suspend fun receiveOfferProbe(
+        channel: SecureChannel,
+        timeoutMillis: Long = OFFER_WAIT_TIMEOUT_MILLIS,
+    ): UpgradeOfferProbe =
+        withTimeoutOrNull(timeoutMillis) {
             val frame = channel.receiveOfflineFrame()
             if (frame.isBandwidthUpgradeEvent(BandwidthUpgradeNegotiationFrame.EventType.UPGRADE_PATH_AVAILABLE)) {
                 UpgradeOfferProbe.Offer(frame)
@@ -625,7 +628,7 @@ internal object BandwidthUpgradeOrchestrator {
     }
 
     private const val UPGRADE_TIMEOUT_MILLIS: Long = 30_000L
-    private const val OFFER_WAIT_TIMEOUT_MILLIS: Long = 1_500L
+    internal const val OFFER_WAIT_TIMEOUT_MILLIS: Long = 1_500L
     private const val SERVER_PEER_SAFE_DRAIN_MILLIS: Long = 500L
     private const val PRIOR_CHANNEL_DISCONNECT_DRAIN_MILLIS: Long = 200L
     private const val DUAL_CHANNEL_DRAIN_IDLE_ATTEMPTS: Int = 25

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/InboundConnectionDriver.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/InboundConnectionDriver.kt
@@ -235,7 +235,17 @@ internal class InboundConnectionDriver(
         // immediately after connection success, before it processes our
         // bandwidth-upgrade offer. Drain one already-buffered frame so the
         // SecureMessage receive sequence remains aligned across the upgrade.
+        // BLE/GATT senders may also send UPGRADE_PATH_REQUEST here when
+        // their opening ConnectionRequest had to omit higher-bandwidth
+        // mediums for receiver compatibility; consume that request and use
+        // it as the upgrade candidate set instead of buffering it into the
+        // later sharing loop.
         val initialWireFrame = pollBufferedInitialWireFrame(channel)
+        val requestedUpgradeMediums =
+            initialWireFrame?.let(BandwidthUpgradeFrames::decodeUpgradePathRequestMediums)
+        if (requestedUpgradeMediums != null) {
+            logger("medium-upgrade: peer requested upgrade mediums=$requestedUpgradeMediums")
+        }
 
         // Step 7: as the Nearby Connections server role, offer the best
         // prepared upgrade medium before the Nearby Share payload
@@ -249,7 +259,7 @@ internal class InboundConnectionDriver(
                     oldChannel = channel,
                     currentMedium = transport.medium,
                     mediumRegistry = mediumRegistry,
-                    peerSupportedMediums = peerSupportedMediums,
+                    peerSupportedMediums = requestedUpgradeMediums ?: peerSupportedMediums,
                     peerEndpointId = initialFrame.v1.connectionRequest.endpointId,
                     logger = logger,
                 )
@@ -257,7 +267,9 @@ internal class InboundConnectionDriver(
         mutableActiveMedium.value = activeTransport.medium
         val initialWireFrames =
             buildList {
-                initialWireFrame?.let(::add)
+                if (requestedUpgradeMediums == null) {
+                    initialWireFrame?.let(::add)
+                }
                 addAll(activeTransport.bufferedFrames)
             }
 

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionDriver.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionDriver.kt
@@ -5,6 +5,7 @@
  */
 package io.github.kyujincho.wvmg.protocol.connection
 
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.BandwidthUpgradeNegotiationFrame
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.V1Frame
 import com.google.protobuf.ByteString
@@ -119,6 +120,7 @@ internal class OutboundConnectionDriver(
      * [OutboundResult]; throws on coroutine cancellation (handled by
      * the caller).
      */
+    @Suppress("ReturnCount")
     suspend fun runLifecycle(): OutboundResult {
         mutableState.value = OutboundConnectionState.Handshaking
         logger(
@@ -127,24 +129,15 @@ internal class OutboundConnectionDriver(
         )
         val transport = FramedConnection(initialTransport).also { framedConnection = it }
 
-        // Step 1: send unencrypted ConnectionRequest. The mediums set
-        // is sourced from the registry's current-medium-aware view:
-        // WIFI_LAN only means "stay on the already-open LAN socket", so
-        // a Bluetooth/BLE bootstrap must not advertise it as an
-        // off-LAN upgrade option. Phase 4's per-medium adapters extend
-        // the set by registering against the registry; absent any extra
-        // provider this is functionally identical to the previous
-        // hard-coded `[WIFI_LAN]` on the legacy LAN path.
-        val advertisedMediums =
-            mediumRegistry
-                .supportedMediumsForCurrentTransport(initialTransport.medium)
-                .let { supportedMediums ->
-                    if (initialTransport.medium == Medium.BLE && Medium.BLE in supportedMediums) {
-                        linkedSetOf(Medium.BLE)
-                    } else {
-                        supportedMediums
-                    }
-                }
+        // Step 1: send unencrypted ConnectionRequest. BLE/GATT
+        // bootstraps still carry the legacy Wi-Fi LAN marker because
+        // stock Quick Share validates that shape before it dispatches
+        // the incoming connection. When a local Wi-Fi Direct provider
+        // is registered, advertise WFD in this opening request as well,
+        // then send a post-accept UPGRADE_PATH_REQUEST if the receiver
+        // does not proactively offer Wi-Fi Direct before payload
+        // streaming.
+        val advertisedMediums = advertisedMediumsForInitialTransport()
         logger("step 1: advertising mediums=$advertisedMediums")
         transport.sendFrame(
             OutboundFrames
@@ -206,7 +199,16 @@ internal class OutboundConnectionDriver(
         // adopt it before the Nearby Share payload negotiation begins.
         // Peers that stay on Wi-Fi LAN send the first sharing payload;
         // buffer that frame so the existing receive loop sees it.
-        val (activeChannel, initialWireFrames) = negotiateBandwidthUpgrade(channel)
+        val negotiated =
+            when (val negotiation = negotiateBandwidthUpgrade(channel)) {
+                is BandwidthNegotiation.Ready -> negotiation
+                is BandwidthNegotiation.Failed -> {
+                    logger("medium-upgrade: ${negotiation.reason}")
+                    runCatching { sendTerminalDisconnection(channel) }
+                    mutableState.value = OutboundConnectionState.Failed(negotiation.reason)
+                    return OutboundResult.Failed(negotiation.reason)
+                }
+            }
 
         // Step 8: build the OutboundSharingFsm with our IntroductionFrame.
         val introduction = buildIntroductionFrame(files)
@@ -217,7 +219,7 @@ internal class OutboundConnectionDriver(
         // Step 9: drive the FSM's initial PKE frame onto the wire,
         // optionally attaching qr_code_handshake_data.
         logger("step 8: sending initial PKE frame")
-        applyEffects(activeChannel, rewriteForQrIfNeeded(negotiationFsm.start()))
+        applyEffects(negotiated.channel, rewriteForQrIfNeeded(negotiationFsm.start()))
 
         // Mark the handshake as complete so a racing UI-side cancel()
         // takes the cooperative FSM path (CANCEL + DISCONNECTION on the
@@ -233,35 +235,78 @@ internal class OutboundConnectionDriver(
         // cancel() in that race would crash the peer with Broken pipe.
         onHandshakeComplete()
 
-        return runReceiveLoop(activeChannel, negotiationFsm, initialWireFrames)
+        return if (requiresWifiDirectUpgradeForBle() && negotiated.medium != Medium.WIFI_DIRECT) {
+            runBleWifiDirectReceiveLoop(
+                channel = negotiated.channel,
+                fsm = negotiationFsm,
+                initialWireFrames = negotiated.initialWireFrames,
+            )
+        } else {
+            runReceiveLoop(negotiated.channel, negotiationFsm, negotiated.initialWireFrames)
+        }
     }
 
-    private suspend fun negotiateBandwidthUpgrade(channel: SecureChannel): Pair<SecureChannel, List<OfflineFrame>> {
+    private fun advertisedMediumsForInitialTransport(): Set<Medium> {
+        val supportedMediums =
+            mediumRegistry.supportedMediumsForCurrentTransport(initialTransport.medium)
+        if (initialTransport.medium != Medium.BLE) return supportedMediums
+
+        return buildSet {
+            add(Medium.WIFI_LAN)
+            add(Medium.BLE)
+            if (Medium.WIFI_DIRECT in supportedMediums) {
+                add(Medium.WIFI_DIRECT)
+            }
+        }
+    }
+
+    private suspend fun negotiateBandwidthUpgrade(channel: SecureChannel): BandwidthNegotiation {
         val initialWireFrames = mutableListOf<OfflineFrame>()
-        val activeChannel =
-            when (val probe = BandwidthUpgradeOrchestrator.receiveOfferProbe(channel)) {
-                UpgradeOfferProbe.None -> channel
+        val requiresWifiDirect = requiresWifiDirectUpgradeForBle()
+        val activeTransport =
+            when (
+                val probe =
+                    BandwidthUpgradeOrchestrator.receiveOfferProbe(
+                        channel = channel,
+                        timeoutMillis =
+                            if (requiresWifiDirect) {
+                                BLE_WIFI_DIRECT_UPGRADE_TIMEOUT_MILLIS
+                            } else {
+                                BandwidthUpgradeOrchestrator.OFFER_WAIT_TIMEOUT_MILLIS
+                            },
+                    )
+            ) {
+                UpgradeOfferProbe.None -> ActiveTransportChannel(channel, initialTransport.medium)
                 is UpgradeOfferProbe.Other -> {
                     initialWireFrames += probe.frame
-                    channel
+                    ActiveTransportChannel(channel, initialTransport.medium)
                 }
                 is UpgradeOfferProbe.Offer -> {
-                    val activeTransport =
-                        BandwidthUpgradeOrchestrator
-                            .runClientUpgradeFromOffer(
-                                oldChannel = channel,
-                                currentMedium = initialTransport.medium,
-                                offer = probe.frame,
-                                mediumRegistry = mediumRegistry,
-                                endpointId = endpointId,
-                                logger = logger,
-                            )
-                    initialWireFrames += activeTransport.bufferedFrames
-                    activeTransport.channel.also { secureChannel = it }
+                    val transport =
+                        BandwidthUpgradeOrchestrator.runClientUpgradeFromOffer(
+                            oldChannel = channel,
+                            currentMedium = initialTransport.medium,
+                            offer = probe.frame,
+                            mediumRegistry = mediumRegistry,
+                            endpointId = endpointId,
+                            logger = logger,
+                        )
+                    if (requiresWifiDirect && transport.medium != Medium.WIFI_DIRECT) {
+                        return BandwidthNegotiation.Failed(
+                            "Wi-Fi Direct upgrade failed after BLE pairing; " +
+                                "stayed on ${transport.medium}",
+                        )
+                    }
+                    initialWireFrames += transport.bufferedFrames
+                    transport.also { secureChannel = it.channel }
                 }
             }
-        return activeChannel to initialWireFrames
+        return BandwidthNegotiation.Ready(activeTransport.channel, activeTransport.medium, initialWireFrames)
     }
+
+    private fun requiresWifiDirectUpgradeForBle(): Boolean =
+        initialTransport.medium == Medium.BLE &&
+            Medium.WIFI_DIRECT in mediumRegistry.supportedMediumsForCurrentTransport(initialTransport.medium)
 
     /**
      * Tear down all owned resources. Safe to call multiple times; each
@@ -450,7 +495,7 @@ internal class OutboundConnectionDriver(
                             "${SAFE_DISCONNECT_ACK_TIMEOUT_MS}ms",
                     )
                 }
-                result
+                publishCompletedIfNeeded(result)
             } finally {
                 // Cancel the KEEP_ALIVE ticker FIRST, before any socket
                 // close: the ticker spends almost all its life parked
@@ -504,6 +549,329 @@ internal class OutboundConnectionDriver(
                 logger("keep-alive: ticker stopped (${e::class.simpleName}: ${e.message ?: "null"})")
             },
         )
+    }
+
+    /**
+     * BLE/GATT sender path for stock Android receivers that advertise
+     * Wi-Fi Direct but do not auto-upgrade before the Nearby Share
+     * consent exchange. Keep the read side single-threaded here: the
+     * bandwidth-upgrade handshake needs to keep using the prior BLE
+     * channel, so the normal inbound pump must not be parked in a
+     * blocking read on that same channel when an offer arrives.
+     */
+    @Suppress("LongMethod", "CyclomaticComplexMethod", "NestedBlockDepth", "ReturnCount")
+    private suspend fun runBleWifiDirectReceiveLoop(
+        channel: SecureChannel,
+        fsm: OutboundSharingFsm,
+        initialWireFrames: List<OfflineFrame> = emptyList(),
+    ): OutboundResult {
+        var activeChannel = channel
+        var activeMedium = initialTransport.medium
+        val bufferedFrames =
+            ArrayDeque<OfflineFrame>().apply {
+                addAll(initialWireFrames)
+            }
+        var remoteAcceptanceDeadlineMillis: Long? = null
+        try {
+            while (true) {
+                if (fsm.state == OutboundSharingState.Disconnected) {
+                    return terminalResultFromState()
+                }
+
+                remoteAcceptanceDeadlineMillis =
+                    updateRemoteAcceptanceDeadline(
+                        fsm = fsm,
+                        currentDeadlineMillis = remoteAcceptanceDeadlineMillis,
+                    )
+                val remoteAcceptanceRemainingMillis = remoteAcceptanceRemainingMillis(remoteAcceptanceDeadlineMillis)
+                if (remoteAcceptanceRemainingMillis == 0L) {
+                    return remoteAcceptanceTimedOut()
+                }
+
+                val event =
+                    nextBleWifiDirectEvent(
+                        channel = activeChannel,
+                        bufferedFrames = bufferedFrames,
+                        remoteAcceptanceRemainingMillis = remoteAcceptanceRemainingMillis,
+                    )
+                logger("fsm: dispatch event=${describeDriverEvent(event)} fsmState=${fsm.state::class.simpleName}")
+
+                if (event is OutboundDriverEvent.Wire &&
+                    event.frame.isBandwidthUpgradeEvent(
+                        BandwidthUpgradeNegotiationFrame.EventType.UPGRADE_PATH_AVAILABLE,
+                    )
+                ) {
+                    val upgraded =
+                        adoptBleWifiDirectOffer(
+                            channel = activeChannel,
+                            currentMedium = activeMedium,
+                            offer = event.frame,
+                        )
+                    if (upgraded.medium != Medium.WIFI_DIRECT) {
+                        return failBleWifiDirect(
+                            "Wi-Fi Direct upgrade failed after BLE pairing; stayed on ${upgraded.medium}",
+                            activeChannel,
+                        )
+                    }
+                    activeChannel = upgraded.channel
+                    activeMedium = upgraded.medium
+                    bufferedFrames.addAll(upgraded.bufferedFrames)
+                    continue
+                }
+
+                when (val outcome = handleBleWifiDirectEvent(activeChannel, fsm, event)) {
+                    BleWifiDirectOutcome.Continue -> Unit
+                    is BleWifiDirectOutcome.Terminal -> {
+                        if (shouldDrainForSafeDisconnect(outcome.result)) {
+                            drainSafeDisconnectAckDirect(activeChannel)
+                        }
+                        return publishCompletedIfNeeded(outcome.result)
+                    }
+                    BleWifiDirectOutcome.ReadyToSendPayloads -> {
+                        val upgraded =
+                            ensureBleWifiDirectBeforePayloads(
+                                channel = activeChannel,
+                                currentMedium = activeMedium,
+                            )
+                        if (upgraded is PayloadChannelSelection.Failed) {
+                            return failBleWifiDirect(upgraded.reason, activeChannel)
+                        }
+                        val ready = upgraded as PayloadChannelSelection.Ready
+                        activeChannel = ready.channel
+                        activeMedium = ready.medium
+                        val result =
+                            coroutineScope {
+                                val keepAliveJob = launch { runKeepAliveTicker(activeChannel) }
+                                try {
+                                    val result = streamFilesAndComplete(activeChannel)
+                                    if (shouldDrainForSafeDisconnect(result)) {
+                                        drainSafeDisconnectAckDirect(activeChannel)
+                                    }
+                                    publishCompletedIfNeeded(result)
+                                } finally {
+                                    keepAliveJob.cancelAndJoin()
+                                }
+                            }
+                        return result
+                    }
+                }
+            }
+        } finally {
+            runCatching { activeChannel.close() }
+            runCatching { initialTransport.close() }
+        }
+    }
+
+    @Suppress("ReturnCount", "SwallowedException", "TooGenericExceptionCaught")
+    private suspend fun nextBleWifiDirectEvent(
+        channel: SecureChannel,
+        bufferedFrames: ArrayDeque<OfflineFrame>,
+        remoteAcceptanceRemainingMillis: Long?,
+    ): OutboundDriverEvent {
+        if (bufferedFrames.isNotEmpty()) {
+            return OutboundDriverEvent.Wire(bufferedFrames.removeFirst())
+        }
+        val deadlineMillis = remoteAcceptanceRemainingMillis?.let { nowMillisSource() + it }
+        while (true) {
+            externalEvents.tryReceive().getOrNull()?.let { return OutboundDriverEvent.External(it) }
+            if (channel.hasBufferedInput()) {
+                return try {
+                    OutboundDriverEvent.Wire(channel.receiveOfflineFrame())
+                } catch (e: EndOfFrameStream) {
+                    OutboundDriverEvent.PeerClosed
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    OutboundDriverEvent.PumpError(e)
+                }
+            }
+            if (deadlineMillis != null && nowMillisSource() >= deadlineMillis) {
+                return OutboundDriverEvent.RemoteAcceptanceTimedOut
+            }
+            delay(BLE_WIFI_DIRECT_POLL_DELAY_MILLIS)
+        }
+    }
+
+    private suspend fun handleBleWifiDirectEvent(
+        channel: SecureChannel,
+        fsm: OutboundSharingFsm,
+        event: OutboundDriverEvent,
+    ): BleWifiDirectOutcome =
+        when (event) {
+            is OutboundDriverEvent.External -> {
+                handleExternalEvent(channel, fsm, event.event)
+                BleWifiDirectOutcome.Continue
+            }
+            is OutboundDriverEvent.Wire -> handleBleWifiDirectInboundFrame(channel, fsm, event.frame)
+            OutboundDriverEvent.PeerClosed -> BleWifiDirectOutcome.Terminal(handlePeerClosed())
+            OutboundDriverEvent.RemoteAcceptanceTimedOut -> BleWifiDirectOutcome.Terminal(remoteAcceptanceTimedOut())
+            is OutboundDriverEvent.PumpError -> {
+                val reason = "Inbound pump error: ${event.cause::class.simpleName}: ${event.cause.message}"
+                mutableState.value = OutboundConnectionState.Failed(reason)
+                BleWifiDirectOutcome.Terminal(OutboundResult.Failed(reason))
+            }
+        }
+
+    @Suppress("ReturnCount")
+    private suspend fun handleBleWifiDirectInboundFrame(
+        channel: SecureChannel,
+        fsm: OutboundSharingFsm,
+        frame: OfflineFrame,
+    ): BleWifiDirectOutcome {
+        if (frame.isDisconnection()) {
+            return BleWifiDirectOutcome.Terminal(cancelFromPeer())
+        }
+        if (frame.hasV1() &&
+            frame.v1.type == V1Frame.FrameType.BANDWIDTH_UPGRADE_NEGOTIATION
+        ) {
+            logger(
+                "fsm: inbound BANDWIDTH_UPGRADE_NEGOTIATION event_type=" +
+                    frame.v1.bandwidthUpgradeNegotiation.eventType,
+            )
+            return BleWifiDirectOutcome.Continue
+        }
+        if (!frame.hasV1() || frame.v1.type != V1Frame.FrameType.PAYLOAD_TRANSFER) {
+            return BleWifiDirectOutcome.Continue
+        }
+        return when (val payloadEvent = inboundAssembler.onPayloadTransfer(frame.v1.payloadTransfer)) {
+            is PayloadEvent.BytesComplete -> handleBleWifiDirectBytesComplete(channel, fsm, payloadEvent)
+            is PayloadEvent.FileComplete,
+            is PayloadEvent.Progress,
+            is PayloadEvent.Ignored,
+            -> BleWifiDirectOutcome.Continue
+        }
+    }
+
+    private suspend fun handleBleWifiDirectBytesComplete(
+        channel: SecureChannel,
+        fsm: OutboundSharingFsm,
+        event: PayloadEvent.BytesComplete,
+    ): BleWifiDirectOutcome {
+        val sharingFrame = SharingFrames.parse(event.data)
+        logger("fsm: rx SharingFrame type=${sharingFrame.v1.type}")
+        val effects = fsm.onEvent(SharingFsmEvent.FrameReceived(sharingFrame))
+        applyEffects(channel, effects)
+        return if (effects.any { it is SharingFsmEffect.ReadyToSendPayloads }) {
+            BleWifiDirectOutcome.ReadyToSendPayloads
+        } else {
+            BleWifiDirectOutcome.Continue
+        }
+    }
+
+    private suspend fun ensureBleWifiDirectBeforePayloads(
+        channel: SecureChannel,
+        currentMedium: Medium,
+    ): PayloadChannelSelection {
+        if (currentMedium == Medium.WIFI_DIRECT) {
+            return PayloadChannelSelection.Ready(channel, currentMedium)
+        }
+        channel.sendOfflineFrame(
+            BandwidthUpgradeFrames.upgradePathRequest(setOf(Medium.WIFI_DIRECT)),
+        )
+        logger("medium-upgrade: requested receiver Wi-Fi Direct upgrade before streaming payloads")
+        logger("medium-upgrade: waiting for receiver Wi-Fi Direct offer before streaming payloads")
+        return when (val probe = pollBleWifiDirectOffer(channel, BLE_WIFI_DIRECT_UPGRADE_TIMEOUT_MILLIS)) {
+            UpgradeOfferProbe.None ->
+                PayloadChannelSelection.Failed("Wi-Fi Direct upgrade was not offered before payload streaming")
+            is UpgradeOfferProbe.Other ->
+                PayloadChannelSelection.Failed(
+                    "Wi-Fi Direct upgrade was required before payload streaming, " +
+                        "but peer sent ${probe.frame.describeFrameType()} first",
+                )
+            is UpgradeOfferProbe.Offer -> {
+                val upgraded =
+                    adoptBleWifiDirectOffer(
+                        channel = channel,
+                        currentMedium = currentMedium,
+                        offer = probe.frame,
+                    )
+                if (upgraded.medium == Medium.WIFI_DIRECT) {
+                    PayloadChannelSelection.Ready(upgraded.channel, upgraded.medium)
+                } else {
+                    PayloadChannelSelection.Failed(
+                        "Wi-Fi Direct upgrade failed before payload streaming; stayed on ${upgraded.medium}",
+                    )
+                }
+            }
+        }
+    }
+
+    @Suppress("ReturnCount")
+    private suspend fun pollBleWifiDirectOffer(
+        channel: SecureChannel,
+        timeoutMillis: Long,
+    ): UpgradeOfferProbe {
+        val deadlineMillis = nowMillisSource() + timeoutMillis
+        while (nowMillisSource() < deadlineMillis) {
+            if (channel.hasBufferedInput()) {
+                val frame = channel.receiveOfflineFrame()
+                when {
+                    frame.isBandwidthUpgradeEvent(
+                        BandwidthUpgradeNegotiationFrame.EventType.UPGRADE_PATH_AVAILABLE,
+                    ) -> return UpgradeOfferProbe.Offer(frame)
+                    frame.hasV1() && frame.v1.type == V1Frame.FrameType.KEEP_ALIVE -> {
+                        logger("medium-upgrade: ignoring KEEP_ALIVE while waiting for Wi-Fi Direct offer")
+                    }
+                    else -> return UpgradeOfferProbe.Other(frame)
+                }
+            }
+            delay(BLE_WIFI_DIRECT_POLL_DELAY_MILLIS)
+        }
+        return UpgradeOfferProbe.None
+    }
+
+    private suspend fun adoptBleWifiDirectOffer(
+        channel: SecureChannel,
+        currentMedium: Medium,
+        offer: OfflineFrame,
+    ): ActiveTransportChannel {
+        val upgraded =
+            BandwidthUpgradeOrchestrator.runClientUpgradeFromOffer(
+                oldChannel = channel,
+                currentMedium = currentMedium,
+                offer = offer,
+                mediumRegistry = mediumRegistry,
+                endpointId = endpointId,
+                logger = logger,
+            )
+        secureChannel = upgraded.channel
+        return upgraded
+    }
+
+    private suspend fun failBleWifiDirect(
+        reason: String,
+        channel: SecureChannel,
+    ): OutboundResult.Failed {
+        logger("medium-upgrade: $reason")
+        mutableState.value = OutboundConnectionState.Failed(reason)
+        runCatching { sendTerminalDisconnection(channel) }
+        return OutboundResult.Failed(reason)
+    }
+
+    private suspend fun drainSafeDisconnectAckDirect(channel: SecureChannel) {
+        val acked =
+            withTimeoutOrNull(SAFE_DISCONNECT_ACK_TIMEOUT_MS) {
+                while (true) {
+                    if (channel.hasBufferedInput()) {
+                        val frame = channel.receiveOfflineFrame()
+                        if (frame.hasV1() && frame.v1.type == V1Frame.FrameType.DISCONNECTION) {
+                            logger(
+                                "fsm: safe-disconnect peer Disconnection ack=" +
+                                    frame.v1.disconnection.ackSafeToDisconnect,
+                            )
+                            return@withTimeoutOrNull true
+                        }
+                    }
+                    delay(BLE_WIFI_DIRECT_POLL_DELAY_MILLIS)
+                }
+                false
+            } == true
+        if (!acked) {
+            logger(
+                "fsm: safe-disconnect drain timed out after " +
+                    "${SAFE_DISCONNECT_ACK_TIMEOUT_MS}ms",
+            )
+        }
     }
 
     /**
@@ -846,8 +1214,14 @@ internal class OutboundConnectionDriver(
         // All files streamed. Emit Disconnection and complete.
         logger("fsm: all files streamed, sending Disconnection")
         runCatching { sendTerminalDisconnection(channel) }
-        mutableState.value = OutboundConnectionState.Completed
         return OutboundResult.Completed
+    }
+
+    private fun publishCompletedIfNeeded(result: OutboundResult): OutboundResult {
+        if (result == OutboundResult.Completed) {
+            mutableState.value = OutboundConnectionState.Completed
+        }
+        return result
     }
 
     /**
@@ -1134,17 +1508,71 @@ internal class OutboundConnectionDriver(
         channel.sendOfflineFrame(OfflineFrames.disconnection(requestSafeToDisconnect = true))
     }
 
+    private fun OfflineFrame.describeFrameType(): String =
+        if (hasV1()) {
+            when (v1.type) {
+                V1Frame.FrameType.BANDWIDTH_UPGRADE_NEGOTIATION ->
+                    "${v1.type}(${v1.bandwidthUpgradeNegotiation.eventType})"
+                V1Frame.FrameType.BANDWIDTH_UPGRADE_RETRY ->
+                    "${v1.type}(request=${v1.bandwidthUpgradeRetry.isRequest})"
+                else -> v1.type.toString()
+            }
+        } else {
+            "NO_V1"
+        }
+
+    private fun OfflineFrame.isBandwidthUpgradeEvent(expected: BandwidthUpgradeNegotiationFrame.EventType): Boolean =
+        hasV1() &&
+            v1.type == V1Frame.FrameType.BANDWIDTH_UPGRADE_NEGOTIATION &&
+            v1.bandwidthUpgradeNegotiation.eventType == expected
+
     private companion object {
+        private const val BLE_WIFI_DIRECT_UPGRADE_TIMEOUT_MILLIS: Long = 12_000L
+        private const val BLE_WIFI_DIRECT_POLL_DELAY_MILLIS: Long = 25L
+
         /**
          * Maximum time the orchestrator waits for the peer's
          * `DisconnectionFrame{ack_safe_to_disconnect=true}` (or peer
          * FIN) after sending its own request. 1500 ms covers Samsung
-         * One UI 8.0.5's observed drain time for an 87 KiB single-chunk
-         * file (~14 ms socket-to-FIN on a clean network plus headroom);
-         * larger payloads dominate over this timeout because the
-         * receiver only acks after writing all pending payloads to
-         * disk.
+         * One UI 8.0.5's observed drain time for small payloads, plus
+         * headroom for stock Quick Share builds that do not send an ack
+         * before their receive UI leaves "Preparing..."; larger payloads
+         * dominate over this timeout because the receiver only acks after
+         * writing all pending payloads to disk.
          */
-        const val SAFE_DISCONNECT_ACK_TIMEOUT_MS: Long = 1500L
+        const val SAFE_DISCONNECT_ACK_TIMEOUT_MS: Long = 5_000L
+    }
+
+    private sealed interface BandwidthNegotiation {
+        data class Ready(
+            val channel: SecureChannel,
+            val medium: Medium,
+            val initialWireFrames: List<OfflineFrame>,
+        ) : BandwidthNegotiation
+
+        data class Failed(
+            val reason: String,
+        ) : BandwidthNegotiation
+    }
+
+    private sealed interface BleWifiDirectOutcome {
+        data object Continue : BleWifiDirectOutcome
+
+        data object ReadyToSendPayloads : BleWifiDirectOutcome
+
+        data class Terminal(
+            val result: OutboundResult,
+        ) : BleWifiDirectOutcome
+    }
+
+    private sealed interface PayloadChannelSelection {
+        data class Ready(
+            val channel: SecureChannel,
+            val medium: Medium,
+        ) : PayloadChannelSelection
+
+        data class Failed(
+            val reason: String,
+        ) : PayloadChannelSelection
     }
 }

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundFrames.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundFrames.kt
@@ -7,6 +7,8 @@ package io.github.kyujincho.wvmg.protocol.connection
 
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.ConnectionRequestFrame
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.ConnectionResponseFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.ConnectionsDevice
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.EndpointType
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.MediumMetadata
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OsInfo
@@ -61,14 +63,11 @@ internal object OutboundFrames {
         // Match NearDrop's ConnectionRequestFrame shape. Stock Quick Share
         // closes the socket immediately if these fields are absent — only
         // endpoint_id and endpoint_info is not enough on Android 14+:
-        //   * mediums = [WIFI_LAN, ...] tells the receiver which transports
-        //     this device can negotiate up to. WIFI_LAN is mandatory because
-        //     it IS the discovery medium for every Quick Share connection
-        //     today; absence of any medium hits a validation in Nearby
-        //     Connections that rejects the request. Phase 4 (#48–#54) adds
-        //     the BANDWIDTH_UPGRADE_NEGOTIATION machinery that lets us
-        //     advertise more than just WIFI_LAN here — the orchestrator
-        //     populates this set from the MediumRegistry's supportedMediums().
+        //   * mediums tells the receiver which transports this device can
+        //     negotiate up to. The default keeps the historical LAN-only
+        //     shape, while off-LAN bootstraps pass their exact medium set so
+        //     a BLE GATT + Wi-Fi Direct handoff does not silently advertise
+        //     Wi-Fi LAN as an available upgrade path.
         //   * keep_alive_interval / timeout are read by the receiver to
         //     decide its own KEEP_ALIVE cadence. We advertise 10 s / 10 min
         //     — PROTOCOL.md documents stock Android emitting KEEP_ALIVE
@@ -79,13 +78,10 @@ internal object OutboundFrames {
         //     empty string keeps modern peers happy and gives legacy peers
         //     a defined value to read.
         //
-        // Always include WIFI_LAN even if the caller forgot — it is the
-        // current connection's medium. Sort the proto-side enum values so
-        // the wire encoding is deterministic for tests and for KAT-style
-        // regression detection.
-        val withWifiLan = supportedMediums + Medium.WIFI_LAN
+        // Sort the proto-side enum values so the wire encoding is
+        // deterministic for tests and for KAT-style regression detection.
         val mediumProtoValues =
-            withWifiLan
+            supportedMediums
                 .map { it.toConnectionRequestMedium() }
                 .sortedBy { it.number }
         val builder =
@@ -95,9 +91,16 @@ internal object OutboundFrames {
                 .setEndpointName("")
                 .setEndpointInfo(ByteString.copyFrom(endpointInfo))
                 .setNonce(nonce)
-                .setMediumMetadata(defaultMediumMetadata())
+                .setMediumMetadata(defaultMediumMetadata(supportedMediums))
                 .setKeepAliveIntervalMillis(KEEP_ALIVE_INTERVAL_MILLIS)
                 .setKeepAliveTimeoutMillis(KEEP_ALIVE_TIMEOUT_MILLIS)
+                .setConnectionsDevice(
+                    ConnectionsDevice
+                        .newBuilder()
+                        .setEndpointId(endpointId)
+                        .setEndpointType(EndpointType.CONNECTIONS_ENDPOINT)
+                        .setEndpointInfo(ByteString.copyFrom(endpointInfo)),
+                )
         for (m in mediumProtoValues) builder.addMediums(m)
         val request = builder.build()
         return OfflineFrame
@@ -147,14 +150,20 @@ internal object OutboundFrames {
      * here keeps the field-shape compatible without introducing
      * `android.*` dependencies into `:core-protocol`.
      */
-    private fun defaultMediumMetadata(): MediumMetadata =
+    private fun defaultMediumMetadata(supportedMediums: Set<Medium>): MediumMetadata =
         MediumMetadata
             .newBuilder()
             .setSupports5Ghz(false)
             .setSupports6Ghz(false)
             .setMobileRadio(false)
             .setApFrequency(-1)
-            .build()
+            .also { builder ->
+                if (Medium.WIFI_DIRECT in supportedMediums) {
+                    builder.addSupportedWifiDirectAuthTypes(
+                        MediumMetadata.WifiDirectAuthType.WIFI_DIRECT_WITH_PASSWORD,
+                    )
+                }
+            }.build()
 
     /** Legacy `status` field value for "STATUS_OK". 0 in the proto enum. */
     private const val STATUS_OK: Int = 0

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/BleServiceData.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/BleServiceData.kt
@@ -102,6 +102,12 @@ public object BleServiceData {
     /** BLE v2 frame type used by stock Nearby for fast advertisements. */
     public const val FRAME_TYPE_FAST_ADVERTISEMENT: Int = 0x4A
 
+    /**
+     * BLE v2 fast-advertisement frame type with the Nearby "second profile"
+     * bit set.
+     */
+    public const val FRAME_TYPE_SECOND_PROFILE_FAST_ADVERTISEMENT: Int = 0x4B
+
     /** Length of the BLE v2 frame type + frame-length prefix. */
     public const val FRAME_HEADER_LEN: Int = 2
 
@@ -251,6 +257,7 @@ public object BleServiceData {
         endpointInfo: EndpointInfo,
         version: Int = DEFAULT_VERSION,
         pcp: Int = DEFAULT_PCP,
+        secondProfile: Boolean = false,
     ): ByteArray {
         val body = encode(endpointId, endpointInfo, version, pcp)
         require(body.size <= MAX_FRAME_BODY_LEN) {
@@ -258,7 +265,12 @@ public object BleServiceData {
         }
         val deviceToken = deriveDeviceToken(body)
         val out = ByteArray(FRAME_HEADER_LEN + body.size + DEVICE_TOKEN_LEN)
-        out[0] = FRAME_TYPE_FAST_ADVERTISEMENT.toByte()
+        out[0] =
+            if (secondProfile) {
+                FRAME_TYPE_SECOND_PROFILE_FAST_ADVERTISEMENT.toByte()
+            } else {
+                FRAME_TYPE_FAST_ADVERTISEMENT.toByte()
+            }
         out[1] = body.size.toByte()
         body.copyInto(out, destinationOffset = FRAME_HEADER_LEN)
         deviceToken.copyInto(out, destinationOffset = FRAME_HEADER_LEN + body.size)
@@ -284,9 +296,10 @@ public object BleServiceData {
         psm: Int,
         version: Int = DEFAULT_VERSION,
         pcp: Int = DEFAULT_PCP,
+        secondProfile: Boolean = false,
     ): ByteArray {
         require(psm in 1..MAX_PSM) { "psm must fit in uint16 and be non-zero, got $psm" }
-        val framed = encodeFramed(endpointId, endpointInfo, version, pcp)
+        val framed = encodeFramed(endpointId, endpointInfo, version, pcp, secondProfile)
         val out = ByteArray(framed.size + EXTRA_FIELDS_MASK_LEN + PSM_LEN)
         framed.copyInto(out)
         out[framed.size] = EXTRA_FIELD_PSM_MASK.toByte()
@@ -306,6 +319,7 @@ public object BleServiceData {
         psm: Int,
         version: Int = DEFAULT_VERSION,
         pcp: Int = DEFAULT_PCP,
+        secondProfile: Boolean = false,
     ): ByteArray =
         encodeFramedWithPsm(
             endpointId = asciiEndpointId(endpointId),
@@ -313,6 +327,7 @@ public object BleServiceData {
             psm = psm,
             version = version,
             pcp = pcp,
+            secondProfile = secondProfile,
         )
 
     /**
@@ -325,12 +340,14 @@ public object BleServiceData {
         endpointInfo: EndpointInfo,
         version: Int = DEFAULT_VERSION,
         pcp: Int = DEFAULT_PCP,
+        secondProfile: Boolean = false,
     ): ByteArray =
         encodeFramed(
             endpointId = asciiEndpointId(endpointId),
             endpointInfo = endpointInfo,
             version = version,
             pcp = pcp,
+            secondProfile = secondProfile,
         )
 
     /**
@@ -433,7 +450,7 @@ public object BleServiceData {
     @Suppress("ReturnCount")
     private fun unwrapFrame(bytes: ByteArray): ByteArray? {
         if (bytes.size < FRAME_HEADER_LEN) return null
-        if ((bytes[0].toInt() and UNSIGNED_BYTE_MASK) != FRAME_TYPE_FAST_ADVERTISEMENT) return null
+        if (!isFastFrameType(bytes[0].toInt() and UNSIGNED_BYTE_MASK)) return null
         val len = bytes[1].toInt() and UNSIGNED_BYTE_MASK
         if (FRAME_HEADER_LEN + len > bytes.size) return null
         return bytes.copyOfRange(FRAME_HEADER_LEN, FRAME_HEADER_LEN + len)
@@ -442,12 +459,16 @@ public object BleServiceData {
     @Suppress("ReturnCount")
     private fun extraFieldsOffset(bytes: ByteArray): Int? {
         if (bytes.size < FRAME_HEADER_LEN) return null
-        if ((bytes[0].toInt() and UNSIGNED_BYTE_MASK) != FRAME_TYPE_FAST_ADVERTISEMENT) return null
+        if (!isFastFrameType(bytes[0].toInt() and UNSIGNED_BYTE_MASK)) return null
         val len = bytes[1].toInt() and UNSIGNED_BYTE_MASK
         val offset = FRAME_HEADER_LEN + len + DEVICE_TOKEN_LEN
         if (offset > bytes.size) return null
         return offset
     }
+
+    private fun isFastFrameType(value: Int): Boolean =
+        value == FRAME_TYPE_FAST_ADVERTISEMENT ||
+            value == FRAME_TYPE_SECOND_PROFILE_FAST_ADVERTISEMENT
 
     private fun asciiEndpointId(endpointId: String): ByteArray {
         // String.toByteArray(US_ASCII) silently substitutes '?' for any

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/sharing/InboundSharingFsm.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/sharing/InboundSharingFsm.kt
@@ -219,6 +219,14 @@ public class InboundSharingFsm(
             return protocolError("non-frame event in ReceivedPairedKeyResult: ${event::class.simpleName}")
         }
         val frame = event.frame
+        if (frame.v1.type == SharingFrameType.RESPONSE) {
+            // On One UI 8.x the sender's local acceptance can race with
+            // INTRODUCTION after the channel moves from BLE to Wi-Fi
+            // Direct. Treat it the same as the documented
+            // INTRODUCTION-then-RESPONSE ordering below: non-terminal
+            // accept/unknown is only the sender declaring readiness.
+            return handlePreemptiveConnectionResponse(frame)
+        }
         if (frame.v1.type != SharingFrameType.INTRODUCTION) {
             return protocolError("expected INTRODUCTION, got ${frame.v1.type}")
         }
@@ -254,13 +262,7 @@ public class InboundSharingFsm(
             //    TIMED_OUT: treat as a peer-side cancel — the sender has
             //    already abandoned the transfer, so our consent UI is
             //    moot.
-            val status = event.frame.v1.connectionResponse.status
-            return when (status) {
-                ConnectionResponseStatus.ACCEPT,
-                ConnectionResponseStatus.UNKNOWN,
-                -> emptyList()
-                else -> handlePeerCancel()
-            }
+            return handlePreemptiveConnectionResponse(event.frame)
         }
         if (event !is SharingFsmEvent.UserConsent) {
             // The peer is not supposed to push a frame at us while we are
@@ -345,6 +347,16 @@ public class InboundSharingFsm(
     private fun handlePeerCancel(): List<SharingFsmEffect> {
         state = InboundSharingState.Disconnected
         return listOf(SharingFsmEffect.Cancelled)
+    }
+
+    private fun handlePreemptiveConnectionResponse(frame: SharingFrame): List<SharingFsmEffect> {
+        val status = frame.v1.connectionResponse.status
+        return when (status) {
+            ConnectionResponseStatus.ACCEPT,
+            ConnectionResponseStatus.UNKNOWN,
+            -> emptyList()
+            else -> handlePeerCancel()
+        }
     }
 
     private fun protocolError(reason: String): List<SharingFsmEffect> {

--- a/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/sharing/SharingFsmState.kt
+++ b/core-protocol/src/main/kotlin/io/github/kyujincho/wvmg/protocol/sharing/SharingFsmState.kt
@@ -46,6 +46,8 @@ package io.github.kyujincho.wvmg.protocol.sharing
  *
  *   ReceivedPairedKeyResult
  *     +-- Frame{INTRODUCTION}               ->  WaitingForUserConsent      (emit IntroductionReceived)
+ *     +-- Frame{RESPONSE, status=ACCEPT|UNKNOWN}
+ *                                            ->  ReceivedPairedKeyResult    (ignore sender pre-consent)
  *     ... (CANCEL / ProtocolError as above)
  *
  *   WaitingForUserConsent

--- a/core-protocol/src/main/proto/offline_wire_formats.proto
+++ b/core-protocol/src/main/proto/offline_wire_formats.proto
@@ -457,6 +457,16 @@ message AutoReconnectFrame {
 }
 
 message MediumMetadata {
+  // Should always match
+  // cs/symbol:location.nearby.proto.connections.WifiDirectAuthType
+  enum WifiDirectAuthType {
+    WIFI_DIRECT_TYPE_UNKNOWN = 0;
+    // WifiDirect type that uses ssid/password for authentication.
+    WIFI_DIRECT_WITH_PASSWORD = 1;
+    // WifiDirect type that uses service_name/pin for authentication.
+    WIFI_DIRECT_WITH_PIN = 2;
+  }
+
   // True if local device supports 5GHz.
   optional bool supports_5_ghz = 1;
   // WiFi LAN BSSID, in the form of a six-byte MAC address: XX:XX:XX:XX:XX:XX
@@ -483,6 +493,9 @@ message MediumMetadata {
   optional WifiHotspotStaUsableChannels wifi_hotspot_sta_usable_channels = 11;
   // The supported medium roles.
   optional MediumRole medium_role = 12;
+  // The supported WifiDirect auth types.
+  repeated WifiDirectAuthType supported_wifi_direct_auth_types = 13
+      [packed = true];
 }
 
 // Available channels on the local device.

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeFramesTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/BandwidthUpgradeFramesTest.kt
@@ -8,6 +8,7 @@ package io.github.kyujincho.wvmg.protocol.connection
 import com.google.common.truth.Truth.assertThat
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.BandwidthUpgradeNegotiationFrame
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.BandwidthUpgradeNegotiationFrame.UpgradePathInfo
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.MediumMetadata
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.V1Frame
 import io.github.kyujincho.wvmg.protocol.medium.Medium
@@ -49,6 +50,21 @@ class BandwidthUpgradeFramesTest {
         assertThat(parsed.upgradePathInfo.supportsClientIntroductionAck).isTrue()
         assertThat(parsed.upgradePathInfo.medium.number).isEqualTo(Medium.WIFI_DIRECT.wireNumber)
         assertThat(parsed.upgradePathInfo.hasWifiLanSocket()).isFalse()
+    }
+
+    @Test
+    fun `upgradePathRequest carries requested Wi-Fi Direct medium and role metadata`() {
+        val frame = BandwidthUpgradeFrames.upgradePathRequest(setOf(Medium.WIFI_DIRECT))
+        val parsed = parse(frame)
+        val request = parsed.upgradePathInfo.upgradePathRequest
+
+        assertThat(parsed.eventType).isEqualTo(BandwidthUpgradeNegotiationFrame.EventType.UPGRADE_PATH_REQUEST)
+        assertThat(request.mediumsList.map { it.number }).containsExactly(Medium.WIFI_DIRECT.wireNumber)
+        assertThat(request.mediumMetaData.supportedWifiDirectAuthTypesList)
+            .containsExactly(MediumMetadata.WifiDirectAuthType.WIFI_DIRECT_WITH_PASSWORD)
+        assertThat(request.mediumMetaData.mediumRole.supportWifiDirectGroupClient).isTrue()
+        assertThat(BandwidthUpgradeFrames.decodeUpgradePathRequestMediums(frame))
+            .containsExactly(Medium.WIFI_DIRECT)
     }
 
     @Test

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/ConnectionRequestMediumsTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/ConnectionRequestMediumsTest.kt
@@ -7,6 +7,8 @@ package io.github.kyujincho.wvmg.protocol.connection
 
 import com.google.common.truth.Truth.assertThat
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.ConnectionRequestFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.EndpointType
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.MediumMetadata
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame
 import io.github.kyujincho.wvmg.protocol.medium.Medium
 import org.junit.jupiter.api.Test
@@ -18,9 +20,10 @@ import org.junit.jupiter.api.Test
  *   1. Default behaviour (no mediums passed) advertises Wi-Fi LAN
  *      only — functionally identical to the project's pre-Phase-4
  *      hard-coded shape and to NearDrop.
- *   2. Multiple mediums survive the wire round-trip and Wi-Fi LAN is
- *      always present (it IS the discovery medium today; absence
- *      breaks Android 14+ Nearby Connections validation).
+ *   2. Multiple mediums survive the wire round-trip without hidden
+ *      expansion. Callers that own an off-LAN bootstrap must be able to
+ *      choose whether the legacy Wi-Fi LAN capability marker belongs in
+ *      that request shape.
  */
 class ConnectionRequestMediumsTest {
     @Test
@@ -48,11 +51,7 @@ class ConnectionRequestMediumsTest {
     }
 
     @Test
-    fun `Wi-Fi LAN is always implicitly present`() {
-        // Even a caller that forgets WIFI_LAN must end up advertising
-        // it because it IS the discovery medium for the current
-        // socket — Android 14+ Nearby Connections rejects absence of
-        // it as malformed.
+    fun `caller supplied off-LAN mediums can omit Wi-Fi LAN`() {
         val frame =
             OutboundFrames.connectionRequest(
                 endpointId = "ABCD",
@@ -60,8 +59,7 @@ class ConnectionRequestMediumsTest {
                 supportedMediums = setOf(Medium.BLUETOOTH),
             )
         val numbers = parseRequest(frame).mediumsList.map { it.number }.toSet()
-        assertThat(numbers).contains(Medium.WIFI_LAN.wireNumber)
-        assertThat(numbers).contains(Medium.BLUETOOTH.wireNumber)
+        assertThat(numbers).containsExactly(Medium.BLUETOOTH.wireNumber)
     }
 
     @Test
@@ -78,19 +76,39 @@ class ConnectionRequestMediumsTest {
     }
 
     @Test
-    fun `keep_alive fields and endpoint_id survive the change`() {
+    fun `keep_alive fields endpoint_id and connections_device survive the change`() {
         // Sanity: pinning the mediums field must not have regressed
-        // the four other fields ConnectionRequestFrame is expected to
+        // the other fields ConnectionRequestFrame is expected to
         // populate (One UI 8.0.5 silent-FIN guards live here).
-        val frame = OutboundFrames.connectionRequest("XYZW", ByteArray(0))
+        val endpointInfo = byteArrayOf(0x01, 0x02, 0x03)
+        val frame = OutboundFrames.connectionRequest("XYZW", endpointInfo)
         val req = parseRequest(frame)
         assertThat(req.endpointId).isEqualTo("XYZW")
         assertThat(req.endpointName).isEqualTo("")
+        assertThat(req.endpointInfo.toByteArray()).isEqualTo(endpointInfo)
         assertThat(req.keepAliveIntervalMillis).isEqualTo(10_000)
         assertThat(req.keepAliveTimeoutMillis).isEqualTo(600_000)
         assertThat(req.hasNonce()).isTrue()
         assertThat(req.hasMediumMetadata()).isTrue()
         assertThat(req.mediumMetadata.apFrequency).isEqualTo(-1)
+        assertThat(req.hasConnectionsDevice()).isTrue()
+        assertThat(req.connectionsDevice.endpointId).isEqualTo("XYZW")
+        assertThat(req.connectionsDevice.endpointType).isEqualTo(EndpointType.CONNECTIONS_ENDPOINT)
+        assertThat(req.connectionsDevice.endpointInfo.toByteArray()).isEqualTo(endpointInfo)
+    }
+
+    @Test
+    fun `Wi-Fi Direct requests advertise password auth support without opening role`() {
+        val frame =
+            OutboundFrames.connectionRequest(
+                endpointId = "ABCD",
+                endpointInfo = ByteArray(0),
+                supportedMediums = setOf(Medium.WIFI_DIRECT, Medium.BLE),
+            )
+        val metadata = parseRequest(frame).mediumMetadata
+        assertThat(metadata.supportedWifiDirectAuthTypesList)
+            .containsExactly(MediumMetadata.WifiDirectAuthType.WIFI_DIRECT_WITH_PASSWORD)
+        assertThat(metadata.hasMediumRole()).isFalse()
     }
 
     @Test

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/connection/OutboundConnectionTest.kt
@@ -6,6 +6,8 @@
 package io.github.kyujincho.wvmg.protocol.connection
 
 import com.google.common.truth.Truth.assertThat
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.MediumMetadata
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.PayloadTransferFrame.PayloadHeader
 import io.github.kyujincho.wvmg.protocol.medium.Medium
 import io.github.kyujincho.wvmg.protocol.medium.MediumLadder
@@ -15,6 +17,7 @@ import io.github.kyujincho.wvmg.protocol.medium.UpgradePathCredentials
 import io.github.kyujincho.wvmg.protocol.medium.UpgradedTransport
 import io.github.kyujincho.wvmg.protocol.payload.FileDestinationFactory
 import io.github.kyujincho.wvmg.protocol.transport.ConnectedTransport
+import io.github.kyujincho.wvmg.protocol.transport.FramedConnection
 import io.github.kyujincho.wvmg.protocol.transport.asConnectedTransport
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -63,6 +66,7 @@ import java.util.concurrent.TimeUnit
  *    → Completed) including a non-empty PIN.
  */
 @Timeout(value = 30, unit = TimeUnit.SECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+@Suppress("LargeClass")
 class OutboundConnectionTest {
     private lateinit var serverSocket: ServerSocket
     private val openedSockets: MutableList<Socket> = mutableListOf()
@@ -220,6 +224,12 @@ class OutboundConnectionTest {
             listener.close()
             return client to server
         }
+    }
+
+    private class SupportedProvider(
+        override val medium: Medium,
+    ) : MediumProvider {
+        override fun isSupported(): Boolean = true
     }
 
     /** Build a [FileSource] backed by an in-memory byte array. */
@@ -497,6 +507,141 @@ class OutboundConnectionTest {
                     assertThat(outbound.state.value).isEqualTo(OutboundConnectionState.Completed)
                 } finally {
                     upgradePair.close()
+                }
+            }
+        }
+
+    @Test
+    fun `preconnected BLE bootstrap upgrades to Wi-Fi Direct from initial medium advertisement`() =
+        runBlocking {
+            withTimeout(WALLCLOCK_TIMEOUT_MS) {
+                val (client, server) = connectedSocketPair()
+                val factory = InMemoryFactory()
+                val directUpgradePair = LoopbackUpgradePair(Medium.WIFI_DIRECT)
+                val hotspotUpgradePair = LoopbackUpgradePair(Medium.WIFI_HOTSPOT)
+                val ladder =
+                    MediumLadder(
+                        listOf(
+                            Medium.WIFI_HOTSPOT,
+                            Medium.WIFI_DIRECT,
+                            Medium.WIFI_LAN,
+                            Medium.BLE,
+                        ),
+                    )
+                val outbound =
+                    OutboundConnection(
+                        transport = client.asConnectedTransport(Medium.BLE),
+                        secureRandom = SecureRandom("outbound-ble-bootstrap-direct".toByteArray()),
+                        mediumRegistry =
+                            MediumRegistry(
+                                providers =
+                                    listOf(
+                                        MediumRegistry.DefaultWifiLan.providerFor(Medium.WIFI_LAN)!!,
+                                        hotspotUpgradePair.clientProvider,
+                                        directUpgradePair.clientProvider,
+                                        SupportedProvider(Medium.BLE),
+                                        SupportedProvider(Medium.BLE_L2CAP),
+                                    ),
+                                ladder = ladder,
+                            ),
+                    )
+
+                val fileBytes = ByteArray(1024) { (it and 0x7F).toByte() }
+                val payloadId = 0x5154L
+                val files = listOf(bytesSource("ble-bootstrap-direct.bin", fileBytes, payloadId))
+
+                try {
+                    coroutineScope {
+                        val outboundJob = async { outbound.run(files) }
+                        val inbound =
+                            InboundConnection(
+                                transport = server.asConnectedTransport(Medium.BLE),
+                                secureRandom = SecureRandom("inbound-ble-bootstrap-direct".toByteArray()),
+                                mediumRegistry =
+                                    MediumRegistry(
+                                        providers =
+                                            listOf(
+                                                MediumRegistry.DefaultWifiLan.providerFor(Medium.WIFI_LAN)!!,
+                                                hotspotUpgradePair.serverProvider,
+                                                directUpgradePair.serverProvider,
+                                                SupportedProvider(Medium.BLE),
+                                                SupportedProvider(Medium.BLE_L2CAP),
+                                            ),
+                                        ladder = ladder,
+                                    ),
+                            )
+
+                        launch {
+                            inbound.state.first { it is InboundConnectionState.WaitingForUserConsent }
+                            inbound.submitUserConsent(accepted = true)
+                        }
+
+                        val inboundResult = inbound.run(factory)
+                        val outboundResult = outboundJob.await()
+
+                        assertThat(outboundResult).isEqualTo(OutboundResult.Completed)
+                        assertThat(inboundResult).isInstanceOf(InboundResult.Completed::class.java)
+                        assertThat(inbound.activeMedium.value).isEqualTo(Medium.WIFI_DIRECT)
+                    }
+
+                    assertThat(factory.output[payloadId]?.toByteArray()).isEqualTo(fileBytes)
+                    assertThat(outbound.state.value).isEqualTo(OutboundConnectionState.Completed)
+                } finally {
+                    directUpgradePair.close()
+                    hotspotUpgradePair.close()
+                }
+            }
+        }
+
+    @Test
+    fun `preconnected BLE bootstrap request advertises LAN marker BLE and Wi-Fi Direct`() =
+        runBlocking {
+            withTimeout(WALLCLOCK_TIMEOUT_MS) {
+                val (client, server) = connectedSocketPair()
+                val directUpgradePair = LoopbackUpgradePair(Medium.WIFI_DIRECT)
+                val outbound =
+                    OutboundConnection(
+                        transport = client.asConnectedTransport(Medium.BLE),
+                        secureRandom = SecureRandom("outbound-ble-bootstrap-request".toByteArray()),
+                        mediumRegistry =
+                            MediumRegistry(
+                                providers =
+                                    listOf(
+                                        MediumRegistry.DefaultWifiLan.providerFor(Medium.WIFI_LAN)!!,
+                                        directUpgradePair.clientProvider,
+                                        SupportedProvider(Medium.BLE),
+                                    ),
+                                ladder = MediumLadder(listOf(Medium.WIFI_DIRECT, Medium.WIFI_LAN, Medium.BLE)),
+                            ),
+                        initialHandshakeTimeoutMillis = SHORT_INITIAL_HANDSHAKE_TIMEOUT_MS,
+                    )
+                val wire = FramedConnection(server.asConnectedTransport(Medium.BLE))
+
+                try {
+                    coroutineScope {
+                        val outboundJob = async { outbound.run(emptyList()) }
+                        val request =
+                            OfflineFrame
+                                .parseFrom(wire.receiveFrame())
+                                .v1
+                                .connectionRequest
+
+                        assertThat(request.mediumsList.map { it.number })
+                            .containsExactly(
+                                Medium.BLE.wireNumber,
+                                Medium.WIFI_LAN.wireNumber,
+                                Medium.WIFI_DIRECT.wireNumber,
+                            ).inOrder()
+                        assertThat(request.mediumMetadata.supportedWifiDirectAuthTypesList)
+                            .containsExactly(MediumMetadata.WifiDirectAuthType.WIFI_DIRECT_WITH_PASSWORD)
+                        assertThat(request.mediumMetadata.hasMediumRole()).isFalse()
+
+                        wire.close()
+                        assertThat(outboundJob.await()).isInstanceOf(OutboundResult.Failed::class.java)
+                    }
+                } finally {
+                    runCatching { wire.close() }
+                    directUpgradePair.close()
                 }
             }
         }

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/BleAdvertisementTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/BleAdvertisementTest.kt
@@ -47,6 +47,20 @@ class BleAdvertisementTest {
         assertThat(BleServiceData.parse(parsed.data)?.endpointInfo).isEqualTo(info)
     }
 
+    @Test
+    fun `parse exposes second-profile fast advertisement wrapper`() {
+        val info = endpointInfo("Pixel")
+        val bytes = BleServiceData.encodeFramed("ABCD", info, secondProfile = true)
+
+        val parsed = BleAdvertisement.parse(bytes)
+
+        assertThat(parsed).isNotNull()
+        assertThat(parsed!!.fastAdvertisement).isTrue()
+        assertThat(parsed.secondProfile).isTrue()
+        assertThat(parsed.serviceIdHash).isNull()
+        assertThat(BleServiceData.parse(parsed.data)?.endpointInfo).isEqualTo(info)
+    }
+
     private fun endpointInfo(name: String): EndpointInfo =
         EndpointInfo(
             version = 1,

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/BleServiceDataTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/endpoint/BleServiceDataTest.kt
@@ -153,6 +153,17 @@ class BleServiceDataTest {
     }
 
     @Test
+    fun `encodeFramed can set the second-profile bit`() {
+        val info = hiddenPhoneEndpointInfo()
+        val payload = BleServiceData.encodeFramed("Wvmg", info, secondProfile = true)
+
+        assertThat(payload).hasLength(27)
+        assertThat(payload[0].toInt() and 0xFF)
+            .isEqualTo(BleServiceData.FRAME_TYPE_SECOND_PROFILE_FAST_ADVERTISEMENT)
+        assertThat(BleServiceData.parse(payload)?.endpointInfo).isEqualTo(info)
+    }
+
+    @Test
     fun `encodeFramedWithPsm rejects invalid PSM values`() {
         val info = hiddenPhoneEndpointInfo()
         assertThrows<IllegalArgumentException> {

--- a/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/sharing/InboundSharingFsmTest.kt
+++ b/core-protocol/src/test/kotlin/io/github/kyujincho/wvmg/protocol/sharing/InboundSharingFsmTest.kt
@@ -255,6 +255,64 @@ class InboundSharingFsmTest {
     // alive; regressing any of these breaks Galaxy → WVMG sends.
 
     @Test
+    fun `preemptive RESPONSE ACCEPT before INTRODUCTION is ignored until introduction arrives`() {
+        val fsm = driveToReceivedPairedKeyResult()
+
+        val responseEffects =
+            fsm.onEvent(
+                SharingFsmEvent.FrameReceived(
+                    SharingFrames.connectionResponse(ConnectionResponseStatus.ACCEPT),
+                ),
+            )
+
+        assertThat(responseEffects).isEmpty()
+        assertThat(fsm.state).isEqualTo(InboundSharingState.ReceivedPairedKeyResult)
+
+        val intro = IntroductionFrame.newBuilder().build()
+        val introEffects =
+            fsm.onEvent(
+                SharingFsmEvent.FrameReceived(
+                    SharingFrames.introduction(intro),
+                ),
+            )
+
+        assertThat(introEffects).hasSize(1)
+        assertThat(introEffects[0]).isInstanceOf(SharingFsmEffect.IntroductionReceived::class.java)
+        assertThat(fsm.state).isEqualTo(InboundSharingState.WaitingForUserConsent)
+    }
+
+    @Test
+    fun `preemptive RESPONSE UNKNOWN before INTRODUCTION is ignored`() {
+        val fsm = driveToReceivedPairedKeyResult()
+
+        val effects =
+            fsm.onEvent(
+                SharingFsmEvent.FrameReceived(
+                    SharingFrames.connectionResponse(ConnectionResponseStatus.UNKNOWN),
+                ),
+            )
+
+        assertThat(effects).isEmpty()
+        assertThat(fsm.state).isEqualTo(InboundSharingState.ReceivedPairedKeyResult)
+    }
+
+    @Test
+    fun `preemptive RESPONSE REJECT before INTRODUCTION is treated as peer cancel`() {
+        val fsm = driveToReceivedPairedKeyResult()
+
+        val effects =
+            fsm.onEvent(
+                SharingFsmEvent.FrameReceived(
+                    SharingFrames.connectionResponse(ConnectionResponseStatus.REJECT),
+                ),
+            )
+
+        assertThat(effects).hasSize(1)
+        assertThat(effects[0]).isInstanceOf(SharingFsmEffect.Cancelled::class.java)
+        assertThat(fsm.state).isEqualTo(InboundSharingState.Disconnected)
+    }
+
+    @Test
     fun `preemptive RESPONSE ACCEPT in WaitingForUserConsent is ignored`() {
         // Samsung's stock Quick Share sends RESPONSE(status=ACCEPT) to
         // the receiver right after INTRODUCTION — the sender treats the
@@ -432,16 +490,24 @@ class InboundSharingFsmTest {
      * starts in [InboundSharingState.WaitingForUserConsent].
      */
     private fun driveToWaitingForUserConsent(): InboundSharingFsm {
-        val fsm = newFsm()
-        fsm.start()
-        fsm.onEvent(SharingFsmEvent.FrameReceived(SharingFrames.pairedKeyEncryption()))
-        fsm.onEvent(SharingFsmEvent.FrameReceived(SharingFrames.pairedKeyResult()))
+        val fsm = driveToReceivedPairedKeyResult()
         fsm.onEvent(
             SharingFsmEvent.FrameReceived(
                 SharingFrames.introduction(IntroductionFrame.newBuilder().build()),
             ),
         )
         check(fsm.state == InboundSharingState.WaitingForUserConsent) {
+            "fixture state setup failed: ${fsm.state}"
+        }
+        return fsm
+    }
+
+    private fun driveToReceivedPairedKeyResult(): InboundSharingFsm {
+        val fsm = newFsm()
+        fsm.start()
+        fsm.onEvent(SharingFsmEvent.FrameReceived(SharingFrames.pairedKeyEncryption()))
+        fsm.onEvent(SharingFsmEvent.FrameReceived(SharingFrames.pairedKeyResult()))
+        check(fsm.state == InboundSharingState.ReceivedPairedKeyResult) {
             "fixture state setup failed: ${fsm.state}"
         }
         return fsm

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareAdvertiser.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareAdvertiser.kt
@@ -638,14 +638,22 @@ public object DefaultPayloadFactory : PayloadFactory {
             serviceId = NearbyServiceId.VALUE,
             gattAdvertisement = gattAdvertisement,
             psm = 0,
+            supportsExtendedAdvertisement = endpointInfo.supportsVisibleExtendedAdvertisement(),
         )
     }
 
     internal fun buildSlotPayload(
         endpointId: ByteArray,
         endpointInfo: EndpointInfo,
-    ): ByteArray = BleServiceData.encode(endpointId, endpointInfo)
+    ): ByteArray =
+        BleServiceData.encodeFramed(
+            endpointId = endpointId,
+            endpointInfo = endpointInfo,
+            secondProfile = true,
+        )
 }
+
+private fun EndpointInfo.supportsVisibleExtendedAdvertisement(): Boolean = !hidden && !deviceName.isNullOrBlank()
 
 /** Optional payload builder for secondary extended advertisements. */
 public fun interface OptionalPayloadFactory {
@@ -669,9 +677,18 @@ public object DefaultVisiblePayloadFactory : OptionalPayloadFactory {
         if (endpointInfo.hidden || endpointInfo.deviceName == null) return null
         val psm = BleDctPsmHolder.currentPsm
         return if (psm != null && psm != DctAdvertisement.DEFAULT_PSM) {
-            BleServiceData.encodeFramedWithPsm(endpointId, endpointInfo, psm)
+            BleServiceData.encodeFramedWithPsm(
+                endpointId = endpointId,
+                endpointInfo = endpointInfo,
+                psm = psm,
+                secondProfile = true,
+            )
         } else {
-            BleServiceData.encodeFramed(endpointId, endpointInfo)
+            BleServiceData.encodeFramed(
+                endpointId = endpointId,
+                endpointInfo = endpointInfo,
+                secondProfile = true,
+            )
         }
     }
 }

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BleGattInitialControlClient.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BleGattInitialControlClient.kt
@@ -313,6 +313,7 @@ private class BleGattClientTransport(
         runCatching { input.close() }
         val openGatt = gatt
         gatt = null
+        writeQueue.clear()
         runCatching { openGatt?.disconnect() }
         runCatching { openGatt?.close() }
         onClose(this)
@@ -383,6 +384,10 @@ private class BleGattClientTransport(
         weaveConnected = true
         Log.i(TAG, "Weave connected raw Nearby stream packetSize=$negotiatedPacketSize device=${device.safeAddress()}")
         sendWeaveMessage(NearbyBleSocketFrames.encodeIntroductionPacket())
+        // Samsung's GMS raw Nearby handler expects the first app payload
+        // immediately after the socket-introduction packet. Waiting after
+        // the intro write leaves the BLE Weave stream open, but the
+        // ConnectionRequestFrame is never dispatched to Nearby Connections.
         if (!ready.isCompleted) ready.complete(true)
     }
 
@@ -446,7 +451,11 @@ private class BleGattClientTransport(
     private fun sendSocketServiceBytes(bytes: ByteArray) {
         if (bytes.isEmpty()) return
         Log.i(TAG, "BLE GATT service write bytes=${bytes.size} preview=${bytes.previewHex()}")
-        sendWeaveMessage(NearbyServiceId.hashPrefix + bytes)
+        sendSocketServiceMessage(bytes)
+    }
+
+    private fun sendSocketServiceMessage(payload: ByteArray) {
+        sendWeaveMessage(NearbyServiceId.hashPrefix + payload)
     }
 
     @Synchronized
@@ -472,7 +481,10 @@ private class BleGattClientTransport(
 
     private fun enqueueWriteLocked(packet: ByteArray) {
         if (closed) return
-        Log.i(TAG, "enqueue write len=${packet.size} header=${packet.firstByteHex()} device=${device.safeAddress()}")
+        Log.i(
+            TAG,
+            "enqueue write len=${packet.size} header=${packet.firstByteHex()} device=${device.safeAddress()}",
+        )
         writeQueue.add(packet)
         drainWritesLocked()
     }

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BleGattInitialControlServer.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BleGattInitialControlServer.kt
@@ -43,6 +43,8 @@ import java.io.PipedOutputStream
 import java.util.ArrayDeque
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 
 /**
@@ -89,9 +91,10 @@ public class BleGattInitialControlServer(
                         return false
                     }
             callback.attach(server)
-            if (!server.addService(callback.service)) {
-                Log.w(TAG, "BluetoothGattServer.addService failed")
+            if (!callback.startAddingServices() || !callback.awaitServicesReady()) {
+                runCatching { server.clearServices() }
                 server.close()
+                callback.close()
                 return false
             }
             val state = ActiveState(server = server, callback = callback)
@@ -100,7 +103,7 @@ public class BleGattInitialControlServer(
                 callback.close()
                 return true
             }
-            Log.i(TAG, "BLE GATT bootstrap active service=$SERVICE_UUID")
+            Log.i(TAG, "BLE GATT bootstrap active services=${callback.services.joinToString { it.uuid.toString() }}")
             true
         }
 
@@ -145,21 +148,40 @@ public class BleGattInitialControlServer(
         endpointId: ByteArray,
         private val acceptTransport: (ConnectedTransport) -> Unit,
     ) : BluetoothGattServerCallback() {
-        val service: BluetoothGattService = buildService(endpointInfo, endpointId)
+        val services: List<BluetoothGattService> =
+            buildServices(
+                endpointInfo = endpointInfo,
+                endpointId = endpointId,
+            )
 
         private val sessions: ConcurrentHashMap<String, BleWeaveGattSession> = ConcurrentHashMap()
         private val fromPeripheral: BluetoothGattCharacteristic =
-            requireNotNull(service.getCharacteristic(FROM_PERIPHERAL_UUID))
+            requireNotNull(services.firstNotNullOfOrNull { it.getCharacteristic(FROM_PERIPHERAL_UUID) })
         private var server: BluetoothGattServer? = null
+        private val serviceAddLock: Any = Any()
+        private val serviceAddLatch: CountDownLatch = CountDownLatch(services.size)
+        private var nextServiceIndex: Int = 0
+        private var serviceAddFailed: Boolean = false
 
         fun attach(server: BluetoothGattServer) {
             this.server = server
+        }
+
+        fun startAddingServices(): Boolean = addNextService()
+
+        fun awaitServicesReady(): Boolean {
+            val ready = serviceAddLatch.await(SERVICE_ADD_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
+            if (!ready) {
+                Log.w(TAG, "timed out adding BLE GATT services")
+            }
+            return ready && !serviceAddFailed
         }
 
         fun close() {
             sessions.values.forEach { it.close() }
             sessions.clear()
             server = null
+            markServiceAddFailed()
         }
 
         override fun onConnectionStateChange(
@@ -180,6 +202,12 @@ public class BleGattInitialControlServer(
             service: BluetoothGattService,
         ) {
             Log.i(TAG, "service added status=$status uuid=${service.uuid}")
+            if (status != BluetoothGatt.GATT_SUCCESS) {
+                markServiceAddFailed()
+                return
+            }
+            serviceAddLatch.countDown()
+            addNextService()
         }
 
         override fun onCharacteristicReadRequest(
@@ -264,6 +292,40 @@ public class BleGattInitialControlServer(
             }
         }
 
+        override fun onDescriptorReadRequest(
+            device: BluetoothDevice,
+            requestId: Int,
+            offset: Int,
+            descriptor: BluetoothGattDescriptor,
+        ) {
+            Log.i(
+                TAG,
+                "read descriptor=${descriptor.uuid} char=${descriptor.characteristic?.uuid} " +
+                    "offset=$offset device=${device.safeAddress()}",
+            )
+            val value =
+                if (descriptor.uuid == CLIENT_CHARACTERISTIC_CONFIG_UUID &&
+                    descriptor.characteristic?.uuid == FROM_PERIPHERAL_UUID
+                ) {
+                    sessionFor(device).cccdValue()
+                } else {
+                    ByteArray(0)
+                }
+            val response =
+                if (offset in 0..value.size) {
+                    value.copyOfRange(offset, value.size)
+                } else {
+                    ByteArray(0)
+                }
+            server?.sendResponse(
+                device,
+                requestId,
+                if (offset in 0..value.size) BluetoothGatt.GATT_SUCCESS else BluetoothGatt.GATT_INVALID_OFFSET,
+                offset,
+                response,
+            )
+        }
+
         override fun onMtuChanged(
             device: BluetoothDevice,
             mtu: Int,
@@ -291,60 +353,45 @@ public class BleGattInitialControlServer(
             }
         }
 
-        private companion object {
-            private fun buildService(
-                endpointInfo: EndpointInfo,
-                endpointId: ByteArray,
-            ): BluetoothGattService {
-                val service =
-                    BluetoothGattService(
-                        SERVICE_UUID,
-                        BluetoothGattService.SERVICE_TYPE_PRIMARY,
-                    )
-                val fromPeripheral =
-                    BluetoothGattCharacteristic(
-                        FROM_PERIPHERAL_UUID,
-                        BluetoothGattCharacteristic.PROPERTY_INDICATE,
-                        0,
-                    )
-                fromPeripheral.addDescriptor(
-                    BluetoothGattDescriptor(
-                        CLIENT_CHARACTERISTIC_CONFIG_UUID,
-                        BluetoothGattDescriptor.PERMISSION_READ or BluetoothGattDescriptor.PERMISSION_WRITE,
-                    ),
-                )
-                val toPeripheral =
-                    BluetoothGattCharacteristic(
-                        TO_PERIPHERAL_UUID,
-                        BluetoothGattCharacteristic.PROPERTY_WRITE,
-                        BluetoothGattCharacteristic.PERMISSION_WRITE,
-                    )
-                service.addCharacteristic(fromPeripheral)
-                service.addCharacteristic(toPeripheral)
-                buildAdvertisementSlots(endpointInfo, endpointId).forEach(service::addCharacteristic)
-                return service
-            }
-
-            private fun buildAdvertisementSlots(
-                endpointInfo: EndpointInfo,
-                endpointId: ByteArray,
-            ): List<BluetoothGattCharacteristic> {
-                // Stock GMS expects GATT slots to host the raw Nearby BLE
-                // advertisement body (0x23 + endpoint_id + EndpointInfo),
-                // not the heavier non-fast wrapper used by some scanners.
-                val visibleAdvertisement =
-                    runCatching { BleServiceData.encode(endpointId, endpointInfo) }
-                        .getOrDefault(ByteArray(0))
-
-                return (0 until GATT_ADVERTISEMENT_SLOT_COUNT).map { slot ->
-                    BluetoothGattCharacteristic(
-                        advertisementSlotUuid(slot),
-                        BluetoothGattCharacteristic.PROPERTY_READ,
-                        BluetoothGattCharacteristic.PERMISSION_READ,
-                    ).apply {
-                        value = if (slot == 0) visibleAdvertisement else ByteArray(0)
+        private fun addNextService(): Boolean {
+            val gattServer = server
+            val service =
+                synchronized(serviceAddLock) {
+                    if (serviceAddFailed || nextServiceIndex >= services.size) {
+                        null
+                    } else {
+                        services[nextServiceIndex++]
                     }
                 }
+
+            val accepted =
+                if (gattServer == null) {
+                    false
+                } else if (service == null) {
+                    true
+                } else {
+                    // Android's BluetoothGattServer keeps one mPendingService internally.
+                    // Queue services from onServiceAdded so descriptor handles are copied
+                    // back onto the right local service before the next add starts.
+                    gattServer.addService(service).also { serviceAccepted ->
+                        if (!serviceAccepted) {
+                            Log.w(TAG, "BluetoothGattServer.addService failed uuid=${service.uuid}")
+                            markServiceAddFailed()
+                        }
+                    }
+                }
+            if (gattServer == null) {
+                markServiceAddFailed()
+            }
+            return accepted
+        }
+
+        private fun markServiceAddFailed() {
+            synchronized(serviceAddLock) {
+                serviceAddFailed = true
+            }
+            while (serviceAddLatch.count > 0) {
+                serviceAddLatch.countDown()
             }
         }
     }
@@ -354,6 +401,10 @@ public class BleGattInitialControlServer(
 
         /** Copresence / Nearby BLE socket service UUID. */
         public val SERVICE_UUID: UUID = UUID.fromString(BleServiceData.SERVICE_UUID_128_STRING)
+
+        /** Nearby BLE second-profile socket service UUID used when GMS owns the first profile. */
+        public val SECOND_PROFILE_SERVICE_UUID: UUID =
+            UUID.fromString("0000fef3-0004-1000-8000-001a11000100")
 
         /** Central writes Weave packets here. */
         public val TO_PERIPHERAL_UUID: UUID = UUID.fromString("00000100-0004-1000-8000-001a11000101")
@@ -368,9 +419,134 @@ public class BleGattInitialControlServer(
             UUID.fromString("00002902-0000-1000-8000-00805f9b34fb")
 
         private const val GATT_ADVERTISEMENT_SLOT_COUNT: Int = 16
+        private const val SERVICE_ADD_TIMEOUT_MILLIS: Long = 2_000L
+
+        internal data class GattServiceSpec(
+            val uuid: UUID,
+            val characteristics: List<GattCharacteristicSpec>,
+        )
+
+        internal data class GattCharacteristicSpec(
+            val uuid: UUID,
+            val properties: Int,
+            val permissions: Int,
+            val descriptors: List<GattDescriptorSpec> = emptyList(),
+            val value: ByteArray = ByteArray(0),
+        )
+
+        internal data class GattDescriptorSpec(
+            val uuid: UUID,
+            val permissions: Int,
+        )
+
+        internal fun buildServiceSpecs(
+            endpointInfo: EndpointInfo,
+            endpointId: ByteArray,
+        ): List<GattServiceSpec> {
+            val advertisementService = buildAdvertisementServiceSpec(endpointInfo, endpointId)
+            val socketService = buildSocketServiceSpec()
+            return listOf(advertisementService, socketService)
+        }
+
+        internal fun buildServices(
+            endpointInfo: EndpointInfo,
+            endpointId: ByteArray,
+        ): List<BluetoothGattService> = buildServiceSpecs(endpointInfo, endpointId).map { it.toBluetoothGattService() }
 
         internal fun advertisementSlotUuid(slot: Int): UUID =
             UUID.fromString("00000000-0000-3000-8000-${slot.toString(radix = 16).padStart(12, '0')}")
+
+        private fun buildAdvertisementServiceSpec(
+            endpointInfo: EndpointInfo,
+            endpointId: ByteArray,
+        ): GattServiceSpec =
+            GattServiceSpec(
+                uuid = SERVICE_UUID,
+                characteristics = buildAdvertisementSlots(endpointInfo, endpointId),
+            )
+
+        private fun buildSocketServiceSpec(): GattServiceSpec {
+            val fromPeripheral =
+                GattCharacteristicSpec(
+                    uuid = FROM_PERIPHERAL_UUID,
+                    properties = BluetoothGattCharacteristic.PROPERTY_INDICATE,
+                    permissions = 0,
+                    descriptors =
+                        listOf(
+                            GattDescriptorSpec(
+                                uuid = CLIENT_CHARACTERISTIC_CONFIG_UUID,
+                                permissions =
+                                    BluetoothGattDescriptor.PERMISSION_READ or
+                                        BluetoothGattDescriptor.PERMISSION_WRITE,
+                            ),
+                        ),
+                )
+            val toPeripheral =
+                GattCharacteristicSpec(
+                    uuid = TO_PERIPHERAL_UUID,
+                    properties = BluetoothGattCharacteristic.PROPERTY_WRITE,
+                    permissions = BluetoothGattCharacteristic.PERMISSION_WRITE,
+                )
+            return GattServiceSpec(
+                uuid = SECOND_PROFILE_SERVICE_UUID,
+                characteristics = listOf(fromPeripheral, toPeripheral),
+            )
+        }
+
+        private fun buildAdvertisementSlots(
+            endpointInfo: EndpointInfo,
+            endpointId: ByteArray,
+        ): List<GattCharacteristicSpec> {
+            // WVMG runs beside Google Play services on Android. GMS may
+            // already own the first 0xFEF3 GATT socket profile, so the
+            // regular service is read-only and advertises the second-profile
+            // bit. Stock senders can still fetch the endpoint from the normal
+            // slot path, then open the socket on the isolated second profile.
+            val visibleAdvertisement =
+                runCatching {
+                    BleServiceData.encodeFramed(
+                        endpointId = endpointId,
+                        endpointInfo = endpointInfo,
+                        secondProfile = true,
+                    )
+                }.getOrDefault(ByteArray(0))
+
+            return (0 until GATT_ADVERTISEMENT_SLOT_COUNT).map { slot ->
+                GattCharacteristicSpec(
+                    uuid = advertisementSlotUuid(slot),
+                    properties = BluetoothGattCharacteristic.PROPERTY_READ,
+                    permissions = BluetoothGattCharacteristic.PERMISSION_READ,
+                    value = if (slot == 0) visibleAdvertisement else ByteArray(0),
+                )
+            }
+        }
+
+        private fun GattServiceSpec.toBluetoothGattService(): BluetoothGattService {
+            val spec = this
+            return BluetoothGattService(
+                uuid,
+                BluetoothGattService.SERVICE_TYPE_PRIMARY,
+            ).apply {
+                spec.characteristics.forEach { addCharacteristic(it.toBluetoothGattCharacteristic()) }
+            }
+        }
+
+        private fun GattCharacteristicSpec.toBluetoothGattCharacteristic(): BluetoothGattCharacteristic =
+            BluetoothGattCharacteristic(
+                uuid,
+                properties,
+                permissions,
+            ).also { characteristic ->
+                characteristic.value = value
+                descriptors.forEach { descriptor ->
+                    characteristic.addDescriptor(
+                        BluetoothGattDescriptor(
+                            descriptor.uuid,
+                            descriptor.permissions,
+                        ),
+                    )
+                }
+            }
     }
 }
 
@@ -408,6 +584,14 @@ private class BleWeaveGattSession(
         )
         drainNotificationsLocked()
     }
+
+    @Synchronized
+    fun cccdValue(): ByteArray =
+        when (subscriptionMode) {
+            GattSubscriptionMode.NOTIFICATION -> BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
+            GattSubscriptionMode.INDICATION -> BluetoothGattDescriptor.ENABLE_INDICATION_VALUE
+            GattSubscriptionMode.DISABLED -> BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE
+        }
 
     @Synchronized
     fun setMtu(mtu: Int) {

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/medium/WifiDirectGroupController.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/medium/WifiDirectGroupController.kt
@@ -26,7 +26,9 @@ import androidx.annotation.RequiresPermission
 import androidx.core.content.ContextCompat
 import io.github.kyujincho.wvmg.protocol.medium.UpgradePathCredentials
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import java.io.Closeable
 import java.io.IOException
@@ -304,10 +306,16 @@ internal class WifiDirectGroupController(
                 cancelConnectQuietly(channel)
             }
 
-        if (!WifiDirectCredentialShape.isValidNetworkName(credentials.ssid) ||
-            !WifiDirectCredentialShape.isValidPassphrase(credentials.passphrase)
-        ) {
-            Log.w(TAG, "Wi-Fi Direct credentials from peer are malformed; declining upgrade")
+        val validNetworkName = WifiDirectCredentialShape.isValidNetworkName(credentials.ssid)
+        val validPassphrase = WifiDirectCredentialShape.isValidPassphrase(credentials.passphrase)
+        if (!validNetworkName || !validPassphrase) {
+            Log.w(
+                TAG,
+                "Wi-Fi Direct credentials from peer are malformed; " +
+                    "ssid=${credentials.ssid} ssidLength=${credentials.ssid.length} " +
+                    "passphraseLength=${credentials.passphrase.length} port=${credentials.port}; " +
+                    "declining upgrade",
+            )
             teardown.close()
             return null
         }
@@ -360,9 +368,7 @@ internal class WifiDirectGroupController(
             }
         val socket =
             try {
-                Socket().also { s ->
-                    s.connect(java.net.InetSocketAddress(address, credentials.port), SOCKET_CONNECT_TIMEOUT_MS)
-                }
+                connectSocketToGroupOwner(address, credentials.port)
             } catch (e: IOException) {
                 Log.w(TAG, "TCP connect to Wi-Fi Direct group owner failed", e)
                 teardown.close()
@@ -370,6 +376,19 @@ internal class WifiDirectGroupController(
             }
         return WifiDirectTransport(socket = socket, teardown = teardown)
     }
+
+    private suspend fun connectSocketToGroupOwner(
+        address: InetAddress,
+        port: Int,
+    ): Socket =
+        withContext(Dispatchers.IO) {
+            Socket().also { socket ->
+                socket.connect(
+                    java.net.InetSocketAddress(address, port),
+                    SOCKET_CONNECT_TIMEOUT_MS,
+                )
+            }
+        }
 
     /**
      * Result of [createGroupAsServer]. The framework hands [credentials]
@@ -674,10 +693,11 @@ internal class WifiDirectGroupController(
 
 internal object WifiDirectCredentialShape {
     private val random = SecureRandom()
-    private val networkNameRegex = Regex("^DIRECT-[A-Za-z0-9]{2}-[A-Za-z0-9_-]+$")
+    private val networkNameRegex = Regex("^DIRECT-[A-Za-z0-9]{2}[A-Za-z0-9_-]*$")
     private const val NETWORK_NAME_RANDOM_CHARS = 2
     private const val NETWORK_NAME_SUFFIX = "WVMG"
     private const val NETWORK_NAME_SESSION_CHARS = 6
+    private const val NETWORK_NAME_MAX_LENGTH = 32
     private const val PASSPHRASE_LENGTH = 16
     private const val PASSPHRASE_MIN_LENGTH = 8
     private const val PASSPHRASE_MAX_LENGTH = 63
@@ -689,7 +709,8 @@ internal object WifiDirectCredentialShape {
 
     fun generatePassphrase(): String = randomToken(PASSPHRASE_LENGTH)
 
-    fun isValidNetworkName(value: String): Boolean = networkNameRegex.matches(value)
+    fun isValidNetworkName(value: String): Boolean =
+        value.length <= NETWORK_NAME_MAX_LENGTH && networkNameRegex.matches(value)
 
     fun isValidPassphrase(value: String): Boolean =
         value.length in PASSPHRASE_MIN_LENGTH..PASSPHRASE_MAX_LENGTH &&

--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/medium/WifiDirectGroupController.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/medium/WifiDirectGroupController.kt
@@ -125,9 +125,10 @@ internal class WifiDirectGroupController(
         channel: WifiP2pManager.Channel,
         requested: RequestedWifiDirectCredentials,
     ): Boolean {
+        primeP2pChannel(channel)
         removeExistingGroupBeforeServerCreate(channel)
         val createOk =
-            awaitActionListener { listener ->
+            awaitActionListener("createGroup") { listener ->
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                     manager.createGroup(channel, requested.toConfig(), listener)
                 } else {
@@ -140,9 +141,28 @@ internal class WifiDirectGroupController(
         return createOk
     }
 
+    @RequiresPermission(Manifest.permission.NEARBY_WIFI_DEVICES)
+    private suspend fun primeP2pChannel(channel: WifiP2pManager.Channel) {
+        val stateChanged = registerStateChangedReceiver()
+        try {
+            val discoverStarted =
+                awaitActionListener("discoverPeers") { listener ->
+                    manager.discoverPeers(channel, listener)
+                }
+            if (discoverStarted) {
+                stateChanged.awaitEnabledOrTimeout(P2P_ENABLE_TIMEOUT_MS)
+            } else {
+                Log.w(TAG, "WifiP2pManager.discoverPeers failed while priming P2P channel")
+            }
+        } finally {
+            stateChanged.unregister()
+            stopPeerDiscoveryQuietly(channel)
+        }
+    }
+
     private suspend fun removeExistingGroupBeforeServerCreate(channel: WifiP2pManager.Channel) {
         val removedExisting =
-            awaitActionListener { listener ->
+            awaitActionListener("removeGroup") { listener ->
                 manager.removeGroup(channel, listener)
             }
         if (removedExisting) {
@@ -311,7 +331,7 @@ internal class WifiDirectGroupController(
                     wps.setup = WpsInfo.PBC
                 }
         val connectOk =
-            awaitActionListener { listener ->
+            awaitActionListener("connect") { listener ->
                 manager.connect(channel, config, listener)
             }
         if (!connectOk) {
@@ -366,16 +386,20 @@ internal class WifiDirectGroupController(
     // suspend-able primitives so the call sites read top-to-bottom.
     // -----------------------------------------------------------------
 
-    private suspend fun awaitActionListener(call: (WifiP2pManager.ActionListener) -> Unit): Boolean {
+    private suspend fun awaitActionListener(
+        label: String,
+        call: (WifiP2pManager.ActionListener) -> Unit,
+    ): Boolean {
         val deferred = CompletableDeferred<Boolean>()
         val listener =
             object : WifiP2pManager.ActionListener {
                 override fun onSuccess() {
+                    Log.w(TAG, "WifiP2pManager.$label onSuccess")
                     deferred.complete(true)
                 }
 
                 override fun onFailure(reason: Int) {
-                    Log.w(TAG, "WifiP2pManager.ActionListener.onFailure reason=$reason")
+                    Log.w(TAG, "WifiP2pManager.$label onFailure reason=$reason")
                     deferred.complete(false)
                 }
             }
@@ -384,7 +408,7 @@ internal class WifiDirectGroupController(
         } catch (
             @Suppress("TooGenericExceptionCaught") t: Throwable,
         ) {
-            Log.w(TAG, "WifiP2pManager call threw before listener invocation", t)
+            Log.w(TAG, "WifiP2pManager.$label threw before listener invocation", t)
             deferred.complete(false)
         }
         return deferred.await()
@@ -442,6 +466,27 @@ internal class WifiDirectGroupController(
         }
     }
 
+    private fun stopPeerDiscoveryQuietly(channel: WifiP2pManager.Channel) {
+        try {
+            manager.stopPeerDiscovery(
+                channel,
+                object : WifiP2pManager.ActionListener {
+                    override fun onSuccess() {
+                        Log.w(TAG, "WifiP2pManager.stopPeerDiscovery onSuccess")
+                    }
+
+                    override fun onFailure(reason: Int) {
+                        Log.w(TAG, "WifiP2pManager.stopPeerDiscovery reason=$reason")
+                    }
+                },
+            )
+        } catch (
+            @Suppress("TooGenericExceptionCaught") t: Throwable,
+        ) {
+            Log.w(TAG, "WifiP2pManager.stopPeerDiscovery threw during P2P prime", t)
+        }
+    }
+
     private fun registerConnectionChangedReceiver(): ConnectionChangedReceiver {
         val receiver = ConnectionChangedReceiver()
         val filter = IntentFilter(WifiP2pManager.WIFI_P2P_CONNECTION_CHANGED_ACTION)
@@ -462,6 +507,25 @@ internal class WifiDirectGroupController(
             @Suppress("TooGenericExceptionCaught") t: Throwable,
         ) {
             Log.w(TAG, "Failed to register P2P connection-changed receiver", t)
+        }
+        receiver.context = context
+        return receiver
+    }
+
+    private fun registerStateChangedReceiver(): StateChangedReceiver {
+        val receiver = StateChangedReceiver()
+        val filter = IntentFilter(WifiP2pManager.WIFI_P2P_STATE_CHANGED_ACTION)
+        try {
+            ContextCompat.registerReceiver(
+                context,
+                receiver,
+                filter,
+                ContextCompat.RECEIVER_NOT_EXPORTED,
+            )
+        } catch (
+            @Suppress("TooGenericExceptionCaught") t: Throwable,
+        ) {
+            Log.w(TAG, "Failed to register P2P state-changed receiver", t)
         }
         receiver.context = context
         return receiver
@@ -532,6 +596,50 @@ internal class WifiDirectGroupController(
         }
     }
 
+    private class StateChangedReceiver : BroadcastReceiver() {
+        var context: Context? = null
+        private val unregistered = AtomicReference(false)
+        private val enabled = CompletableDeferred<Unit>()
+
+        override fun onReceive(
+            context: Context?,
+            intent: Intent?,
+        ) {
+            if (intent?.action != WifiP2pManager.WIFI_P2P_STATE_CHANGED_ACTION) return
+            val state =
+                intent.getIntExtra(
+                    WifiP2pManager.EXTRA_WIFI_STATE,
+                    WifiP2pManager.WIFI_P2P_STATE_DISABLED,
+                )
+            Log.w(TAG, "WIFI_P2P_STATE_CHANGED state=$state")
+            if (state == WifiP2pManager.WIFI_P2P_STATE_ENABLED && !enabled.isCompleted) {
+                enabled.complete(Unit)
+            }
+        }
+
+        suspend fun awaitEnabledOrTimeout(timeoutMillis: Long) {
+            try {
+                withTimeout(timeoutMillis) {
+                    enabled.await()
+                }
+            } catch (_: TimeoutCancellationException) {
+                Log.w(TAG, "Wi-Fi Direct state enable wait timed out after ${timeoutMillis}ms")
+            }
+        }
+
+        fun unregister() {
+            if (!unregistered.compareAndSet(false, true)) return
+            val ctx = context ?: return
+            try {
+                ctx.unregisterReceiver(this)
+            } catch (
+                @Suppress("TooGenericExceptionCaught") t: IllegalArgumentException,
+            ) {
+                Log.d(TAG, "P2P state-changed receiver not registered at unregister time", t)
+            }
+        }
+    }
+
     private fun closeable(action: () -> Unit): Closeable {
         val closed = AtomicReference(false)
         return Closeable {
@@ -552,6 +660,9 @@ internal class WifiDirectGroupController(
 
         /** Wait at most this long for the WIFI_P2P_CONNECTION_CHANGED broadcast. */
         const val GROUP_FORMATION_TIMEOUT_MS: Long = 30_000
+
+        /** Short preflight wait for OEMs that lazily enable P2P after discoverPeers. */
+        const val P2P_ENABLE_TIMEOUT_MS: Long = 2_000
 
         /** Sender-side equivalent of [GROUP_FORMATION_TIMEOUT_MS]. */
         const val CONNECT_TIMEOUT_MS: Long = 30_000

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareAdvertiserTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/ble/BleQuickShareAdvertiserTest.kt
@@ -7,6 +7,7 @@ package io.github.kyujincho.wvmg.discovery.ble
 
 import android.bluetooth.le.AdvertiseSettings
 import com.google.common.truth.Truth.assertThat
+import io.github.kyujincho.wvmg.protocol.endpoint.BleAdvertisement
 import io.github.kyujincho.wvmg.protocol.endpoint.BleAdvertisementHeader
 import io.github.kyujincho.wvmg.protocol.endpoint.BleServiceData
 import io.github.kyujincho.wvmg.protocol.endpoint.DctAdvertisement
@@ -97,6 +98,9 @@ class BleQuickShareAdvertiserTest {
         assertThat(BleServiceData.parse(payload)).isNull()
 
         val slotPayload = DefaultPayloadFactory.buildSlotPayload(endpointId("Wvmg"), info)
+        val slotAdvertisement = BleAdvertisement.parse(slotPayload)
+        assertThat(slotAdvertisement).isNotNull()
+        assertThat(slotAdvertisement!!.secondProfile).isTrue()
         val slot = BleServiceData.parse(slotPayload)
         assertThat(slot).isNotNull()
         assertThat(String(slot!!.endpointId, Charsets.US_ASCII)).isEqualTo("Wvmg")
@@ -132,6 +136,7 @@ class BleQuickShareAdvertiserTest {
         assertThat(header).isNotNull()
         assertThat(header!!.numSlots).isEqualTo(1)
         assertThat(header.psm).isEqualTo(0)
+        assertThat(header.supportsExtendedAdvertisement).isTrue()
         assertThat(BleServiceData.parse(payload)).isNull()
 
         assertThat(dctPayload).isNotNull()
@@ -141,7 +146,8 @@ class BleQuickShareAdvertiserTest {
         assertThat(dct.psm).isEqualTo(DctAdvertisement.DEFAULT_PSM)
 
         assertThat(visiblePayload).isNotNull()
-        val visibleInfo = BleServiceData.parse(visiblePayload!!)!!.endpointInfo
+        assertThat(BleAdvertisement.parse(visiblePayload!!)!!.secondProfile).isTrue()
+        val visibleInfo = BleServiceData.parse(visiblePayload)!!.endpointInfo
         assertThat(visibleInfo.hidden).isFalse()
         assertThat(visibleInfo.deviceName).isEqualTo("WhenVivoMeetsGoogle")
         assertThat(BleServiceData.parsePsmExtraField(visiblePayload)).isNull()
@@ -167,6 +173,7 @@ class BleQuickShareAdvertiserTest {
             assertThat(header).isNotNull()
             assertThat(header!!.psm).isEqualTo(0)
             assertThat(header.numSlots).isEqualTo(1)
+            assertThat(header.supportsExtendedAdvertisement).isTrue()
             val dct = DctAdvertisement.parse(call.dctPayload!!)!!
             assertThat(dct.psm).isEqualTo(0x1234)
             assertThat(BleServiceData.parsePsmExtraField(call.visiblePayload!!)).isEqualTo(0x1234)

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BleGattInitialControlServerTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/bootstrap/BleGattInitialControlServerTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 WhenVivoMeetsGoogle contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+
+package io.github.kyujincho.wvmg.discovery.bootstrap
+
+import com.google.common.truth.Truth.assertThat
+import io.github.kyujincho.wvmg.protocol.endpoint.BleServiceData
+import io.github.kyujincho.wvmg.protocol.endpoint.DeviceType
+import io.github.kyujincho.wvmg.protocol.endpoint.EndpointInfo
+import org.junit.Test
+import java.nio.charset.StandardCharsets
+
+class BleGattInitialControlServerTest {
+    @Test
+    fun `regular service UUID stays the GATT advertisement slot host`() {
+        assertThat(BleGattInitialControlServer.SERVICE_UUID.toString())
+            .isEqualTo(BleServiceData.SERVICE_UUID_128_STRING)
+    }
+
+    @Test
+    fun `second-profile service UUID matches stock Nearby socket lookup`() {
+        assertThat(BleGattInitialControlServer.SECOND_PROFILE_SERVICE_UUID.toString())
+            .isEqualTo("0000fef3-0004-1000-8000-001a11000100")
+    }
+
+    @Test
+    fun `regular slot service points stock sender at second-profile socket`() {
+        val serviceSpecs =
+            BleGattInitialControlServer.buildServiceSpecs(
+                endpointInfo = sampleEndpointInfo(),
+                endpointId = "P0ZK".toByteArray(StandardCharsets.US_ASCII),
+            )
+
+        assertThat(serviceSpecs.map { it.uuid })
+            .containsExactly(
+                BleGattInitialControlServer.SERVICE_UUID,
+                BleGattInitialControlServer.SECOND_PROFILE_SERVICE_UUID,
+            ).inOrder()
+
+        val advertisementService = serviceSpecs[0]
+        val socketService = serviceSpecs[1]
+
+        assertThat(advertisementService.characteristicUuids())
+            .contains(BleGattInitialControlServer.GATT_SLOT_0_UUID)
+        assertThat(advertisementService.characteristicUuids())
+            .doesNotContain(BleGattInitialControlServer.FROM_PERIPHERAL_UUID)
+        assertThat(advertisementService.characteristicUuids())
+            .doesNotContain(BleGattInitialControlServer.TO_PERIPHERAL_UUID)
+
+        assertThat(socketService.characteristicUuids())
+            .doesNotContain(BleGattInitialControlServer.GATT_SLOT_0_UUID)
+        assertThat(socketService.characteristicUuids())
+            .contains(BleGattInitialControlServer.FROM_PERIPHERAL_UUID)
+        assertThat(socketService.characteristicUuids())
+            .contains(BleGattInitialControlServer.TO_PERIPHERAL_UUID)
+
+        val slotValue =
+            requireNotNull(
+                advertisementService.characteristics.firstOrNull {
+                    it.uuid == BleGattInitialControlServer.GATT_SLOT_0_UUID
+                },
+            ).value
+        assertThat(slotValue)
+            .isNotNull()
+        assertThat(slotValue[0].toInt() and 0xFF)
+            .isEqualTo(BleServiceData.FRAME_TYPE_SECOND_PROFILE_FAST_ADVERTISEMENT)
+    }
+
+    private fun BleGattInitialControlServer.Companion.GattServiceSpec.characteristicUuids() =
+        characteristics.map { it.uuid }
+
+    private fun sampleEndpointInfo(): EndpointInfo =
+        EndpointInfo(
+            version = 1,
+            hidden = false,
+            deviceType = DeviceType.PHONE,
+            reserved = false,
+            metadata = ByteArray(EndpointInfo.METADATA_LEN) { index -> index.toByte() },
+            deviceName = "WhenVivoMeetsGoogle",
+        )
+}

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/medium/WifiDirectMediumProviderTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/medium/WifiDirectMediumProviderTest.kt
@@ -152,6 +152,7 @@ class WifiDirectMediumProviderTest {
         assertThat(
             WifiDirectCredentialShape.isValidNetworkName("DIRECT-O3-Kyujin's vivo X300 Ult"),
         ).isFalse()
+        assertThat(WifiDirectCredentialShape.isValidNetworkName("DIRECT-14F768FDC")).isTrue()
         assertThat(WifiDirectCredentialShape.isValidNetworkName("DIRECT-ab-WVMG")).isTrue()
     }
 

--- a/docs/testing/interop-stock-quick-share-android.md
+++ b/docs/testing/interop-stock-quick-share-android.md
@@ -14,9 +14,12 @@ the [Phase 1 epic](https://github.com/kyujin-cho/WhenVivoMeetsGoogle/issues/1).
 > Issue #137 adds a sender-side non-LAN bootstrap path: WVMG can now
 > discover stock peers through Bluetooth-adjacent discovery surfaces and
 > start the initial control channel without requiring the same Wi-Fi LAN.
+> Issue #145 adds the reciprocal receiver path for stock Samsung senders:
+> WVMG can be discovered through the stock Quick Share picker, accept the
+> initial BLE GATT socket, and hand the transfer off to Wi-Fi Direct.
 > Shared-LAN mDNS is still the baseline regression path, and stock sender
-> -> WVMG receiver regression should still be exercised on a shared LAN
-> unless a future issue changes the receiver-side bootstrap story.
+> -> WVMG receiver regression should now be exercised both on a shared
+> LAN and on the BLE GATT -> Wi-Fi Direct path when hardware supports it.
 
 ---
 
@@ -49,6 +52,11 @@ Two network topologies matter now:
 - [ ] Both devices have **Wi-Fi turned on**.
 - [ ] For the **off-LAN sender** cells, both devices also have
       **Bluetooth turned on**.
+- [ ] For the **stock sender -> WVMG receiver BLE GATT** cells, Bluetooth
+      is on for discovery/bootstrap, and Wi-Fi Direct is available on
+      both devices for the bandwidth upgrade. The sender's infrastructure
+      Wi-Fi may be off; the transfer should still complete after the
+      Wi-Fi Direct handoff.
 - [ ] Location permission is granted to Google Play Services on the
       stock device (Quick Share requires it for Wi-Fi scans).
 
@@ -110,7 +118,7 @@ Every cell in the matrix must be exercised once per RC build.
 | 3 | WVMG -> Samsung  | Samsung | Shared-LAN picker / mDNS regression      | Everyone                   |        |
 | 4 | WVMG -> Samsung  | Samsung | Off-LAN sender bootstrap (#137)          | Everyone                   |        |
 | 5 | Pixel -> WVMG    | Pixel   | Pixel device picker                      | n/a (sender side picks us) |        |
-| 6 | Samsung -> WVMG  | Samsung | Samsung Quick Share UI                   | n/a                        |        |
+| 6 | Samsung -> WVMG  | Samsung | Samsung Quick Share UI / BLE GATT -> Wi-Fi Direct | n/a                        |        |
 
 For each cell, run **both** a small file (≤ 1 MB, e.g. a JPEG) and a
 large file (≥ 200 MB, e.g. a video). The large-file run is what catches
@@ -167,6 +175,56 @@ discover and start the session without relying on same-LAN mDNS.
       and any `medium-upgrade:` lines in `WvmgOutbound`.
 - [ ] Immediately rerun the same peer pair on a **shared LAN** and
       confirm the regression path still chooses `route=lan=<ip>:<port>`.
+
+### Test 5 / Test 6: Receive file from a stock Android phone
+
+Use this checklist for the stock sender -> WVMG receiver path. It covers
+the shared-LAN regression and the BLE GATT -> Wi-Fi Direct receiver path.
+
+- [ ] Install the WVMG debug APK on the receiver and start the receiver
+      foreground service. If the install stalls on vivo for more than 5 s,
+      clear the vendor Security Care consent prompt and continue.
+- [ ] Open WVMG on the receiver and enable **Always Visible**.
+- [ ] Capture receiver logs:
+      `adb logcat -s WvmgBleGatt WvmgBleAdv WvmgMdnsGate WvmgDiscovery WvmgReceive WvmgInbound WvmgWifiDirect`
+- [ ] Capture Samsung sender logs:
+      `adb logcat -s NearbySharing ShareLive NearbyConnections NearbyMediums BtGatt BluetoothGatt WifiP2pService WifiDirectController`
+- [ ] On the stock sender, share a small file through the Samsung Quick
+      Share UI and select the WVMG row.
+- [ ] Confirm the BLE GATT bootstrap reaches WVMG. Receiver logs should
+      show a CCCD write on `00000100-0004-1000-8000-001a11000102`, a
+      write on `00000100-0004-1000-8000-001a11000101`, and
+      `BLE socket introduction accepted`.
+- [ ] Confirm the transfer upgrades to Wi-Fi Direct. Receiver logs should
+      show `WifiP2pManager.createGroup onSuccess`, a `Wi-Fi Direct group
+      ready` line, `medium-upgrade: server offering WIFI_DIRECT`, and
+      `medium-upgrade: server completed WIFI_DIRECT`.
+- [ ] On the sender, confirm the channel changes from encrypted BLE to
+      encrypted Wi-Fi Direct, then the Quick Share UI reports **Sent**.
+- [ ] On the receiver, accept consent, wait for `Completed`, and verify
+      the received file's SHA-256 hash matches the sender source.
+
+#### Validated BLE GATT -> Wi-Fi Direct receiver result (#145)
+
+2026-05-02 actual-device run:
+
+- **Sender:** Galaxy S26 Ultra (`SM-S948N`) using Samsung ShareLive /
+  stock Quick Share.
+- **Receiver:** vivo X300 Ultra (`V2547A`) running WVMG debug.
+- **Topology:** Galaxy Wi-Fi disabled, Bluetooth on; receiver formed the
+  Wi-Fi Direct group after BLE GATT bootstrap.
+- **Receiver evidence:** WVMG published the regular `0xFEF3` slot service
+  and the Nearby second-profile socket service
+  `0000fef3-0004-1000-8000-001a11000100`; Samsung wrote the socket CCCD
+  and TO-peripheral characteristic, WVMG logged
+  `BLE socket using raw Nearby stream`, then completed `WIFI_DIRECT`.
+- **Sender evidence:** Samsung logged a successful connection to
+  `DIRECT-pX-WVMG-PlRuIQ` and replaced the endpoint channel from
+  `ENCRYPTED_BLE` to `ENCRYPTED_WIFI_DIRECT`; ShareLive reported `Sent`.
+- **Payload evidence:** `issue-145-galaxy-to-vivo-repro.txt` was written
+  to `/sdcard/Download/WVMG/` with 52 bytes and SHA-256
+  `95e6c8f9462c24715a79e956b92956d7ce4f0677a0f8cf37284ce1a145e8e648`,
+  matching the Galaxy source file.
 
 #### BLE-only / no-shared-LAN sender repro (#143)
 

--- a/docs/testing/medium-wifi-direct.md
+++ b/docs/testing/medium-wifi-direct.md
@@ -187,3 +187,11 @@ adb logcat -s WvmgOutbound | grep -E 'UPGRADE_FAILURE|UpgradeAborted'
   this is not an issue in practice; if you see missed broadcasts on a
   vivo device, double-check the receiver lifecycle isn't tied to an
   activity.
+* **vivo X300 Ultra / Funtouch OS** may leave Wi-Fi Direct in a disabled
+  state until a peer-discovery operation primes the P2P stack. The
+  receiver path now calls `discoverPeers`, waits briefly for
+  `WIFI_P2P_STATE_CHANGED state=2`, stops discovery, removes any stale
+  group, and only then calls `createGroup`. In a successful Galaxy ->
+  vivo BLE GATT handoff, `WvmgWifiDirect` should show
+  `discoverPeers onSuccess`, `stopPeerDiscovery onSuccess`, and
+  `createGroup onSuccess` before the group-ready line.


### PR DESCRIPTION
## Summary
- Publish WVMG receiver discovery on the regular Nearby `0xFEF3` GATT slot service while routing stock senders to the isolated second-profile BLE socket service.
- Mark visible fast advertisements with the second-profile frame bit and add tests for slot payloads, parser round-trips, and GATT service shape.
- Prime vivo Wi-Fi Direct before group creation and tolerate Samsung's post-Wi-Fi-Direct `RESPONSE` / `INTRODUCTION` ordering race on the inbound sharing FSM.
- Document and validate the Galaxy S26 Ultra -> vivo X300 Ultra BLE GATT + Wi-Fi Direct receiver path on actual devices.

Fixes #145

Stacked on #144 / `fix/issue-143-ble-only-bootstrap` because the receiver fix builds on the BLE GATT bootstrap work from issue #143.

## Verification
- `./gradlew staticAnalysis :discovery-android:testDebugUnitTest --tests '*BleGattInitialControlServerTest' --tests '*BleQuickShareAdvertiserTest' :app:assembleDebug`
- `./gradlew :core-protocol:test --tests '*BleServiceDataTest' --tests '*BleAdvertisementTest'`
- `./gradlew :core-protocol:test --tests '*InboundSharingFsmTest' --tests '*BleServiceDataTest' --tests '*BleAdvertisementTest' staticAnalysis :discovery-android:testDebugUnitTest --tests '*BleGattInitialControlServerTest' --tests '*BleQuickShareAdvertiserTest' :app:assembleDebug`
- Actual devices, 2026-05-02: Galaxy S26 Ultra (`SM-S948N`) -> vivo X300 Ultra (`V2547A`) transferred `issue-145-galaxy-to-vivo-repro.txt` through BLE GATT initial control and Wi-Fi Direct handoff with Galaxy infrastructure Wi-Fi disabled.
- Post-PR actual-device validation, 2026-05-02: Galaxy S26 Ultra -> vivo X300 Ultra transferred `issue-145-pr146-wvmg-final.txt` after the inbound FSM ordering fix. The receiver consent was submitted by the ADB debug loop after `WaitingForUserConsent` was observed.
- Receiver evidence: Samsung wrote the second-profile socket CCCD and TO-peripheral characteristic; WVMG logged `BLE socket using raw Nearby stream`, `WifiP2pManager.createGroup onSuccess`, Wi-Fi Direct group `DIRECT-om-WVMG-8UHPST`, `medium-upgrade: server completed WIFI_DIRECT`, `WaitingForUserConsent`, `sharing: sending RESPONSE`, `Receiving`, and `Completed(... bytesWritten=70)`.
- Sender evidence: Samsung connected to `DIRECT-om-WVMG-8UHPST`, replaced the endpoint channel from `ENCRYPTED_BLE` to `ENCRYPTED_WIFI_DIRECT`, and ShareLive showed the `WhenVivoMeetsGoogle` row as `Sent`.
- Payload evidence: received file at `/sdcard/Download/WVMG/issue-145-pr146-wvmg-final.txt` had SHA-256 `c571d9aede2c0cb8287da778b3778adfa3570aeb98cdcebc0e66ed70597e3945`, matching the Galaxy source file.