### PR TITLE
chore: disable Bluetooth Classic user surface

### DIFF
--- a/app/src/main/kotlin/dev/bluehouse/libredrop/onboarding/PermissionRequirements.kt
+++ b/app/src/main/kotlin/dev/bluehouse/libredrop/onboarding/PermissionRequirements.kt
@@ -27,8 +27,8 @@ import dev.bluehouse.libredrop.R
  *
  * Runtime permissions are gated by API level:
  *   * `ACCESS_FINE_LOCATION` is required on Android 11 and lower for
- *     Bluetooth discovery / BLE scans; older platform releases route
- *     nearby-device discovery through the location runtime permission.
+ *     Bluetooth Low Energy scans; older platform releases route nearby-device
+ *     discovery through the location runtime permission.
  *   * `NEARBY_WIFI_DEVICES` and `POST_NOTIFICATIONS` only exist on API 33+.
  *   * `BLUETOOTH_ADVERTISE`, `BLUETOOTH_SCAN`, and `BLUETOOTH_CONNECT` only
  *     exist on API 31+ — on API ≤ 30 the legacy install-time
@@ -42,7 +42,7 @@ import dev.bluehouse.libredrop.R
  *     without it Phase 1 cannot run mDNS discovery at all.
  *   * Optional denials let the app run in a degraded mode. Today that
  *     means missing notifications (silent transfers) or missing nearby
- *     Bluetooth / off-LAN discovery.
+ *     BLE / off-LAN discovery.
  *
  * Onboarding is allowed to complete with optional-only denials; the
  * service-start gate re-checks at runtime so the user can grant later
