### PR TITLE
feat: hide non-negotiable peers from share-target picker

### DIFF
--- a/app/src/main/kotlin/dev/bluehouse/libredrop/send/SendBootstrapPlan.kt
+++ b/app/src/main/kotlin/dev/bluehouse/libredrop/send/SendBootstrapPlan.kt
@@ -155,6 +155,9 @@ internal data class SendBootstrapPlan(
                 val lanAddress = lan?.primaryAddress()
                 val ble = peer.bleAdvertisement
                 val blePsm = ble?.l2capPsm
+                if (peer.endpointInfo == null) {
+                    add("peer endpoint info could not be parsed")
+                }
                 if (lan == null || lanAddress == null) {
                     add("no shared Wi-Fi LAN route")
                 }
@@ -164,13 +167,10 @@ internal data class SendBootstrapPlan(
                 if (ble != null && blePsm == null && !ble.gattConnectable) {
                     add("receiver BLE GATT bootstrap is not verified")
                 }
-                if (ble != null && peer.endpointInfo?.hidden != false) {
-                    add("BLE observation does not confirm a visible receiver")
-                }
             }.distinct().takeIf { it.isNotEmpty() }?.joinToString(separator = "; ")
 
         private fun lanRoute(peer: NearbyPeer): NearbyPeerRoute.Lan? =
-            peer.lanEndpoint?.let { lan ->
+            peer.lanEndpoint?.takeIf { peer.endpointInfo != null }?.let { lan ->
                 lan.primaryAddress()?.let { address ->
                     NearbyPeerRoute.Lan(address = address, port = lan.port)
                 }
@@ -181,13 +181,14 @@ internal data class SendBootstrapPlan(
             val lanAddress = lan?.primaryAddress()
             return when {
                 lan == null -> "wifi-lan=missing"
+                peer.endpointInfo == null -> "wifi-lan=endpoint-info-unparseable"
                 lanAddress == null -> "wifi-lan=no-primary-address"
                 else -> "wifi-lan=unusable"
             }
         }
 
         private fun bleL2capRoute(peer: NearbyPeer): NearbyPeerRoute.BleL2cap? =
-            peer.bleAdvertisement?.let { ble ->
+            peer.bleAdvertisement?.takeIf { peer.endpointInfo != null }?.let { ble ->
                 val address = ble.advertiserAddress
                 val psm = ble.l2capPsm
                 if (address != null && psm != null) {
@@ -204,15 +205,16 @@ internal data class SendBootstrapPlan(
             return when {
                 ble == null -> "ble=missing"
                 bleAddress == null -> "ble=no-address"
+                peer.endpointInfo == null -> "ble-l2cap=no-endpoint-info"
                 blePsm == null -> "ble-l2cap=peer-psm-missing"
                 else -> "ble-l2cap=unusable"
             }
         }
 
         private fun bleGattRoute(peer: NearbyPeer): NearbyPeerRoute.BleGatt? =
-            peer.bleAdvertisement?.let { ble ->
+            peer.bleAdvertisement?.takeIf { peer.endpointInfo != null }?.let { ble ->
                 val address = ble.advertiserAddress
-                if (address != null && ble.gattConnectable && peer.endpointInfo?.hidden == false) {
+                if (address != null && ble.gattConnectable) {
                     NearbyPeerRoute.BleGatt(macAddress = address)
                 } else {
                     null
@@ -226,9 +228,8 @@ internal data class SendBootstrapPlan(
             return when {
                 ble == null -> "ble-gatt=missing"
                 bleAddress == null -> "ble-gatt=no-address"
-                !ble.gattConnectable -> "ble-gatt=not-verified"
                 endpointInfo == null -> "ble-gatt=no-endpoint-info"
-                endpointInfo.hidden -> "ble-gatt=peer-hidden"
+                !ble.gattConnectable -> "ble-gatt=not-verified"
                 else -> "ble-gatt=unusable"
             }
         }

--- a/app/src/main/kotlin/dev/bluehouse/libredrop/send/SendPeerPickerController.kt
+++ b/app/src/main/kotlin/dev/bluehouse/libredrop/send/SendPeerPickerController.kt
@@ -200,6 +200,10 @@ internal class SendPeerPickerController(
     }
 
     private fun upsertResolvedPeer(incoming: NearbyPeer) {
+        if (!planFor(incoming).isConnectable) {
+            peers.removeAll { it.stableId == incoming.stableId }
+            return
+        }
         val existingIndex = peers.indexOfFirst { it.stableId == incoming.stableId }
         if (existingIndex >= 0) {
             peers[existingIndex] = incoming
@@ -216,25 +220,22 @@ internal class SendPeerPickerController(
         val container = binding.sendPeerList
         container.removeAllViews()
         val inflater = LayoutInflater.from(context)
-        val hasConnectablePeer = peers.any { planFor(it).isConnectable }
         for (peer in peers) {
             val plan = planFor(peer)
+            if (!plan.isConnectable) continue
             val row = ItemPeerRowBinding.inflate(inflater, container, false)
             row.peerRowTitle.text = peerLabel(peer)
             row.peerRowSubtitle.text = plan.subtitle
-            row.root.isEnabled = plan.isConnectable
-            row.root.alpha = if (plan.isConnectable) 1f else DISABLED_PEER_ALPHA
-            row.root.setOnClickListener {
-                if (plan.isConnectable) onPeerSelected(peer)
-            }
+            row.root.isEnabled = true
+            row.root.alpha = 1f
+            row.root.setOnClickListener { onPeerSelected(peer) }
             container.addView(row.root)
         }
         binding.sendEmptyState.visibility = if (peers.isEmpty()) View.VISIBLE else View.GONE
         binding.sendSubtitle.setText(
             when {
                 peers.isEmpty() -> R.string.send_subtitle_discovering
-                hasConnectablePeer -> R.string.send_subtitle_pick_peer
-                else -> R.string.send_subtitle_no_usable_route
+                else -> R.string.send_subtitle_pick_peer
             },
         )
         updateEmptyPeerHintVisibility()
@@ -250,13 +251,11 @@ internal class SendPeerPickerController(
     }
 
     private fun updateEmptyPeerHintVisibility() {
-        val onlyUnroutablePeers = peers.isNotEmpty() && peers.none { planFor(it).isConnectable }
         val show =
-            (!emptyPeerHintTimer.isDismissed() && onlyUnroutablePeers) ||
-                emptyPeerHintTimer.shouldShowHint(
-                    nowMillis = System.currentTimeMillis(),
-                    peerListEmpty = peers.isEmpty(),
-                )
+            emptyPeerHintTimer.shouldShowHint(
+                nowMillis = System.currentTimeMillis(),
+                peerListEmpty = peers.isEmpty(),
+            )
         binding.sendNetworkHint.visibility = if (show) View.VISIBLE else View.GONE
     }
 
@@ -300,7 +299,6 @@ internal class SendPeerPickerController(
 
     private companion object {
         private const val BLE_TAG: String = "LibreDropDiscovery"
-        private const val DISABLED_PEER_ALPHA: Float = 0.6f
     }
 }
 

--- a/app/src/test/kotlin/dev/bluehouse/libredrop/send/SendBootstrapPlanTest.kt
+++ b/app/src/test/kotlin/dev/bluehouse/libredrop/send/SendBootstrapPlanTest.kt
@@ -37,12 +37,26 @@ class SendBootstrapPlanTest {
     }
 
     @Test
-    fun `visible BLE peer stays unavailable when GATT is not connectable`() {
+    fun `peer with malformed endpoint info stays unavailable`() {
+        val peer =
+            peer(
+                lanAddress = "192.168.1.20",
+                endpointInfoPresent = false,
+            )
+
+        val plan = SendBootstrapPlan.resolve(peer = peer)
+
+        assertFalse(plan.isConnectable)
+        assertTrue(plan.failureReason!!.contains("peer endpoint info could not be parsed"))
+        assertTrue(plan.rejectedCandidates.contains("wifi-lan=endpoint-info-unparseable"))
+    }
+
+    @Test
+    fun `BLE peer stays unavailable when GATT is not connectable`() {
         val peer =
             peer(
                 bleAddress = "AA:BB:CC:DD:EE:FF",
                 blePsm = null,
-                bleVisible = true,
                 bleGattConnectable = false,
             )
 
@@ -52,15 +66,16 @@ class SendBootstrapPlanTest {
         assertTrue(plan.failureReason!!.contains("no shared Wi-Fi LAN route"))
         assertTrue(plan.failureReason!!.contains("receiver BLE advertisement has no L2CAP PSM"))
         assertTrue(plan.failureReason!!.contains("receiver BLE GATT bootstrap is not verified"))
+        assertTrue(plan.rejectedCandidates.contains("ble-gatt=not-verified"))
     }
 
     @Test
-    fun `verified visible BLE peer without PSM uses direct GATT bootstrap`() {
+    fun `verified BLE peer without PSM uses GATT regardless of visibility bit`() {
         val peer =
             peer(
                 bleAddress = "AA:BB:CC:DD:EE:FF",
                 blePsm = null,
-                bleVisible = true,
+                endpointInfoHidden = true,
             )
 
         val plan = SendBootstrapPlan.resolve(peer = peer)
@@ -75,48 +90,12 @@ class SendBootstrapPlanTest {
     }
 
     @Test
-    fun `hidden BLE observation stays unavailable without verified bootstrap metadata`() {
-        val peer =
-            peer(
-                bleAddress = "AA:BB:CC:DD:EE:FF",
-                blePsm = null,
-                bleVisible = false,
-            )
-
-        val plan = SendBootstrapPlan.resolve(peer = peer)
-
-        assertFalse(plan.isConnectable)
-        assertTrue(plan.failureReason!!.contains("visible receiver"))
-        assertTrue(plan.rejectedCandidates.contains("ble-gatt=peer-hidden"))
-    }
-
-    @Test
-    fun `BLE GATT route wins before Bluetooth Classic when receiver is visible`() {
+    fun `Bluetooth Classic candidate is ignored when BLE GATT bootstrap is unverified`() {
         val peer =
             peer(
                 bluetoothMac = "11:22:33:44:55:66",
                 bleAddress = "AA:BB:CC:DD:EE:FF",
                 blePsm = null,
-                bleVisible = true,
-            )
-
-        val plan = SendBootstrapPlan.resolve(peer = peer)
-
-        assertTrue(plan.isConnectable)
-        assertEquals(
-            NearbyPeerRoute.BleGatt("AA:BB:CC:DD:EE:FF"),
-            (plan.action as SendBootstrapPlan.Action.Direct).route,
-        )
-    }
-
-    @Test
-    fun `Bluetooth Classic candidate is ignored when visible BLE GATT bootstrap is unverified`() {
-        val peer =
-            peer(
-                bluetoothMac = "11:22:33:44:55:66",
-                bleAddress = "AA:BB:CC:DD:EE:FF",
-                blePsm = null,
-                bleVisible = true,
                 bleGattConnectable = false,
             )
 
@@ -126,48 +105,22 @@ class SendBootstrapPlanTest {
         assertEquals(SendBootstrapPlan.Action.Unavailable, plan.action)
         assertTrue(plan.rejectedCandidates.contains("ble-gatt=not-verified"))
         assertTrue(plan.rejectedCandidates.contains("bluetooth-classic=disabled"))
-        assertFalse(plan.failureReason!!.contains("Bluetooth Classic"))
     }
 
     @Test
-    fun `Samsung peer reachable only via BLE GATT uses the normal GATT route`() {
-        // Real-device validation on Galaxy S26 Ultra showed that the
-        // gchm "No handler registered" logs can coexist with a working
-        // Weave/Nearby receive path. BLE-GATT-only Samsung rows should
-        // therefore remain normal selectable routes.
+    fun `BLE L2CAP route requires parsed endpoint info`() {
         val peer =
             peer(
                 bleAddress = "AA:BB:CC:DD:EE:FF",
-                blePsm = null,
-                bleVisible = true,
+                blePsm = 0x1234,
+                endpointInfoPresent = false,
             )
 
         val plan = SendBootstrapPlan.resolve(peer = peer)
 
-        assertTrue(plan.isConnectable)
-        assertEquals(
-            NearbyPeerRoute.BleGatt("AA:BB:CC:DD:EE:FF"),
-            (plan.action as SendBootstrapPlan.Action.Direct).route,
-        )
-        assertEquals("BLE GATT AA:BB:CC:DD:EE:FF", plan.subtitle)
-    }
-
-    @Test
-    fun `Samsung peer reachable via Wi-Fi LAN still prefers LAN`() {
-        val peer =
-            peer(
-                lanAddress = "192.168.1.20",
-                lanPort = 7654,
-                bleAddress = "AA:BB:CC:DD:EE:FF",
-                bleVisible = true,
-            )
-
-        val plan = SendBootstrapPlan.resolve(peer = peer)
-
-        assertEquals(
-            NearbyPeerRoute.Lan(InetAddress.getByName("192.168.1.20"), 7654),
-            (plan.action as SendBootstrapPlan.Action.Direct).route,
-        )
+        assertFalse(plan.isConnectable)
+        assertTrue(plan.rejectedCandidates.contains("ble-l2cap=no-endpoint-info"))
+        assertTrue(plan.rejectedCandidates.contains("ble-gatt=no-endpoint-info"))
     }
 
     @Test
@@ -187,22 +140,25 @@ class SendBootstrapPlanTest {
         bluetoothMac: String? = null,
         bleAddress: String? = null,
         blePsm: Int? = null,
-        bleVisible: Boolean? = null,
         bleGattConnectable: Boolean = true,
+        endpointInfoPresent: Boolean = true,
+        endpointInfoHidden: Boolean = false,
     ): NearbyPeer =
         NearbyPeer(
             stableId = "peer-1",
             endpointId = "ABCD",
             endpointInfo =
-                bleVisible?.let { visible ->
+                if (endpointInfoPresent) {
                     EndpointInfo(
                         version = 1,
-                        hidden = !visible,
+                        hidden = endpointInfoHidden,
                         deviceType = DeviceType.PHONE,
                         reserved = false,
                         metadata = ByteArray(EndpointInfo.METADATA_LEN),
-                        deviceName = if (visible) "Galaxy S26 Ultra" else null,
+                        deviceName = if (endpointInfoHidden) null else "Galaxy S26 Ultra",
                     )
+                } else {
+                    null
                 },
             lanEndpoint =
                 lanAddress?.let {

--- a/discovery-android/src/main/kotlin/dev/bluehouse/libredrop/discovery/NearbyPeer.kt
+++ b/discovery-android/src/main/kotlin/dev/bluehouse/libredrop/discovery/NearbyPeer.kt
@@ -20,6 +20,10 @@ import java.net.InetAddress
  * represented for tests and future feature re-enable work, but normal
  * user-facing route selection hides them while
  * [UserFacingMediumFeatures.BLUETOOTH_CLASSIC_USER_FACING_ENABLED] is false.
+ *
+ * A parsed [endpointInfo] is part of negotiability: the sender UI should not
+ * offer peers whose identity bytes are malformed even if some transport signal
+ * (for example a LAN address tuple or BLE PSM) was discovered.
  */
 public data class NearbyPeer(
     val stableId: String,
@@ -62,11 +66,14 @@ public data class NearbyPeer(
      * a peer is already reachable by mDNS + TCP. BLE L2CAP is the preferred
      * off-LAN bootstrap path when the receiver advertises a PSM. A visible
      * BLE receiver without a PSM is only a GATT bootstrap candidate after
-     * the GATT advertisement-slot probe verifies the service; header-only,
-     * hidden, and raw scan-result-only BLE observations remain discovery
-     * metadata until another route confirms a transport.
+     * the GATT advertisement-slot probe verifies the service; header-only
+     * and raw scan-result-only BLE observations remain discovery metadata
+     * until another route confirms a transport.
      */
     public fun preferredRoute(): NearbyPeerRoute? {
+        if (endpointInfo == null) {
+            return null
+        }
         val lan = lanEndpoint
         val primaryAddress = lan?.primaryAddress()
         if (lan != null && primaryAddress != null) {
@@ -81,7 +88,7 @@ public data class NearbyPeer(
         if (bleAddress != null && l2capPsm != null) {
             return NearbyPeerRoute.BleL2cap(macAddress = bleAddress, psm = l2capPsm)
         }
-        if (bleAddress != null && ble.gattConnectable && endpointInfo?.hidden == false) {
+        if (bleAddress != null && ble.gattConnectable) {
             return NearbyPeerRoute.BleGatt(macAddress = bleAddress)
         }
         if (UserFacingMediumFeatures.BLUETOOTH_CLASSIC_USER_FACING_ENABLED) {

--- a/discovery-android/src/main/kotlin/dev/bluehouse/libredrop/discovery/NearbyPeerDiscovery.kt
+++ b/discovery-android/src/main/kotlin/dev/bluehouse/libredrop/discovery/NearbyPeerDiscovery.kt
@@ -8,6 +8,7 @@
 package dev.bluehouse.libredrop.discovery
 
 import android.content.Context
+import android.util.Log
 import dev.bluehouse.libredrop.discovery.ble.BleFastAdvertisementScanner
 import dev.bluehouse.libredrop.discovery.classic.BluetoothClassicPeerScanner
 import dev.bluehouse.libredrop.protocol.endpoint.EndpointInfo
@@ -17,6 +18,8 @@ import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.launch
 import java.net.InetAddress
+
+private const val DISCOVERY_TAG: String = "LibreDropDiscovery"
 
 /**
  * Aggregates sender-side peer discovery across multiple media.
@@ -250,9 +253,54 @@ private class PeerAggregator {
         after: NearbyPeer?,
     ): List<NearbyPeerEvent> {
         if (after == null) return emptyList()
-        if (before == after) return emptyList()
+
+        val beforeVisible = before?.isConnectable == true
+        val afterVisible = after.isConnectable
+
+        if (!afterVisible) {
+            logFilteredPeer(after)
+            return if (beforeVisible) listOf(NearbyPeerEvent.Lost(after.stableId)) else emptyList()
+        }
+        if (before == after && beforeVisible) return emptyList()
         return listOf(NearbyPeerEvent.Resolved(after))
     }
+
+    private fun logFilteredPeer(peer: NearbyPeer) {
+        Log.i(
+            DISCOVERY_TAG,
+            "picker filter: hiding peer=${peer.stableId} " +
+                "endpointId=${peer.endpointId ?: "<none>"} reason=${filterReason(peer)}",
+        )
+    }
+
+    private fun filterReason(peer: NearbyPeer): String =
+        buildList {
+            if (peer.endpointInfo == null) {
+                add("endpoint-info-unparseable")
+            }
+
+            val lan = peer.lanEndpoint
+            when {
+                lan == null -> add("wifi-lan-missing")
+                lan.primaryAddress() == null -> add("wifi-lan-no-primary-address")
+            }
+
+            val ble = peer.bleAdvertisement
+            when {
+                ble == null -> add("ble-missing")
+                ble.advertiserAddress == null -> add("ble-no-address")
+                ble.l2capPsm != null -> Unit
+                ble.gattConnectable -> add("ble-gatt-pending-endpoint-info")
+                else -> add("ble-no-verified-bootstrap")
+            }
+
+            if (
+                peer.bluetoothEndpoint != null &&
+                !UserFacingMediumFeatures.BLUETOOTH_CLASSIC_USER_FACING_ENABLED
+            ) {
+                add("bluetooth-classic-disabled")
+            }
+        }.distinct().joinToString(separator = ",")
 }
 
 private data class MutablePeer(

--- a/discovery-android/src/main/kotlin/dev/bluehouse/libredrop/discovery/ble/BleFastAdvertisementScanner.kt
+++ b/discovery-android/src/main/kotlin/dev/bluehouse/libredrop/discovery/ble/BleFastAdvertisementScanner.kt
@@ -605,7 +605,6 @@ public class BleFastAdvertisementScanner(
 private fun BleFastAdvertisementScanner.Observation.requiresGattVerification(): Boolean =
     advertiserAddress != null &&
         l2capPsm == null &&
-        endpointInfo?.hidden == false &&
         !gattConnectable
 
 private fun DctAdvertisement.Parsed.toEndpointInfo(): EndpointInfo =

--- a/discovery-android/src/test/kotlin/dev/bluehouse/libredrop/discovery/NearbyPeerDiscoveryTest.kt
+++ b/discovery-android/src/test/kotlin/dev/bluehouse/libredrop/discovery/NearbyPeerDiscoveryTest.kt
@@ -22,7 +22,7 @@ import java.net.InetAddress
 @OptIn(ExperimentalCoroutinesApi::class)
 class NearbyPeerDiscoveryTest {
     @Test
-    fun `bluetooth and LAN sightings merge into one LAN-first peer`() =
+    fun `Bluetooth metadata stays hidden until LAN route arrives`() =
         runTest {
             val lanEvents = MutableSharedFlow<DiscoveryEvent>()
             val bleEvents = MutableSharedFlow<BleFastAdvertisementScanner.Observation>()
@@ -39,7 +39,6 @@ class NearbyPeerDiscoveryTest {
                     discovery.browse().collect { seen += it }
                 }
             runCurrent()
-            runCurrent()
 
             val endpointInfo = endpointInfo(name = "Pixel 9")
             bluetoothEvents.emit(
@@ -50,6 +49,9 @@ class NearbyPeerDiscoveryTest {
                     advertisedName = "nearby-bt",
                 ),
             )
+            runCurrent()
+            assertThat(seen).isEmpty()
+
             lanEvents.emit(
                 DiscoveryEvent.Resolved(
                     DiscoveredService(
@@ -63,11 +65,10 @@ class NearbyPeerDiscoveryTest {
             )
             runCurrent()
 
-            val resolved = seen.filterIsInstance<NearbyPeerEvent.Resolved>().last().peer
-            assertThat(seen.filterIsInstance<NearbyPeerEvent.Resolved>()).hasSize(2)
-            assertThat(resolved.stableId).isEqualTo("endpoint:ABCD")
-            assertThat(resolved.candidateMediums).containsExactly(Medium.WIFI_LAN)
-            assertThat(resolved.preferredRoute()).isEqualTo(
+            val resolved = seen.single() as NearbyPeerEvent.Resolved
+            assertThat(resolved.peer.stableId).isEqualTo("endpoint:ABCD")
+            assertThat(resolved.peer.candidateMediums).containsExactly(Medium.WIFI_LAN)
+            assertThat(resolved.peer.preferredRoute()).isEqualTo(
                 NearbyPeerRoute.Lan(
                     address = InetAddress.getByName("192.168.1.44"),
                     port = 54321,
@@ -78,7 +79,7 @@ class NearbyPeerDiscoveryTest {
         }
 
     @Test
-    fun `LAN loss keeps bluetooth-discovered peer alive as unroutable metadata`() =
+    fun `LAN loss removes peer once only disabled metadata remains`() =
         runTest {
             val lanEvents = MutableSharedFlow<DiscoveryEvent>()
             val bleEvents = MutableSharedFlow<BleFastAdvertisementScanner.Observation>()
@@ -119,17 +120,33 @@ class NearbyPeerDiscoveryTest {
             lanEvents.emit(DiscoveryEvent.Lost("instance-2"))
             runCurrent()
 
-            assertThat(seen.filterIsInstance<NearbyPeerEvent.Lost>()).isEmpty()
-            val resolved = seen.filterIsInstance<NearbyPeerEvent.Resolved>().last().peer
-            assertThat(resolved.candidateMediums).isEmpty()
-            assertThat(resolved.bluetoothEndpoint?.macAddress).isEqualTo("11:22:33:44:55:66")
-            assertThat(resolved.preferredRoute()).isNull()
+            assertThat(seen).containsExactly(
+                NearbyPeerEvent.Resolved(
+                    NearbyPeer(
+                        stableId = "endpoint:WXYZ",
+                        endpointId = "WXYZ",
+                        endpointInfo = endpointInfo,
+                        lanEndpoint =
+                            NearbyPeer.LanEndpoint(
+                                instanceNames = setOf("instance-2"),
+                                addresses = listOf(InetAddress.getByName("192.168.1.45")),
+                                port = 11111,
+                            ),
+                        bluetoothEndpoint =
+                            NearbyPeer.BluetoothEndpoint(
+                                macAddress = "11:22:33:44:55:66",
+                                advertisedName = "nearby-bt",
+                            ),
+                    ),
+                ),
+                NearbyPeerEvent.Lost("endpoint:WXYZ"),
+            )
 
             collector.cancel()
         }
 
     @Test
-    fun `BLE fast advertisement merges with disabled bluetooth metadata`() =
+    fun `non-negotiable BLE metadata stays hidden`() =
         runTest {
             val lanEvents = MutableSharedFlow<DiscoveryEvent>()
             val bleEvents = MutableSharedFlow<BleFastAdvertisementScanner.Observation>()
@@ -168,11 +185,7 @@ class NearbyPeerDiscoveryTest {
             )
             runCurrent()
 
-            val resolved = seen.filterIsInstance<NearbyPeerEvent.Resolved>().last().peer
-            assertThat(resolved.candidateMediums).containsExactly(Medium.BLE)
-            assertThat(resolved.bleAdvertisement?.advertiserAddress).isEqualTo("77:88:99:AA:BB:CC")
-            assertThat(resolved.bluetoothEndpoint?.macAddress).isEqualTo("66:55:44:33:22:11")
-            assertThat(resolved.preferredRoute()).isNull()
+            assertThat(seen).isEmpty()
 
             collector.cancel()
         }
@@ -209,10 +222,10 @@ class NearbyPeerDiscoveryTest {
             )
             runCurrent()
 
-            val resolved = seen.filterIsInstance<NearbyPeerEvent.Resolved>().last().peer
-            assertThat(resolved.isConnectable).isTrue()
-            assertThat(resolved.candidateMediums).containsExactly(Medium.BLE, Medium.BLE_L2CAP)
-            assertThat(resolved.preferredRoute()).isEqualTo(
+            val resolved = seen.single() as NearbyPeerEvent.Resolved
+            assertThat(resolved.peer.isConnectable).isTrue()
+            assertThat(resolved.peer.candidateMediums).containsExactly(Medium.BLE, Medium.BLE_L2CAP)
+            assertThat(resolved.peer.preferredRoute()).isEqualTo(
                 NearbyPeerRoute.BleL2cap(
                     macAddress = "77:88:99:AA:BB:CC",
                     psm = 0x1234,
@@ -223,7 +236,7 @@ class NearbyPeerDiscoveryTest {
         }
 
     @Test
-    fun `verified visible BLE GATT advertisement without PSM is connectable over GATT`() =
+    fun `verified BLE GATT route ignores visibility bit`() =
         runTest {
             val lanEvents = MutableSharedFlow<DiscoveryEvent>()
             val bleEvents = MutableSharedFlow<BleFastAdvertisementScanner.Observation>()
@@ -241,7 +254,7 @@ class NearbyPeerDiscoveryTest {
                 }
             runCurrent()
 
-            val endpointInfo = endpointInfo(name = "Galaxy")
+            val endpointInfo = endpointInfo(name = null, hidden = true)
             bleEvents.emit(
                 BleFastAdvertisementScanner.Observation(
                     endpointId = "RINE",
@@ -254,10 +267,10 @@ class NearbyPeerDiscoveryTest {
             )
             runCurrent()
 
-            val resolved = seen.filterIsInstance<NearbyPeerEvent.Resolved>().last().peer
-            assertThat(resolved.isConnectable).isTrue()
-            assertThat(resolved.candidateMediums).containsExactly(Medium.BLE)
-            assertThat(resolved.preferredRoute()).isEqualTo(
+            val resolved = seen.single() as NearbyPeerEvent.Resolved
+            assertThat(resolved.peer.isConnectable).isTrue()
+            assertThat(resolved.peer.candidateMediums).containsExactly(Medium.BLE)
+            assertThat(resolved.peer.preferredRoute()).isEqualTo(
                 NearbyPeerRoute.BleGatt(
                     macAddress = "77:88:99:AA:BB:CC",
                 ),
@@ -267,7 +280,7 @@ class NearbyPeerDiscoveryTest {
         }
 
     @Test
-    fun `visible BLE advertisement without PSM waits for GATT verification`() =
+    fun `BLE advertisement without PSM stays hidden until verification succeeds`() =
         runTest {
             val lanEvents = MutableSharedFlow<DiscoveryEvent>()
             val bleEvents = MutableSharedFlow<BleFastAdvertisementScanner.Observation>()
@@ -297,60 +310,22 @@ class NearbyPeerDiscoveryTest {
                 ),
             )
             runCurrent()
+            assertThat(seen).isEmpty()
 
-            val resolved = seen.filterIsInstance<NearbyPeerEvent.Resolved>().last().peer
-            assertThat(resolved.isConnectable).isFalse()
-            assertThat(resolved.candidateMediums).containsExactly(Medium.BLE)
-            assertThat(resolved.preferredRoute()).isNull()
-
-            collector.cancel()
-        }
-
-    @Test
-    fun `verified BLE GATT route is kept across later raw scan observations`() =
-        runTest {
-            val lanEvents = MutableSharedFlow<DiscoveryEvent>()
-            val bleEvents = MutableSharedFlow<BleFastAdvertisementScanner.Observation>()
-            val bluetoothEvents = MutableSharedFlow<BluetoothClassicPeerScanner.Observation>()
-            val discovery =
-                NearbyPeerDiscovery.forTesting(
-                    lanEvents = lanEvents,
-                    bleEvents = bleEvents,
-                    bluetoothEvents = bluetoothEvents,
-                )
-            val seen = mutableListOf<NearbyPeerEvent>()
-            val collector =
-                backgroundScope.launch {
-                    discovery.browse().collect { seen += it }
-                }
-            runCurrent()
-
-            val endpointInfo = endpointInfo(name = "Galaxy")
             bleEvents.emit(
                 BleFastAdvertisementScanner.Observation(
                     endpointId = "RINE",
                     endpointInfo = endpointInfo,
                     advertiserAddress = "77:88:99:AA:BB:CC",
-                    rssi = -47,
+                    rssi = -46,
                     l2capPsm = null,
                     gattConnectable = true,
                 ),
             )
-            bleEvents.emit(
-                BleFastAdvertisementScanner.Observation(
-                    endpointId = "RINE",
-                    endpointInfo = endpointInfo,
-                    advertiserAddress = "77:88:99:AA:BB:CC",
-                    rssi = -48,
-                    l2capPsm = null,
-                    gattConnectable = false,
-                ),
-            )
             runCurrent()
 
-            val resolved = seen.filterIsInstance<NearbyPeerEvent.Resolved>().last().peer
-            assertThat(resolved.isConnectable).isTrue()
-            assertThat(resolved.preferredRoute()).isEqualTo(
+            val resolved = seen.single() as NearbyPeerEvent.Resolved
+            assertThat(resolved.peer.preferredRoute()).isEqualTo(
                 NearbyPeerRoute.BleGatt(
                     macAddress = "77:88:99:AA:BB:CC",
                 ),
@@ -360,7 +335,7 @@ class NearbyPeerDiscoveryTest {
         }
 
     @Test
-    fun `BLE advertisement without Classic or L2CAP is observation-only`() =
+    fun `LAN peer stays hidden until endpoint info parses`() =
         runTest {
             val lanEvents = MutableSharedFlow<DiscoveryEvent>()
             val bleEvents = MutableSharedFlow<BleFastAdvertisementScanner.Observation>()
@@ -378,30 +353,46 @@ class NearbyPeerDiscoveryTest {
                 }
             runCurrent()
 
-            bleEvents.emit(
-                BleFastAdvertisementScanner.Observation(
-                    endpointId = null,
-                    endpointInfo = null,
-                    advertiserAddress = "28:1B:3E:BA:B1:1B",
-                    rssi = -41,
-                    l2capPsm = null,
-                    gattConnectable = true,
+            lanEvents.emit(
+                DiscoveryEvent.Resolved(
+                    DiscoveredService(
+                        instanceName = "instance-3",
+                        endpointId = "ABCD".toByteArray(Charsets.US_ASCII),
+                        addresses = listOf(InetAddress.getByName("192.168.1.50")),
+                        port = 54321,
+                        endpointInfo = null,
+                    ),
+                ),
+            )
+            runCurrent()
+            assertThat(seen).isEmpty()
+
+            lanEvents.emit(
+                DiscoveryEvent.Resolved(
+                    DiscoveredService(
+                        instanceName = "instance-3",
+                        endpointId = "ABCD".toByteArray(Charsets.US_ASCII),
+                        addresses = listOf(InetAddress.getByName("192.168.1.50")),
+                        port = 54321,
+                        endpointInfo = endpointInfo(name = "Pixel 9"),
+                    ),
                 ),
             )
             runCurrent()
 
-            val resolved = seen.filterIsInstance<NearbyPeerEvent.Resolved>().last().peer
-            assertThat(resolved.isConnectable).isFalse()
-            assertThat(resolved.candidateMediums).containsExactly(Medium.BLE)
-            assertThat(resolved.displayName()).isEqualTo("Quick Share BLE device")
-            assertThat(resolved.displayNameSource()).isEqualTo("ble-advertisement")
-            assertThat(resolved.preferredRoute()).isNull()
+            val resolved = seen.single() as NearbyPeerEvent.Resolved
+            assertThat(resolved.peer.preferredRoute()).isEqualTo(
+                NearbyPeerRoute.Lan(
+                    address = InetAddress.getByName("192.168.1.50"),
+                    port = 54321,
+                ),
+            )
 
             collector.cancel()
         }
 
     @Test
-    fun `BLE GATT advertisement uses parsed BLE display name before endpoint fallback`() =
+    fun `LAN peer stays hidden until primary address resolves`() =
         runTest {
             val lanEvents = MutableSharedFlow<DiscoveryEvent>()
             val bleEvents = MutableSharedFlow<BleFastAdvertisementScanner.Observation>()
@@ -419,75 +410,52 @@ class NearbyPeerDiscoveryTest {
                 }
             runCurrent()
 
-            bleEvents.emit(
-                BleFastAdvertisementScanner.Observation(
-                    endpointId = "RINE",
-                    endpointInfo = null,
-                    advertiserAddress = "28:1B:3E:BA:B1:1B",
-                    rssi = -41,
-                    l2capPsm = null,
-                    gattConnectable = true,
-                    displayName = "Galaxy S26",
-                    displayNameSource =
-                        BleFastAdvertisementScanner.DisplayNameSource.BLE_LOCAL_NAME,
+            val endpointInfo = endpointInfo(name = "Pixel 9")
+            lanEvents.emit(
+                DiscoveryEvent.Resolved(
+                    DiscoveredService(
+                        instanceName = "instance-4",
+                        endpointId = "EFGH".toByteArray(Charsets.US_ASCII),
+                        addresses = emptyList(),
+                        port = 54321,
+                        endpointInfo = endpointInfo,
+                    ),
+                ),
+            )
+            runCurrent()
+            assertThat(seen).isEmpty()
+
+            lanEvents.emit(
+                DiscoveryEvent.Resolved(
+                    DiscoveredService(
+                        instanceName = "instance-4",
+                        endpointId = "EFGH".toByteArray(Charsets.US_ASCII),
+                        addresses = listOf(InetAddress.getByName("192.168.1.51")),
+                        port = 54321,
+                        endpointInfo = endpointInfo,
+                    ),
                 ),
             )
             runCurrent()
 
-            val resolved = seen.filterIsInstance<NearbyPeerEvent.Resolved>().last().peer
-            assertThat(resolved.displayName()).isEqualTo("Galaxy S26")
-            assertThat(resolved.displayNameSource()).isEqualTo("ble-local-name")
-            assertThat(resolved.bleAdvertisement?.displayName).isEqualTo("Galaxy S26")
-            assertThat(resolved.isConnectable).isFalse()
-            assertThat(resolved.preferredRoute()).isNull()
-
-            collector.cancel()
-        }
-
-    @Test
-    fun `BLE GATT advertisement falls back to endpoint id before generic label`() =
-        runTest {
-            val lanEvents = MutableSharedFlow<DiscoveryEvent>()
-            val bleEvents = MutableSharedFlow<BleFastAdvertisementScanner.Observation>()
-            val bluetoothEvents = MutableSharedFlow<BluetoothClassicPeerScanner.Observation>()
-            val discovery =
-                NearbyPeerDiscovery.forTesting(
-                    lanEvents = lanEvents,
-                    bleEvents = bleEvents,
-                    bluetoothEvents = bluetoothEvents,
-                )
-            val seen = mutableListOf<NearbyPeerEvent>()
-            val collector =
-                backgroundScope.launch {
-                    discovery.browse().collect { seen += it }
-                }
-            runCurrent()
-
-            bleEvents.emit(
-                BleFastAdvertisementScanner.Observation(
-                    endpointId = "RINE",
-                    endpointInfo = null,
-                    advertiserAddress = "28:1B:3E:BA:B1:1B",
-                    rssi = -41,
-                    l2capPsm = null,
-                    gattConnectable = true,
+            val resolved = seen.single() as NearbyPeerEvent.Resolved
+            assertThat(resolved.peer.preferredRoute()).isEqualTo(
+                NearbyPeerRoute.Lan(
+                    address = InetAddress.getByName("192.168.1.51"),
+                    port = 54321,
                 ),
             )
-            runCurrent()
-
-            val resolved = seen.filterIsInstance<NearbyPeerEvent.Resolved>().last().peer
-            assertThat(resolved.displayName()).isEqualTo("Quick Share device (RINE)")
-            assertThat(resolved.displayNameSource()).isEqualTo("endpoint-id")
-            assertThat(resolved.isConnectable).isFalse()
-            assertThat(resolved.preferredRoute()).isNull()
 
             collector.cancel()
         }
 
-    private fun endpointInfo(name: String?): EndpointInfo =
+    private fun endpointInfo(
+        name: String?,
+        hidden: Boolean = false,
+    ): EndpointInfo =
         EndpointInfo(
             version = 1,
-            hidden = false,
+            hidden = hidden,
             deviceType = DeviceType.PHONE,
             reserved = false,
             metadata = ByteArray(EndpointInfo.METADATA_LEN) { it.toByte() },


### PR DESCRIPTION
## Summary
- hide non-negotiable peers before they reach the share-target picker instead of rendering disabled rows
- require parsed endpoint info plus a supported user-facing route before a peer becomes selectable, while keeping the filter reactive as discovery metadata improves
- remove picker-side dependence on `EndpointInfo.hidden` for BLE GATT bootstrap eligibility and add coverage for reactive LAN/BLE visibility changes

## Verification
- `./gradlew :discovery-android:test --stacktrace`
- `./gradlew :app:testDebugUnitTest --stacktrace`
- `./gradlew :core-protocol:test --stacktrace`
- `./gradlew staticAnalysis --stacktrace`
- `./gradlew :app:assembleDebug --stacktrace`
- `git diff --check`

Closes #158