### PR TITLE
fix(discovery): bind NsdServiceInfo binary setAttribute via reflection

### DIFF
--- a/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/AndroidNsdRegistrar.kt
+++ b/discovery-android/src/main/kotlin/io/github/kyujincho/wvmg/discovery/AndroidNsdRegistrar.kt
@@ -34,18 +34,20 @@ import kotlin.coroutines.resumeWithException
  *     re-encode any byte >= 0x80 into two wire bytes and corrupt the
  *     payload.
  *
- *     `setAttribute(String, ByteArray)` became public API in
- *     `Build.VERSION_CODES.TIRAMISU` (API 33). On API 24-32 the same
- *     method exists in the platform with the same signature but is
- *     marked `@hide @UnsupportedAppUsage` (no `maxTargetSdk`), placing it
- *     on the unconditional greylist and therefore reflectively
- *     accessible from any target SDK. We reflect into it on those API
- *     levels rather than fall back to the lossy String overload.
- *
- *     The reflection target's signature was verified against AOSP
- *     `android/net/nsd/NsdServiceInfo.java` for API 35 and 36 — the
- *     method has existed unchanged since API 16, so the lookup is
- *     stable across every supported API level (24..32).
+ *     `setAttribute(String, ByteArray)` was made public in API 33
+ *     (`Build.VERSION_CODES.TIRAMISU`), but the compile-time stub jar
+ *     for that overload is not present in every Android SDK platform
+ *     install — the GitHub Actions Linux runner's `setup-android`
+ *     provisioning, for example, ships a platform-36 stub that only
+ *     exposes the String/String overload, which would silently route
+ *     the byte payload through `getBytes("UTF-8")`. To stay portable
+ *     across both stubs, we always invoke the byte[] method
+ *     reflectively. On every API level 24..36 the same underlying
+ *     method exists in the device's runtime framework (AOSP has
+ *     shipped `NsdServiceInfo.setAttribute(String, byte[])` unchanged
+ *     since API 16, marked `@hide @UnsupportedAppUsage` without a
+ *     `maxTargetSdk` on pre-33 platforms — i.e. on the unconditional
+ *     greylist), so the reflective lookup is stable everywhere.
  *
  *  2. **Auto-suffixed instance names.** When Android observes a name
  *     collision on the LAN it appends ` (1)`, ` (2)`, etc. The
@@ -268,13 +270,13 @@ internal class AndroidNsdRegistrar(
         /**
          * Apply [attributes] to [serviceInfo].
          *
-         * On API 33+ this calls the public byte[] overload of
-         * `NsdServiceInfo.setAttribute` directly. On API 24-32 the same
-         * underlying method is reflectively invoked because the public
-         * String overload UTF-8-re-encodes its value (see
-         * AOSP `NsdServiceInfo.setAttribute(String, String)` which calls
-         * `value.getBytes("UTF-8")`), which would corrupt any
-         * attribute byte >= 0x80.
+         * Reflectively invokes the byte[] overload of
+         * `NsdServiceInfo.setAttribute` on every API level — see the
+         * file-level KDoc for why we do not call it directly even on
+         * API 33+. The String overload is intentionally avoided because
+         * AOSP `NsdServiceInfo.setAttribute(String, String)` calls
+         * `value.getBytes("UTF-8")` internally, which would corrupt
+         * any attribute byte >= 0x80.
          *
          * The [setBytes] callback exists as a test seam so unit tests
          * can drive the lambda without instantiating the platform
@@ -295,9 +297,9 @@ internal class AndroidNsdRegistrar(
         /**
          * Test-friendly form of [applyAttributes]. The single setter
          * lambda always receives the raw [ByteArray] payload — there is
-         * no second branch on API level inside this helper because both
-         * API levels resolve to the same byte[]-based platform method
-         * (one publicly, one reflectively).
+         * no API-level branching inside this helper because every API
+         * level resolves to the same byte[]-based platform method via
+         * reflection.
          */
         @JvmStatic
         internal fun applyAttributes(
@@ -310,31 +312,39 @@ internal class AndroidNsdRegistrar(
         }
 
         /**
-         * Production binary-attribute setter. Picks the public byte[]
-         * overload on API 33+ and falls back to a reflective invoke of
-         * the same hidden method on API 24-32. Never delegates to the
-         * String overload — that path is lossy for any byte >= 0x80.
+         * Production binary-attribute setter. Always invokes the byte[]
+         * overload of `NsdServiceInfo.setAttribute` reflectively, even on
+         * API 33+ where it is also reachable as a public method.
+         *
+         * The compile-time stub for the public overload is not exposed
+         * uniformly across Android SDK platform jars — some platform 36
+         * stubs (notably the one provisioned by `setup-android` on the
+         * GitHub Actions Linux runner) only declare the String/String
+         * overload, which makes a direct call fail Kotlin's overload
+         * resolution. Reflection sidesteps that: the lookup binds at
+         * runtime against the device's framework, where the byte[]
+         * method has existed unchanged since API 16.
+         *
+         * Never delegates to the String overload — that path is lossy
+         * for any byte >= 0x80 because AOSP `setAttribute(String,
+         * String)` calls `value.getBytes("UTF-8")` internally.
          */
         private fun setBinaryAttribute(
             info: NsdServiceInfo,
             key: String,
             value: ByteArray,
         ) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                info.setAttribute(key, value)
-            } else {
-                try {
-                    reflectiveSetAttribute.invoke(info, key, value)
-                } catch (e: InvocationTargetException) {
-                    // Unwrap: the platform method threw; surface its own
-                    // message rather than wrapping it twice.
-                    throw IllegalStateException(
-                        "NsdServiceInfo.setAttribute(String, byte[]) reflective invoke failed " +
-                            "for key=$key (sdkInt=${Build.VERSION.SDK_INT}): " +
-                            "${e.targetException?.message ?: e.message}",
-                        e.targetException ?: e,
-                    )
-                }
+            try {
+                reflectiveSetAttribute.invoke(info, key, value)
+            } catch (e: InvocationTargetException) {
+                // Unwrap: the platform method threw; surface its own
+                // message rather than wrapping it twice.
+                throw IllegalStateException(
+                    "NsdServiceInfo.setAttribute(String, byte[]) reflective invoke failed " +
+                        "for key=$key (sdkInt=${Build.VERSION.SDK_INT}): " +
+                        "${e.targetException?.message ?: e.message}",
+                    e.targetException ?: e,
+                )
             }
         }
     }

