### PR TITLE
fix: warn when pre-rename WhenVivoMeetsGoogle install is still present

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -151,6 +151,21 @@
          killers from severing in-flight transfers. -->
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
+    <!-- #145: probe whether a coresident pre-rename WhenVivoMeetsGoogle install
+         is still present so the launcher can warn the user to uninstall it. The
+         old install registers a duplicate `0xFEF3` GATT advertisement service on
+         the same controller, which causes stock Quick Share senders to read the
+         slot from one service but open the BLE socket against another (see
+         issue #145). Package-visibility filtering on API 30+ silently turns
+         `getPackageInfo` into NameNotFoundException for unknown packages, so
+         the detector cannot find the legacy install without this carve-out.
+         The query is by exact package name only and reveals nothing other than
+         "is the legacy WVMG app present?", so the surface stays minimal. -->
+    <queries>
+        <package android:name="io.github.kyujincho.wvmg" />
+        <package android:name="io.github.kyujincho.wvmg.debug" />
+    </queries>
+
     <application
         android:name=".LibreDropApplication"
         android:allowBackup="false"

--- a/app/src/main/kotlin/dev/bluehouse/libredrop/MainActivity.kt
+++ b/app/src/main/kotlin/dev/bluehouse/libredrop/MainActivity.kt
@@ -21,6 +21,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.SwitchCompat
 import dev.bluehouse.libredrop.battery.BatteryOptimizationOemHelper
 import dev.bluehouse.libredrop.battery.BatteryOptimizationPreferences
+import dev.bluehouse.libredrop.migration.LegacyPackageDetectorAndroid
 import dev.bluehouse.libredrop.onboarding.PermissionRequirements
 import dev.bluehouse.libredrop.onboarding.PermissionsOnboardingActivity
 import dev.bluehouse.libredrop.send.SendActivity
@@ -100,6 +101,15 @@ class MainActivity : AppCompatActivity() {
      */
     private lateinit var saveLocationLauncher: ActivityResultLauncher<Uri?>
 
+    /**
+     * Most recent result of [LegacyPackageDetectorAndroid.findInstalledLegacy].
+     * Captured by [refreshLegacyWvmgBanner] so the Uninstall click
+     * handler does not have to re-probe (which could race with a
+     * partially-completed uninstall and target the wrong variant when
+     * both `wvmg` and `wvmg.debug` are present).
+     */
+    private var legacyPackageInBanner: String? = null
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
@@ -159,6 +169,14 @@ class MainActivity : AppCompatActivity() {
         }
         findViewById<Button>(R.id.main_battery_banner_skip).setOnClickListener {
             onBatteryBannerSkipClicked()
+        }
+
+        // #145 legacy-WhenVivoMeetsGoogle migration banner. The button is
+        // wired in onCreate so it survives configuration changes;
+        // visibility is recomputed in onStart so it disappears the
+        // moment the user comes back from the system uninstall flow.
+        findViewById<Button>(R.id.main_legacy_wvmg_banner_uninstall).setOnClickListener {
+            onLegacyWvmgUninstallClicked()
         }
 
         // Save-location settings (#42). The launcher must be registered
@@ -239,6 +257,13 @@ class MainActivity : AppCompatActivity() {
         // hides automatically the moment the platform reports us as
         // exempt, even if the user never tapped Skip.
         refreshBatteryBanner()
+
+        // Re-evaluate the legacy-WVMG banner on every resume so it
+        // disappears immediately after the user returns from the system
+        // uninstall confirmation. Cheap PackageManager probe — two
+        // entries in the manifest <queries> block, no allocation when
+        // both lookups miss.
+        refreshLegacyWvmgBanner()
 
         // Re-read the save-location preference on every onStart so the
         // label reflects an external change (e.g. the user revoked the
@@ -364,6 +389,48 @@ class MainActivity : AppCompatActivity() {
                 R.string.main_advertised_name_current,
                 AdvertisedDeviceNames.resolve(this),
             )
+    }
+
+    /**
+     * Show or hide the #145 migration banner based on whether a
+     * coresident legacy WhenVivoMeetsGoogle install is still present.
+     * Stores the detected legacy package id in [legacyPackageInBanner]
+     * so the Uninstall button click handler can route directly without
+     * re-running detection (avoids a TOCTOU race where the user
+     * uninstalls one variant while both were detected).
+     */
+    private fun refreshLegacyWvmgBanner() {
+        val legacyPackage = LegacyPackageDetectorAndroid.findInstalledLegacy(this)
+        legacyPackageInBanner = legacyPackage
+        val banner = findViewById<View>(R.id.main_legacy_wvmg_banner)
+        banner.visibility = if (legacyPackage != null) View.VISIBLE else View.GONE
+    }
+
+    /**
+     * Open Android's standard uninstall confirmation dialog for the
+     * legacy WhenVivoMeetsGoogle package using `Intent.ACTION_DELETE`.
+     * That action does not need any extra permission and does not
+     * require us to be a device owner — the platform shows its own
+     * confirmation UI before tearing the package down.
+     *
+     * On the rare ROM that has stripped `ACTION_DELETE` (we have not
+     * seen one in the wild on the OEMs we care about), surface a Toast
+     * and let the user uninstall manually rather than crashing the
+     * activity.
+     */
+    private fun onLegacyWvmgUninstallClicked() {
+        val target = legacyPackageInBanner ?: return
+        val intent =
+            Intent(Intent.ACTION_DELETE).apply {
+                data = Uri.fromParts("package", target, null)
+            }
+        try {
+            startActivity(intent)
+        } catch (e: ActivityNotFoundException) {
+            Log.w(TAG, "ACTION_DELETE not resolvable for $target: ${e.message}", e)
+            val message = getString(R.string.main_legacy_wvmg_banner_unavailable, target)
+            Toast.makeText(this, message, Toast.LENGTH_LONG).show()
+        }
     }
 
     private fun onBatteryBannerSkipClicked() {

--- a/app/src/main/kotlin/dev/bluehouse/libredrop/migration/LegacyPackageDetector.kt
+++ b/app/src/main/kotlin/dev/bluehouse/libredrop/migration/LegacyPackageDetector.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 LibreDrop contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.libredrop.migration
+
+/**
+ * Detector for a coresident pre-rename WhenVivoMeetsGoogle install (issue #145
+ * / PR #148).
+ *
+ * Before commit `27f2d31` the app shipped under `io.github.kyujincho.wvmg`
+ * (release) and `io.github.kyujincho.wvmg.debug` (debug). The rename to
+ * `dev.bluehouse.libredrop` made the new install coresident with any earlier
+ * one Android did not auto-uninstall. Both processes register their own
+ * `0xFEF3` GATT advertisement service on the same Bluetooth controller, so a
+ * stock Quick Share sender walking the peripheral's GATT tree finds **two**
+ * slot-bearing `0xFEF3-0000-...` services side-by-side. Issue #145 was
+ * filed against this exact symptom: Samsung's GMS read the slot from one
+ * service but opened the BLE socket against another, so the receiver saw
+ * the GATT connection but never saw the `ConnectionRequestFrame` write.
+ *
+ * The fix is purely additive: detect the legacy package at launcher
+ * resume time and surface a non-dismissible banner pointing the user at
+ * the system uninstall flow. The banner clears itself the next time the
+ * launcher resumes after the package is gone.
+ *
+ * The shape mirrors [dev.bluehouse.libredrop.battery.BatteryOptimizationOemHelper]:
+ *
+ *   1. **Data layer** — [findLegacy] takes a snapshot of installed
+ *      package names (a `Set<String>`) and returns the first legacy
+ *      identifier present, or `null`. Pure JVM, exercised in
+ *      `:app:testDebugUnitTest` without Robolectric. **Lives in this
+ *      file and does not import any `android.*` types** so the JVM
+ *      verifier can load the class on a host JVM without resolving
+ *      stub `android.jar` exceptions whose stripped Code attributes
+ *      crash class loading (this is what bit the original draft of
+ *      [LegacyPackageDetectorTest] before the Android-side wrapper
+ *      moved to `LegacyPackageDetectorAndroid.kt`).
+ *   2. **Android layer** — `LegacyPackageDetectorAndroid.findInstalledLegacy`
+ *      (separate file) queries the platform `PackageManager`. Wraps
+ *      the data layer with the production input source.
+ *
+ * The package names are intentionally constants on the object so they
+ * can also be referenced from [dev.bluehouse.libredrop.MainActivity] (the
+ * uninstall deep-link uses the same string) and from tests.
+ */
+internal object LegacyPackageDetector {
+    /**
+     * Pre-rename release package id. Users who upgraded from a Play /
+     * sideload install built before commit `27f2d31` will still have
+     * this package present until they manually uninstall it.
+     */
+    internal const val LEGACY_RELEASE_PACKAGE: String = "io.github.kyujincho.wvmg"
+
+    /**
+     * Pre-rename debug package id (`applicationIdSuffix = ".debug"`).
+     * Most often hit by developers and CI machines that have both
+     * variants of the same APK installed at once.
+     */
+    internal const val LEGACY_DEBUG_PACKAGE: String = "io.github.kyujincho.wvmg.debug"
+
+    /**
+     * Ordered list of legacy package ids to check. The order matters
+     * only as a tie-break — if both happen to be installed, [findLegacy]
+     * surfaces the release id first because that's the more common
+     * production case (the user upgraded from Play, not from a debug
+     * sideload).
+     */
+    internal val LEGACY_PACKAGES: List<String> =
+        listOf(LEGACY_RELEASE_PACKAGE, LEGACY_DEBUG_PACKAGE)
+
+    /**
+     * Pure-JVM detector. Returns the first legacy package id present in
+     * [installedPackages], or `null` if none is present.
+     *
+     * @param installedPackages snapshot of currently-installed package
+     *   names. Production code passes the result of
+     *   [PackageManager.getInstalledPackages] (mapped to package names);
+     *   tests pass an arbitrary set.
+     */
+    internal fun findLegacy(installedPackages: Set<String>): String? =
+        LEGACY_PACKAGES.firstOrNull { it in installedPackages }
+}

--- a/app/src/main/kotlin/dev/bluehouse/libredrop/migration/LegacyPackageDetectorAndroid.kt
+++ b/app/src/main/kotlin/dev/bluehouse/libredrop/migration/LegacyPackageDetectorAndroid.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 LibreDrop contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.libredrop.migration
+
+import android.content.Context
+import android.content.pm.PackageManager
+
+/**
+ * Android-side wrapper around [LegacyPackageDetector] (issue #145).
+ *
+ * Lives in its own file — separate from the pure-data layer in
+ * [LegacyPackageDetector] — so JVM unit tests in
+ * `:app:testDebugUnitTest` never have to load this object. The host
+ * JVM cannot verify the class because the stub `android.jar` ships
+ * `android.content.pm.PackageManager$NameNotFoundException` with no
+ * Code attribute on its `<init>` chain, and the Kotlin compiler emits
+ * a `Class.forName` resolution for the catch clause below. Keeping
+ * the catch out of the testable file is the same trick
+ * [dev.bluehouse.libredrop.battery.BatteryOptimizationOemHelper] uses
+ * for its `Intent` / `PowerManager` translation.
+ *
+ * Production callers (currently [dev.bluehouse.libredrop.MainActivity])
+ * route through [findInstalledLegacy]; tests stop at
+ * [LegacyPackageDetector.findLegacy] above.
+ */
+internal object LegacyPackageDetectorAndroid {
+    /**
+     * Returns the first legacy package id that
+     * [PackageManager.getPackageInfo] reports as installed for the
+     * current user, or `null` when nothing legacy is installed.
+     *
+     * Uses per-package `getPackageInfo` rather than
+     * `getInstalledPackages` so we do not need the
+     * `QUERY_ALL_PACKAGES` permission on API 30+. The visibility
+     * carve-out for the legacy package ids is declared as a
+     * `<queries><package />` block in
+     * `app/src/main/AndroidManifest.xml`; without that, the platform
+     * silently throws `NameNotFoundException` for installed packages
+     * our app does not declare a relationship to.
+     */
+    internal fun findInstalledLegacy(context: Context): String? {
+        val packageManager = context.packageManager
+        return LegacyPackageDetector.LEGACY_PACKAGES.firstOrNull { isInstalled(packageManager, it) }
+    }
+
+    @Suppress("SwallowedException")
+    private fun isInstalled(
+        packageManager: PackageManager,
+        packageName: String,
+    ): Boolean =
+        try {
+            packageManager.getPackageInfo(packageName, 0)
+            true
+        } catch (_: PackageManager.NameNotFoundException) {
+            false
+        }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -31,6 +31,60 @@
             android:textAppearance="?android:attr/textAppearanceLarge" />
 
         <!--
+          Legacy-WhenVivoMeetsGoogle banner (#145). Hidden by default;
+          MainActivity reveals it only when the migration detector finds
+          a coresident pre-rename install still on the device. The
+          banner is non-dismissible — the legacy install registers a
+          duplicate 0xFEF3 GATT service that defeats the Quick Share
+          slot-redirect, so the user must actually uninstall the old
+          package for off-LAN BLE bootstrap to work. The banner
+          disappears automatically the next time onStart fires after the
+          uninstall completes.
+        -->
+        <LinearLayout
+            android:id="@+id/main_legacy_wvmg_banner"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:background="?android:attr/colorBackgroundFloating"
+            android:orientation="vertical"
+            android:padding="16dp"
+            android:visibility="gone">
+
+            <TextView
+                android:id="@+id/main_legacy_wvmg_banner_title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/main_legacy_wvmg_banner_title"
+                android:textAppearance="@style/TextAppearance.AppCompat.Title"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/main_legacy_wvmg_banner_body"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="@string/main_legacy_wvmg_banner_body"
+                android:textAppearance="@style/TextAppearance.AppCompat.Body1" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:gravity="end"
+                android:orientation="horizontal">
+
+                <Button
+                    android:id="@+id/main_legacy_wvmg_banner_uninstall"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/main_legacy_wvmg_banner_uninstall" />
+
+            </LinearLayout>
+
+        </LinearLayout>
+
+        <!--
           Battery-optimization banner (#47). Hidden by default so the
           activity does not flicker on launch; MainActivity reveals it
           only when the helper detects the app is not yet exempt and

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,6 +47,20 @@
          is intentionally vendor-neutral so the same string serves every
          OEM family; the helper takes the user to the right Settings
          page. -->
+    <!-- #145 legacy-WhenVivoMeetsGoogle migration banner. Shown when the
+         launcher detects a coresident pre-rename install
+         (io.github.kyujincho.wvmg or .debug). The legacy build registers a
+         duplicate 0xFEF3 GATT advertisement service that prevents stock
+         Quick Share senders from completing the BLE bootstrap, so the
+         banner is non-dismissible: only uninstalling the old package
+         resolves it. The Uninstall button opens Android's standard
+         confirm-uninstall dialog for the legacy package via
+         ACTION_DELETE — no extra permission required. -->
+    <string name="main_legacy_wvmg_banner_title">Uninstall the previous app</string>
+    <string name="main_legacy_wvmg_banner_body">An older build of this app, named WhenVivoMeetsGoogle, is still installed on this device. The two installs interfere on Bluetooth, which prevents Galaxy and other stock Quick Share senders from reaching this device. Tap Uninstall to remove the older build.</string>
+    <string name="main_legacy_wvmg_banner_uninstall">Uninstall older build</string>
+    <string name="main_legacy_wvmg_banner_unavailable">Could not open the uninstall dialog for %1$s. Please uninstall it manually from system Settings.</string>
+
     <string name="main_battery_banner_title">Allow background activity</string>
     <string name="main_battery_banner_body">This phone may stop receiving Quick Share files in the background unless this app is exempted from battery optimization. Tap Open Settings to add the exemption, or Skip if you only use Quick Share with the app open.</string>
     <string name="main_battery_banner_open">Open Settings</string>

--- a/app/src/test/kotlin/dev/bluehouse/libredrop/migration/LegacyPackageDetectorTest.kt
+++ b/app/src/test/kotlin/dev/bluehouse/libredrop/migration/LegacyPackageDetectorTest.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 LibreDrop contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.libredrop.migration
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * JVM-only unit tests for the pure-data layer of [LegacyPackageDetector].
+ *
+ * The Android-side wrapper [LegacyPackageDetector.findInstalledLegacy]
+ * needs a real `Context` / `PackageManager`, so it is exercised on-device
+ * during the #145 migration debug-loop validation rather than here.
+ *
+ * The data-layer entry point [LegacyPackageDetector.findLegacy] takes a
+ * pre-collected `Set<String>` of installed package names, which is
+ * trivially constructible in JVM tests and decouples the detection logic
+ * from any platform stub.
+ */
+class LegacyPackageDetectorTest {
+    @Test
+    fun `findLegacy returns null when no legacy package is installed`() {
+        val installed =
+            setOf(
+                "dev.bluehouse.libredrop",
+                "dev.bluehouse.libredrop.debug",
+                "com.google.android.gms",
+                "com.samsung.android.app.sharelive",
+            )
+
+        assertNull(LegacyPackageDetector.findLegacy(installed))
+    }
+
+    @Test
+    fun `findLegacy detects the release legacy package`() {
+        val installed =
+            setOf(
+                "dev.bluehouse.libredrop.debug",
+                LegacyPackageDetector.LEGACY_RELEASE_PACKAGE,
+            )
+
+        assertEquals(
+            LegacyPackageDetector.LEGACY_RELEASE_PACKAGE,
+            LegacyPackageDetector.findLegacy(installed),
+        )
+    }
+
+    @Test
+    fun `findLegacy detects the debug legacy package`() {
+        val installed =
+            setOf(
+                "dev.bluehouse.libredrop.debug",
+                LegacyPackageDetector.LEGACY_DEBUG_PACKAGE,
+            )
+
+        assertEquals(
+            LegacyPackageDetector.LEGACY_DEBUG_PACKAGE,
+            LegacyPackageDetector.findLegacy(installed),
+        )
+    }
+
+    @Test
+    fun `findLegacy prefers the release id over the debug id when both are installed`() {
+        // Two coresident legacy installs (release + debug) is the
+        // worst case for users who migrated from a Play install AND a
+        // local sideload. The detector should pick a stable winner
+        // (release) so the banner CTA / Toast text does not flap on
+        // every resume.
+        val installed =
+            setOf(
+                "dev.bluehouse.libredrop.debug",
+                LegacyPackageDetector.LEGACY_RELEASE_PACKAGE,
+                LegacyPackageDetector.LEGACY_DEBUG_PACKAGE,
+            )
+
+        assertEquals(
+            LegacyPackageDetector.LEGACY_RELEASE_PACKAGE,
+            LegacyPackageDetector.findLegacy(installed),
+        )
+    }
+
+    @Test
+    fun `LEGACY_PACKAGES enumerates exactly the two known pre-rename ids`() {
+        // Pin the constant list so future renames do not silently
+        // expand the detector's surface without an explicit code review.
+        assertEquals(
+            listOf(
+                LegacyPackageDetector.LEGACY_RELEASE_PACKAGE,
+                LegacyPackageDetector.LEGACY_DEBUG_PACKAGE,
+            ),
+            LegacyPackageDetector.LEGACY_PACKAGES,
+        )
+    }
+}


### PR DESCRIPTION
Closes #145.

## Summary

- Detect coresident pre-rename `io.github.kyujincho.wvmg(.debug)` install on every `MainActivity.onStart`.
- Surface a non-dismissible banner whose action fires `Intent.ACTION_DELETE` for Android's standard uninstall confirmation; the banner clears on the next resume after the legacy package is gone.
- Manifest `<queries>` carve-out for both legacy package ids so the detector works on API 30+ without `QUERY_ALL_PACKAGES`.
- Pure-data detector (`LegacyPackageDetector`) split from its Android-side wrapper (`LegacyPackageDetectorAndroid`) so JVM unit tests load only the data layer — without that split, the stub `PackageManager$NameNotFoundException` ships without a Code attribute and trips `ClassFormatError` on a host JVM.

## Why

Hardware reproduction on Galaxy S26 Ultra → Vivo X300 Ultra (V2547A on Funtouch 16, OriginOS 16.0.19.10.W10) confirmed issue #145's "duplicate `0xFEF3` services" symptom is caused by the pre-rename WVMG install left behind after PR #148. Each app registers its own `0xFEF3-0000` slot service via `BleGattInitialControlServer`, so a stock Quick Share sender walking the receiver's GATT tree sees three services with the same UUID — GMS's Weave-only one, the legacy WVMG slot service, and LibreDrop's slot service. GMS reads the slot from one but opens the BLE socket against another, exactly matching `BleSocketOutputStream failed to write data`. The second-profile redirect (`0xFEF3-0004`) only does its job when there is a single `0xFEF3-0000` slot service alongside GMS's canonical Weave-only one.

With the legacy package uninstalled the existing receive path works end-to-end: BLE GATT bootstrap on `0xFEF3-0004` → Weave handshake → `WIFI_DIRECT` bandwidth upgrade → consent → text payload delivered (verified with the inbound log under `getExternalFilesDir(null)/libredrop-inbound.log`). The fix is purely additive — no protocol behavior change.

## Validation

`:app:assembleDebug` + `:app:testDebugUnitTest` (5 new tests) + ktlint + detekt are green. On hardware: with no legacy package the banner stays hidden and Galaxy → Vivo Quick Share completes through to `Completed(items=[Text(...)])`; with `wvmg.debug` reinstalled alongside, the banner appears with the documented title/body, the Uninstall button launches `com.android.packageinstaller/.UninstallerActivity`, and the banner clears on the next `onStart` after the legacy package is removed.