### PR TITLE
chore: drop .aab from release pipeline and rename release APK

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,13 +53,30 @@ jobs:
           printf '%s' "$KEYSTORE_B64" | base64 -d > "$RUNNER_TEMP/release.keystore"
           chmod 600 "$RUNNER_TEMP/release.keystore"
 
-      - name: Build signed release APK and bundle
+      - name: Build signed release APK
         env:
           KEYSTORE_FILE: ${{ runner.temp }}/release.keystore
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
-        run: ./gradlew :app:assembleRelease :app:bundleRelease --stacktrace
+        run: ./gradlew :app:assembleRelease --stacktrace
+
+      - name: Resolve signed APK path
+        id: release_apk
+        shell: bash
+        run: |
+          shopt -s nullglob
+          apks=(app/build/outputs/apk/release/*.apk)
+          if [ "${#apks[@]}" -ne 1 ]; then
+            printf 'Expected exactly one release APK, found %s\n' "${#apks[@]}" >&2
+            printf 'Matches: %s\n' "${apks[*]:-<none>}" >&2
+            exit 1
+          fi
+
+          apk_path="${apks[0]}"
+          apk_name="$(basename "$apk_path")"
+          printf 'apk_path=%s\n' "$apk_path" >> "$GITHUB_OUTPUT"
+          printf 'apk_name=%s\n' "$apk_name" >> "$GITHUB_OUTPUT"
 
       - name: Remove decoded keystore
         if: always()
@@ -68,11 +85,9 @@ jobs:
       - name: Upload release artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: libredrop-release-${{ github.ref_name }}
+          name: ${{ steps.release_apk.outputs.apk_name }}
           if-no-files-found: error
-          path: |
-            app/build/outputs/apk/release/app-release.apk
-            app/build/outputs/bundle/release/app-release.aab
+          path: ${{ steps.release_apk.outputs.apk_path }}
 
       - name: Attach assets to matching GitHub Release
         env:
@@ -85,8 +100,7 @@ jobs:
             if gh release view "$release_tag" --repo "$repo" >/dev/null 2>&1; then
               gh release upload "$release_tag" \
                 --repo "$repo" \
-                app/build/outputs/apk/release/app-release.apk \
-                app/build/outputs/bundle/release/app-release.aab \
+                "${{ steps.release_apk.outputs.apk_path }}" \
                 --clobber
               exit 0
             fi

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.android.build.gradle.internal.api.BaseVariantOutputImpl
+
 // :app — Android application module. Empty by design at this stage; the
 // real share intent handling (#24), settings UI, and device list land in
 // later issues. This module's job is to wire :service-android,
@@ -113,6 +115,21 @@ android {
 
     buildFeatures {
         viewBinding = true
+    }
+}
+
+android.applicationVariants.configureEach {
+    if (buildType.name != "release") {
+        return@configureEach
+    }
+
+    val applicationId = applicationId
+    val versionName =
+        mergedFlavor.versionName
+            ?: error("Release APK filename requires a versionName.")
+
+    outputs.configureEach {
+        (this as BaseVariantOutputImpl).outputFileName = "$applicationId-$versionName.apk"
     }
 }
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -5,10 +5,12 @@ The workflow is separate from normal CI and runs when:
 
 - a tag matching `v*` is pushed, such as `v1.2.3`
 
-The workflow builds `:app:assembleRelease` and `:app:bundleRelease`, signs them
-with a keystore supplied through GitHub Actions secrets, uploads the signed APK
-and AAB as workflow artifacts, and attaches them to a matching GitHub Release
-when one exists for the tag. The decoded keystore lives in
+The workflow builds `:app:assembleRelease`, signs the APK with a keystore
+supplied through GitHub Actions secrets, uploads the signed APK as a workflow
+artifact, and attaches it to a matching GitHub Release when one exists for the
+tag. Release APK filenames come from the Gradle release variant and follow
+`<applicationId>-<versionName>.apk`, for example
+`dev.bluehouse.libredrop-0.1.0-alpha01.apk`. The decoded keystore lives in
 `$RUNNER_TEMP/release.keystore` for the Gradle step only and is removed before
 artifact upload.
 
@@ -64,9 +66,10 @@ Paste the encoded value into the `KEYSTORE_B64` repository secret.
 
 ## Release Assets
 
-The workflow always uploads the signed APK/AAB to the Actions run as a workflow
-artifact. If the tag already has a matching GitHub Release, the workflow also
-attaches the same files to the Release page.
+The workflow always uploads the signed APK to the Actions run as a workflow
+artifact using the same filename as the on-disk release APK. If the tag already
+has a matching GitHub Release, the workflow also attaches that APK to the
+Release page.
 
 ## Local Signed Build
 


### PR DESCRIPTION
## Summary
- stop building and uploading the release AAB so the release pipeline ships APKs only
- rename the release APK in Gradle to `<applicationId>-<versionName>.apk`
- resolve the generated APK path in the workflow so the artifact label and GitHub Release asset use the same filename

## Verification
- ruby -e \"require 'yaml'; YAML.load_file('.github/workflows/release.yml'); puts 'yaml ok'\"
- KEYSTORE_FILE=/tmp/libredrop-issue-160.keystore KEYSTORE_PASSWORD=testpass123 KEY_ALIAS=testkey KEY_PASSWORD=testpass123 ./gradlew :app:assembleRelease --stacktrace
- find app/build/outputs -maxdepth 3 \\( -name '*.apk' -o -name '*.aab' \\) | sort
- ./gradlew staticAnalysis --stacktrace
- git diff --check