### PR TITLE
feat: shake-to-report bug reporting flow

### DIFF
--- a/app/src/main/kotlin/dev/bluehouse/libredrop/MainActivity.kt
+++ b/app/src/main/kotlin/dev/bluehouse/libredrop/MainActivity.kt
@@ -21,6 +21,8 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.SwitchCompat
 import dev.bluehouse.libredrop.battery.BatteryOptimizationOemHelper
 import dev.bluehouse.libredrop.battery.BatteryOptimizationPreferences
+import dev.bluehouse.libredrop.bugreport.BugReportFlowSupport
+import dev.bluehouse.libredrop.bugreport.BugReportPreferences
 import dev.bluehouse.libredrop.migration.LegacyPackageDetectorAndroid
 import dev.bluehouse.libredrop.onboarding.PermissionRequirements
 import dev.bluehouse.libredrop.onboarding.PermissionsOnboardingActivity
@@ -109,10 +111,12 @@ class MainActivity : AppCompatActivity() {
      * both `wvmg` and `wvmg.debug` are present).
      */
     private var legacyPackageInBanner: String? = null
+    private lateinit var bugReportFlowSupport: BugReportFlowSupport
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+        bugReportFlowSupport = BugReportFlowSupport.install(this)
         // Restore the flag across configuration changes so we don't
         // re-route on rotate.
         savedInstanceState?.let {
@@ -125,6 +129,13 @@ class MainActivity : AppCompatActivity() {
         switch.isChecked = MdnsVisibilityOverrideHolder.isActive
         switch.setOnCheckedChangeListener { _, checked ->
             MdnsVisibilityOverrideHolder.setAlwaysVisible(checked)
+        }
+
+        val bugReportSwitch = findViewById<SwitchCompat>(R.id.main_bug_report_switch)
+        val bugReportPreferences = BugReportPreferences.from(this)
+        bugReportSwitch.isChecked = bugReportPreferences.isShakeToReportEnabled()
+        bugReportSwitch.setOnCheckedChangeListener { _, checked ->
+            bugReportPreferences.setShakeToReportEnabled(checked)
         }
 
         // SAF tree-picker (#38). The launcher must be registered during
@@ -235,6 +246,12 @@ class MainActivity : AppCompatActivity() {
         findViewById<SwitchCompat>(R.id.main_always_visible_switch)?.let {
             if (it.isChecked != MdnsVisibilityOverrideHolder.isActive) {
                 it.isChecked = MdnsVisibilityOverrideHolder.isActive
+            }
+        }
+        findViewById<SwitchCompat>(R.id.main_bug_report_switch)?.let {
+            val enabled = BugReportPreferences.from(this).isShakeToReportEnabled()
+            if (it.isChecked != enabled) {
+                it.isChecked = enabled
             }
         }
 

--- a/app/src/main/kotlin/dev/bluehouse/libredrop/bugreport/BugReportArchiveWriter.kt
+++ b/app/src/main/kotlin/dev/bluehouse/libredrop/bugreport/BugReportArchiveWriter.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 LibreDrop contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.libredrop.bugreport
+
+import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+internal data class BugReportArchiveEntry(
+    val path: String,
+    val bytes: ByteArray,
+)
+
+internal object BugReportArchiveWriter {
+    fun write(
+        destination: File,
+        entries: List<BugReportArchiveEntry>,
+    ) {
+        ZipOutputStream(destination.outputStream().buffered()).use { zip ->
+            entries.forEach { entry ->
+                zip.putNextEntry(ZipEntry(entry.path))
+                zip.write(entry.bytes)
+                zip.closeEntry()
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/dev/bluehouse/libredrop/bugreport/BugReportCollector.kt
+++ b/app/src/main/kotlin/dev/bluehouse/libredrop/bugreport/BugReportCollector.kt
@@ -1,0 +1,591 @@
+/*
+ * Copyright 2026 LibreDrop contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.libredrop.bugreport
+
+import android.Manifest
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothManager
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.net.ConnectivityManager
+import android.net.LinkAddress
+import android.net.Uri
+import android.net.wifi.WifiManager
+import android.os.BatteryManager
+import android.os.Build
+import android.os.Environment
+import android.os.Handler
+import android.os.Looper
+import android.os.PowerManager
+import android.os.SystemClock
+import android.view.PixelCopy
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+import androidx.core.content.pm.PackageInfoCompat
+import dev.bluehouse.libredrop.discovery.DiscoveryDiagnostics
+import dev.bluehouse.libredrop.discovery.diagnostics.DiagnosticLog
+import dev.bluehouse.libredrop.service.receiver.ActiveBleScannerHolder
+import dev.bluehouse.libredrop.service.receiver.MdnsVisibilityOverrideHolder
+import dev.bluehouse.libredrop.service.receiver.OutboundSessionActiveHolder
+import dev.bluehouse.libredrop.service.receiver.QrSessionActiveHolder
+import dev.bluehouse.libredrop.service.receiver.ReceiverAdvertisementStateHolder
+import dev.bluehouse.libredrop.service.receiver.ReceiverBugReportDiagnostics
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.FileInputStream
+import java.time.Instant
+import java.util.Locale
+import java.util.TimeZone
+import kotlin.coroutines.resume
+import kotlin.math.max
+
+internal data class PreparedBugReport(
+    val suggestedName: String,
+    val tempZip: File,
+)
+
+internal class BugReportCollector(
+    private val context: Context,
+) {
+    suspend fun collect(
+        activity: AppCompatActivity,
+        includeWifiBssid: Boolean,
+    ): PreparedBugReport =
+        withContext(Dispatchers.IO) {
+            val now = Instant.now()
+            val failures = linkedMapOf<String, String>()
+            val packageInfo = readPackageInfo()
+
+            val screenshotResult = captureScreenshot(activity)
+            if (screenshotResult.failureReason != null) {
+                failures["screenshot"] = screenshotResult.failureReason
+            }
+
+            val outboundLogBytes = readOptionalExternalFile("libredrop-outbound.log", failures, "outbound_log")
+            val ringbufferText =
+                DiagnosticLog.dumpRecent(
+                    maxAgeMillis = DiagnosticLog.DEFAULT_MAX_AGE_MILLIS,
+                    nowMillis = System.currentTimeMillis(),
+                )
+            if (ringbufferText.isBlank()) {
+                failures["ringbuffer"] = "not_available: no buffered lines in the last 15 minutes"
+            }
+
+            val discoverySnapshot = ReceiverBugReportDiagnostics.discoverySnapshot()
+            if (discoverySnapshot == null) {
+                failures["discovery_snapshot"] = "not_available: receiver discovery service is not running"
+            }
+            failures["recent_crash_markers"] = "not_available: crash marker persistence is not implemented"
+
+            val entries =
+                listOf(
+                    BugReportArchiveEntry("README.txt", buildReadme().encodeToByteArray()),
+                    BugReportArchiveEntry(
+                        "metadata.json",
+                        buildMetadataJson(
+                            generatedAt = now,
+                            includeWifiBssid = includeWifiBssid,
+                            screenshotRedacted = screenshotResult.redacted,
+                            failures = failures,
+                        ).encodeToByteArray(),
+                    ),
+                    BugReportArchiveEntry(
+                        "device.txt",
+                        buildDeviceDiagnostics(
+                            packageInfo = packageInfo,
+                            includeWifiBssid = includeWifiBssid,
+                        ).encodeToByteArray(),
+                    ),
+                    BugReportArchiveEntry(
+                        "permissions.txt",
+                        buildPermissionsSnapshot().encodeToByteArray(),
+                    ),
+                    BugReportArchiveEntry(
+                        "discovery.txt",
+                        buildDiscoverySnapshot(discoverySnapshot).encodeToByteArray(),
+                    ),
+                    BugReportArchiveEntry(
+                        "logs/outbound.log",
+                        outboundLogBytes ?: "not_available\n".encodeToByteArray(),
+                    ),
+                    BugReportArchiveEntry(
+                        "logs/ringbuffer.txt",
+                        ringbufferText.ifBlank { "not_available\n" }.encodeToByteArray(),
+                    ),
+                    BugReportArchiveEntry(
+                        "screenshot.png",
+                        screenshotResult.pngBytes,
+                    ),
+                )
+
+            val tempZip = File.createTempFile("libredrop-bugreport-", ".zip", context.cacheDir)
+            BugReportArchiveWriter.write(tempZip, entries)
+            PreparedBugReport(
+                suggestedName = BugReportFileNaming.archiveName(now),
+                tempZip = tempZip,
+            )
+        }
+
+    fun writeToUri(
+        report: PreparedBugReport,
+        destination: Uri,
+    ) {
+        context.contentResolver.openOutputStream(destination)?.use { out ->
+            FileInputStream(report.tempZip).use { input ->
+                input.copyTo(out)
+            }
+        } ?: error("Could not open output stream for $destination")
+    }
+
+    private fun buildReadme(): String =
+        """
+        LibreDrop bug report archive
+        
+        Contents:
+        - metadata.json: machine-readable collection summary and per-source failures
+        - device.txt: device, app, locale, battery, Bluetooth, and network snapshot
+        - permissions.txt: granted/denied runtime permissions
+        - discovery.txt: receiver/discovery runtime state
+        - logs/outbound.log: on-disk outbound diagnostic log when available
+        - logs/ringbuffer.txt: recent in-memory diagnostics from the last 15 minutes
+        - screenshot.png: screenshot of the current LibreDrop activity, or a placeholder when redacted
+        
+        This archive stays on-device until you choose where to save it and manually attach it to a bug report.
+        """.trimIndent()
+
+    private fun buildMetadataJson(
+        generatedAt: Instant,
+        includeWifiBssid: Boolean,
+        screenshotRedacted: Boolean,
+        failures: Map<String, String>,
+    ): String {
+        val root = JSONObject()
+        root.put("generated_at_utc", generatedAt.toString())
+        root.put("application_id", context.packageName)
+        root.put("include_wifi_bssid", includeWifiBssid)
+        root.put("screenshot_redacted", screenshotRedacted)
+        val failureObject = JSONObject()
+        failures.forEach { (key, value) -> failureObject.put(key, value) }
+        root.put("collection_failures", failureObject)
+        return root.toString(2)
+    }
+
+    @Suppress("LongMethod", "CyclomaticComplexMethod")
+    private fun buildDeviceDiagnostics(
+        packageInfo: PackageInfo?,
+        includeWifiBssid: Boolean,
+    ): String {
+        val batteryIntent =
+            context.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+        val batteryLevel = batteryIntent?.getIntExtra(BatteryManager.EXTRA_LEVEL, -1) ?: -1
+        val batteryScale = batteryIntent?.getIntExtra(BatteryManager.EXTRA_SCALE, -1) ?: -1
+        val batteryPercent =
+            if (batteryLevel >= 0 && batteryScale > 0) {
+                batteryLevel * BATTERY_PERCENT_SCALE / batteryScale
+            } else {
+                null
+            }
+        val batteryStatus =
+            batteryIntent?.getIntExtra(BatteryManager.EXTRA_STATUS, BatteryManager.BATTERY_STATUS_UNKNOWN)
+        val powerManager = context.getSystemService(Context.POWER_SERVICE) as? PowerManager
+        val locale = Locale.getDefault()
+        val connectivity = context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+        val linkProperties = connectivity?.getLinkProperties(connectivity.activeNetwork)
+        val wifiSnapshot = readWifiDiagnostics(includeWifiBssid)
+        val bluetoothSnapshot = readBluetoothDiagnostics()
+        val externalDir = context.getExternalFilesDir(null)
+        val isDebuggable =
+            (context.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) != 0
+        val buildType =
+            if (context.packageName.endsWith(".debug")) {
+                "debug"
+            } else {
+                "release"
+            }
+
+        return buildString {
+            appendLine("manufacturer=${Build.MANUFACTURER}")
+            appendLine("brand=${Build.BRAND}")
+            appendLine("model=${Build.MODEL}")
+            appendLine("device=${Build.DEVICE}")
+            appendLine("product=${Build.PRODUCT}")
+            appendLine("fingerprint=${Build.FINGERPRINT}")
+            appendLine("hardware=${Build.HARDWARE}")
+            appendLine("board=${Build.BOARD}")
+            appendLine("socManufacturer=${Build.SOC_MANUFACTURER}")
+            appendLine("socModel=${Build.SOC_MODEL}")
+            appendLine("release=${Build.VERSION.RELEASE}")
+            appendLine("sdkInt=${Build.VERSION.SDK_INT}")
+            appendLine("incremental=${Build.VERSION.INCREMENTAL}")
+            appendLine("codename=${Build.VERSION.CODENAME}")
+            appendLine("applicationId=${context.packageName}")
+            appendLine("versionName=${packageInfo?.versionName ?: "unknown"}")
+            appendLine("versionCode=${packageInfo?.let(PackageInfoCompat::getLongVersionCode) ?: 0L}")
+            appendLine("debug=$isDebuggable")
+            appendLine("buildType=$buildType")
+            appendLine("installer=${readInstallSource()}")
+            appendLine("packageLastUpdateMillis=${packageInfo?.lastUpdateTime ?: -1L}")
+            appendLine("locale=${locale.toLanguageTag()}")
+            appendLine("timezone=${TimeZone.getDefault().id}")
+            appendLine("uptimeMillis=${SystemClock.elapsedRealtime()}")
+            appendLine("batteryPercent=${batteryPercent ?: "not_available"}")
+            appendLine(
+                "batteryCharging=" +
+                    (
+                        batteryStatus == BatteryManager.BATTERY_STATUS_CHARGING ||
+                            batteryStatus == BatteryManager.BATTERY_STATUS_FULL
+                    ),
+            )
+            appendLine("powerSaveMode=${powerManager?.isPowerSaveMode ?: false}")
+            appendLine("wifiSsid=${wifiSnapshot.ssid}")
+            appendLine("wifiBssid=${wifiSnapshot.bssid}")
+            appendLine("wifiLinkSpeedMbps=${wifiSnapshot.linkSpeedMbps ?: "not_available"}")
+            appendLine("wifiFrequencyMhz=${wifiSnapshot.frequencyMhz ?: "not_available"}")
+            appendLine("ipFamilies=${describeIpFamilies(linkProperties?.linkAddresses.orEmpty())}")
+            appendLine("bluetoothState=${bluetoothSnapshot.state}")
+            appendLine("bluetoothName=${bluetoothSnapshot.name}")
+            appendLine("bondedDeviceCount=${bluetoothSnapshot.bondedDeviceCount ?: "not_available"}")
+            appendLine("bleFeatures=${bluetoothSnapshot.bleFeatures}")
+            appendLine(
+                "receiverServiceLikelyRunning=" +
+                    ReceiverBugReportDiagnostics.isReceiverServiceLikelyRunning(),
+            )
+            appendLine("receiverAdvertising=${ReceiverAdvertisementStateHolder.isAdvertising}")
+            appendLine("outboundSessionActive=${OutboundSessionActiveHolder.isActive}")
+            appendLine("mdnsOverrideActive=${MdnsVisibilityOverrideHolder.isActive}")
+            appendLine("qrSessionActive=${QrSessionActiveHolder.isActive}")
+            appendLine("externalFilesDirFreeBytes=${externalDir?.usableSpace ?: -1L}")
+            appendLine("downloadsState=${Environment.getExternalStorageState()}")
+        }
+    }
+
+    private fun buildPermissionsSnapshot(): String {
+        val packageInfo = readPackageInfo(flags = PackageManager.GET_PERMISSIONS.toLong())
+        val permissions =
+            packageInfo?.requestedPermissions?.sorted().orEmpty()
+        if (permissions.isEmpty()) {
+            return "not_available: no requested permissions reported by PackageManager"
+        }
+        return buildString {
+            permissions.forEach { permission ->
+                val granted =
+                    ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+                append(permission)
+                append('=')
+                append(if (granted) "granted" else "denied")
+                append('\n')
+            }
+        }.trimEnd()
+    }
+
+    private fun buildDiscoverySnapshot(discoveryDiagnostics: DiscoveryDiagnostics?): String =
+        buildString {
+            appendLine("receiverAdvertising=${ReceiverAdvertisementStateHolder.isAdvertising}")
+            appendLine("outboundSessionActive=${OutboundSessionActiveHolder.isActive}")
+            appendLine("mdnsOverrideActive=${MdnsVisibilityOverrideHolder.isActive}")
+            appendLine("qrSessionActive=${QrSessionActiveHolder.isActive}")
+            appendLine("bleScannerPresent=${ActiveBleScannerHolder.current() != null}")
+            if (discoveryDiagnostics == null) {
+                appendLine("discoverySnapshot=not_available")
+            } else {
+                appendLine("advertiseBoundAddress=${discoveryDiagnostics.advertiseBoundAddress?.hostAddress ?: "none"}")
+                appendLine("browseBoundAddress=${discoveryDiagnostics.browseBoundAddress?.hostAddress ?: "none"}")
+                appendLine("multicastLockHeld=${discoveryDiagnostics.multicastLockHeld}")
+                appendLine("advertising=${discoveryDiagnostics.advertising}")
+                appendLine("browsing=${discoveryDiagnostics.browsing}")
+                appendLine("recentEvents=")
+                discoveryDiagnostics.recentEvents.forEach { event ->
+                    appendLine("  - ${event.timestampMillis} ${event.kind.name}:${event.instanceName}")
+                }
+            }
+        }.trimEnd()
+
+    private fun readPackageInfo(flags: Long = 0L): PackageInfo? =
+        runCatching {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                context.packageManager.getPackageInfo(
+                    context.packageName,
+                    PackageManager.PackageInfoFlags.of(flags),
+                )
+            } else {
+                @Suppress("DEPRECATION")
+                context.packageManager.getPackageInfo(context.packageName, flags.toInt())
+            }
+        }.getOrNull()
+
+    @Suppress("DEPRECATION")
+    private fun readInstallSource(): String =
+        runCatching {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                context.packageManager.getInstallSourceInfo(context.packageName).installingPackageName
+            } else {
+                context.packageManager.getInstallerPackageName(context.packageName)
+            } ?: "unknown"
+        }.getOrElse { "unknown" }
+
+    private suspend fun captureScreenshot(activity: AppCompatActivity): ScreenshotResult {
+        if (BugReportSensitiveScreens.shouldRedact(activity)) {
+            return ScreenshotResult(
+                pngBytes = renderPlaceholderPng("Screenshot redacted on a sensitive screen."),
+                redacted = true,
+                failureReason = null,
+            )
+        }
+
+        return withContext(Dispatchers.Main) {
+            suspendCancellableCoroutine { continuation ->
+                val decorView = activity.window.decorView
+                val width = max(decorView.width, 1)
+                val height = max(decorView.height, 1)
+                val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+                val handler = Handler(Looper.getMainLooper())
+                PixelCopy.request(
+                    activity.window,
+                    bitmap,
+                    { result ->
+                        if (result == PixelCopy.SUCCESS) {
+                            continuation.resume(
+                                ScreenshotResult(
+                                    pngBytes = bitmap.toPngBytes(),
+                                    redacted = false,
+                                    failureReason = null,
+                                ),
+                            )
+                        } else {
+                            continuation.resume(
+                                ScreenshotResult(
+                                    pngBytes = renderPlaceholderPng("Screenshot unavailable."),
+                                    redacted = false,
+                                    failureReason = "not_available: PixelCopy failed with code=$result",
+                                ),
+                            )
+                        }
+                    },
+                    handler,
+                )
+            }
+        }
+    }
+
+    private fun readOptionalExternalFile(
+        fileName: String,
+        failures: MutableMap<String, String>,
+        failureKey: String,
+    ): ByteArray? {
+        val file = context.getExternalFilesDir(null)?.resolve(fileName)
+        if (file == null || !file.exists()) {
+            failures[failureKey] = "not_available: $fileName does not exist"
+            return null
+        }
+        return runCatching { file.readBytes() }.getOrElse { t ->
+            failures[failureKey] = "not_available: could not read $fileName (${t.message})"
+            null
+        }
+    }
+
+    @SuppressLint("MissingPermission", "HardwareIds", "MissingPermission")
+    private fun readWifiDiagnostics(includeWifiBssid: Boolean): WifiDiagnostics {
+        val wifi =
+            context.applicationContext.getSystemService(Context.WIFI_SERVICE) as? WifiManager
+                ?: return unavailableWifiDiagnostics(includeWifiBssid = true)
+        return runCatching {
+            val info = wifi.connectionInfo
+            val ssid = sanitizeWifiSsid(info?.ssid) ?: "not_available"
+            val bssid =
+                when {
+                    !includeWifiBssid -> "<redacted>"
+                    info?.bssid.isNullOrBlank() -> "not_available"
+                    else -> info?.bssid ?: "not_available"
+                }
+            WifiDiagnostics(
+                ssid = ssid,
+                bssid = bssid,
+                linkSpeedMbps = info?.linkSpeed?.takeIf { it > 0 },
+                frequencyMhz = info?.frequency?.takeIf { it > 0 },
+            )
+        }.getOrElse {
+            unavailableWifiDiagnostics(includeWifiBssid)
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun readBluetoothDiagnostics(): BluetoothDiagnostics {
+        val manager = context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
+        val adapter = manager?.adapter
+        if (adapter == null) {
+            return if (manager == null) {
+                BluetoothDiagnostics("not_available", "not_available", null, "not_available")
+            } else {
+                BluetoothDiagnostics("absent", "absent", null, "not_available")
+            }
+        }
+        val packageManager = context.packageManager
+        val bleFeatures =
+            listOf(
+                "le2m=${packageManager.hasSystemFeature(PackageManager.FEATURE_BLUETOOTH_LE)}",
+                "leExtended=${packageManager.hasSystemFeature(PackageManager.FEATURE_BLUETOOTH_LE)}",
+                "l2capCoc=${Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q}",
+            ).joinToString(separator = ",")
+        val connectGranted =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                ContextCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_CONNECT) ==
+                    PackageManager.PERMISSION_GRANTED
+            } else {
+                true
+            }
+        val redactedName =
+            if (connectGranted) {
+                adapter.name?.let { clampBluetoothName(it) } ?: "not_available"
+            } else {
+                "<redacted: missing BLUETOOTH_CONNECT>"
+            }
+        val bondedCount =
+            if (connectGranted) {
+                runCatching { adapter.bondedDevices?.size }.getOrNull()
+            } else {
+                null
+            }
+        return BluetoothDiagnostics(
+            state = bluetoothStateLabel(adapter.state),
+            name = redactedName,
+            bondedDeviceCount = bondedCount,
+            bleFeatures = bleFeatures,
+        )
+    }
+
+    private fun clampBluetoothName(name: String): String =
+        when {
+            name.isBlank() -> "not_available"
+            name.length <= BLUETOOTH_NAME_VISIBLE_PREFIX_LENGTH -> "*".repeat(name.length)
+            else ->
+                "${name.take(BLUETOOTH_NAME_VISIBLE_PREFIX_LENGTH)}" +
+                    "…(${name.length} chars)"
+        }
+
+    private fun bluetoothStateLabel(state: Int): String =
+        when (state) {
+            BluetoothAdapter.STATE_ON -> "on"
+            BluetoothAdapter.STATE_OFF -> "off"
+            BluetoothAdapter.STATE_TURNING_ON -> "turning_on"
+            BluetoothAdapter.STATE_TURNING_OFF -> "turning_off"
+            else -> "unknown($state)"
+        }
+
+    private fun describeIpFamilies(addresses: List<LinkAddress>): String {
+        val hasIpv4 = addresses.any { it.address.hostAddress?.contains('.') == true }
+        val hasIpv6 = addresses.any { it.address.hostAddress?.contains(':') == true }
+        return "ipv4=$hasIpv4,ipv6=$hasIpv6"
+    }
+
+    private fun renderPlaceholderPng(label: String): ByteArray {
+        val bitmap =
+            Bitmap.createBitmap(
+                PLACEHOLDER_BITMAP_WIDTH,
+                PLACEHOLDER_BITMAP_HEIGHT,
+                Bitmap.Config.ARGB_8888,
+            )
+        val canvas = Canvas(bitmap)
+        canvas.drawColor(Color.WHITE)
+        val titlePaint =
+            Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                color = Color.BLACK
+                textSize = PLACEHOLDER_TITLE_TEXT_SIZE
+                textAlign = Paint.Align.LEFT
+            }
+        val bodyPaint =
+            Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                color = Color.DKGRAY
+                textSize = PLACEHOLDER_BODY_TEXT_SIZE
+                textAlign = Paint.Align.LEFT
+            }
+        canvas.drawText(
+            "LibreDrop bug report",
+            PLACEHOLDER_TEXT_X,
+            PLACEHOLDER_TITLE_Y,
+            titlePaint,
+        )
+        canvas.drawText(label, PLACEHOLDER_TEXT_X, PLACEHOLDER_BODY_LINE_1_Y, bodyPaint)
+        canvas.drawText(
+            "No sensitive in-app content was captured.",
+            PLACEHOLDER_TEXT_X,
+            PLACEHOLDER_BODY_LINE_2_Y,
+            bodyPaint,
+        )
+        return bitmap.toPngBytes()
+    }
+
+    private fun Bitmap.toPngBytes(): ByteArray {
+        val out = ByteArrayOutputStream()
+        compress(Bitmap.CompressFormat.PNG, PNG_COMPRESSION_QUALITY, out)
+        return out.toByteArray()
+    }
+
+    private fun sanitizeWifiSsid(raw: String?): String? {
+        if (raw.isNullOrBlank() || raw == "<unknown ssid>") return null
+        val stripped =
+            if (raw.length >= 2 && raw.startsWith('"') && raw.endsWith('"')) {
+                raw.substring(1, raw.length - 1)
+            } else {
+                raw
+            }
+        return stripped.takeUnless { it.isBlank() || it == "<unknown ssid>" }
+    }
+
+    private fun unavailableWifiDiagnostics(includeWifiBssid: Boolean): WifiDiagnostics =
+        WifiDiagnostics(
+            ssid = "not_available",
+            bssid = if (includeWifiBssid) "not_available" else "<redacted>",
+            linkSpeedMbps = null,
+            frequencyMhz = null,
+        )
+
+    private companion object {
+        private const val BATTERY_PERCENT_SCALE: Int = 100
+        private const val BLUETOOTH_NAME_VISIBLE_PREFIX_LENGTH: Int = 3
+        private const val PLACEHOLDER_BITMAP_WIDTH: Int = 1080
+        private const val PLACEHOLDER_BITMAP_HEIGHT: Int = 1920
+        private const val PLACEHOLDER_TITLE_TEXT_SIZE: Float = 48f
+        private const val PLACEHOLDER_BODY_TEXT_SIZE: Float = 36f
+        private const val PLACEHOLDER_TEXT_X: Float = 80f
+        private const val PLACEHOLDER_TITLE_Y: Float = 160f
+        private const val PLACEHOLDER_BODY_LINE_1_Y: Float = 260f
+        private const val PLACEHOLDER_BODY_LINE_2_Y: Float = 320f
+        private const val PNG_COMPRESSION_QUALITY: Int = 100
+    }
+}
+
+private data class ScreenshotResult(
+    val pngBytes: ByteArray,
+    val redacted: Boolean,
+    val failureReason: String?,
+)
+
+private data class WifiDiagnostics(
+    val ssid: String,
+    val bssid: String,
+    val linkSpeedMbps: Int?,
+    val frequencyMhz: Int?,
+)
+
+private data class BluetoothDiagnostics(
+    val state: String,
+    val name: String,
+    val bondedDeviceCount: Int?,
+    val bleFeatures: String,
+)

--- a/app/src/main/kotlin/dev/bluehouse/libredrop/bugreport/BugReportFileNaming.kt
+++ b/app/src/main/kotlin/dev/bluehouse/libredrop/bugreport/BugReportFileNaming.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2026 LibreDrop contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.libredrop.bugreport
+
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+
+internal object BugReportFileNaming {
+    private val archiveFormatter: DateTimeFormatter =
+        DateTimeFormatter
+            .ofPattern("yyyyMMdd-HHmmss")
+            .withZone(ZoneOffset.UTC)
+
+    fun archiveName(now: Instant): String = "libredrop-bugreport-${archiveFormatter.format(now)}Z.zip"
+}

--- a/app/src/main/kotlin/dev/bluehouse/libredrop/bugreport/BugReportFlowSupport.kt
+++ b/app/src/main/kotlin/dev/bluehouse/libredrop/bugreport/BugReportFlowSupport.kt
@@ -1,0 +1,269 @@
+/*
+ * Copyright 2026 LibreDrop contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.libredrop.bugreport
+
+import android.app.AlertDialog
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import android.net.Uri
+import android.os.SystemClock
+import android.view.ViewGroup
+import android.widget.CheckBox
+import android.widget.LinearLayout
+import android.widget.TextView
+import android.widget.Toast
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import dev.bluehouse.libredrop.R
+import dev.bluehouse.libredrop.discovery.diagnostics.DiagnosticLog
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlin.math.sqrt
+
+internal class BugReportFlowSupport private constructor(
+    private val activity: AppCompatActivity,
+) {
+    private val preferences: BugReportPreferences = BugReportPreferences.from(activity)
+    private val collector: BugReportCollector = BugReportCollector(activity.applicationContext)
+    private val sensorManager: SensorManager? =
+        activity.getSystemService(Context.SENSOR_SERVICE) as? SensorManager
+    private val accelerometer: Sensor? = sensorManager?.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)
+
+    private var pendingReport: PreparedBugReport? = null
+    private var saveInFlight: Boolean = false
+    private var lastPromptAtMillis: Long = 0L
+    private var shakeCandidateCount: Int = 0
+    private var lastShakeCandidateAt: Long = 0L
+
+    private val saveLauncher: ActivityResultLauncher<String> =
+        activity.registerForActivityResult(ActivityResultContracts.CreateDocument("application/zip")) { uri ->
+            handleSaveResult(uri)
+        }
+
+    private val shakeObserver =
+        object : DefaultLifecycleObserver, SensorEventListener {
+            override fun onStart(owner: LifecycleOwner) {
+                val sensor = accelerometer ?: return
+                sensorManager?.registerListener(this, sensor, SensorManager.SENSOR_DELAY_UI)
+            }
+
+            override fun onStop(owner: LifecycleOwner) {
+                sensorManager?.unregisterListener(this)
+                shakeCandidateCount = 0
+            }
+
+            override fun onSensorChanged(event: SensorEvent) {
+                if (preferences.isShakeToReportEnabled() && !saveInFlight) {
+                    val gForce =
+                        sqrt(
+                            (event.values[0] * event.values[0]) +
+                                (event.values[1] * event.values[1]) +
+                                (event.values[2] * event.values[2]),
+                        ) / SensorManager.GRAVITY_EARTH
+                    if (gForce >= SHAKE_G_FORCE_THRESHOLD) {
+                        val now = SystemClock.elapsedRealtime()
+                        val promptReady =
+                            registerShakeCandidate(now) &&
+                                now - lastPromptAtMillis >= SHAKE_DEBOUNCE_MILLIS
+                        if (promptReady) {
+                            lastPromptAtMillis = now
+                            showConfirmationDialog()
+                        }
+                    }
+                }
+            }
+
+            override fun onAccuracyChanged(
+                sensor: Sensor?,
+                accuracy: Int,
+            ) = Unit
+        }
+
+    init {
+        activity.lifecycle.addObserver(shakeObserver)
+    }
+
+    private fun showConfirmationDialog() {
+        val checkbox =
+            CheckBox(activity).apply {
+                text = activity.getString(R.string.bug_report_include_bssid_label)
+                isChecked = false
+            }
+        val message =
+            TextView(activity).apply {
+                text = activity.getString(R.string.bug_report_confirm_body)
+            }
+        val container =
+            LinearLayout(activity).apply {
+                orientation = LinearLayout.VERTICAL
+                val padding =
+                    (CONFIRM_DIALOG_HORIZONTAL_PADDING_DP * resources.displayMetrics.density).toInt()
+                setPadding(padding, padding / 2, padding, 0)
+                addView(
+                    message,
+                    ViewGroup.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT,
+                    ),
+                )
+                addView(
+                    checkbox,
+                    ViewGroup.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT,
+                    ),
+                )
+            }
+
+        AlertDialog
+            .Builder(activity)
+            .setTitle(R.string.bug_report_confirm_title)
+            .setView(container)
+            .setNegativeButton(R.string.bug_report_confirm_no, null)
+            .setPositiveButton(R.string.bug_report_confirm_yes) { dialog, _ ->
+                dialog.dismiss()
+                startCollection(checkbox.isChecked)
+            }.show()
+    }
+
+    private fun startCollection(includeWifiBssid: Boolean) {
+        if (saveInFlight) return
+        saveInFlight = true
+        val progressDialog =
+            AlertDialog
+                .Builder(activity)
+                .setMessage(R.string.bug_report_collecting)
+                .setCancelable(false)
+                .create()
+        progressDialog.show()
+        activity.lifecycleScope.launch {
+            val result =
+                runCatching {
+                    collector.collect(
+                        activity = activity,
+                        includeWifiBssid = includeWifiBssid,
+                    )
+                }
+            progressDialog.dismiss()
+            result
+                .onSuccess { report ->
+                    pendingReport = report
+                    saveLauncher.launch(report.suggestedName)
+                }.onFailure { t ->
+                    saveInFlight = false
+                    Toast
+                        .makeText(
+                            activity,
+                            activity.getString(R.string.bug_report_collect_failed, t.message ?: "unknown error"),
+                            Toast.LENGTH_LONG,
+                        ).show()
+                }
+        }
+    }
+
+    private fun handleSaveResult(uri: Uri?) {
+        val report = pendingReport ?: return
+        if (uri == null) {
+            report.tempZip.delete()
+            pendingReport = null
+            saveInFlight = false
+            Toast.makeText(activity, R.string.bug_report_save_cancelled, Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        activity.lifecycleScope.launch {
+            val result =
+                runCatching {
+                    withContext(Dispatchers.IO) {
+                        collector.writeToUri(report, uri)
+                    }
+                }
+            report.tempZip.delete()
+            pendingReport = null
+            saveInFlight = false
+            result
+                .onSuccess {
+                    showPostSaveDialog()
+                }.onFailure { t ->
+                    Toast
+                        .makeText(
+                            activity,
+                            activity.getString(R.string.bug_report_save_failed, t.message ?: "unknown error"),
+                            Toast.LENGTH_LONG,
+                        ).show()
+                }
+        }
+    }
+
+    private fun showPostSaveDialog() {
+        AlertDialog
+            .Builder(activity)
+            .setTitle(R.string.bug_report_saved_title)
+            .setMessage(R.string.bug_report_saved_body)
+            .setNegativeButton(R.string.bug_report_saved_dismiss, null)
+            .setPositiveButton(R.string.bug_report_saved_open_issue) { _, _ ->
+                openIssuePage()
+            }.show()
+    }
+
+    private fun openIssuePage() {
+        val issueUri =
+            Uri
+                .parse("https://github.com/kyujin-cho/LibreDrop/issues/new")
+                .buildUpon()
+                .appendQueryParameter("title", "Bug report (auto-generated)")
+                .appendQueryParameter(
+                    "body",
+                    "Please describe what happened and attach the saved libredrop bug-report zip from your device.",
+                ).build()
+        val viewIntent = Intent(Intent.ACTION_VIEW, issueUri)
+        try {
+            activity.startActivity(
+                Intent.createChooser(
+                    viewIntent,
+                    activity.getString(R.string.bug_report_issue_chooser),
+                ),
+            )
+        } catch (e: ActivityNotFoundException) {
+            DiagnosticLog.w(TAG, "Could not open GitHub issue page", e)
+            Toast.makeText(activity, R.string.bug_report_issue_unavailable, Toast.LENGTH_LONG).show()
+        }
+    }
+
+    private fun registerShakeCandidate(now: Long): Boolean {
+        if (now - lastShakeCandidateAt > SHAKE_CLUSTER_WINDOW_MILLIS) {
+            shakeCandidateCount = 0
+        }
+        lastShakeCandidateAt = now
+        shakeCandidateCount += 1
+        val ready = shakeCandidateCount >= REQUIRED_SHAKE_HITS
+        if (ready) {
+            shakeCandidateCount = 0
+        }
+        return ready
+    }
+
+    internal companion object {
+        private const val TAG: String = "LibreDropBugReport"
+        private const val CONFIRM_DIALOG_HORIZONTAL_PADDING_DP: Int = 24
+        private const val SHAKE_G_FORCE_THRESHOLD: Double = 2.35
+        private const val REQUIRED_SHAKE_HITS: Int = 2
+        private const val SHAKE_CLUSTER_WINDOW_MILLIS: Long = 650L
+        private const val SHAKE_DEBOUNCE_MILLIS: Long = 5_000L
+
+        fun install(activity: AppCompatActivity): BugReportFlowSupport = BugReportFlowSupport(activity)
+    }
+}

--- a/app/src/main/kotlin/dev/bluehouse/libredrop/bugreport/BugReportPreferences.kt
+++ b/app/src/main/kotlin/dev/bluehouse/libredrop/bugreport/BugReportPreferences.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 LibreDrop contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.libredrop.bugreport
+
+import android.content.Context
+import android.content.SharedPreferences
+
+internal class BugReportPreferences(
+    private val prefs: SharedPreferences,
+) {
+    fun isShakeToReportEnabled(): Boolean = prefs.getBoolean(KEY_SHAKE_TO_REPORT_ENABLED, false)
+
+    fun setShakeToReportEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_SHAKE_TO_REPORT_ENABLED, enabled).apply()
+    }
+
+    internal companion object {
+        private const val PREFS_NAME = "libredrop.bug_report"
+        private const val KEY_SHAKE_TO_REPORT_ENABLED = "shake_to_report_enabled"
+
+        fun from(context: Context): BugReportPreferences =
+            BugReportPreferences(
+                context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE),
+            )
+    }
+}

--- a/app/src/main/kotlin/dev/bluehouse/libredrop/bugreport/BugReportSensitiveScreens.kt
+++ b/app/src/main/kotlin/dev/bluehouse/libredrop/bugreport/BugReportSensitiveScreens.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 LibreDrop contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.libredrop.bugreport
+
+import androidx.appcompat.app.AppCompatActivity
+
+/**
+ * Sensitive-screen matcher for screenshot redaction.
+ *
+ * The policy is intentionally conservative: every screen that can expose the
+ * 4-digit consent PIN or QR handshake material is treated as sensitive and
+ * therefore receives a placeholder bitmap in bug reports.
+ */
+internal object BugReportSensitiveScreens {
+    private val sensitiveClassNames: Set<String> =
+        setOf(
+            "dev.bluehouse.libredrop.consent.ConsentTrampolineActivity",
+            "dev.bluehouse.libredrop.send.ShowQrActivity",
+            "dev.bluehouse.libredrop.send.SendActivity",
+        )
+
+    fun shouldRedact(activity: AppCompatActivity): Boolean = shouldRedact(activity.javaClass.name)
+
+    fun shouldRedact(className: String): Boolean = className in sensitiveClassNames
+}

--- a/app/src/main/kotlin/dev/bluehouse/libredrop/consent/ConsentTrampolineActivity.kt
+++ b/app/src/main/kotlin/dev/bluehouse/libredrop/consent/ConsentTrampolineActivity.kt
@@ -15,6 +15,7 @@ import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import dev.bluehouse.libredrop.R
+import dev.bluehouse.libredrop.bugreport.BugReportFlowSupport
 import dev.bluehouse.libredrop.protocol.connection.TransferItem
 import dev.bluehouse.libredrop.service.receiver.consent.ConsentBroadcastReceiver
 import dev.bluehouse.libredrop.service.receiver.consent.ConsentDiagnostic
@@ -87,6 +88,7 @@ class ConsentTrampolineActivity : AppCompatActivity() {
     private var connectionId: Long = ConsentIntents.MISSING_CONNECTION_ID
     private var decisionSubmitted: Boolean = false
     private var modalRegistered: Boolean = false
+    private lateinit var bugReportFlowSupport: BugReportFlowSupport
 
     override fun onCreate(savedInstanceState: Bundle?) {
         // setShowWhenLocked / setTurnScreenOn must be called BEFORE
@@ -97,6 +99,7 @@ class ConsentTrampolineActivity : AppCompatActivity() {
         applyIncomingCallFlags()
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_consent_trampoline)
+        bugReportFlowSupport = BugReportFlowSupport.install(this)
 
         ConsentDiagnostic.log(this, "trampoline.onCreate intent.id=${incomingId(intent)}")
         bindIntent(intent)

--- a/app/src/main/kotlin/dev/bluehouse/libredrop/onboarding/PermissionsOnboardingActivity.kt
+++ b/app/src/main/kotlin/dev/bluehouse/libredrop/onboarding/PermissionsOnboardingActivity.kt
@@ -18,6 +18,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import dev.bluehouse.libredrop.R
+import dev.bluehouse.libredrop.bugreport.BugReportFlowSupport
 import dev.bluehouse.libredrop.databinding.ActivityPermissionsOnboardingBinding
 import dev.bluehouse.libredrop.databinding.ItemPermissionRowBinding
 
@@ -39,6 +40,7 @@ import dev.bluehouse.libredrop.databinding.ItemPermissionRowBinding
  */
 class PermissionsOnboardingActivity : AppCompatActivity() {
     private lateinit var binding: ActivityPermissionsOnboardingBinding
+    private lateinit var bugReportFlowSupport: BugReportFlowSupport
     private val rowsByPermission: MutableMap<String, ItemPermissionRowBinding> = mutableMapOf()
 
     /**
@@ -77,6 +79,7 @@ class PermissionsOnboardingActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivityPermissionsOnboardingBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        bugReportFlowSupport = BugReportFlowSupport.install(this)
 
         // Restore launch state across configuration changes so we don't
         // mistakenly treat a rotation as a fresh first run.

--- a/app/src/main/kotlin/dev/bluehouse/libredrop/send/SendActivity.kt
+++ b/app/src/main/kotlin/dev/bluehouse/libredrop/send/SendActivity.kt
@@ -8,12 +8,12 @@ package dev.bluehouse.libredrop.send
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
-import android.util.Log
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
 import dev.bluehouse.libredrop.R
+import dev.bluehouse.libredrop.bugreport.BugReportFlowSupport
 import dev.bluehouse.libredrop.databinding.ActivitySendBinding
 import dev.bluehouse.libredrop.discovery.NearbyPeer
 import dev.bluehouse.libredrop.discovery.NearbyPeerRoute
@@ -22,6 +22,7 @@ import dev.bluehouse.libredrop.discovery.bootstrap.BleGattInitialControlClient
 import dev.bluehouse.libredrop.discovery.bootstrap.BleGattInitialControlServer
 import dev.bluehouse.libredrop.discovery.bootstrap.BleL2capInitialControlClient
 import dev.bluehouse.libredrop.discovery.bootstrap.BluetoothClassicBootstrapClient
+import dev.bluehouse.libredrop.discovery.diagnostics.DiagnosticLog
 import dev.bluehouse.libredrop.discovery.medium.MediumRegistries
 import dev.bluehouse.libredrop.protocol.connection.CancelCause
 import dev.bluehouse.libredrop.protocol.connection.FileSource
@@ -70,6 +71,7 @@ import java.security.SecureRandom
 @Suppress("TooManyFunctions")
 public class SendActivity : AppCompatActivity() {
     private lateinit var binding: ActivitySendBinding
+    private lateinit var bugReportFlowSupport: BugReportFlowSupport
     private lateinit var fileSourceFactory: UriFileSourceFactory
     private lateinit var documentTreeFactory: DocumentTreeFileSourceFactory
     private lateinit var payloadResolver: SendPayloadResolver
@@ -100,6 +102,7 @@ public class SendActivity : AppCompatActivity() {
         OutboundSessionActiveHolder.setOutboundSessionActive(true)
         binding = ActivitySendBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        bugReportFlowSupport = BugReportFlowSupport.install(this)
 
         fileSourceFactory = UriFileSourceFactory(contentResolver)
         documentTreeFactory = DocumentTreeFileSourceFactory(contentResolver)
@@ -306,7 +309,7 @@ public class SendActivity : AppCompatActivity() {
         // address list (so we can spot IPv6 vs IPv4 selection bugs),
         // and the parsed EndpointInfo header byte / device name.
         val targetSnapshot = peerPickerController.formatPeerSnapshot(peer, chosenRoute)
-        Log.e(OUTBOUND_TAG, "picked target: $targetSnapshot")
+        DiagnosticLog.e(OUTBOUND_TAG, "picked target: $targetSnapshot")
         appendOutboundLog("picked target: $targetSnapshot")
         // Stop discovery and the wake-up pulse once we've made our pick.
         // BLE GATT bootstrap reuses the Bluetooth controller immediately;
@@ -635,12 +638,12 @@ public class SendActivity : AppCompatActivity() {
     }
 
     private fun logOutboundDiagnostic(line: String) {
-        Log.e(OUTBOUND_TAG, line)
+        DiagnosticLog.e(OUTBOUND_TAG, line)
         appendOutboundLog(line)
     }
 
     private fun logOutboundWireMessage(line: String) {
-        Log.e(OUTBOUND_TAG, line)
+        DiagnosticLog.e(OUTBOUND_TAG, line)
         appendOutboundLog(line)
     }
 

--- a/app/src/main/kotlin/dev/bluehouse/libredrop/send/SendPeerPickerController.kt
+++ b/app/src/main/kotlin/dev/bluehouse/libredrop/send/SendPeerPickerController.kt
@@ -6,7 +6,6 @@
 package dev.bluehouse.libredrop.send
 
 import android.content.Context
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import androidx.lifecycle.Lifecycle
@@ -25,6 +24,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import dev.bluehouse.libredrop.discovery.diagnostics.DiagnosticLog as Log
 
 internal class SendPeerPickerController(
     private val context: Context,

--- a/app/src/main/kotlin/dev/bluehouse/libredrop/send/ShowQrActivity.kt
+++ b/app/src/main/kotlin/dev/bluehouse/libredrop/send/ShowQrActivity.kt
@@ -7,6 +7,7 @@ package dev.bluehouse.libredrop.send
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import dev.bluehouse.libredrop.bugreport.BugReportFlowSupport
 import dev.bluehouse.libredrop.databinding.ActivityShowQrBinding
 import dev.bluehouse.libredrop.protocol.qr.QrKeyData
 import dev.bluehouse.libredrop.protocol.qr.QrUrl
@@ -42,11 +43,13 @@ import kotlin.math.min
  */
 public class ShowQrActivity : AppCompatActivity() {
     private lateinit var binding: ActivityShowQrBinding
+    private lateinit var bugReportFlowSupport: BugReportFlowSupport
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityShowQrBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        bugReportFlowSupport = BugReportFlowSupport.install(this)
 
         val generated = QrKeyData.generate()
         val url = QrUrl.build(generated.qrKeyData)

--- a/app/src/main/kotlin/dev/bluehouse/libredrop/send/UriFileSourceFactory.kt
+++ b/app/src/main/kotlin/dev/bluehouse/libredrop/send/UriFileSourceFactory.kt
@@ -11,11 +11,11 @@ import android.database.Cursor
 import android.net.Uri
 import android.provider.MediaStore
 import android.provider.OpenableColumns
-import android.util.Log
 import dev.bluehouse.libredrop.protocol.connection.FileSource
 import java.nio.channels.Channels
 import java.nio.channels.ReadableByteChannel
 import kotlin.math.absoluteValue
+import dev.bluehouse.libredrop.discovery.diagnostics.DiagnosticLog as Log
 
 /**
  * Translates Android `content://` URIs (received from the system share

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -266,6 +266,21 @@
             android:text="@string/main_always_visible_subtitle"
             android:textAppearance="?android:attr/textAppearanceSmall" />
 
+        <androidx.appcompat.widget.SwitchCompat
+            android:id="@+id/main_bug_report_switch"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:text="@string/main_bug_report_title" />
+
+        <TextView
+            android:id="@+id/main_bug_report_subtitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:text="@string/main_bug_report_subtitle"
+            android:textAppearance="?android:attr/textAppearanceSmall" />
+
         <!--
           Folder-send entry point (#38). The system share sheet does not
           expose a way to share a directory — it only routes individual

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,6 +8,8 @@
          wants to be discoverable to nearby senders. -->
     <string name="main_always_visible_title">Always visible</string>
     <string name="main_always_visible_subtitle">Keep this device discoverable on Wi-Fi even without a Bluetooth pulse from a nearby sender. Turn off to save power; the receiver will only appear briefly while a sender is scanning.</string>
+    <string name="main_bug_report_title">Shake to report a bug</string>
+    <string name="main_bug_report_subtitle">When enabled, shaking the phone while LibreDrop is open offers to package recent diagnostics, device state, and a screenshot into a zip that you save yourself. Nothing is uploaded automatically.</string>
 
     <!-- Save location settings (#42). The "current location" line shows
          either the picked folder's display name or "Downloads" as the
@@ -169,6 +171,23 @@
     <string name="send_status_duration_seconds" tools:ignore="PluralsCandidate">%1$d seconds</string>
     <string name="send_status_duration_about_minutes" tools:ignore="PluralsCandidate">about %1$d minutes</string>
     <string name="send_status_duration_about_hours" tools:ignore="PluralsCandidate">about %1$d hours</string>
+
+    <!-- Shake-to-report bug-report flow (#162). -->
+    <string name="bug_report_confirm_title">Trying to report a bug?</string>
+    <string name="bug_report_confirm_body">LibreDrop will collect recent app diagnostics, device state, and a screenshot into a zip that stays on this device until you choose where to save it.</string>
+    <string name="bug_report_confirm_yes">Yes</string>
+    <string name="bug_report_confirm_no">No</string>
+    <string name="bug_report_include_bssid_label">Include the current Wi-Fi BSSID (more identifying)</string>
+    <string name="bug_report_collecting">Preparing bug report…</string>
+    <string name="bug_report_collect_failed">Could not prepare the bug report: %1$s</string>
+    <string name="bug_report_save_cancelled">Bug report save cancelled.</string>
+    <string name="bug_report_save_failed">Could not save the bug report: %1$s</string>
+    <string name="bug_report_saved_title">Bug report saved</string>
+    <string name="bug_report_saved_body">The bug report zip is saved. You can open GitHub now and attach it to a new issue manually.</string>
+    <string name="bug_report_saved_open_issue">Open GitHub issue</string>
+    <string name="bug_report_saved_dismiss">Dismiss</string>
+    <string name="bug_report_issue_chooser">Open with</string>
+    <string name="bug_report_issue_unavailable">No browser or compatible app is available to open GitHub.</string>
 
     <!-- QR-code (#20 + #84) screen. -->
     <string name="show_qr_title">Scan from receiver</string>

--- a/app/src/test/kotlin/dev/bluehouse/libredrop/bugreport/BugReportArchiveWriterTest.kt
+++ b/app/src/test/kotlin/dev/bluehouse/libredrop/bugreport/BugReportArchiveWriterTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 LibreDrop contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.libredrop.bugreport
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.io.File
+import java.util.zip.ZipFile
+
+class BugReportArchiveWriterTest {
+    @Test
+    fun write_createsStableEntryLayout() {
+        val tempFile = File.createTempFile("bugreport-writer-test", ".zip")
+
+        BugReportArchiveWriter.write(
+            destination = tempFile,
+            entries =
+                listOf(
+                    BugReportArchiveEntry("README.txt", "hello".encodeToByteArray()),
+                    BugReportArchiveEntry("metadata.json", "{}".encodeToByteArray()),
+                    BugReportArchiveEntry("logs/ringbuffer.txt", "lines".encodeToByteArray()),
+                ),
+        )
+
+        ZipFile(tempFile).use { zip ->
+            assertEquals(
+                listOf("README.txt", "metadata.json", "logs/ringbuffer.txt"),
+                zip
+                    .entries()
+                    .asSequence()
+                    .map { it.name }
+                    .toList(),
+            )
+            assertEquals(
+                "hello",
+                zip.getInputStream(zip.getEntry("README.txt")).bufferedReader().readText(),
+            )
+        }
+    }
+}

--- a/app/src/test/kotlin/dev/bluehouse/libredrop/bugreport/BugReportFileNamingTest.kt
+++ b/app/src/test/kotlin/dev/bluehouse/libredrop/bugreport/BugReportFileNamingTest.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 LibreDrop contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.libredrop.bugreport
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.time.Instant
+
+class BugReportFileNamingTest {
+    @Test
+    fun archiveName_usesUtcTimestampFormat() {
+        assertEquals(
+            "libredrop-bugreport-20260505-103500Z.zip",
+            BugReportFileNaming.archiveName(Instant.parse("2026-05-05T10:35:00Z")),
+        )
+    }
+}

--- a/app/src/test/kotlin/dev/bluehouse/libredrop/bugreport/BugReportSensitiveScreensTest.kt
+++ b/app/src/test/kotlin/dev/bluehouse/libredrop/bugreport/BugReportSensitiveScreensTest.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 LibreDrop contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.libredrop.bugreport
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BugReportSensitiveScreensTest {
+    @Test
+    fun shouldRedact_matchesSensitiveActivities() {
+        assertTrue(BugReportSensitiveScreens.shouldRedact("dev.bluehouse.libredrop.send.SendActivity"))
+        assertTrue(BugReportSensitiveScreens.shouldRedact("dev.bluehouse.libredrop.send.ShowQrActivity"))
+        assertTrue(
+            BugReportSensitiveScreens.shouldRedact(
+                "dev.bluehouse.libredrop.consent.ConsentTrampolineActivity",
+            ),
+        )
+    }
+
+    @Test
+    fun shouldRedact_allowsNonSensitiveActivities() {
+        assertFalse(BugReportSensitiveScreens.shouldRedact("dev.bluehouse.libredrop.MainActivity"))
+        assertFalse(
+            BugReportSensitiveScreens.shouldRedact(
+                "dev.bluehouse.libredrop.onboarding.PermissionsOnboardingActivity",
+            ),
+        )
+    }
+}

--- a/discovery-android/src/main/kotlin/dev/bluehouse/libredrop/discovery/AndroidNsdBrowser.kt
+++ b/discovery-android/src/main/kotlin/dev/bluehouse/libredrop/discovery/AndroidNsdBrowser.kt
@@ -8,7 +8,6 @@ package dev.bluehouse.libredrop.discovery
 import android.net.nsd.NsdManager
 import android.net.nsd.NsdServiceInfo
 import android.os.Build
-import android.util.Log
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -25,6 +24,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 import java.net.InetAddress
 import java.util.concurrent.atomic.AtomicBoolean
+import dev.bluehouse.libredrop.discovery.diagnostics.DiagnosticLog as Log
 
 /**
  * Production [NsdBrowser] backed by Android's [NsdManager].

--- a/discovery-android/src/main/kotlin/dev/bluehouse/libredrop/discovery/Discovery.kt
+++ b/discovery-android/src/main/kotlin/dev/bluehouse/libredrop/discovery/Discovery.kt
@@ -7,7 +7,6 @@ package dev.bluehouse.libredrop.discovery
 
 import android.content.Context
 import android.net.nsd.NsdManager
-import android.util.Log
 import dev.bluehouse.libredrop.protocol.endpoint.Base64Url
 import dev.bluehouse.libredrop.protocol.endpoint.EndpointInfo
 import kotlinx.coroutines.Dispatchers
@@ -23,6 +22,7 @@ import java.io.IOException
 import java.net.InetAddress
 import java.net.NetworkInterface
 import java.util.concurrent.atomic.AtomicBoolean
+import dev.bluehouse.libredrop.discovery.diagnostics.DiagnosticLog as Log
 
 /**
  * High-level Quick Share mDNS API.

--- a/discovery-android/src/main/kotlin/dev/bluehouse/libredrop/discovery/NearbyPeerDiscovery.kt
+++ b/discovery-android/src/main/kotlin/dev/bluehouse/libredrop/discovery/NearbyPeerDiscovery.kt
@@ -8,9 +8,9 @@
 package dev.bluehouse.libredrop.discovery
 
 import android.content.Context
-import android.util.Log
 import dev.bluehouse.libredrop.discovery.ble.BleFastAdvertisementScanner
 import dev.bluehouse.libredrop.discovery.classic.BluetoothClassicPeerScanner
+import dev.bluehouse.libredrop.discovery.diagnostics.DiagnosticLog
 import dev.bluehouse.libredrop.protocol.endpoint.EndpointInfo
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
@@ -266,7 +266,7 @@ private class PeerAggregator {
     }
 
     private fun logFilteredPeer(peer: NearbyPeer) {
-        Log.i(
+        DiagnosticLog.i(
             DISCOVERY_TAG,
             "picker filter: hiding peer=${peer.stableId} " +
                 "endpointId=${peer.endpointId ?: "<none>"} reason=${filterReason(peer)}",

--- a/discovery-android/src/main/kotlin/dev/bluehouse/libredrop/discovery/ble/BleAdvertiser.kt
+++ b/discovery-android/src/main/kotlin/dev/bluehouse/libredrop/discovery/ble/BleAdvertiser.kt
@@ -19,10 +19,10 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.ParcelUuid
-import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.annotation.RequiresPermission
 import androidx.core.content.ContextCompat
+import dev.bluehouse.libredrop.discovery.diagnostics.DiagnosticLog
 import java.io.Closeable
 import java.security.SecureRandom
 import java.util.UUID
@@ -128,7 +128,7 @@ public class BleAdvertiser internal constructor(
                     onClosed = { active.compareAndSet(it, null) },
                 )
             active.set(handle)
-            Log.w(
+            DiagnosticLog.w(
                 TAG,
                 "BLE advertise: startAdvertising submitted bytes=" + payload.size +
                     " uuid=" + BleAdvertisePayload.SERVICE_UUID_128,
@@ -142,7 +142,7 @@ public class BleAdvertiser internal constructor(
             // them mean "we couldn't start"; collapse to null + warn.
             @Suppress("TooGenericExceptionCaught") t: Throwable,
         ) {
-            Log.w(TAG, "BLE advertise: startAdvertising threw — pulse skipped", t)
+            DiagnosticLog.w(TAG, "BLE advertise: startAdvertising threw — pulse skipped", t)
             null
         }
     }
@@ -155,12 +155,12 @@ public class BleAdvertiser internal constructor(
      */
     private fun preflight(): BluetoothLeAdvertiser? {
         if (!provider.hasAdvertisePermission()) {
-            Log.w(TAG, "BLE advertise: BLUETOOTH_ADVERTISE not granted — pulse skipped")
+            DiagnosticLog.w(TAG, "BLE advertise: BLUETOOTH_ADVERTISE not granted — pulse skipped")
             return null
         }
         val advertiser = provider.advertiser()
         if (advertiser == null) {
-            Log.w(TAG, "BLE advertise: no BluetoothLeAdvertiser available — pulse skipped")
+            DiagnosticLog.w(TAG, "BLE advertise: no BluetoothLeAdvertiser available — pulse skipped")
         }
         return advertiser
     }
@@ -281,7 +281,7 @@ public class BleAdvertiser internal constructor(
             if (!activeFlag.compareAndSet(true, false)) return
             try {
                 advertiser.stopAdvertising(callback)
-                Log.w(TAG, "BLE advertise: stopAdvertising complete")
+                DiagnosticLog.w(TAG, "BLE advertise: stopAdvertising complete")
             } catch (
                 // stopAdvertising can throw SecurityException if the user
                 // revoked BLUETOOTH_ADVERTISE while we were running, or
@@ -290,7 +290,7 @@ public class BleAdvertiser internal constructor(
                 // there is nothing to recover.
                 @Suppress("TooGenericExceptionCaught") t: Throwable,
             ) {
-                Log.w(TAG, "BLE advertise: stopAdvertising threw; ignoring", t)
+                DiagnosticLog.w(TAG, "BLE advertise: stopAdvertising threw; ignoring", t)
             }
             onClosed(this)
         }
@@ -309,12 +309,12 @@ public class BleAdvertiser internal constructor(
             private set
 
         override fun onStartSuccess(settingsInEffect: AdvertiseSettings?) {
-            Log.w(TAG, "BLE advertise: onStartSuccess settings=$settingsInEffect")
+            DiagnosticLog.w(TAG, "BLE advertise: onStartSuccess settings=$settingsInEffect")
         }
 
         override fun onStartFailure(errorCode: Int) {
             lastError = errorCode
-            Log.w(TAG, "BLE advertise: onStartFailure code=$errorCode (${describeError(errorCode)})")
+            DiagnosticLog.w(TAG, "BLE advertise: onStartFailure code=$errorCode (${describeError(errorCode)})")
         }
 
         private fun describeError(code: Int): String =

--- a/discovery-android/src/main/kotlin/dev/bluehouse/libredrop/discovery/ble/BleQuickShareAdvertiser.kt
+++ b/discovery-android/src/main/kotlin/dev/bluehouse/libredrop/discovery/ble/BleQuickShareAdvertiser.kt
@@ -19,7 +19,6 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.ParcelUuid
-import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.annotation.RequiresPermission
 import androidx.core.content.ContextCompat
@@ -30,6 +29,7 @@ import dev.bluehouse.libredrop.protocol.endpoint.EndpointInfo
 import dev.bluehouse.libredrop.protocol.endpoint.NearbyServiceId
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicReference
+import dev.bluehouse.libredrop.discovery.diagnostics.DiagnosticLog as Log
 
 /**
  * Receiver-side BLE pulse advertiser for Quick Share (issue #121).

--- a/discovery-android/src/main/kotlin/dev/bluehouse/libredrop/discovery/ble/BleQuickShareScanner.kt
+++ b/discovery-android/src/main/kotlin/dev/bluehouse/libredrop/discovery/ble/BleQuickShareScanner.kt
@@ -17,7 +17,6 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.ParcelUuid
-import android.util.Log
 import androidx.annotation.RequiresPermission
 import androidx.core.content.ContextCompat
 import kotlinx.coroutines.CoroutineScope
@@ -34,6 +33,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import dev.bluehouse.libredrop.discovery.diagnostics.DiagnosticLog as Log
 
 /**
  * Quick Share BLE pulse scanner.

--- a/discovery-android/src/main/kotlin/dev/bluehouse/libredrop/discovery/diagnostics/DiagnosticLog.kt
+++ b/discovery-android/src/main/kotlin/dev/bluehouse/libredrop/discovery/diagnostics/DiagnosticLog.kt
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2026 LibreDrop contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.libredrop.discovery.diagnostics
+
+import android.util.Log
+import java.io.PrintWriter
+import java.io.StringWriter
+import java.util.ArrayDeque
+
+/**
+ * Shared Android logging facade that also mirrors recent lines into an in-memory
+ * ring buffer for the bug-report flow.
+ *
+ * Android 16+ restricts third-party access to process-external logcat, so the
+ * bug-report collector cannot rely on reading the system buffer at report time.
+ * Instead, the app writes its own high-signal diagnostics into
+ * [recentLogBuffer] as they are emitted.
+ */
+public object DiagnosticLog {
+    private val recentLogBuffer: RecentLogRingBuffer = RecentLogRingBuffer()
+
+    public fun i(
+        tag: String,
+        message: String,
+    ): Int {
+        recentLogBuffer.record(
+            timestampMillis = System.currentTimeMillis(),
+            level = 'I',
+            tag = tag,
+            message = message,
+        )
+        return Log.i(tag, message)
+    }
+
+    public fun w(
+        tag: String,
+        message: String,
+    ): Int {
+        recentLogBuffer.record(
+            timestampMillis = System.currentTimeMillis(),
+            level = 'W',
+            tag = tag,
+            message = message,
+        )
+        return Log.w(tag, message)
+    }
+
+    public fun w(
+        tag: String,
+        message: String,
+        throwable: Throwable,
+    ): Int {
+        recentLogBuffer.record(
+            timestampMillis = System.currentTimeMillis(),
+            level = 'W',
+            tag = tag,
+            message = messageWithThrowable(message, throwable),
+        )
+        return Log.w(tag, message, throwable)
+    }
+
+    public fun e(
+        tag: String,
+        message: String,
+    ): Int {
+        recentLogBuffer.record(
+            timestampMillis = System.currentTimeMillis(),
+            level = 'E',
+            tag = tag,
+            message = message,
+        )
+        return Log.e(tag, message)
+    }
+
+    public fun e(
+        tag: String,
+        message: String,
+        throwable: Throwable,
+    ): Int {
+        recentLogBuffer.record(
+            timestampMillis = System.currentTimeMillis(),
+            level = 'E',
+            tag = tag,
+            message = messageWithThrowable(message, throwable),
+        )
+        return Log.e(tag, message, throwable)
+    }
+
+    /**
+     * Dumps recent buffered lines as timestamped plain text, oldest first.
+     */
+    public fun dumpRecent(
+        maxAgeMillis: Long = DEFAULT_MAX_AGE_MILLIS,
+        nowMillis: Long = System.currentTimeMillis(),
+    ): String =
+        recentLogBuffer
+            .snapshotSince(
+                cutoffMillis = nowMillis - maxAgeMillis,
+            ).joinToString(separator = "\n") { line ->
+                "${line.timestampMillis} ${line.level}/${line.tag}: ${line.message}"
+            }
+
+    internal fun clearForTesting() {
+        recentLogBuffer.clear()
+    }
+
+    private fun messageWithThrowable(
+        message: String,
+        throwable: Throwable,
+    ): String {
+        val stacktrace = StringWriter()
+        PrintWriter(stacktrace).use { throwable.printStackTrace(it) }
+        return "$message\n${stacktrace.toString().trimEnd()}"
+    }
+
+    public const val DEFAULT_MAX_AGE_MILLIS: Long = 15 * 60 * 1000L
+}
+
+/**
+ * Pure-Kotlin bounded buffer for recent log lines.
+ */
+internal class RecentLogRingBuffer(
+    private val maxEntries: Int = DEFAULT_MAX_ENTRIES,
+) {
+    private val lines: ArrayDeque<BufferedLogLine> = ArrayDeque(maxEntries)
+
+    @Synchronized
+    fun record(
+        timestampMillis: Long,
+        level: Char,
+        tag: String,
+        message: String,
+    ) {
+        if (lines.size >= maxEntries) {
+            lines.removeFirst()
+        }
+        lines.addLast(
+            BufferedLogLine(
+                timestampMillis = timestampMillis,
+                level = level,
+                tag = tag,
+                message = message,
+            ),
+        )
+    }
+
+    @Synchronized
+    fun snapshotSince(cutoffMillis: Long): List<BufferedLogLine> = lines.filter { it.timestampMillis >= cutoffMillis }
+
+    @Synchronized
+    fun clear() {
+        lines.clear()
+    }
+
+    internal companion object {
+        const val DEFAULT_MAX_ENTRIES: Int = 2_048
+    }
+}
+
+internal data class BufferedLogLine(
+    val timestampMillis: Long,
+    val level: Char,
+    val tag: String,
+    val message: String,
+)

--- a/discovery-android/src/test/kotlin/dev/bluehouse/libredrop/discovery/diagnostics/DiagnosticLogBufferTest.kt
+++ b/discovery-android/src/test/kotlin/dev/bluehouse/libredrop/discovery/diagnostics/DiagnosticLogBufferTest.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 LibreDrop contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.libredrop.discovery.diagnostics
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class DiagnosticLogBufferTest {
+    @Test
+    fun `record keeps the newest lines within capacity`() {
+        val buffer = RecentLogRingBuffer(maxEntries = 2)
+
+        buffer.record(timestampMillis = 1L, level = 'I', tag = "one", message = "first")
+        buffer.record(timestampMillis = 2L, level = 'W', tag = "two", message = "second")
+        buffer.record(timestampMillis = 3L, level = 'E', tag = "three", message = "third")
+
+        assertThat(buffer.snapshotSince(cutoffMillis = 0L))
+            .containsExactly(
+                BufferedLogLine(timestampMillis = 2L, level = 'W', tag = "two", message = "second"),
+                BufferedLogLine(timestampMillis = 3L, level = 'E', tag = "three", message = "third"),
+            ).inOrder()
+    }
+
+    @Test
+    fun `snapshotSince filters out older lines`() {
+        val buffer = RecentLogRingBuffer(maxEntries = 4)
+
+        buffer.record(timestampMillis = 100L, level = 'I', tag = "old", message = "older")
+        buffer.record(timestampMillis = 200L, level = 'I', tag = "new", message = "newer")
+
+        assertThat(buffer.snapshotSince(cutoffMillis = 150L)).containsExactly(
+            BufferedLogLine(timestampMillis = 200L, level = 'I', tag = "new", message = "newer"),
+        )
+    }
+}

--- a/docs/testing/bug-report-flow.md
+++ b/docs/testing/bug-report-flow.md
@@ -1,0 +1,141 @@
+# Bug report flow runbook
+
+Issue [#162](https://github.com/kyujin-cho/LibreDrop/issues/162) adds an
+opt-in "shake to report a bug" flow that packages recent diagnostics,
+device state, and a screenshot into a user-saved zip archive.
+
+This runbook verifies the flow manually on at least one Pixel device and
+one Samsung device.
+
+## Preconditions
+
+- Build and install the debug APK:
+
+```bash
+./gradlew :app:assembleDebug
+adb -s <device> install -r app/build/outputs/apk/debug/app-debug.apk
+```
+
+- Use a device pair that can exercise LibreDrop normally:
+  - one Pixel or other AOSP-like GMS device
+  - one Samsung Galaxy device with current Quick Share
+- Clear any previous saved bug-report archives from Downloads or the
+  test folder you plan to use, so the new archive is easy to identify.
+
+## Core flow
+
+Run this on both the Pixel and Samsung device:
+
+1. Open LibreDrop and confirm the new launcher toggle "Shake to report a bug"
+   is visible and off by default.
+2. Turn the toggle on.
+3. With LibreDrop still foregrounded, shake the device firmly.
+4. Confirm the modal appears with:
+   - "Trying to report a bug?"
+   - Yes / No actions
+   - an unchecked "Include the current Wi-Fi BSSID" checkbox
+5. Tap No and confirm nothing is collected.
+6. Shake again, leave the BSSID checkbox unchecked, and tap Yes.
+7. Confirm the app shows the temporary "Preparing bug report…" dialog.
+8. When the SAF save sheet appears, save the archive to a user-visible
+   location such as Downloads with the suggested filename.
+9. Confirm the post-save dialog appears and offers "Open GitHub issue".
+10. Tap Dismiss once, then repeat the flow and verify that "Open GitHub issue"
+    launches the browser to LibreDrop's new-issue page.
+
+## Archive checks
+
+After saving, inspect the archive:
+
+```bash
+adb -s <device> shell ls /sdcard/Download | grep libredrop-bugreport
+adb -s <device> pull /sdcard/Download/<archive-name>.zip /tmp/
+unzip -l /tmp/<archive-name>.zip
+```
+
+Verify the zip contains exactly these paths:
+
+- `README.txt`
+- `metadata.json`
+- `device.txt`
+- `permissions.txt`
+- `discovery.txt`
+- `logs/outbound.log`
+- `logs/ringbuffer.txt`
+- `screenshot.png`
+
+Inspect the text files:
+
+```bash
+unzip -p /tmp/<archive-name>.zip metadata.json
+unzip -p /tmp/<archive-name>.zip device.txt
+unzip -p /tmp/<archive-name>.zip permissions.txt
+unzip -p /tmp/<archive-name>.zip discovery.txt
+unzip -p /tmp/<archive-name>.zip logs/ringbuffer.txt
+```
+
+Confirm:
+
+- `metadata.json` records whether Wi-Fi BSSID inclusion was enabled.
+- `device.txt` includes app/device/runtime state and does not contain
+  raw Bluetooth MAC addresses.
+- `logs/ringbuffer.txt` contains recent lines from the `LibreDropDiscovery`,
+  `LibreDropBleScan`, `LibreDropBleAdv`, `LibreDropMdnsGate`, or
+  `LibreDropOutbound` tags after exercising the app.
+
+## BSSID privacy check
+
+1. Save one archive with the BSSID checkbox unchecked.
+2. Save a second archive with the checkbox checked.
+3. Compare `device.txt` in both archives.
+
+Expected result:
+
+- unchecked archive: `wifiBssid=<redacted>`
+- checked archive: real BSSID when the app can read it, otherwise
+  `not_available`
+
+## Sensitive-screen redaction
+
+Verify both sensitive-screen cases on at least one device:
+
+### QR screen
+
+1. Open LibreDrop's QR screen.
+2. Shake the device and save a bug report.
+3. Extract `screenshot.png`.
+
+Expected result:
+
+- the screenshot is a placeholder image
+- the live QR code is not visible
+
+### Consent screen
+
+1. Trigger an incoming share so `ConsentTrampolineActivity` is visible.
+2. Shake the device and save a bug report.
+3. Extract `screenshot.png`.
+
+Expected result:
+
+- the screenshot is a placeholder image
+- the 4-digit consent PIN is not visible
+
+## Debounce check
+
+1. With the toggle still enabled, shake the device repeatedly during one
+   active report flow.
+2. Confirm only one confirmation modal / save flow is active at a time.
+
+## Regression notes
+
+- No new privileged permissions should appear in the manifest or runtime
+  prompts.
+- If the flow fails on one device family only, capture:
+
+```bash
+adb logcat -s LibreDropDiscovery LibreDropSend LibreDropOutbound LibreDropBleScan LibreDropBleAdv LibreDropMdnsGate
+```
+
+- Record whether the failure is collection, SAF save, screenshot capture,
+  or browser launch.

--- a/service-android/src/main/kotlin/dev/bluehouse/libredrop/service/receiver/MdnsAdvertisementGate.kt
+++ b/service-android/src/main/kotlin/dev/bluehouse/libredrop/service/receiver/MdnsAdvertisementGate.kt
@@ -5,8 +5,8 @@
  */
 package dev.bluehouse.libredrop.service.receiver
 
-import android.util.Log
 import dev.bluehouse.libredrop.discovery.ble.ScanActivity
+import dev.bluehouse.libredrop.discovery.diagnostics.DiagnosticLog
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -221,9 +221,9 @@ public class MdnsAdvertisementGate(
             if (session.isAdvertising) {
                 try {
                     session.unpublishAdvertisement()
-                    Log.w(TAG, "unpublish: outbound send active; mDNS taken down immediately")
+                    DiagnosticLog.w(TAG, "unpublish: outbound send active; mDNS taken down immediately")
                 } catch (t: Throwable) {
-                    Log.w(TAG, "unpublish: threw during outbound veto", t)
+                    DiagnosticLog.w(TAG, "unpublish: threw during outbound veto", t)
                 }
             }
             stopBleSafely(reason = "outbound send active")
@@ -244,13 +244,13 @@ public class MdnsAdvertisementGate(
             if (!session.isAdvertising) {
                 try {
                     session.publishAdvertisement()
-                    Log.w(TAG, "publish: published mDNS (decision=$decision)")
+                    DiagnosticLog.w(TAG, "publish: published mDNS (decision=$decision)")
                 } catch (t: Throwable) {
                     // The session may have been stopped between the
                     // collector firing and the publish call. Treat as
                     // benign — the decision will be re-evaluated if the
                     // session is restarted.
-                    Log.w(TAG, "publish: failed (decision=$decision)", t)
+                    DiagnosticLog.w(TAG, "publish: failed (decision=$decision)", t)
                 }
             }
             return
@@ -274,12 +274,12 @@ public class MdnsAdvertisementGate(
                 if (isActive) {
                     try {
                         session.unpublishAdvertisement()
-                        Log.w(TAG, "unpublish: idle for ${debounceIdleMillis}ms; mDNS taken down")
+                        DiagnosticLog.w(TAG, "unpublish: idle for ${debounceIdleMillis}ms; mDNS taken down")
                     } catch (t: Throwable) {
                         // Best-effort: the session may have been stopped
                         // first, in which case the advertisement is
                         // already torn down.
-                        Log.w(TAG, "unpublish: threw", t)
+                        DiagnosticLog.w(TAG, "unpublish: threw", t)
                     }
                     // Symmetric BLE teardown — same debounce window so
                     // the BLE advertiser does not flap on intermittent
@@ -303,12 +303,12 @@ public class MdnsAdvertisementGate(
             val started = bleBroadcaster.start()
             if (started) {
                 bleAdvertising = true
-                Log.w(TAG, "publish: BLE pulse advertise started (decision=$decision)")
+                DiagnosticLog.w(TAG, "publish: BLE pulse advertise started (decision=$decision)")
             } else {
-                Log.w(TAG, "publish: BLE pulse advertise unavailable (decision=$decision)")
+                DiagnosticLog.w(TAG, "publish: BLE pulse advertise unavailable (decision=$decision)")
             }
         } catch (t: Throwable) {
-            Log.w(TAG, "publish: BLE pulse advertise threw (decision=$decision)", t)
+            DiagnosticLog.w(TAG, "publish: BLE pulse advertise threw (decision=$decision)", t)
         }
     }
 
@@ -323,9 +323,9 @@ public class MdnsAdvertisementGate(
         try {
             bleBroadcaster.stop()
             bleAdvertising = false
-            Log.w(TAG, "unpublish: BLE pulse advertise stopped ($reason)")
+            DiagnosticLog.w(TAG, "unpublish: BLE pulse advertise stopped ($reason)")
         } catch (t: Throwable) {
-            Log.w(TAG, "unpublish: BLE pulse advertise stop threw ($reason)", t)
+            DiagnosticLog.w(TAG, "unpublish: BLE pulse advertise stop threw ($reason)", t)
         }
     }
 

--- a/service-android/src/main/kotlin/dev/bluehouse/libredrop/service/receiver/ReceiverBugReportDiagnostics.kt
+++ b/service-android/src/main/kotlin/dev/bluehouse/libredrop/service/receiver/ReceiverBugReportDiagnostics.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026 LibreDrop contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.libredrop.service.receiver
+
+import dev.bluehouse.libredrop.discovery.DiscoveryDiagnostics
+
+/**
+ * Narrow bug-report-facing bridge into receiver runtime state.
+ *
+ * `:app` owns the UI flow that packages a user-visible bug report, but the
+ * high-signal receiver diagnostics live inside `:service-android`. This object
+ * exposes read-only snapshots without opening the rest of the service internals
+ * to the app module.
+ */
+public object ReceiverBugReportDiagnostics {
+    public fun discoverySnapshot(): DiscoveryDiagnostics? = ActiveDiscoveryHolder.current()?.snapshot()
+
+    public fun isReceiverServiceLikelyRunning(): Boolean =
+        ActiveDiscoveryHolder.current() != null || ActiveBleScannerHolder.current() != null
+}

--- a/service-android/src/main/kotlin/dev/bluehouse/libredrop/service/receiver/ReceiverForegroundService.kt
+++ b/service-android/src/main/kotlin/dev/bluehouse/libredrop/service/receiver/ReceiverForegroundService.kt
@@ -18,7 +18,6 @@ import android.os.Build
 import android.os.Handler
 import android.os.IBinder
 import android.os.Looper
-import android.util.Log
 import androidx.core.app.ServiceCompat
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.DefaultLifecycleObserver
@@ -28,6 +27,7 @@ import dev.bluehouse.libredrop.discovery.Discovery
 import dev.bluehouse.libredrop.discovery.ble.BleQuickShareAdvertiser
 import dev.bluehouse.libredrop.discovery.ble.BleQuickShareScanner
 import dev.bluehouse.libredrop.discovery.bootstrap.BleGattInitialControlServer
+import dev.bluehouse.libredrop.discovery.diagnostics.DiagnosticLog
 import dev.bluehouse.libredrop.discovery.medium.MediumRegistries
 import dev.bluehouse.libredrop.protocol.endpoint.BleServiceData
 import dev.bluehouse.libredrop.protocol.endpoint.EndpointInfo
@@ -396,7 +396,7 @@ public class ReceiverForegroundService : Service() {
             nextIdentityProvider = { AdvertisedDeviceNames.createEndpointInfo(applicationContext) },
             bleBroadcasterFactory = { buildBleBroadcaster() },
             logger = { line ->
-                Log.e(INBOUND_DIAG_TAG, line)
+                DiagnosticLog.e(INBOUND_DIAG_TAG, line)
                 appendInboundLog(line)
             },
         ).start(serviceScope, newSession)
@@ -570,7 +570,7 @@ public class ReceiverForegroundService : Service() {
                     val discovery = ActiveDiscoveryHolder.current()
                     if (discovery != null) {
                         val snap = discovery.snapshot()
-                        Log.i(
+                        DiagnosticLog.i(
                             DIAGNOSTICS_TAG,
                             "discovery snapshot: " +
                                 "advertising=${snap.advertising} browsing=${snap.browsing} " +
@@ -593,7 +593,7 @@ public class ReceiverForegroundService : Service() {
                     "completion id=${completion.connectionId} " +
                         "ref=${System.identityHashCode(completion.connection)} " +
                         "result=${completion.result}"
-                Log.e(INBOUND_DIAG_TAG, line)
+                DiagnosticLog.e(INBOUND_DIAG_TAG, line)
                 appendInboundLog(line)
             }
         }
@@ -601,12 +601,12 @@ public class ReceiverForegroundService : Service() {
             session.activeConnections.collect { conn ->
                 val ref = System.identityHashCode(conn)
                 val accepted = "accepted ref=$ref"
-                Log.e(INBOUND_DIAG_TAG, accepted)
+                DiagnosticLog.e(INBOUND_DIAG_TAG, accepted)
                 appendInboundLog(accepted)
                 serviceScope.launch {
                     conn.state.collect { st ->
                         val line = "state ref=$ref -> $st"
-                        Log.e(INBOUND_DIAG_TAG, line)
+                        DiagnosticLog.e(INBOUND_DIAG_TAG, line)
                         appendInboundLog(line)
                     }
                 }
@@ -741,7 +741,7 @@ public class ReceiverForegroundService : Service() {
             // launches even from foreground services. Fall through
             // silently — the heads-up notification path is the
             // documented fallback for exactly this case.
-            Log.w(MODAL_TAG, "Could not launch consent trampoline as modal: ${e.message}", e)
+            DiagnosticLog.w(MODAL_TAG, "Could not launch consent trampoline as modal: ${e.message}", e)
             ConsentDiagnostic.log(
                 this,
                 "service.launchModal id=$connectionId startActivity=SecurityException msg=${e.message}",
@@ -1068,7 +1068,7 @@ public class ReceiverForegroundService : Service() {
             context: Context,
             line: String,
         ) {
-            Log.e(INBOUND_DIAG_TAG, line)
+            DiagnosticLog.e(INBOUND_DIAG_TAG, line)
             runCatching {
                 val dir = context.getExternalFilesDir(null) ?: return
                 val file = java.io.File(dir, "libredrop-inbound.log")

--- a/service-android/src/main/kotlin/dev/bluehouse/libredrop/service/receiver/consent/ConsentDiagnostic.kt
+++ b/service-android/src/main/kotlin/dev/bluehouse/libredrop/service/receiver/consent/ConsentDiagnostic.kt
@@ -6,7 +6,7 @@
 package dev.bluehouse.libredrop.service.receiver.consent
 
 import android.content.Context
-import android.util.Log
+import dev.bluehouse.libredrop.discovery.diagnostics.DiagnosticLog
 import java.io.File
 
 /**
@@ -62,7 +62,7 @@ public object ConsentDiagnostic {
         context: Context,
         line: String,
     ) {
-        Log.e(TAG, line)
+        DiagnosticLog.e(TAG, line)
         try {
             val dir = context.getExternalFilesDir(null) ?: return
             val f = File(dir, FILE_NAME)
@@ -70,7 +70,7 @@ public object ConsentDiagnostic {
         } catch (t: Throwable) {
             // Best-effort instrumentation; never propagate a failure
             // to the caller.
-            Log.w(TAG, "ConsentDiagnostic.log: could not append to file", t)
+            DiagnosticLog.w(TAG, "ConsentDiagnostic.log: could not append to file", t)
         }
     }
 }


### PR DESCRIPTION
## Summary
- add an opt-in shake-to-report bug flow across LibreDrop activities
- collect diagnostics into a structured zip with screenshot redaction and Wi-Fi BSSID opt-in
- mirror key discovery and outbound logs into an in-memory ring buffer and document the manual runbook

Closes #162

## Verification
- ./gradlew :discovery-android:testDebugUnitTest :app:testDebugUnitTest staticAnalysis :app:assembleDebug --stacktrace