### PR TITLE
chore: add signed release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,71 @@
+name: Release
+
+# This workflow is intentionally separate from CI. It runs only for release
+# publishing surfaces: version tags that start with "v" and published GitHub
+# Releases. The normal pull-request CI workflow remains unchanged.
+on:
+  push:
+    tags:
+      - 'v*'
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  build-release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Decode release keystore
+        env:
+          KEYSTORE_B64: ${{ secrets.KEYSTORE_B64 }}
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        run: |
+          missing=()
+          for name in KEYSTORE_B64 KEYSTORE_PASSWORD KEY_ALIAS KEY_PASSWORD; do
+            if [ -z "${!name}" ]; then
+              missing+=("$name")
+            fi
+          done
+
+          if [ "${#missing[@]}" -ne 0 ]; then
+            printf 'Missing required release signing secret(s): %s\n' "${missing[*]}" >&2
+            exit 1
+          fi
+
+          printf '%s' "$KEYSTORE_B64" | base64 -d > "$RUNNER_TEMP/release.keystore"
+          chmod 600 "$RUNNER_TEMP/release.keystore"
+
+      - name: Build signed release APK and bundle
+        env:
+          KEYSTORE_FILE: ${{ runner.temp }}/release.keystore
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        run: ./gradlew :app:assembleRelease :app:bundleRelease --stacktrace
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: libredrop-release-${{ github.ref_name }}
+          if-no-files-found: error
+          path: |
+            app/build/outputs/apk/release/*.apk
+            app/build/outputs/bundle/release/*.aab

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,12 @@
 name: Release
 
-# This workflow is intentionally separate from CI. It runs only for release
-# publishing surfaces: version tags that start with "v" and published GitHub
-# Releases. The normal pull-request CI workflow remains unchanged.
+# This workflow is intentionally separate from CI. Tag pushes are the single
+# source of truth for release binaries so we build each version exactly once.
+# The normal pull-request CI workflow remains unchanged.
 on:
   push:
     tags:
       - 'v*'
-  release:
-    types: [published]
 
 permissions:
   contents: read
@@ -30,6 +28,8 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: true
 
       - name: Decode release keystore
         env:
@@ -61,11 +61,15 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
         run: ./gradlew :app:assembleRelease :app:bundleRelease --stacktrace
 
+      - name: Remove decoded keystore
+        if: always()
+        run: rm -f "${{ runner.temp }}/release.keystore"
+
       - name: Upload release artifacts
         uses: actions/upload-artifact@v4
         with:
           name: libredrop-release-${{ github.ref_name }}
           if-no-files-found: error
           path: |
-            app/build/outputs/apk/release/*.apk
-            app/build/outputs/bundle/release/*.aab
+            app/build/outputs/apk/release/app-release.apk
+            app/build/outputs/bundle/release/app-release.aab

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ local.properties
 *.ap_
 *.dex
 *.iml
+*.jks
+*.keystore
 captures/
 .externalNativeBuild/
 .cxx/

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ visibility:
   used to live here, preserved verbatim.
 - [Stock Android interop runbook](docs/testing/interop-stock-quick-share-android.md)
 - [NearDrop macOS interop runbook](docs/testing/interop-neardrop-macos.md)
+- [Release builds](docs/release.md)
 - [Research notes](docs/research/)
 - [Agent/contributor guidance](AGENTS.md)
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,7 +15,12 @@ data class ReleaseSigningInputs(
     val keyPassword: String,
 )
 
-fun releaseSigningInputs(): ReleaseSigningInputs? {
+fun isReleaseTaskRequested(): Boolean =
+    gradle.startParameter.taskNames.any { taskName ->
+        taskName.substringAfterLast(':').contains("release", ignoreCase = true)
+    }
+
+fun releaseSigningInputs(releaseTaskRequested: Boolean): ReleaseSigningInputs? {
     fun propertyOrEnvironment(name: String): String? =
         providers
             .gradleProperty(name)
@@ -36,8 +41,11 @@ fun releaseSigningInputs(): ReleaseSigningInputs? {
     }
 
     val missing = values.filterValues { it == null }.keys
-    check(missing.isEmpty()) {
-        "Release signing config is incomplete. Missing: ${missing.joinToString()}"
+    if (missing.isNotEmpty()) {
+        if (releaseTaskRequested) {
+            error("Release signing config is incomplete. Missing: ${missing.joinToString()}")
+        }
+        return null
     }
 
     return ReleaseSigningInputs(
@@ -48,7 +56,7 @@ fun releaseSigningInputs(): ReleaseSigningInputs? {
     )
 }
 
-val releaseSigningInputs = releaseSigningInputs()
+val releaseSigningInputs = releaseSigningInputs(isReleaseTaskRequested())
 
 android {
     namespace = "dev.bluehouse.libredrop"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,6 +8,48 @@ plugins {
     alias(libs.plugins.kotlin.android)
 }
 
+data class ReleaseSigningInputs(
+    val keystoreFile: String,
+    val keystorePassword: String,
+    val keyAlias: String,
+    val keyPassword: String,
+)
+
+fun releaseSigningInputs(): ReleaseSigningInputs? {
+    fun propertyOrEnvironment(name: String): String? =
+        providers
+            .gradleProperty(name)
+            .orElse(providers.environmentVariable(name))
+            .orNull
+            ?.takeIf { it.isNotBlank() }
+
+    val values =
+        mapOf(
+            "KEYSTORE_FILE" to propertyOrEnvironment("KEYSTORE_FILE"),
+            "KEYSTORE_PASSWORD" to propertyOrEnvironment("KEYSTORE_PASSWORD"),
+            "KEY_ALIAS" to propertyOrEnvironment("KEY_ALIAS"),
+            "KEY_PASSWORD" to propertyOrEnvironment("KEY_PASSWORD"),
+        )
+    val present = values.filterValues { it != null }
+    if (present.isEmpty()) {
+        return null
+    }
+
+    val missing = values.filterValues { it == null }.keys
+    check(missing.isEmpty()) {
+        "Release signing config is incomplete. Missing: ${missing.joinToString()}"
+    }
+
+    return ReleaseSigningInputs(
+        keystoreFile = values.getValue("KEYSTORE_FILE")!!,
+        keystorePassword = values.getValue("KEYSTORE_PASSWORD")!!,
+        keyAlias = values.getValue("KEY_ALIAS")!!,
+        keyPassword = values.getValue("KEY_PASSWORD")!!,
+    )
+}
+
+val releaseSigningInputs = releaseSigningInputs()
+
 android {
     namespace = "dev.bluehouse.libredrop"
     compileSdk =
@@ -31,6 +73,17 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    signingConfigs {
+        if (releaseSigningInputs != null) {
+            create("release") {
+                storeFile = file(releaseSigningInputs.keystoreFile)
+                storePassword = releaseSigningInputs.keystorePassword
+                keyAlias = releaseSigningInputs.keyAlias
+                keyPassword = releaseSigningInputs.keyPassword
+            }
+        }
+    }
+
     buildTypes {
         debug {
             applicationIdSuffix = ".debug"
@@ -38,6 +91,9 @@ android {
         }
         release {
             isMinifyEnabled = false
+            if (releaseSigningInputs != null) {
+                signingConfig = signingConfigs.getByName("release")
+            }
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }
     }

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,14 +1,15 @@
 # Release Builds
 
 LibreDrop release builds are produced by `.github/workflows/release.yml`.
-The workflow is separate from normal CI and runs when either:
+The workflow is separate from normal CI and runs when:
 
 - a tag matching `v*` is pushed, such as `v1.2.3`
-- a GitHub Release is published
 
 The workflow builds `:app:assembleRelease` and `:app:bundleRelease`, signs them
 with a keystore supplied through GitHub Actions secrets, and uploads the signed
-APK and AAB as workflow artifacts.
+APK and AAB as workflow artifacts. The decoded keystore lives in
+`$RUNNER_TEMP/release.keystore` for the Gradle step only and is removed before
+artifact upload.
 
 ## Required GitHub Secrets
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,76 @@
+# Release Builds
+
+LibreDrop release builds are produced by `.github/workflows/release.yml`.
+The workflow is separate from normal CI and runs when either:
+
+- a tag matching `v*` is pushed, such as `v1.2.3`
+- a GitHub Release is published
+
+The workflow builds `:app:assembleRelease` and `:app:bundleRelease`, signs them
+with a keystore supplied through GitHub Actions secrets, and uploads the signed
+APK and AAB as workflow artifacts.
+
+## Required GitHub Secrets
+
+Configure these repository secrets before publishing a release:
+
+| Secret | Purpose |
+| --- | --- |
+| `KEYSTORE_B64` | Base64-encoded Android release keystore file |
+| `KEYSTORE_PASSWORD` | Password for the keystore file |
+| `KEY_ALIAS` | Alias of the signing key inside the keystore |
+| `KEY_PASSWORD` | Password for the signing key |
+
+Do not commit keystore files or passwords. The workflow decodes
+`KEYSTORE_B64` into `$RUNNER_TEMP/release.keystore`, which is outside the
+workspace and is discarded with the runner.
+
+## Generate A Keystore
+
+Create a keystore locally if you do not already have one:
+
+```bash
+keytool -genkeypair \
+  -v \
+  -keystore release.keystore \
+  -alias libredrop \
+  -keyalg RSA \
+  -keysize 2048 \
+  -validity 10000
+```
+
+Record the keystore password, key alias, and key password in the matching
+GitHub secrets.
+
+## Encode The Keystore
+
+GitHub secrets are text-only, so store the binary keystore as base64 text.
+
+On macOS:
+
+```bash
+base64 -i release.keystore | pbcopy
+```
+
+On Linux:
+
+```bash
+base64 -w0 release.keystore
+```
+
+Paste the encoded value into the `KEYSTORE_B64` repository secret.
+
+## Local Signed Build
+
+For local release signing, pass the same values as Gradle properties or
+environment variables:
+
+```bash
+./gradlew :app:assembleRelease \
+  -PKEYSTORE_FILE=/absolute/path/to/release.keystore \
+  -PKEYSTORE_PASSWORD="$KEYSTORE_PASSWORD" \
+  -PKEY_ALIAS="$KEY_ALIAS" \
+  -PKEY_PASSWORD="$KEY_PASSWORD"
+```
+
+If no signing values are supplied, local release builds remain unsigned.


### PR DESCRIPTION
## Summary

- Add a separate release workflow triggered by `v*` tags and published GitHub Releases.
- Decode `KEYSTORE_B64` into `$RUNNER_TEMP/release.keystore`, pass signing values through environment variables, and upload signed APK/AAB artifacts.
- Add conditional release signing configuration in `app/build.gradle.kts` and document release secrets in `docs/release.md`.

## Verification

- `git diff --check`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); puts 'yaml ok'"`
- `./gradlew :app:assembleRelease :app:bundleRelease`
- `KEYSTORE_FILE=/tmp/libredrop-release-test.keystore KEYSTORE_PASSWORD=testpass123 KEY_ALIAS=libredrop KEY_PASSWORD=testpass123 ./gradlew :app:assembleRelease :app:bundleRelease`
- `/Users/kyujin/Library/Android/sdk/build-tools/35.0.0/apksigner verify --print-certs app/build/outputs/apk/release/app-release.apk`
- `./gradlew staticAnalysis :core-protocol:test check :app:assembleDebug`

Closes #156