--- a/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/AndroidNsdRobolectricTest.kt
+++ b/discovery-android/src/test/kotlin/io/github/kyujincho/wvmg/discovery/AndroidNsdRobolectricTest.kt
@@ -209,9 +209,7 @@ private fun nsdServiceInfo(
         this.port = port
         @Suppress("DEPRECATION")
         host = InetAddress.getByName("192.0.2.44")
-        for ((key, value) in attributes) {
-            setAttribute(key, value)
-        }
+        AndroidNsdRegistrar.applyAttributes(this, attributes)
     }
 
 @Implements(NsdManager::class)
@@ -334,8 +332,6 @@ internal class TestShadowNsdManager {
             copy.port = port
             @Suppress("DEPRECATION")
             copy.host = host
-            for ((key, value) in attributes.orEmpty()) {
-                copy.setAttribute(key, value)
-            }
+            AndroidNsdRegistrar.applyAttributes(copy, attributes.orEmpty())
         }
 }


### PR DESCRIPTION
## Summary

CI on `main` has been red since commit `bb7a2ee` (#134) with:

```
AndroidNsdRegistrar.kt: Argument type mismatch:
  actual type is 'kotlin.ByteArray', but 'kotlin.String!' was expected.
```

The compile-time stub jar for Android platform 36 provisioned by `setup-android` on the GitHub Actions Linux runner only declares the `setAttribute(String, String)` overload, so Kotlin's overload resolution rejects the byte[] argument. Studio's locally-installed platform-36 stub exposes both overloads, which is why the breakage was invisible on developer machines.

## Fix

Always invoke `NsdServiceInfo.setAttribute(String, byte[])` reflectively, even on API 33+. The reflective lookup binds against the device's runtime framework (where the method has existed unchanged since API 16, marked `@hide @UnsupportedAppUsage` on the unconditional greylist pre-33), so it works across `minSdk = 24` .. `compileSdk = 36`. We never fall back to the String overload because AOSP `setAttribute(String, String)` calls `value.getBytes("UTF-8")` internally and would corrupt any TXT byte >= 0x80.

The reflective path already existed for API 24-32; collapsing the `if (SDK_INT >= TIRAMISU)` branch removes the only compile-time reference to the byte[] overload.

## Things to be aware of

- **No behavioral change on devices.** Both the previous direct call (API 33+) and the reflective path bind to the same underlying platform method; the only difference is the dispatch site.
- **One-off reflection cost.** The `Method` handle is cached in a `by lazy` companion object, so the lookup happens once per process. A typical advertise sets ~3 attributes, so the per-call overhead is negligible.

## Test plan

- [x] `./gradlew :discovery-android:compileDebugKotlin` — fails on previous tip; passes here.
- [x] `./gradlew :discovery-android:testDebugUnitTest` (incl. Robolectric).
- [x] `./gradlew :discovery-android:ktlintCheck :discovery-android:detekt`.
- [ ] On-device sanity: confirm a published Quick Share mDNS record's `n=` TXT carries verbatim binary bytes (not UTF-8 re-encoded). Cross-check with `dns-sd -B _FC9F5ED42C8A._tcp` from another machine on the LAN.