### PR TITLE
fix: guard bug report SoC diagnostics on pre-API-31

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,5 +46,8 @@ jobs:
       - name: Run :app JVM unit tests
         run: ./gradlew :app:testDebugUnitTest --stacktrace
 
+      - name: Check bug-report Android API compatibility
+        run: ./scripts/check-app-bugreport-api-compat.sh
+
       - name: Assemble debug APK
         run: ./gradlew :app:assembleDebug --stacktrace

--- a/app/src/main/kotlin/dev/bluehouse/libredrop/bugreport/BugReportCollector.kt
+++ b/app/src/main/kotlin/dev/bluehouse/libredrop/bugreport/BugReportCollector.kt
@@ -219,6 +219,8 @@ internal class BugReportCollector(
                 "release"
             }
 
+        val socDiagnostics = BugReportSocDiagnostics.read()
+
         return buildString {
             appendLine("manufacturer=${Build.MANUFACTURER}")
             appendLine("brand=${Build.BRAND}")
@@ -228,8 +230,8 @@ internal class BugReportCollector(
             appendLine("fingerprint=${Build.FINGERPRINT}")
             appendLine("hardware=${Build.HARDWARE}")
             appendLine("board=${Build.BOARD}")
-            appendLine("socManufacturer=${Build.SOC_MANUFACTURER}")
-            appendLine("socModel=${Build.SOC_MODEL}")
+            appendLine("socManufacturer=${socDiagnostics.manufacturer}")
+            appendLine("socModel=${socDiagnostics.model}")
             appendLine("release=${Build.VERSION.RELEASE}")
             appendLine("sdkInt=${Build.VERSION.SDK_INT}")
             appendLine("incremental=${Build.VERSION.INCREMENTAL}")

--- a/app/src/main/kotlin/dev/bluehouse/libredrop/bugreport/BugReportSocDiagnostics.kt
+++ b/app/src/main/kotlin/dev/bluehouse/libredrop/bugreport/BugReportSocDiagnostics.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 LibreDrop contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.libredrop.bugreport
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+
+internal data class SocDiagnostics(
+    val manufacturer: String,
+    val model: String,
+)
+
+internal object BugReportSocDiagnostics {
+    internal const val UNAVAILABLE_PRE_API31: String = "unavailable_pre_api31"
+
+    fun read(): SocDiagnostics = resolveForSdkInt(Build.VERSION.SDK_INT) { readApi31Values() }
+
+    internal fun resolveForSdkInt(
+        sdkInt: Int,
+        readApi31Values: () -> SocDiagnostics,
+    ): SocDiagnostics =
+        if (sdkInt >= Build.VERSION_CODES.S) {
+            readApi31Values()
+        } else {
+            fallback()
+        }
+
+    private fun fallback(): SocDiagnostics = SocDiagnostics(UNAVAILABLE_PRE_API31, UNAVAILABLE_PRE_API31)
+
+    @RequiresApi(Build.VERSION_CODES.S)
+    private fun readApi31Values(): SocDiagnostics =
+        SocDiagnostics(
+            manufacturer = Build.SOC_MANUFACTURER,
+            model = Build.SOC_MODEL,
+        )
+}

--- a/app/src/test/kotlin/dev/bluehouse/libredrop/bugreport/BugReportSocDiagnosticsTest.kt
+++ b/app/src/test/kotlin/dev/bluehouse/libredrop/bugreport/BugReportSocDiagnosticsTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 LibreDrop contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.libredrop.bugreport
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BugReportSocDiagnosticsTest {
+    @Test
+    fun resolveForSdkInt_preApi31_returnsFallbackWithoutInvokingApi31Reader() {
+        var invoked = false
+
+        val diagnostics =
+            BugReportSocDiagnostics.resolveForSdkInt(sdkInt = 29) {
+                invoked = true
+                SocDiagnostics(manufacturer = "unexpected", model = "unexpected")
+            }
+
+        assertFalse(invoked)
+        assertEquals(BugReportSocDiagnostics.UNAVAILABLE_PRE_API31, diagnostics.manufacturer)
+        assertEquals(BugReportSocDiagnostics.UNAVAILABLE_PRE_API31, diagnostics.model)
+    }
+
+    @Test
+    fun resolveForSdkInt_api31_invokesApi31Reader() {
+        var invoked = false
+
+        val diagnostics =
+            BugReportSocDiagnostics.resolveForSdkInt(sdkInt = 31) {
+                invoked = true
+                SocDiagnostics(manufacturer = "Qualcomm", model = "SM8650")
+            }
+
+        assertTrue(invoked)
+        assertEquals("Qualcomm", diagnostics.manufacturer)
+        assertEquals("SM8650", diagnostics.model)
+    }
+}

--- a/scripts/check-app-bugreport-api-compat.sh
+++ b/scripts/check-app-bugreport-api-compat.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+BUGREPORT_DIR="$ROOT_DIR/app/src/main/kotlin/dev/bluehouse/libredrop/bugreport"
+ALLOWED_FILE="$BUGREPORT_DIR/BugReportSocDiagnostics.kt"
+
+matches=()
+if command -v rg >/dev/null 2>&1; then
+  while IFS= read -r match; do
+    matches+=("$match")
+  done < <(rg -n 'Build\.SOC_(MANUFACTURER|MODEL)' "$BUGREPORT_DIR" || true)
+else
+  while IFS= read -r match; do
+    matches+=("$match")
+  done < <(grep -R -n -E 'Build\.SOC_(MANUFACTURER|MODEL)' "$BUGREPORT_DIR" || true)
+fi
+
+if [[ "${#matches[@]}" -eq 0 ]]; then
+  echo "Expected guarded Build.SOC_* access in $ALLOWED_FILE, but found none." >&2
+  exit 1
+fi
+
+unexpected_matches=()
+for match in "${matches[@]}"; do
+  match_file=${match%%:*}
+  if [[ "$match_file" != "$ALLOWED_FILE" ]]; then
+    unexpected_matches+=("$match")
+  fi
+done
+
+if [[ "${#unexpected_matches[@]}" -ne 0 ]]; then
+  echo "Forbidden direct Build.SOC_* access outside $ALLOWED_FILE:" >&2
+  printf '  %s\n' "${unexpected_matches[@]}" >&2
+  exit 1
+fi
+
+echo "Bug-report Android API compatibility check passed"


### PR DESCRIPTION
## Summary
- guard bug-report SoC diagnostics behind an API-31 helper and return a stable fallback on older Android versions
- add a JVM regression test that proves the pre-API-31 path never evaluates the API-31 supplier
- add a narrow CI script that blocks direct `Build.SOC_*` access from the bug-report collector path

## Test plan
- [x] `./gradlew :app:testDebugUnitTest --stacktrace`
- [x] `./scripts/check-app-bugreport-api-compat.sh`
- [x] `./gradlew :app:assembleDebug --stacktrace`
- [x] `./gradlew staticAnalysis --stacktrace`

Closes #171