@@ -173,8 +173,8 @@ internal object PermissionRequirements {
 
     /**
      * True when the only outstanding permissions are non-blocking ones
-     * (`POST_NOTIFICATIONS`, nearby Bluetooth/off-LAN discovery, and
-     * the BLE permissions). The service can run in degraded mode in
+     * (`POST_NOTIFICATIONS`, nearby BLE/off-LAN discovery, and the BLE
+     * permissions). The service can run in degraded mode in
      * that case — see issue #26 / #31 acceptance criteria. Returns
      * false when no permissions are missing (use [allGranted] to detect
      * that case).

--- a/app/src/main/kotlin/dev/bluehouse/libredrop/send/SendActivity.kt
+++ b/app/src/main/kotlin/dev/bluehouse/libredrop/send/SendActivity.kt
@@ -17,6 +17,7 @@ import dev.bluehouse.libredrop.R
 import dev.bluehouse.libredrop.databinding.ActivitySendBinding
 import dev.bluehouse.libredrop.discovery.NearbyPeer
 import dev.bluehouse.libredrop.discovery.NearbyPeerRoute
+import dev.bluehouse.libredrop.discovery.UserFacingMediumFeatures
 import dev.bluehouse.libredrop.discovery.bootstrap.BleGattInitialControlClient
 import dev.bluehouse.libredrop.discovery.bootstrap.BleGattInitialControlServer
 import dev.bluehouse.libredrop.discovery.bootstrap.BleL2capInitialControlClient
@@ -193,6 +194,7 @@ public class SendActivity : AppCompatActivity() {
                     logger = ::logOutboundWireMessage,
                 )
             is NearbyPeerRoute.BluetoothClassic -> {
+                if (!UserFacingMediumFeatures.BLUETOOTH_CLASSIC_USER_FACING_ENABLED) return null
                 val client = BluetoothClassicBootstrapClient(applicationContext)
                 bluetoothBootstrapClient = client
                 val transport =

--- a/app/src/main/kotlin/dev/bluehouse/libredrop/send/SendBootstrapPlan.kt
+++ b/app/src/main/kotlin/dev/bluehouse/libredrop/send/SendBootstrapPlan.kt
@@ -7,6 +7,7 @@ package dev.bluehouse.libredrop.send
 
 import dev.bluehouse.libredrop.discovery.NearbyPeer
 import dev.bluehouse.libredrop.discovery.NearbyPeerRoute
+import dev.bluehouse.libredrop.discovery.UserFacingMediumFeatures
 
 internal data class SendBootstrapPlan(
     val action: Action,
@@ -77,7 +78,7 @@ internal data class SendBootstrapPlan(
             val subtitle =
                 when (route) {
                     is NearbyPeerRoute.Lan -> "Wi-Fi LAN ${route.address.hostAddress}:${route.port}"
-                    is NearbyPeerRoute.BluetoothClassic -> "Bluetooth Classic ${route.macAddress}"
+                    is NearbyPeerRoute.BluetoothClassic -> "Unsupported Bluetooth route"
                     is NearbyPeerRoute.BleL2cap -> "BLE L2CAP ${route.macAddress} psm=${route.psm}"
                     is NearbyPeerRoute.BleGatt -> "BLE GATT ${route.macAddress}"
                 }
@@ -121,7 +122,7 @@ internal data class SendBootstrapPlan(
                     rejectedCandidates += lanRejection(peer)
                     rejectedCandidates += bleL2capRejection(peer)
                     rejectedCandidates += bleGattRejection(peer)
-                    rejectedCandidates += "bluetooth-classic=missing"
+                    rejectedCandidates += bluetoothClassicRejection(peer)
                     null
                 }
             }
@@ -162,9 +163,6 @@ internal data class SendBootstrapPlan(
                 }
                 if (ble != null && blePsm == null && !ble.gattConnectable) {
                     add("receiver BLE GATT bootstrap is not verified")
-                }
-                if (ble != null) {
-                    add("no Bluetooth Classic bootstrap identity")
                 }
                 if (ble != null && peer.endpointInfo?.hidden != false) {
                     add("BLE observation does not confirm a visible receiver")
@@ -236,6 +234,18 @@ internal data class SendBootstrapPlan(
         }
 
         private fun bluetoothRoute(peer: NearbyPeer): NearbyPeerRoute.BluetoothClassic? =
-            peer.bluetoothEndpoint?.let { NearbyPeerRoute.BluetoothClassic(it.macAddress) }
+            if (UserFacingMediumFeatures.BLUETOOTH_CLASSIC_USER_FACING_ENABLED) {
+                peer.bluetoothEndpoint?.let { NearbyPeerRoute.BluetoothClassic(it.macAddress) }
+            } else {
+                null
+            }
+
+        private fun bluetoothClassicRejection(peer: NearbyPeer): String =
+            when {
+                !UserFacingMediumFeatures.BLUETOOTH_CLASSIC_USER_FACING_ENABLED ->
+                    "bluetooth-classic=disabled"
+                peer.bluetoothEndpoint == null -> "bluetooth-classic=missing"
+                else -> "bluetooth-classic=unusable"
+            }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -102,11 +102,11 @@
 
     <!-- BLUETOOTH_CONNECT (API 31+, Phase 4 Bluetooth transports). -->
     <string name="permission_bluetooth_connect_title">Bluetooth connections</string>
-    <string name="permission_bluetooth_connect_rationale">Used to accept and open Bluetooth peer-to-peer links when the two devices cannot reach each other over the current Wi-Fi network. Transfers still use Quick Share encryption.</string>
+    <string name="permission_bluetooth_connect_rationale">Used to open Bluetooth Low Energy direct links and read Bluetooth adapter state for nearby Quick Share discovery. Transfers still use Quick Share encryption.</string>
 
     <!-- ACCESS_FINE_LOCATION (API 24-30, legacy nearby-device discovery). -->
     <string name="permission_legacy_nearby_location_title">Nearby device location access</string>
-    <string name="permission_legacy_nearby_location_rationale">Android 11 and lower route Bluetooth device discovery and BLE scan results through the location permission. LibreDrop uses it only to discover nearby Quick Share devices; it does not use your physical location.</string>
+    <string name="permission_legacy_nearby_location_rationale">Android 11 and lower route Bluetooth Low Energy scan results through the location permission. LibreDrop uses it only to discover nearby Quick Share devices; it does not use your physical location.</string>
 
     <!-- Permission status labels. -->
     <string name="permission_status_granted">Granted</string>

--- a/app/src/test/kotlin/dev/bluehouse/libredrop/send/SendBootstrapPlanTest.kt
+++ b/app/src/test/kotlin/dev/bluehouse/libredrop/send/SendBootstrapPlanTest.kt
@@ -110,7 +110,7 @@ class SendBootstrapPlanTest {
     }
 
     @Test
-    fun `Bluetooth Classic is used when visible BLE GATT bootstrap is unverified`() {
+    fun `Bluetooth Classic candidate is ignored when visible BLE GATT bootstrap is unverified`() {
         val peer =
             peer(
                 bluetoothMac = "11:22:33:44:55:66",
@@ -122,13 +122,11 @@ class SendBootstrapPlanTest {
 
         val plan = SendBootstrapPlan.resolve(peer = peer)
 
-        assertTrue(plan.isConnectable)
-        assertEquals(
-            NearbyPeerRoute.BluetoothClassic("11:22:33:44:55:66"),
-            (plan.action as SendBootstrapPlan.Action.Direct).route,
-        )
-        assertTrue(plan.subtitle.contains("Bluetooth Classic"))
+        assertFalse(plan.isConnectable)
+        assertEquals(SendBootstrapPlan.Action.Unavailable, plan.action)
         assertTrue(plan.rejectedCandidates.contains("ble-gatt=not-verified"))
+        assertTrue(plan.rejectedCandidates.contains("bluetooth-classic=disabled"))
+        assertFalse(plan.failureReason!!.contains("Bluetooth Classic"))
     }
 
     @Test

--- a/discovery-android/src/main/kotlin/dev/bluehouse/libredrop/discovery/NearbyPeer.kt
+++ b/discovery-android/src/main/kotlin/dev/bluehouse/libredrop/discovery/NearbyPeer.kt
@@ -16,9 +16,10 @@ import java.net.InetAddress
  * surface.
  *
  * A peer can be discovered by one or more mediums at the same time:
- * Wi-Fi LAN mDNS, Bluetooth Classic device-name discovery, and BLE fast
- * advertisements. The sender UI and bootstrap path consume this model
- * instead of directly binding themselves to [DiscoveredService].
+ * Wi-Fi LAN mDNS and BLE fast advertisements. Bluetooth Classic fields remain
+ * represented for tests and future feature re-enable work, but normal
+ * user-facing route selection hides them while
+ * [UserFacingMediumFeatures.BLUETOOTH_CLASSIC_USER_FACING_ENABLED] is false.
  */
 public data class NearbyPeer(
     val stableId: String,
@@ -38,7 +39,12 @@ public data class NearbyPeer(
         get() =
             buildSet {
                 if (lanEndpoint != null) add(Medium.WIFI_LAN)
-                if (bluetoothEndpoint != null) add(Medium.BLUETOOTH)
+                if (
+                    bluetoothEndpoint != null &&
+                    UserFacingMediumFeatures.BLUETOOTH_CLASSIC_USER_FACING_ENABLED
+                ) {
+                    add(Medium.BLUETOOTH)
+                }
                 if (bleAdvertisement != null) {
                     add(Medium.BLE)
                     if (bleAdvertisement.l2capPsm != null) add(Medium.BLE_L2CAP)
@@ -58,8 +64,7 @@ public data class NearbyPeer(
      * BLE receiver without a PSM is only a GATT bootstrap candidate after
      * the GATT advertisement-slot probe verifies the service; header-only,
      * hidden, and raw scan-result-only BLE observations remain discovery
-     * metadata until another route confirms a transport. Bluetooth Classic
-     * remains only a last fallback for peers that still expose it.
+     * metadata until another route confirms a transport.
      */
     public fun preferredRoute(): NearbyPeerRoute? {
         val lan = lanEndpoint
@@ -79,9 +84,11 @@ public data class NearbyPeer(
         if (bleAddress != null && ble.gattConnectable && endpointInfo?.hidden == false) {
             return NearbyPeerRoute.BleGatt(macAddress = bleAddress)
         }
-        val bluetooth = bluetoothEndpoint
-        if (bluetooth != null) {
-            return NearbyPeerRoute.BluetoothClassic(bluetooth.macAddress)
+        if (UserFacingMediumFeatures.BLUETOOTH_CLASSIC_USER_FACING_ENABLED) {
+            val bluetooth = bluetoothEndpoint
+            if (bluetooth != null) {
+                return NearbyPeerRoute.BluetoothClassic(bluetooth.macAddress)
+            }
         }
         return null
     }
@@ -137,8 +144,7 @@ public data class NearbyPeer(
 
     /**
      * BLE fast-advertisement candidate. Observation-only today; useful for
-     * dedupe/aggregation even when Bluetooth Classic provides the actual
-     * initial-control path.
+     * dedupe/aggregation across LAN and BLE discovery surfaces.
      */
     public data class BleAdvertisement(
         val advertiserAddress: String?,

--- a/discovery-android/src/main/kotlin/dev/bluehouse/libredrop/discovery/NearbyPeerDiscovery.kt
+++ b/discovery-android/src/main/kotlin/dev/bluehouse/libredrop/discovery/NearbyPeerDiscovery.kt
@@ -14,16 +14,18 @@ import dev.bluehouse.libredrop.protocol.endpoint.EndpointInfo
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.launch
 import java.net.InetAddress
 
 /**
  * Aggregates sender-side peer discovery across multiple media.
  *
- * The existing LAN mDNS path remains intact, but its output is merged with
- * Bluetooth Classic Nearby device-name discovery and BLE fast
- * advertisements so the sender UI is no longer hard-wired to
- * [DiscoveredService].
+ * The existing LAN mDNS path remains intact, but its output is merged with BLE
+ * fast advertisements so the sender UI is no longer hard-wired to
+ * [DiscoveredService]. Bluetooth Classic aggregation remains available to
+ * tests and future feature re-enable work, but production user-facing flows do
+ * not start the Classic scanner.
  */
 public class NearbyPeerDiscovery internal constructor(
     private val lanEvents: Flow<DiscoveryEvent>,
@@ -33,7 +35,12 @@ public class NearbyPeerDiscovery internal constructor(
     public constructor(context: Context) : this(
         lanEvents = Discovery(context.applicationContext).browse(),
         bleEvents = BleFastAdvertisementScanner(context.applicationContext).scan(),
-        bluetoothEvents = BluetoothClassicPeerScanner(context.applicationContext).scan(),
+        bluetoothEvents =
+            if (UserFacingMediumFeatures.BLUETOOTH_CLASSIC_USER_FACING_ENABLED) {
+                BluetoothClassicPeerScanner(context.applicationContext).scan()
+            } else {
+                emptyFlow()
+            },
     )
 
     public fun browse(): Flow<NearbyPeerEvent> =

--- a/discovery-android/src/main/kotlin/dev/bluehouse/libredrop/discovery/UserFacingMediumFeatures.kt
+++ b/discovery-android/src/main/kotlin/dev/bluehouse/libredrop/discovery/UserFacingMediumFeatures.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2026 LibreDrop contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.libredrop.discovery
+
+/**
+ * Feature gates for discovery / bootstrap mediums that are exposed through
+ * normal user-facing app flows.
+ */
+public object UserFacingMediumFeatures {
+    /**
+     * Bluetooth Classic RFCOMM remains implemented for future re-enable
+     * work, but normal discovery, picker routing, and bootstrap flows must
+     * not expose it to users.
+     */
+    public const val BLUETOOTH_CLASSIC_USER_FACING_ENABLED: Boolean = false
+}

--- a/discovery-android/src/main/kotlin/dev/bluehouse/libredrop/discovery/bootstrap/BleGattInitialControlClient.kt
+++ b/discovery-android/src/main/kotlin/dev/bluehouse/libredrop/discovery/bootstrap/BleGattInitialControlClient.kt
@@ -195,16 +195,25 @@ private class BleGattClientTransport(
         }
 
     fun start(): Boolean {
-        val phyMask = BluetoothDevice.PHY_LE_2M_MASK or BluetoothDevice.PHY_LE_1M_MASK
         val opened =
-            device.connectGatt(
-                context,
-                false,
-                this,
-                BluetoothDevice.TRANSPORT_LE,
-                phyMask,
-                mainHandler,
-            )
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                val phyMask = BluetoothDevice.PHY_LE_2M_MASK or BluetoothDevice.PHY_LE_1M_MASK
+                device.connectGatt(
+                    context,
+                    false,
+                    this,
+                    BluetoothDevice.TRANSPORT_LE,
+                    phyMask,
+                    mainHandler,
+                )
+            } else {
+                device.connectGatt(
+                    context,
+                    false,
+                    this,
+                    BluetoothDevice.TRANSPORT_LE,
+                )
+            }
         gatt = opened
         // Force a GATT cache refresh as soon as the connection is
         // available. Android's BLE stack caches discovered services

--- a/discovery-android/src/test/kotlin/dev/bluehouse/libredrop/discovery/NearbyPeerDiscoveryTest.kt
+++ b/discovery-android/src/test/kotlin/dev/bluehouse/libredrop/discovery/NearbyPeerDiscoveryTest.kt
@@ -66,7 +66,7 @@ class NearbyPeerDiscoveryTest {
             val resolved = seen.filterIsInstance<NearbyPeerEvent.Resolved>().last().peer
             assertThat(seen.filterIsInstance<NearbyPeerEvent.Resolved>()).hasSize(2)
             assertThat(resolved.stableId).isEqualTo("endpoint:ABCD")
-            assertThat(resolved.candidateMediums).containsExactly(Medium.WIFI_LAN, Medium.BLUETOOTH)
+            assertThat(resolved.candidateMediums).containsExactly(Medium.WIFI_LAN)
             assertThat(resolved.preferredRoute()).isEqualTo(
                 NearbyPeerRoute.Lan(
                     address = InetAddress.getByName("192.168.1.44"),
@@ -78,7 +78,7 @@ class NearbyPeerDiscoveryTest {
         }
 
     @Test
-    fun `LAN loss keeps bluetooth-discovered peer alive`() =
+    fun `LAN loss keeps bluetooth-discovered peer alive as unroutable metadata`() =
         runTest {
             val lanEvents = MutableSharedFlow<DiscoveryEvent>()
             val bleEvents = MutableSharedFlow<BleFastAdvertisementScanner.Observation>()
@@ -121,16 +121,15 @@ class NearbyPeerDiscoveryTest {
 
             assertThat(seen.filterIsInstance<NearbyPeerEvent.Lost>()).isEmpty()
             val resolved = seen.filterIsInstance<NearbyPeerEvent.Resolved>().last().peer
-            assertThat(resolved.candidateMediums).containsExactly(Medium.BLUETOOTH)
-            assertThat(resolved.preferredRoute()).isEqualTo(
-                NearbyPeerRoute.BluetoothClassic("11:22:33:44:55:66"),
-            )
+            assertThat(resolved.candidateMediums).isEmpty()
+            assertThat(resolved.bluetoothEndpoint?.macAddress).isEqualTo("11:22:33:44:55:66")
+            assertThat(resolved.preferredRoute()).isNull()
 
             collector.cancel()
         }
 
     @Test
-    fun `BLE fast advertisement merges into bluetooth bootstrap candidate`() =
+    fun `BLE fast advertisement merges with disabled bluetooth metadata`() =
         runTest {
             val lanEvents = MutableSharedFlow<DiscoveryEvent>()
             val bleEvents = MutableSharedFlow<BleFastAdvertisementScanner.Observation>()
@@ -170,11 +169,10 @@ class NearbyPeerDiscoveryTest {
             runCurrent()
 
             val resolved = seen.filterIsInstance<NearbyPeerEvent.Resolved>().last().peer
-            assertThat(resolved.candidateMediums).containsExactly(Medium.BLE, Medium.BLUETOOTH)
+            assertThat(resolved.candidateMediums).containsExactly(Medium.BLE)
             assertThat(resolved.bleAdvertisement?.advertiserAddress).isEqualTo("77:88:99:AA:BB:CC")
-            assertThat(resolved.preferredRoute()).isEqualTo(
-                NearbyPeerRoute.BluetoothClassic("66:55:44:33:22:11"),
-            )
+            assertThat(resolved.bluetoothEndpoint?.macAddress).isEqualTo("66:55:44:33:22:11")
+            assertThat(resolved.preferredRoute()).isNull()
 
             collector.cancel()
         }


### PR DESCRIPTION
## Summary
- Add a user-facing medium feature gate that keeps Bluetooth Classic/RFCOMM implemented but disabled in normal discovery, picker routing, and bootstrap flows.
- Stop sender route planning from selecting Bluetooth Classic fallback candidates and keep Classic observations as non-routable metadata in tests.
- Reword Bluetooth permission rationale copy so onboarding only describes BLE/off-LAN discovery that remains active.
- Fix the BLE GATT client API 24-25 connectGatt fallback so Android lint passes on minSdk 24.

## Verification
- ./gradlew :app:testDebugUnitTest --tests 'dev.bluehouse.libredrop.send.SendBootstrapPlanTest' --tests 'dev.bluehouse.libredrop.onboarding.PermissionRequirementsTest'
- ./gradlew :discovery-android:testDebugUnitTest --tests 'dev.bluehouse.libredrop.discovery.NearbyPeerDiscoveryTest'
- ./gradlew :discovery-android:lintDebug
- ./gradlew staticAnalysis :core-protocol:test check :app:assembleDebug

Closes #153