### PR TITLE
feat: adapt outbound file chunk size

### DIFF
--- a/core-protocol/src/main/kotlin/dev/bluehouse/libredrop/protocol/connection/OutboundConnectionDriver.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/libredrop/protocol/connection/OutboundConnectionDriver.kt
@@ -1225,9 +1225,9 @@ internal class OutboundConnectionDriver(
     }
 
     /**
-     * Stream a single [file] in 512 KiB chunks. Returns a non-null
-     * terminal result if the user cancelled mid-file; null on
-     * successful completion of this single file.
+     * Stream a single [file] in deterministic, size-based chunks.
+     * Returns a non-null terminal result if the user cancelled mid-file;
+     * null on successful completion of this single file.
      */
     private suspend fun streamOneFile(
         channel: SecureChannel,
@@ -1235,14 +1235,19 @@ internal class OutboundConnectionDriver(
     ): OutboundResult? {
         val source = file.openChannel()
         var chunkIdx = 0
+        val chunkSize = PayloadTransferEncoder.selectFileChunkSize(file.size)
         try {
+            logger(
+                "fsm: streamOneFile chunkSize=$chunkSize " +
+                    "name=${file.name} size=${file.size} payloadId=${file.payloadId}",
+            )
             val frames =
                 PayloadTransferEncoder.encodeFilePayload(
                     payloadId = file.payloadId,
                     fileName = file.name,
                     totalSize = file.size,
                     source = source,
-                    chunkSize = PayloadTransferEncoder.DEFAULT_FILE_CHUNK_SIZE,
+                    chunkSize = chunkSize,
                     lastModifiedTimestampMillis = file.lastModifiedTimestampMillis,
                     // `parent_folder` is also carried on every PayloadHeader,
                     // not just on FileMetadata. Quick Share receivers can

--- a/core-protocol/src/main/kotlin/dev/bluehouse/libredrop/protocol/connection/OutboundConnectionDriver.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/libredrop/protocol/connection/OutboundConnectionDriver.kt
@@ -115,6 +115,9 @@ internal class OutboundConnectionDriver(
     /** The most recent active payload, for progress UI. */
     private var currentItemPayloadId: Long? = null
 
+    /** Buffered inbound frames to service while the dispatch loop is streaming files. */
+    private var streamingWireChannel: Channel<OutboundWireMessage>? = null
+
     /**
      * Drive the entire sender-side lifecycle. Returns the terminal
      * [OutboundResult]; throws on coroutine cancellation (handled by
@@ -450,10 +453,14 @@ internal class OutboundConnectionDriver(
         initialWireFrames: List<OfflineFrame> = emptyList(),
     ): OutboundResult =
         coroutineScope {
-            // RENDEZVOUS capacity — same back-pressure rationale as
-            // InboundConnectionDriver.
-            val wireChannel: Channel<OutboundWireMessage> = Channel(Channel.RENDEZVOUS)
+            // FILE streaming temporarily monopolizes the dispatch loop, so a
+            // rendezvous wire channel can wedge the inbound pump on the
+            // first receiver KEEP_ALIVE that lands mid-transfer. Buffer small
+            // control frames here so the pump keeps draining the socket while
+            // streamOneFile() is busy pushing outbound chunks.
+            val wireChannel: Channel<OutboundWireMessage> = Channel(Channel.UNLIMITED)
             val pumpJob: Job = launch { runInboundPump(channel, wireChannel) }
+            streamingWireChannel = wireChannel
             // Outbound KEEP_ALIVE ticker (issue #37). PROTOCOL.md:
             // "Android sends offline frames of type KEEP_ALIVE every
             // 10 seconds and expects the server to do the same. If you
@@ -497,6 +504,7 @@ internal class OutboundConnectionDriver(
                 }
                 publishCompletedIfNeeded(result)
             } finally {
+                streamingWireChannel = null
                 // Cancel the KEEP_ALIVE ticker FIRST, before any socket
                 // close: the ticker spends almost all its life parked
                 // in delay() (which is cancellable, unlike a blocking
@@ -643,7 +651,10 @@ internal class OutboundConnectionDriver(
                             coroutineScope {
                                 val keepAliveJob = launch { runKeepAliveTicker(activeChannel) }
                                 try {
-                                    val result = streamFilesAndComplete(activeChannel)
+                                    val result =
+                                        streamFilesAndComplete(activeChannel) {
+                                            drainDirectInboundWhileStreaming(activeChannel)
+                                        }
                                     if (shouldDrainForSafeDisconnect(result)) {
                                         drainSafeDisconnectAckDirect(activeChannel)
                                     }
@@ -1168,22 +1179,27 @@ internal class OutboundConnectionDriver(
         val effects = fsm.onEvent(SharingFsmEvent.FrameReceived(sharingFrame))
         applyEffects(channel, effects)
         if (effects.any { it is SharingFsmEffect.ReadyToSendPayloads }) {
-            return streamFilesAndComplete(channel)
+            return streamFilesAndComplete(channel) {
+                drainBufferedInboundWhileStreaming(streamingWireChannel)
+            }
         }
         return null
     }
 
     /**
-     * Stream every announced file in 512 KiB chunks, then send
-     * `Disconnection`. This is the happy-path terminal: returns
-     * [OutboundResult.Completed] on success.
+     * Stream every announced file in deterministic, size-based chunks,
+     * then send `Disconnection`. This is the happy-path terminal:
+     * returns [OutboundResult.Completed] on success.
      *
      * Cancellation during streaming is cooperative: the dispatch loop
      * is suspended while we run, but [externalEvents] is polled on
      * each chunk so a `cancel()` call still emits a CANCEL frame
      * before we close.
      */
-    private suspend fun streamFilesAndComplete(channel: SecureChannel): OutboundResult {
+    private suspend fun streamFilesAndComplete(
+        channel: SecureChannel,
+        pollInboundWhileStreaming: suspend () -> OutboundResult? = { null },
+    ): OutboundResult {
         logger("fsm: streamFilesAndComplete START files=${files.size} totalSize=$totalSize")
         // Seed the rate estimator with a zero-bytes sample so the
         // first chunk write produces a non-degenerate Δt for the EMA.
@@ -1203,7 +1219,7 @@ internal class OutboundConnectionDriver(
         for (file in files) {
             currentItemPayloadId = file.payloadId
             logger("fsm: streamOneFile START name=${file.name} size=${file.size} payloadId=${file.payloadId}")
-            val cancelled = streamOneFile(channel, file)
+            val cancelled = streamOneFile(channel, file, pollInboundWhileStreaming)
             if (cancelled != null) {
                 logger("fsm: streamOneFile EARLY-RETURN ${cancelled::class.simpleName}")
                 return cancelled
@@ -1229,9 +1245,11 @@ internal class OutboundConnectionDriver(
      * Returns a non-null terminal result if the user cancelled mid-file;
      * null on successful completion of this single file.
      */
+    @Suppress("ReturnCount") // The streaming loop must bail out immediately on cancel or peer terminal frames.
     private suspend fun streamOneFile(
         channel: SecureChannel,
         file: FileSource,
+        pollInboundWhileStreaming: suspend () -> OutboundResult?,
     ): OutboundResult? {
         val source = file.openChannel()
         var chunkIdx = 0
@@ -1259,6 +1277,7 @@ internal class OutboundConnectionDriver(
                     parentFolder = file.parentFolder,
                 )
             for (frame in frames) {
+                pollInboundWhileStreaming()?.let { return it }
                 // Poll for cancellation between chunks. trySend semantics
                 // for an UNLIMITED channel never block — receive() also
                 // never blocks if there's no event waiting.
@@ -1273,12 +1292,75 @@ internal class OutboundConnectionDriver(
                     logger("fsm: streamOneFile first chunk written bytesSent=$bytesSent")
                 }
                 chunkIdx++
+                pollInboundWhileStreaming()?.let { return it }
             }
             logger("fsm: streamOneFile loop end chunks=$chunkIdx bytesSent=$bytesSent")
         } finally {
             runCatching { source.close() }
         }
         return null
+    }
+
+    @Suppress("ReturnCount") // Early returns keep the non-blocking queue-drain readable.
+    private suspend fun drainBufferedInboundWhileStreaming(
+        wireChannel: Channel<OutboundWireMessage>?,
+    ): OutboundResult? {
+        if (wireChannel == null) return null
+        while (true) {
+            when (val message = wireChannel.tryReceive().getOrNull() ?: return null) {
+                is OutboundWireMessage.Frame -> {
+                    handleInboundFrameWhileStreaming(message.frame)?.let { return it }
+                }
+                OutboundWireMessage.Closed -> return handlePeerClosed()
+                is OutboundWireMessage.Error -> return inboundPumpFailed(message.cause)
+            }
+        }
+    }
+
+    @Suppress(
+        "ReturnCount",
+        "SwallowedException",
+    ) // EndOfFrameStream is intentionally mapped to the peer-closed terminal.
+    private suspend fun drainDirectInboundWhileStreaming(channel: SecureChannel): OutboundResult? {
+        while (channel.hasBufferedInput()) {
+            val frame =
+                try {
+                    channel.receiveOfflineFrame()
+                } catch (e: EndOfFrameStream) {
+                    return handlePeerClosed()
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (
+                    @Suppress("TooGenericExceptionCaught") e: Throwable,
+                ) {
+                    return inboundPumpFailed(e)
+                }
+            handleInboundFrameWhileStreaming(frame)?.let { return it }
+        }
+        return null
+    }
+
+    @Suppress("ReturnCount") // Mid-stream control handling is clearest as one branch per frame shape.
+    private fun handleInboundFrameWhileStreaming(frame: OfflineFrame): OutboundResult? {
+        if (frame.isDisconnection()) {
+            return cancelFromPeer()
+        }
+        if (!frame.hasV1()) return null
+
+        return when (frame.v1.type) {
+            V1Frame.FrameType.KEEP_ALIVE -> null
+            V1Frame.FrameType.BANDWIDTH_UPGRADE_NEGOTIATION -> {
+                logger(
+                    "fsm: streaming drain ignored BANDWIDTH_UPGRADE_NEGOTIATION event_type=" +
+                        frame.v1.bandwidthUpgradeNegotiation.eventType,
+                )
+                null
+            }
+            else -> {
+                logger("fsm: streaming drain buffered ${frame.describeFrameType()} for post-send handling")
+                null
+            }
+        }
     }
 
     /** Returns the body size (data bytes) of the chunk in [frame]. */
@@ -1364,6 +1446,12 @@ internal class OutboundConnectionDriver(
         logger("fsm: cancelFromPeer (peer Disconnection observed)")
         publishCancelled(CancelCause.PEER)
         return OutboundResult.Cancelled(CancelCause.PEER)
+    }
+
+    private fun inboundPumpFailed(cause: Throwable): OutboundResult.Failed {
+        val reason = "Inbound pump error: ${cause::class.simpleName}: ${cause.message}"
+        mutableState.value = OutboundConnectionState.Failed(reason)
+        return OutboundResult.Failed(reason)
     }
 
     /**

--- a/core-protocol/src/main/kotlin/dev/bluehouse/libredrop/protocol/connection/OutboundConnectionDriver.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/libredrop/protocol/connection/OutboundConnectionDriver.kt
@@ -1253,10 +1253,49 @@ internal class OutboundConnectionDriver(
     ): OutboundResult? {
         val source = file.openChannel()
         var chunkIdx = 0
-        val chunkSize = PayloadTransferEncoder.selectFileChunkSize(file.size)
+        val tierChunkSize = PayloadTransferEncoder.selectFileChunkSize(file.size)
+        val desiredChunkSize =
+            PayloadTransferEncoder.limitAdaptiveFileChunkSizeForTransport(
+                desiredChunkSize = tierChunkSize,
+                maxEncryptedFrameLength = channel.maxOutgoingFrameLength,
+            )
+        val chunkSize =
+            PayloadTransferEncoder.capFileChunkSizeToEncryptedFrameBudget(
+                payloadId = file.payloadId,
+                fileName = file.name,
+                totalSize = file.size,
+                desiredChunkSize = desiredChunkSize,
+                maxEncryptedFrameLength = channel.maxOutgoingFrameLength,
+                lastModifiedTimestampMillis = file.lastModifiedTimestampMillis,
+                parentFolder = file.parentFolder,
+            )
+        val modeledEncryptedFrameLength =
+            PayloadTransferEncoder.modeledEncryptedFrameLengthForChunk(
+                payloadId = file.payloadId,
+                fileName = file.name,
+                totalSize = file.size,
+                bodySize = chunkSize,
+                lastModifiedTimestampMillis = file.lastModifiedTimestampMillis,
+                parentFolder = file.parentFolder,
+            )
         try {
+            if (desiredChunkSize != tierChunkSize) {
+                logger(
+                    "fsm: streamOneFile transport-limited chunkSize=$desiredChunkSize " +
+                        "tierChunkSize=$tierChunkSize frameBudget=${channel.maxOutgoingFrameLength}",
+                )
+            }
+            if (chunkSize != desiredChunkSize) {
+                logger(
+                    "fsm: streamOneFile capped chunkSize=$chunkSize " +
+                        "desiredChunkSize=$desiredChunkSize " +
+                        "frameBudget=${channel.maxOutgoingFrameLength} to fit encrypted frame budget",
+                )
+            }
             logger(
                 "fsm: streamOneFile chunkSize=$chunkSize " +
+                    "frameBudget=${channel.maxOutgoingFrameLength} " +
+                    "modeledEncryptedFrameLength=$modeledEncryptedFrameLength " +
                     "name=${file.name} size=${file.size} payloadId=${file.payloadId}",
             )
             val frames =

--- a/core-protocol/src/main/kotlin/dev/bluehouse/libredrop/protocol/crypto/securemessage/SecureChannel.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/libredrop/protocol/crypto/securemessage/SecureChannel.kt
@@ -168,6 +168,9 @@ public class SecureChannel internal constructor(
     internal suspend fun receiveRawOfflineFrame(): OfflineFrame =
         OfflineFrame.parseFrom(framedConnection.receiveFrame())
 
+    internal val maxOutgoingFrameLength: Int
+        get() = framedConnection.maxOutgoingFrameLength
+
     /**
      * The next outgoing sequence number that [sendOfflineFrame] WOULD use,
      * exposed for diagnostics and tests. The value increases by exactly

--- a/core-protocol/src/main/kotlin/dev/bluehouse/libredrop/protocol/payload/PayloadTransferEncoder.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/libredrop/protocol/payload/PayloadTransferEncoder.kt
@@ -11,6 +11,7 @@ import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.Payl
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.PayloadTransferFrame.PayloadHeader
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.V1Frame
 import com.google.protobuf.ByteString
+import dev.bluehouse.libredrop.protocol.transport.FramedConnection
 import java.nio.ByteBuffer
 import java.nio.channels.ReadableByteChannel
 
@@ -42,6 +43,19 @@ public object PayloadTransferEncoder {
      * eat into the TCP send buffer and stall progress reporting.
      */
     public const val DEFAULT_FILE_CHUNK_SIZE: Int = 512 * 1024
+
+    private const val ADAPTIVE_FILE_CHUNK_SIZE_256_KIB: Int = 256 * 1024
+    private const val ADAPTIVE_FILE_CHUNK_SIZE_1_MIB: Int = 1024 * 1024
+    private const val ADAPTIVE_FILE_CHUNK_SIZE_2_MIB: Int = 2 * 1024 * 1024
+    private const val ADAPTIVE_FILE_TIER_1_MAX_SIZE: Long = 1024L * 1024L
+    private const val ADAPTIVE_FILE_TIER_2_MAX_SIZE: Long = 8L * 1024L * 1024L
+    private const val ADAPTIVE_FILE_TIER_3_MAX_SIZE: Long = 64L * 1024L * 1024L
+
+    init {
+        check(ADAPTIVE_FILE_CHUNK_SIZE_2_MIB < FramedConnection.SANE_FRAME_LENGTH) {
+            "Adaptive file chunk size cap must stay below FramedConnection.SANE_FRAME_LENGTH"
+        }
+    }
 
     /**
      * Encode an outbound BYTES payload.
@@ -225,6 +239,25 @@ public object PayloadTransferEncoder {
                         .build(),
                 ),
             )
+        }
+    }
+
+    /**
+     * Deterministic sender-side policy for outbound FILE payload chunking.
+     *
+     * The sender always stays comfortably below
+     * [FramedConnection.SANE_FRAME_LENGTH] by capping chunks at 2 MiB,
+     * which still leaves roughly 3 MiB of headroom for protobuf and
+     * SecureMessage envelope overhead inside the framed transport.
+     */
+    internal fun selectFileChunkSize(totalSize: Long): Int {
+        require(totalSize >= 0) { "totalSize must be non-negative, got $totalSize" }
+
+        return when {
+            totalSize <= ADAPTIVE_FILE_TIER_1_MAX_SIZE -> ADAPTIVE_FILE_CHUNK_SIZE_256_KIB
+            totalSize <= ADAPTIVE_FILE_TIER_2_MAX_SIZE -> DEFAULT_FILE_CHUNK_SIZE
+            totalSize <= ADAPTIVE_FILE_TIER_3_MAX_SIZE -> ADAPTIVE_FILE_CHUNK_SIZE_1_MIB
+            else -> ADAPTIVE_FILE_CHUNK_SIZE_2_MIB
         }
     }
 

--- a/core-protocol/src/main/kotlin/dev/bluehouse/libredrop/protocol/payload/PayloadTransferEncoder.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/libredrop/protocol/payload/PayloadTransferEncoder.kt
@@ -11,6 +11,7 @@ import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.Payl
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.PayloadTransferFrame.PayloadHeader
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.V1Frame
 import com.google.protobuf.ByteString
+import dev.bluehouse.libredrop.protocol.crypto.securemessage.SecureMessageCodec
 import dev.bluehouse.libredrop.protocol.transport.FramedConnection
 import java.nio.ByteBuffer
 import java.nio.channels.ReadableByteChannel
@@ -50,6 +51,11 @@ public object PayloadTransferEncoder {
     private const val ADAPTIVE_FILE_TIER_1_MAX_SIZE: Long = 1024L * 1024L
     private const val ADAPTIVE_FILE_TIER_2_MAX_SIZE: Long = 8L * 1024L * 1024L
     private const val ADAPTIVE_FILE_TIER_3_MAX_SIZE: Long = 64L * 1024L * 1024L
+    private const val FRAME_SIZING_SEQUENCE_NUMBER: Int = Int.MAX_VALUE
+
+    private val frameSizingEncryptKey = ByteArray(SecureMessageCodec.AES_KEY_SIZE)
+    private val frameSizingHmacKey = ByteArray(SecureMessageCodec.HMAC_KEY_SIZE)
+    private val frameSizingIv = ByteArray(SecureMessageCodec.IV_SIZE)
 
     init {
         check(ADAPTIVE_FILE_CHUNK_SIZE_2_MIB < FramedConnection.SANE_FRAME_LENGTH) {
@@ -181,16 +187,13 @@ public object PayloadTransferEncoder {
         require(totalSize >= 0) { "totalSize must be non-negative, got $totalSize" }
 
         val header =
-            PayloadHeader
-                .newBuilder()
-                .setId(payloadId)
-                .setType(PayloadHeader.PayloadType.FILE)
-                .setTotalSize(totalSize)
-                .setFileName(fileName)
-                .setParentFolder(parentFolder)
-                .setLastModifiedTimestampMillis(lastModifiedTimestampMillis)
-                .setIsSensitive(false)
-                .build()
+            buildFilePayloadHeader(
+                payloadId = payloadId,
+                fileName = fileName,
+                totalSize = totalSize,
+                parentFolder = parentFolder,
+                lastModifiedTimestampMillis = lastModifiedTimestampMillis,
+            )
 
         return sequence {
             val readBuffer = ByteBuffer.allocate(chunkSize)
@@ -245,10 +248,11 @@ public object PayloadTransferEncoder {
     /**
      * Deterministic sender-side policy for outbound FILE payload chunking.
      *
-     * The sender always stays comfortably below
-     * [FramedConnection.SANE_FRAME_LENGTH] by capping chunks at 2 MiB,
-     * which still leaves roughly 3 MiB of headroom for protobuf and
-     * SecureMessage envelope overhead inside the framed transport.
+     * This returns the optimistic tier target; callers that intend to
+     * send over Nearby Connections still need to pass the result through
+     * [capFileChunkSizeToEncryptedFrameBudget], because Google Play
+     * Services enforces a much smaller per-frame cap on the encrypted
+     * upgraded transport than our local 5 MiB framing guard does.
      */
     internal fun selectFileChunkSize(totalSize: Long): Int {
         require(totalSize >= 0) { "totalSize must be non-negative, got $totalSize" }
@@ -259,6 +263,152 @@ public object PayloadTransferEncoder {
             totalSize <= ADAPTIVE_FILE_TIER_3_MAX_SIZE -> ADAPTIVE_FILE_CHUNK_SIZE_1_MIB
             else -> ADAPTIVE_FILE_CHUNK_SIZE_2_MIB
         }
+    }
+
+    /**
+     * Keep constrained upgraded transports on the known-good 512 KiB sender
+     * chunk path. The file-size tiers are safe on unconstrained transports
+     * such as Wi-Fi LAN, but Google Play Services applies a hidden, unstable
+     * parser ceiling on some upgraded links (notably stock Galaxy Wi-Fi
+     * Direct), so larger adaptive chunks cannot be trusted there yet.
+     */
+    internal fun limitAdaptiveFileChunkSizeForTransport(
+        desiredChunkSize: Int,
+        maxEncryptedFrameLength: Int,
+    ): Int {
+        require(desiredChunkSize > 0) { "desiredChunkSize must be positive, got $desiredChunkSize" }
+        require(maxEncryptedFrameLength > 0) {
+            "maxEncryptedFrameLength must be positive, got $maxEncryptedFrameLength"
+        }
+
+        return if (maxEncryptedFrameLength < FramedConnection.SANE_FRAME_LENGTH - 1) {
+            desiredChunkSize.coerceAtMost(DEFAULT_FILE_CHUNK_SIZE)
+        } else {
+            desiredChunkSize
+        }
+    }
+
+    /**
+     * Cap FILE chunk bodies against the active encrypted-frame budget, not
+     * just against our local 5 MiB framing guard.
+     *
+     * Callers on upgraded Google Play Services transports should pass the
+     * peer-specific limit from [dev.bluehouse.libredrop.protocol.transport.TransportFrameBudget].
+     */
+    internal fun capFileChunkSizeToEncryptedFrameBudget(
+        payloadId: Long,
+        fileName: String,
+        totalSize: Long,
+        desiredChunkSize: Int,
+        maxEncryptedFrameLength: Int = FramedConnection.SANE_FRAME_LENGTH - 1,
+        lastModifiedTimestampMillis: Long = 0L,
+        parentFolder: String = "",
+    ): Int {
+        require(totalSize >= 0) { "totalSize must be non-negative, got $totalSize" }
+        require(desiredChunkSize > 0) { "desiredChunkSize must be positive, got $desiredChunkSize" }
+        require(maxEncryptedFrameLength > 0) {
+            "maxEncryptedFrameLength must be positive, got $maxEncryptedFrameLength"
+        }
+
+        val header =
+            buildFilePayloadHeader(
+                payloadId = payloadId,
+                fileName = fileName,
+                totalSize = totalSize,
+                parentFolder = parentFolder,
+                lastModifiedTimestampMillis = lastModifiedTimestampMillis,
+            )
+        if (modeledEncryptedFrameLengthForDataChunk(header, desiredChunkSize) <=
+            maxEncryptedFrameLength
+        ) {
+            return desiredChunkSize
+        }
+
+        var low = 1
+        var high = desiredChunkSize
+        var best = 0
+        while (low <= high) {
+            val mid = low + ((high - low) ushr 1)
+            if (modeledEncryptedFrameLengthForDataChunk(header, mid) <=
+                maxEncryptedFrameLength
+            ) {
+                best = mid
+                low = mid + 1
+            } else {
+                high = mid - 1
+            }
+        }
+        check(best > 0) {
+            "Could not fit any FILE chunk into the Google Nearby encrypted frame budget"
+        }
+        return best
+    }
+
+    internal fun modeledEncryptedFrameLengthForChunk(
+        payloadId: Long,
+        fileName: String,
+        totalSize: Long,
+        bodySize: Int,
+        lastModifiedTimestampMillis: Long = 0L,
+        parentFolder: String = "",
+    ): Int {
+        val header =
+            buildFilePayloadHeader(
+                payloadId = payloadId,
+                fileName = fileName,
+                totalSize = totalSize,
+                parentFolder = parentFolder,
+                lastModifiedTimestampMillis = lastModifiedTimestampMillis,
+            )
+        return modeledEncryptedFrameLengthForDataChunk(header, bodySize)
+    }
+
+    private fun buildFilePayloadHeader(
+        payloadId: Long,
+        fileName: String,
+        totalSize: Long,
+        parentFolder: String,
+        lastModifiedTimestampMillis: Long,
+    ): PayloadHeader =
+        PayloadHeader
+            .newBuilder()
+            .setId(payloadId)
+            .setType(PayloadHeader.PayloadType.FILE)
+            .setTotalSize(totalSize)
+            .setFileName(fileName)
+            .setParentFolder(parentFolder)
+            .setLastModifiedTimestampMillis(lastModifiedTimestampMillis)
+            .setIsSensitive(false)
+            .build()
+
+    private fun modeledEncryptedFrameLengthForDataChunk(
+        header: PayloadHeader,
+        bodySize: Int,
+    ): Int {
+        val offset = header.totalSize.coerceAtLeast(bodySize.toLong()) - bodySize.toLong()
+        val dataFrame =
+            wrap(
+                header = header,
+                chunk =
+                    PayloadChunk
+                        .newBuilder()
+                        .setFlags(0)
+                        .setOffset(offset)
+                        .setBody(ByteString.copyFrom(ByteArray(bodySize)))
+                        .build(),
+            )
+        val d2dBytes =
+            SecureMessageCodec.wrapDeviceToDeviceMessage(
+                offlineFrame = dataFrame.toByteArray(),
+                sequenceNumber = FRAME_SIZING_SEQUENCE_NUMBER,
+            )
+        return SecureMessageCodec
+            .encryptAndSign(
+                payload = d2dBytes,
+                encryptKey = frameSizingEncryptKey,
+                hmacKey = frameSizingHmacKey,
+                iv = frameSizingIv,
+            ).size
     }
 
     /**

--- a/core-protocol/src/main/kotlin/dev/bluehouse/libredrop/protocol/transport/FramedConnection.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/libredrop/protocol/transport/FramedConnection.kt
@@ -58,11 +58,13 @@ public class FramedConnection(
     private val input: InputStream,
     private val output: OutputStream,
     private val closeAction: () -> Unit,
+    internal val maxOutgoingFrameLength: Int = SANE_FRAME_LENGTH - 1,
 ) : AutoCloseable {
     public constructor(transport: ConnectedTransport) : this(
         input = transport.inputStream,
         output = transport.outputStream,
         closeAction = { transport.close() },
+        maxOutgoingFrameLength = TransportFrameBudget.maxOutgoingFrameLength(transport.medium),
     )
 
     public constructor(socket: Socket) : this(
@@ -86,12 +88,6 @@ public class FramedConnection(
      * particular needs each ClientInit/ServerInit flush to be visible to
      * the peer before the next read).
      *
-     * Note: the outgoing-frame size is **not** checked against
-     * [SANE_FRAME_LENGTH]. The cap exists to bound peer-controlled
-     * allocations on the receive side; on the send side the caller is
-     * already trusted, and Quick Share file payloads are chunked by an
-     * upper layer (`PayloadTransferFrame`) well below this limit.
-     *
      * @throws IOException if the socket write fails or the connection is
      *   already closed.
      */
@@ -104,6 +100,12 @@ public class FramedConnection(
                 // re-buffers — but it avoids two flushes on small frames
                 // (which UKEY2 has many of).
                 val length = bytes.size
+                if (length <= 0 || length > maxOutgoingFrameLength) {
+                    throw OutboundFrameTooLargeException(
+                        actualLength = length,
+                        maxAllowedLength = maxOutgoingFrameLength,
+                    )
+                }
                 val framed = ByteArray(LENGTH_PREFIX_BYTES + length)
                 framed[BYTE_OFFSET_0] = (length ushr BIT_SHIFT_24).toByte()
                 framed[BYTE_OFFSET_1] = (length ushr BIT_SHIFT_16).toByte()
@@ -302,4 +304,17 @@ public class OversizedFrameException(
 ) : IOException(
         "Declared frame length $declaredLength is outside " +
             "1..${FramedConnection.SANE_FRAME_LENGTH - 1}",
+    )
+
+/**
+ * Thrown by [FramedConnection.sendFrame] when the local sender attempts to
+ * write a frame that exceeds the peer-specific ceiling for the active
+ * transport.
+ */
+public class OutboundFrameTooLargeException(
+    public val actualLength: Int,
+    public val maxAllowedLength: Int,
+) : IOException(
+        "Outgoing frame length $actualLength exceeds the transport limit " +
+            "1..$maxAllowedLength",
     )

--- a/core-protocol/src/main/kotlin/dev/bluehouse/libredrop/protocol/transport/TransportFrameBudget.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/libredrop/protocol/transport/TransportFrameBudget.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 LibreDrop contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.libredrop.protocol.transport
+
+import dev.bluehouse.libredrop.protocol.medium.Medium
+
+/**
+ * Peer-specific outbound frame ceilings layered on top of the local 5 MiB
+ * receive-side framing guard in [FramedConnection].
+ *
+ * Stock Google Play Services rejects some upgraded Wi-Fi Direct
+ * `SecureMessage` frames well below the generic 5 MiB transport cap. Live
+ * Galaxy interop runs failed at 2,097,144, 2,097,128, 2,097,112, 2,097,080
+ * bytes, so the sender must enforce a tighter ceiling before it writes into
+ * the upgraded socket buffer. Otherwise several oversized writes can be
+ * accepted locally and only later cause a peer-side reset.
+ *
+ * The exact parser ceiling is internal to Play Services, so keep a small
+ * guard band below the smallest observed reject to absorb protobuf-varint and
+ * block-padding drift without materially impacting throughput.
+ */
+internal object TransportFrameBudget {
+    internal const val PLAY_SERVICES_UPGRADED_MAX_FRAME_LENGTH: Int = (2 * 1024 * 1024) - 4096
+
+    fun maxOutgoingFrameLength(medium: Medium): Int =
+        when (medium) {
+            Medium.WIFI_DIRECT -> PLAY_SERVICES_UPGRADED_MAX_FRAME_LENGTH
+            else -> FramedConnection.SANE_FRAME_LENGTH - 1
+        }
+}

--- a/core-protocol/src/test/kotlin/dev/bluehouse/libredrop/protocol/connection/OutboundConnectionTest.kt
+++ b/core-protocol/src/test/kotlin/dev/bluehouse/libredrop/protocol/connection/OutboundConnectionTest.kt
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Timeout
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
+import java.io.OutputStream
 import java.net.InetAddress
 import java.net.ServerSocket
 import java.net.Socket
@@ -286,6 +287,55 @@ class OutboundConnectionTest {
             closed = true
             inputStream.close()
             outputStream.close()
+        }
+    }
+
+    /**
+     * Slows only large frame writes. Small control frames stay fast so the
+     * handshake finishes quickly; FILE payload frames larger than
+     * [slowThresholdBytes] are written in small slices with sleeps between
+     * them so one frame spans the 10-second KEEP_ALIVE interval.
+     */
+    private class LargeFrameSlowOutputStream(
+        private val delegate: OutputStream,
+        private val slowThresholdBytes: Int,
+        private val chunkBytes: Int,
+        private val interChunkDelayMillis: Long,
+    ) : OutputStream() {
+        override fun write(b: Int) {
+            delegate.write(b)
+        }
+
+        override fun write(
+            b: ByteArray,
+            off: Int,
+            len: Int,
+        ) {
+            if (len < slowThresholdBytes) {
+                delegate.write(b, off, len)
+                delegate.flush()
+                return
+            }
+
+            var position = off
+            val end = off + len
+            while (position < end) {
+                val toWrite = minOf(chunkBytes, end - position)
+                delegate.write(b, position, toWrite)
+                delegate.flush()
+                position += toWrite
+                if (position < end) {
+                    Thread.sleep(interChunkDelayMillis)
+                }
+            }
+        }
+
+        override fun flush() {
+            delegate.flush()
+        }
+
+        override fun close() {
+            delegate.close()
         }
     }
 
@@ -935,6 +985,64 @@ class OutboundConnectionTest {
                 val received = factory.output[payloadId]?.toByteArray()
                 assertThat(received?.size).isEqualTo(largeBytes.size)
                 assertThat(received).isEqualTo(largeBytes)
+            }
+        }
+
+    @Test
+    fun `slow payload frame spanning keep alive interval still completes`() =
+        runBlocking {
+            withTimeout(LONG_WALLCLOCK_TIMEOUT_MS) {
+                val (client, server) = connectedSocketPair()
+                val outboundLogs = mutableListOf<String>()
+                val outbound =
+                    OutboundConnection(
+                        transport =
+                            object : ConnectedTransport {
+                                override val medium: Medium = Medium.BLUETOOTH
+                                override val inputStream: InputStream = client.getInputStream()
+                                override val outputStream: OutputStream =
+                                    LargeFrameSlowOutputStream(
+                                        delegate = client.getOutputStream(),
+                                        slowThresholdBytes = 128 * 1024,
+                                        chunkBytes = 8 * 1024,
+                                        interChunkDelayMillis = 350L,
+                                    )
+
+                                override fun close() {
+                                    client.close()
+                                }
+                            },
+                        secureRandom = SecureRandom("outbound-slow-frame".toByteArray()),
+                        logger = outboundLogs::add,
+                    )
+                val factory = InMemoryFactory()
+                val fileBytes = ByteArray(300_000) { ((it * 17) and 0xFF).toByte() }
+                val payloadId = 9090L
+                val files = listOf(bytesSource("slow-frame.bin", fileBytes, payloadId))
+
+                coroutineScope {
+                    val outboundJob = async { outbound.run(files) }
+                    val inbound =
+                        InboundConnection(
+                            transport = server.asConnectedTransport(Medium.BLUETOOTH),
+                            secureRandom = SecureRandom("inbound-slow-frame".toByteArray()),
+                        )
+
+                    launch {
+                        inbound.state.first { it is InboundConnectionState.WaitingForUserConsent }
+                        inbound.submitUserConsent(accepted = true)
+                    }
+
+                    val inboundResult = inbound.run(factory)
+                    val outboundResult = outboundJob.await()
+
+                    assertThat(outboundResult).isEqualTo(OutboundResult.Completed)
+                    assertThat(inboundResult).isInstanceOf(InboundResult.Completed::class.java)
+                }
+
+                assertThat(factory.output[payloadId]?.toByteArray()).isEqualTo(fileBytes)
+                assertThat(outboundLogs.any { it.contains("streamOneFile chunkSize=262144") }).isTrue()
+                assertThat(outboundLogs.any { it.contains("keep-alive: ticker stopped") }).isFalse()
             }
         }
 

--- a/core-protocol/src/test/kotlin/dev/bluehouse/libredrop/protocol/payload/PayloadAssemblerTest.kt
+++ b/core-protocol/src/test/kotlin/dev/bluehouse/libredrop/protocol/payload/PayloadAssemblerTest.kt
@@ -898,6 +898,34 @@ class PayloadAssemblerTest {
     }
 
     @Test
+    fun `assembler accepts FILE frames produced by the encoder with selector chosen non-default chunk size`() {
+        val data = Random(0xC168).nextBytes(900_000)
+        val selectedChunkSize = PayloadTransferEncoder.selectFileChunkSize(data.size.toLong())
+        assertThat(selectedChunkSize).isEqualTo(256 * 1024)
+
+        val source = Channels.newChannel(java.io.ByteArrayInputStream(data))
+        val frames =
+            PayloadTransferEncoder
+                .encodeFilePayload(
+                    payloadId = 315,
+                    fileName = "selector.bin",
+                    totalSize = data.size.toLong(),
+                    source = source,
+                    chunkSize = selectedChunkSize,
+                ).toList()
+
+        val factory = CapturingFactory()
+        val assembler = PayloadAssembler(fileDestinationFactory = factory)
+        var lastEvent: PayloadEvent? = null
+        for (frame in frames) {
+            lastEvent = assembler.onPayloadTransfer(frame.v1.payloadTransfer)
+        }
+
+        assertThat(lastEvent).isInstanceOf(PayloadEvent.FileComplete::class.java)
+        assertThat(factory.outputs[315]!!.toByteArray()).isEqualTo(data)
+    }
+
+    @Test
     fun `large file streamed in tiny chunks completes correctly`() {
         // Simulates a slow peer that sends 100 KiB chunks of a 10 MiB file.
         // Confirms the assembler scales linearly with chunk count and does

--- a/core-protocol/src/test/kotlin/dev/bluehouse/libredrop/protocol/payload/PayloadTransferEncoderTest.kt
+++ b/core-protocol/src/test/kotlin/dev/bluehouse/libredrop/protocol/payload/PayloadTransferEncoderTest.kt
@@ -10,6 +10,7 @@ import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.Offl
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.PayloadTransferFrame
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.PayloadTransferFrame.PayloadHeader
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.V1Frame
+import dev.bluehouse.libredrop.protocol.transport.FramedConnection
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.io.ByteArrayInputStream
@@ -25,6 +26,27 @@ import kotlin.random.Random
  * [PayloadAssemblerTest].
  */
 class PayloadTransferEncoderTest {
+    @Test
+    fun `selectFileChunkSize uses deterministic size tiers below the framed transport cap`() {
+        assertThat(PayloadTransferEncoder.selectFileChunkSize(0)).isEqualTo(256 * 1024)
+        assertThat(PayloadTransferEncoder.selectFileChunkSize(1024L * 1024L)).isEqualTo(256 * 1024)
+        assertThat(PayloadTransferEncoder.selectFileChunkSize((1024L * 1024L) + 1L)).isEqualTo(512 * 1024)
+        assertThat(PayloadTransferEncoder.selectFileChunkSize(8L * 1024L * 1024L)).isEqualTo(512 * 1024)
+        assertThat(PayloadTransferEncoder.selectFileChunkSize((8L * 1024L * 1024L) + 1L)).isEqualTo(1024 * 1024)
+        assertThat(PayloadTransferEncoder.selectFileChunkSize(64L * 1024L * 1024L)).isEqualTo(1024 * 1024)
+
+        val largestTier = PayloadTransferEncoder.selectFileChunkSize(Long.MAX_VALUE)
+        assertThat(largestTier).isEqualTo(2 * 1024 * 1024)
+        assertThat(largestTier).isLessThan(FramedConnection.SANE_FRAME_LENGTH)
+    }
+
+    @Test
+    fun `selectFileChunkSize rejects negative total size`() {
+        assertThrows<IllegalArgumentException> {
+            PayloadTransferEncoder.selectFileChunkSize(-1)
+        }
+    }
+
     @Test
     fun `encodeBytesPayload emits exactly two frames in the Android quirk shape`() {
         val data = "abcde".toByteArray()

--- a/core-protocol/src/test/kotlin/dev/bluehouse/libredrop/protocol/payload/PayloadTransferEncoderTest.kt
+++ b/core-protocol/src/test/kotlin/dev/bluehouse/libredrop/protocol/payload/PayloadTransferEncoderTest.kt
@@ -8,9 +8,13 @@ package dev.bluehouse.libredrop.protocol.payload
 import com.google.common.truth.Truth.assertThat
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.PayloadTransferFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.PayloadTransferFrame.PayloadChunk
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.PayloadTransferFrame.PayloadHeader
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.V1Frame
+import com.google.protobuf.ByteString
+import dev.bluehouse.libredrop.protocol.crypto.securemessage.SecureMessageCodec
 import dev.bluehouse.libredrop.protocol.transport.FramedConnection
+import dev.bluehouse.libredrop.protocol.transport.TransportFrameBudget
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.io.ByteArrayInputStream
@@ -26,6 +30,10 @@ import kotlin.random.Random
  * [PayloadAssemblerTest].
  */
 class PayloadTransferEncoderTest {
+    private val sizingEncryptKey = ByteArray(SecureMessageCodec.AES_KEY_SIZE)
+    private val sizingHmacKey = ByteArray(SecureMessageCodec.HMAC_KEY_SIZE)
+    private val sizingIv = ByteArray(SecureMessageCodec.IV_SIZE)
+
     @Test
     fun `selectFileChunkSize uses deterministic size tiers below the framed transport cap`() {
         assertThat(PayloadTransferEncoder.selectFileChunkSize(0)).isEqualTo(256 * 1024)
@@ -45,6 +53,70 @@ class PayloadTransferEncoderTest {
         assertThrows<IllegalArgumentException> {
             PayloadTransferEncoder.selectFileChunkSize(-1)
         }
+    }
+
+    @Test
+    fun `limitAdaptiveFileChunkSizeForTransport keeps constrained upgraded links on the safe default chunk size`() {
+        val unconstrained = 2 * 1024 * 1024
+
+        assertThat(
+            PayloadTransferEncoder.limitAdaptiveFileChunkSizeForTransport(
+                desiredChunkSize = unconstrained,
+                maxEncryptedFrameLength = FramedConnection.SANE_FRAME_LENGTH - 1,
+            ),
+        ).isEqualTo(unconstrained)
+
+        assertThat(
+            PayloadTransferEncoder.limitAdaptiveFileChunkSizeForTransport(
+                desiredChunkSize = unconstrained,
+                maxEncryptedFrameLength = TransportFrameBudget.PLAY_SERVICES_UPGRADED_MAX_FRAME_LENGTH,
+            ),
+        ).isEqualTo(PayloadTransferEncoder.DEFAULT_FILE_CHUNK_SIZE)
+    }
+
+    @Test
+    fun `capFileChunkSizeToEncryptedFrameBudget stays below observed Galaxy wifi direct rejects`() {
+        val totalSize = 341_064_318L
+        val desiredChunkSize = PayloadTransferEncoder.selectFileChunkSize(totalSize)
+        assertThat(desiredChunkSize).isEqualTo(2 * 1024 * 1024)
+
+        val cappedChunkSize =
+            PayloadTransferEncoder.capFileChunkSizeToEncryptedFrameBudget(
+                payloadId = 3_481_759_869_812_819_740L,
+                fileName = "Sonos_85.00.23.apk",
+                totalSize = totalSize,
+                desiredChunkSize = desiredChunkSize,
+                maxEncryptedFrameLength = TransportFrameBudget.PLAY_SERVICES_UPGRADED_MAX_FRAME_LENGTH,
+            )
+
+        assertThat(cappedChunkSize).isLessThan(desiredChunkSize)
+        assertThat(cappedChunkSize).isGreaterThan(1024 * 1024)
+
+        val header =
+            PayloadHeader
+                .newBuilder()
+                .setId(3_481_759_869_812_819_740L)
+                .setType(PayloadHeader.PayloadType.FILE)
+                .setTotalSize(totalSize)
+                .setFileName("Sonos_85.00.23.apk")
+                .setParentFolder("")
+                .setLastModifiedTimestampMillis(0L)
+                .setIsSensitive(false)
+                .build()
+        val receiverBudget = TransportFrameBudget.PLAY_SERVICES_UPGRADED_MAX_FRAME_LENGTH
+
+        val oldFrameLength = encryptedFrameLengthForDataChunk(header, desiredChunkSize)
+        val cappedFrameLength = encryptedFrameLengthForDataChunk(header, cappedChunkSize)
+        val firstRejectedLiveChunkFrameLength = encryptedFrameLengthForDataChunk(header, 2_096_969)
+        val laterRejectedLiveChunkFrameLength = encryptedFrameLengthForDataChunk(header, 2_096_953)
+
+        assertThat(oldFrameLength).isGreaterThan(receiverBudget)
+        assertThat(firstRejectedLiveChunkFrameLength).isGreaterThan(receiverBudget)
+        assertThat(laterRejectedLiveChunkFrameLength).isGreaterThan(receiverBudget)
+        assertThat(cappedFrameLength).isAtMost(receiverBudget)
+        assertThat(cappedChunkSize).isLessThan(2_096_921)
+        assertThat(cappedFrameLength).isLessThan(laterRejectedLiveChunkFrameLength)
+        assertThat(encryptedFrameLengthForDataChunk(header, cappedChunkSize + 1)).isGreaterThan(receiverBudget)
     }
 
     @Test
@@ -237,5 +309,47 @@ class PayloadTransferEncoderTest {
         assertThat(header.parentFolder).isEqualTo("Documents")
         assertThat(header.lastModifiedTimestampMillis).isEqualTo(1_700_000_000_000L)
         assertThat(header.type).isEqualTo(PayloadHeader.PayloadType.FILE)
+    }
+
+    private fun encryptedFrameLengthForDataChunk(
+        header: PayloadHeader,
+        bodySize: Int,
+    ): Int {
+        val offset = header.totalSize.coerceAtLeast(bodySize.toLong()) - bodySize.toLong()
+        val frame =
+            OfflineFrame
+                .newBuilder()
+                .setVersion(OfflineFrame.Version.V1)
+                .setV1(
+                    V1Frame
+                        .newBuilder()
+                        .setType(V1Frame.FrameType.PAYLOAD_TRANSFER)
+                        .setPayloadTransfer(
+                            PayloadTransferFrame
+                                .newBuilder()
+                                .setPacketType(PayloadTransferFrame.PacketType.DATA)
+                                .setPayloadHeader(header)
+                                .setPayloadChunk(
+                                    PayloadChunk
+                                        .newBuilder()
+                                        .setFlags(0)
+                                        .setOffset(offset)
+                                        .setBody(ByteString.copyFrom(ByteArray(bodySize)))
+                                        .build(),
+                                ).build(),
+                        ).build(),
+                ).build()
+        val d2dBytes =
+            SecureMessageCodec.wrapDeviceToDeviceMessage(
+                offlineFrame = frame.toByteArray(),
+                sequenceNumber = Int.MAX_VALUE,
+            )
+        return SecureMessageCodec
+            .encryptAndSign(
+                payload = d2dBytes,
+                encryptKey = sizingEncryptKey,
+                hmacKey = sizingHmacKey,
+                iv = sizingIv,
+            ).size
     }
 }

--- a/core-protocol/src/test/kotlin/dev/bluehouse/libredrop/protocol/transport/FramedConnectionTest.kt
+++ b/core-protocol/src/test/kotlin/dev/bluehouse/libredrop/protocol/transport/FramedConnectionTest.kt
@@ -83,6 +83,27 @@ class FramedConnectionTest {
         }
 
     @Test
+    fun `sendFrame rejects writes above the configured outbound limit before touching the socket`() =
+        runTest {
+            val (client, server) = connectedSocketPair()
+            val sender =
+                FramedConnection(
+                    input = client.getInputStream(),
+                    output = client.getOutputStream(),
+                    closeAction = { client.close() },
+                    maxOutgoingFrameLength = 8,
+                )
+
+            val ex =
+                assertThrows<OutboundFrameTooLargeException> {
+                    sender.sendFrame(ByteArray(9))
+                }
+            assertThat(ex.actualLength).isEqualTo(9)
+            assertThat(ex.maxAllowedLength).isEqualTo(8)
+            assertThat(server.getInputStream().available()).isEqualTo(0)
+        }
+
+    @Test
     fun `receiveFrame round-trips a payload sent by sendFrame`() =
         runTest {
             val (client, server) = connectedSocketPair()

--- a/docs/testing/interop-stock-quick-share-android.md
+++ b/docs/testing/interop-stock-quick-share-android.md
@@ -184,6 +184,10 @@ discover and start the session without relying on same-LAN mDNS.
 - [ ] Record whether the connection stayed on the initial medium or
       upgraded. Look for `step 1: initial transport open medium=...`
       and any `medium-upgrade:` lines in `LibreDropOutbound`.
+- [ ] For the **large-file** run, also record the sender's adaptive FILE
+      chunk size from the `LibreDropOutbound` line
+      `fsm: streamOneFile chunkSize=<bytes> ...` and note the observed
+      throughput / completion behavior alongside it.
 - [ ] Immediately rerun the same peer pair on a **shared LAN** and
       confirm the regression path still chooses `route=lan=<ip>:<port>`.
 


### PR DESCRIPTION
## Summary
- replace the sender's fixed 512 KiB FILE chunk size with a deterministic file-size selector
- log the selected chunk size on each outbound file transfer and keep the tier cap well below the 5 MiB framed transport limit
- add JVM coverage for the selector policy, a selector-chosen non-default encoder/assembler round trip, and document where manual Wi-Fi Direct runs should record the chosen size

Closes #168

## Verification
- `./gradlew :core-protocol:test --stacktrace`
- `./gradlew staticAnalysis :discovery-android:testDebugUnitTest :app:testDebugUnitTest :app:assembleDebug --stacktrace`
- `git diff --check`

## Manual verification
- Device-side large-file Wi-Fi Direct verification was not run in this turn. The runbook now calls out the `LibreDropOutbound` `chunkSize=` log line to record during that pass.