### PR TITLE
fix: Prevent Android 10 runtime crashes from newer JDK API references in core-protocol

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,11 @@ jobs:
       - name: Run :core-protocol JVM tests
         run: ./gradlew :core-protocol:test --stacktrace
 
+      - name: Check :core-protocol Android API 29 compatibility
+        run: |
+          ./gradlew :core-protocol:jar --stacktrace
+          ./scripts/check-core-protocol-android-api29-compat.sh
+
       - name: Run :discovery-android JVM unit tests
         run: ./gradlew :discovery-android:testDebugUnitTest --stacktrace
 

--- a/core-protocol/src/main/kotlin/dev/bluehouse/libredrop/protocol/payload/FileDestinationFactory.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/libredrop/protocol/payload/FileDestinationFactory.kt
@@ -9,6 +9,7 @@ import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.Payl
 import java.nio.channels.SeekableByteChannel
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.Paths
 import java.nio.file.StandardOpenOption
 
 /**
@@ -197,7 +198,11 @@ public class TempFileDestinationFactory(
         )
     }
 
-    private fun defaultDir(): Path = Path.of(System.getProperty("java.io.tmpdir"), "libredrop-payload-receive")
+    private fun defaultDir(): Path =
+        Paths.get(
+            System.getProperty("java.io.tmpdir"),
+            "libredrop-payload-receive",
+        )
 
     private fun sanitize(name: String): String = name.map { ch -> if (isSafeFileChar(ch)) ch else '_' }.joinToString("")
 

--- a/core-protocol/src/main/kotlin/dev/bluehouse/libredrop/protocol/ukey2/Ukey2KeyEncoding.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/libredrop/protocol/ukey2/Ukey2KeyEncoding.kt
@@ -213,7 +213,7 @@ internal object Ukey2KeyEncoding {
         }
 
         // y^2 mod p
-        val lhs = y.modPow(BigInteger.TWO, p)
+        val lhs = y.modPow(BIG_INTEGER_TWO, p)
         // x^3 + a*x + b mod p
         val rhs =
             x
@@ -331,6 +331,7 @@ internal object Ukey2KeyEncoding {
 
     private const val BYTE_MASK = 0xFF
     private const val HEX_RADIX = 16
+    private val BIG_INTEGER_TWO: BigInteger = BigInteger.valueOf(2L)
 
     /** Exponent in the Weierstrass curve equation `y^2 = x^3 + a*x + b`. */
     private const val CURVE_EQ_X_EXPONENT: Long = 3

--- a/scripts/check-core-protocol-android-api29-compat.sh
+++ b/scripts/check-core-protocol-android-api29-compat.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+JAR_PATH="${1:-}"
+
+if [[ -z "$JAR_PATH" ]]; then
+  JAR_CANDIDATES=()
+  while IFS= read -r jar_candidate; do
+    JAR_CANDIDATES+=("$jar_candidate")
+  done < <(find "$ROOT_DIR/core-protocol/build/libs" -maxdepth 1 -name '*.jar' | sort)
+  if [[ "${#JAR_CANDIDATES[@]}" -ne 1 ]]; then
+    echo "Expected exactly one :core-protocol jar under core-protocol/build/libs, found ${#JAR_CANDIDATES[@]}." >&2
+    printf 'Candidates:\n' >&2
+    printf '  %s\n' "${JAR_CANDIDATES[@]}" >&2
+    exit 1
+  fi
+  JAR_PATH="${JAR_CANDIDATES[0]}"
+fi
+
+if [[ ! -f "$JAR_PATH" ]]; then
+  echo "Jar not found: $JAR_PATH" >&2
+  exit 1
+fi
+
+check_reference() {
+  local class_name="$1"
+  local output="$2"
+  local matched=0
+
+  if grep -q 'Fieldref.*java/math/BigInteger.TWO:' <<<"$output"; then
+    echo "Forbidden Android API 29-incompatible field reference in $class_name: java/math/BigInteger.TWO" >&2
+    matched=1
+  fi
+
+  if grep -q 'Methodref.*java/nio/file/Path.of:' <<<"$output" || \
+    grep -q 'InterfaceMethodref.*java/nio/file/Path.of:' <<<"$output"; then
+    echo "Forbidden Android API 29-incompatible method reference in $class_name: java/nio/file/Path.of(...)" >&2
+    matched=1
+  fi
+
+  return "$matched"
+}
+
+FOUND_INCOMPATIBLE_REF=0
+
+CLASS_CANDIDATES=()
+if command -v zipgrep >/dev/null 2>&1; then
+  while IFS= read -r entry; do
+    [[ "$entry" == *.class ]] || continue
+    CLASS_CANDIDATES+=("$entry")
+  done < <(
+    {
+      zipgrep -a -h -l 'java/math/BigInteger' "$JAR_PATH" || true
+      zipgrep -a -h -l 'java/nio/file/Path' "$JAR_PATH" || true
+    } | sort -u
+  )
+else
+  while IFS= read -r entry; do
+    [[ "$entry" == *.class ]] || continue
+    class_strings=$(unzip -p "$JAR_PATH" "$entry" | strings)
+    if ! grep -q 'java/math/BigInteger' <<<"$class_strings" && \
+      ! grep -q 'java/nio/file/Path' <<<"$class_strings"; then
+      continue
+    fi
+    CLASS_CANDIDATES+=("$entry")
+  done < <(jar tf "$JAR_PATH")
+fi
+
+for entry in "${CLASS_CANDIDATES[@]}"; do
+  class_name=${entry%.class}
+  class_name=${class_name//\//.}
+  javap_output=$(javap -classpath "$JAR_PATH" -verbose "$class_name")
+  if ! check_reference "$class_name" "$javap_output"; then
+    FOUND_INCOMPATIBLE_REF=1
+  fi
+done
+
+if [[ "$FOUND_INCOMPATIBLE_REF" -ne 0 ]]; then
+  exit 1
+fi
+
+echo "Android API 29 compatibility check passed for $JAR_PATH"


### PR DESCRIPTION
## Summary
- replace the Android 10-incompatible `BigInteger.TWO` and `Path.of(...)` calls in `:core-protocol`
- add a CI guard that inspects the built `:core-protocol` jar for newer JDK member references
- keep the compatibility check cheap enough for local runs and CI by prefiltering candidate classes before `javap`

Closes #163

## Verification
- `./gradlew :core-protocol:test :core-protocol:jar :discovery-android:testDebugUnitTest :app:testDebugUnitTest staticAnalysis :app:assembleDebug --stacktrace`
- `./scripts/check-core-protocol-android-api29-compat.sh`
- `git diff --check`