### PR TITLE
fix: Handle pre-UKEY2 BLE bandwidth upgrades

### DIFF
--- a/app/src/main/kotlin/dev/bluehouse/bada/send/SendActivity.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/send/SendActivity.kt
@@ -252,6 +252,7 @@ public class SendActivity : AppCompatActivity() {
     private suspend fun buildOutboundConnection(
         route: NearbyPeerRoute,
         endpointInfo: ByteArray,
+        useNearbyMultiplexInitialTransport: Boolean = false,
     ): OutboundConnection? {
         val mediumRegistry = MediumRegistries.defaultForContext(applicationContext)
         return when (route) {
@@ -261,6 +262,7 @@ public class SendActivity : AppCompatActivity() {
                     port = route.port,
                     endpointId = senderEndpointId,
                     endpointInfo = endpointInfo,
+                    useNearbyMultiplexInitialTransport = useNearbyMultiplexInitialTransport,
                     mediumRegistry = mediumRegistry,
                     logger = ::logOutboundWireMessage,
                 )
@@ -325,7 +327,11 @@ public class SendActivity : AppCompatActivity() {
     ): PreparedConnection =
         when (val action = plan.action) {
             is SendBootstrapPlan.Action.Direct -> {
-                val connection = buildOutboundConnection(action.route, endpointInfo)
+                val connection =
+                    buildOutboundConnection(
+                        route = action.route,
+                        endpointInfo = endpointInfo,
+                    )
                 if (connection != null) {
                     PreparedConnection.Ready(connection)
                 } else {
@@ -379,12 +385,12 @@ public class SendActivity : AppCompatActivity() {
         val targetSnapshot = peerPickerController.formatPeerSnapshot(peer, chosenRoute)
         DiagnosticLog.e(OUTBOUND_TAG, "picked target: $targetSnapshot")
         appendOutboundLog("picked target: $targetSnapshot")
-        // Stop discovery and the wake-up pulse once we've made our pick.
-        // BLE GATT bootstrap reuses the Bluetooth controller immediately;
-        // leaving the pulse active during the dial adds avoidable role
-        // churn on stock Quick Share receivers.
+        // Stop peer-list discovery once we've made our pick, but keep
+        // the sender wake-up BLE pulse active through the pre-secure
+        // bootstrap. Stock Quick Share receivers can drop back to a
+        // "no sender nearby" state between a same-Wi-Fi LAN timeout and
+        // a BLE GATT fallback if the pulse disappears too early.
         peerPickerController.suspendPicker()
-        peerPickerController.stopBleAdvertise()
 
         // Smoothly resize the card outline as the picker chrome
         // collapses and the status panel grows in.
@@ -414,15 +420,14 @@ public class SendActivity : AppCompatActivity() {
         // not advertised on mDNS.
         //
         // Connect-attempt loop with transport fallback. The picker
-        // ranks all viable routes ahead of time (BLE-L2CAP > BLE-GATT
-        // > Wi-Fi LAN > Bluetooth Classic by [SendBootstrapPlan.viableRoutes]);
-        // we try the primary first, and if its TCP / transport connect
-        // bottoms out with "Initial connect failed: …" we retry the
-        // remaining routes in order. The fallback is gated on
-        // transport-level failures only — once the SecureChannel is
-        // up, any subsequent failure (UKEY2 mismatch, peer rejection,
-        // payload-streaming I/O error) is protocol-layer and keeps
-        // the original terminal so the user sees the actual reason.
+        // ranks all viable routes ahead of time (Wi-Fi LAN > BLE-L2CAP
+        // > BLE-GATT > Bluetooth Classic by [SendBootstrapPlan.viableRoutes]);
+        // we try the primary first, and if its TCP / initial-control
+        // leg fails before a SecureChannel exists, we retry the
+        // remaining routes in order. Once the SecureChannel is up, any
+        // subsequent failure (UKEY2 mismatch, peer rejection,
+        // payload-streaming I/O error) is protocol-layer and keeps the
+        // original terminal so the user sees the actual reason.
         connectionJob =
             lifecycleScope.launch {
                 val routes = SendBootstrapPlan.viableRoutes(peer)
@@ -462,7 +467,7 @@ public class SendActivity : AppCompatActivity() {
                     val shouldFallback =
                         !isLastAttempt &&
                             outcome is OutboundResult.Failed &&
-                            isTransportLevelFailure(outcome.reason)
+                            SendBootstrapRetryPolicy.isRetryableBootstrapFailure(outcome.reason)
                     if (shouldFallback) {
                         continue
                     }
@@ -537,26 +542,6 @@ public class SendActivity : AppCompatActivity() {
         }
     }
 
-    /**
-     * `true` when [reason] looks like a transport-layer / TCP-layer
-     * failure that the next-priority route may avoid — typically the
-     * "Initial connect failed: …" prefix produced by
-     * [OutboundConnection]'s `IOException` catch around `socket.connect`.
-     * Covers EHOSTUNREACH (router blocks Wi-Fi peer-to-peer frames),
-     * ETIMEDOUT (connect timeout), ECONNREFUSED (peer's mDNS-published
-     * port is stale or the receiver's listener is down), and
-     * SocketException / NoRouteToHost variations.
-     *
-     * Failures that do NOT look transport-layer (UKEY2 mismatch,
-     * "Peer closed connection unexpectedly" mid-handshake, payload I/O
-     * error after SecureChannel up) intentionally fall through to the
-     * terminal so the user sees the real reason — retrying via BLE
-     * would not change a wire-protocol incompatibility, and bouncing
-     * the user through three attempts of the same protocol error is
-     * worse UX than surfacing it once.
-     */
-    private fun isTransportLevelFailure(reason: String): Boolean = reason.startsWith("Initial connect failed:")
-
     private sealed interface PreparedConnection {
         data class Ready(
             val connection: OutboundConnection,
@@ -598,14 +583,14 @@ public class SendActivity : AppCompatActivity() {
                 binding.sendStatusMessage.text = peerPickerController.peerSubtitle(peer)
             }
             OutboundConnectionState.Handshaking -> {
-                // The transport is up. The wake-up pulse is already
-                // stopped on selection; keep this idempotent call for any
-                // older path that reaches Handshaking without a picker tap.
-                peerPickerController.stopBleAdvertise()
+                // Still pre-secure. Keep the sender wake-up BLE pulse
+                // active until the receiver has surfaced the acceptance
+                // window or the attempt reaches a terminal state.
                 binding.sendStatusPhase.setText(R.string.send_phase_handshaking)
                 binding.sendPin.visibility = View.GONE
             }
             is OutboundConnectionState.AwaitingRemoteAcceptance -> {
+                peerPickerController.stopBleAdvertise()
                 binding.sendStatusPhase.setText(R.string.send_phase_awaiting_acceptance)
                 binding.sendPin.text = state.pin
                 binding.sendPin.visibility = View.VISIBLE
@@ -691,6 +676,7 @@ public class SendActivity : AppCompatActivity() {
         message: String,
         isSuccess: Boolean = false,
     ) {
+        peerPickerController.stopBleAdvertise()
         beginCardBoundsTransition(BOUNDS_DURATION_MS)
         binding.sendStatusPanel.visibility = View.VISIBLE
         binding.sendStatusPhase.text = phaseText

--- a/app/src/main/kotlin/dev/bluehouse/bada/send/SendBootstrapPlan.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/send/SendBootstrapPlan.kt
@@ -75,25 +75,24 @@ internal data class SendBootstrapPlan(
          * All connect-attempt-viable routes for [peer] in the same
          * priority order as [resolve], with the highest-priority entry
          * first. Used by the sender's retry-with-fallback loop: the
-         * primary attempt uses the first entry; if its TCP / transport
-         * connect fails ("Initial connect failed: …" surfaced as
-         * `OutboundResult.Failed`), the loop walks down the list and
-         * retries each remaining route until one bootstrap completes
-         * the UKEY2 handshake — at which point the SecureChannel is
-         * up and any subsequent failure is protocol-layer, not
-         * transport-layer, so we stop falling back.
+         * primary attempt uses the first entry; if its TCP /
+         * initial-control leg fails before the SecureChannel exists,
+         * the loop walks down the list and retries each remaining route
+         * until one bootstrap completes the UKEY2 handshake. At that
+         * point any subsequent failure is protocol-layer, not a
+         * bootstrap-route failure, so we stop falling back.
          *
-         * The order mirrors [directRoute]'s `when` chain (BLE-first):
-         * BLE-L2CAP → BLE-GATT → Wi-Fi LAN → Bluetooth Classic. An
+         * The order mirrors [directRoute]'s `when` chain:
+         * Wi-Fi LAN → BLE-L2CAP → BLE-GATT → Bluetooth Classic. An
          * empty list means no usable route; the caller falls through
          * to the same "no route" terminal that [Action.Unavailable]
          * would render.
          */
         fun viableRoutes(peer: NearbyPeer): List<NearbyPeerRoute> =
             listOfNotNull(
+                lanRoute(peer),
                 bleL2capRoute(peer),
                 bleGattRoute(peer),
-                lanRoute(peer),
                 bluetoothRoute(peer),
             )
 
@@ -144,33 +143,18 @@ internal data class SendBootstrapPlan(
             val bleL2capRoute = bleL2capRoute(peer)
             val bleGattRoute = bleGattRoute(peer)
             val bluetoothRoute = bluetoothRoute(peer)
-            // BLE-first preference. BLE bootstraps bypass the AP entirely,
-            // so on Wi-Fi networks that block client-to-client traffic (AP
-            // isolation, vendor APF rules dropping peer ARP, dual-band
-            // band-steering that segregates clients onto different L2
-            // segments, etc.) BLE remains reachable while a same-subnet
-            // Wi-Fi LAN connect would EHOSTUNREACH out. Once the BLE
-            // initial control plane is up, the post-handshake bandwidth
-            // upgrade can still negotiate Wi-Fi Direct / Hotspot for the
-            // payload streaming, so the user-visible cost is just the
-            // brief BLE GATT/L2CAP setup latency.
             return when {
+                lanRoute != null -> lanRoute
                 bleL2capRoute != null -> bleL2capRoute
                 bleGattRoute != null -> {
                     rejectedCandidates += bleL2capRejection(peer)
                     bleGattRoute
                 }
 
-                lanRoute != null -> {
-                    rejectedCandidates += bleL2capRejection(peer)
-                    rejectedCandidates += bleGattRejection(peer)
-                    lanRoute
-                }
-
                 bluetoothRoute != null -> {
+                    rejectedCandidates += lanRejection(peer)
                     rejectedCandidates += bleL2capRejection(peer)
                     rejectedCandidates += bleGattRejection(peer)
-                    rejectedCandidates += lanRejection(peer)
                     bluetoothRoute
                 }
 

--- a/app/src/main/kotlin/dev/bluehouse/bada/send/SendBootstrapRetryPolicy.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/send/SendBootstrapRetryPolicy.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.send
+
+internal object SendBootstrapRetryPolicy {
+    private const val INITIAL_CONNECT_FAILED: String = "Initial connect failed:"
+    private const val INITIAL_HANDSHAKE_TIMED_OUT: String = "Initial handshake timed out after"
+
+    /**
+     * `true` when [reason] describes a failed initial-control route
+     * before the SecureChannel exists. The next-priority route may avoid
+     * these failures because stock receivers can publish both same-Wi-Fi
+     * LAN and BLE bootstrap surfaces while only one is actively accepting
+     * the Nearby stream.
+     *
+     * Failures after the secure channel is up intentionally fall through
+     * so the sender does not hide peer rejection, UKEY2 incompatibility,
+     * or payload-streaming errors behind a retry.
+     */
+    fun isRetryableBootstrapFailure(reason: String): Boolean =
+        reason.startsWith(INITIAL_CONNECT_FAILED) ||
+            reason.startsWith(INITIAL_HANDSHAKE_TIMED_OUT)
+}

--- a/app/src/test/kotlin/dev/bluehouse/bada/send/SendBootstrapPlanTest.kt
+++ b/app/src/test/kotlin/dev/bluehouse/bada/send/SendBootstrapPlanTest.kt
@@ -17,7 +17,7 @@ import java.net.InetAddress
 
 class SendBootstrapPlanTest {
     @Test
-    fun `BLE L2CAP route wins before Wi-Fi LAN and other BLE bootstrap routes`() {
+    fun `same Wi-Fi LAN route wins before BLE route when both are available`() {
         val peer =
             peer(
                 lanAddress = "192.168.1.20",
@@ -29,10 +29,24 @@ class SendBootstrapPlanTest {
 
         val plan = SendBootstrapPlan.resolve(peer = peer)
 
-        // BLE-first preference (see SendBootstrapPlan.directRoute): BLE
-        // bootstraps bypass the AP and stay reachable on Wi-Fi networks
-        // that drop peer-to-peer LAN frames, so we'd rather pay the brief
-        // BLE setup latency than fail with EHOSTUNREACH on isolated SSIDs.
+        assertTrue(plan.isConnectable)
+        assertEquals(
+            NearbyPeerRoute.Lan(InetAddress.getByName("192.168.1.20"), 7654),
+            (plan.action as SendBootstrapPlan.Action.Direct).route,
+        )
+    }
+
+    @Test
+    fun `BLE L2CAP route is used when no same Wi-Fi LAN route is available`() {
+        val peer =
+            peer(
+                bluetoothMac = "11:22:33:44:55:66",
+                bleAddress = "AA:BB:CC:DD:EE:FF",
+                blePsm = 0x1234,
+            )
+
+        val plan = SendBootstrapPlan.resolve(peer = peer)
+
         assertTrue(plan.isConnectable)
         assertEquals(
             NearbyPeerRoute.BleL2cap("AA:BB:CC:DD:EE:FF", 0x1234),
@@ -41,7 +55,7 @@ class SendBootstrapPlanTest {
     }
 
     @Test
-    fun `Wi-Fi LAN is used as a fallback when no BLE route is available`() {
+    fun `Wi-Fi LAN is used when no BLE route is available`() {
         val peer =
             peer(
                 lanAddress = "192.168.1.20",
@@ -54,6 +68,28 @@ class SendBootstrapPlanTest {
         assertEquals(
             NearbyPeerRoute.Lan(InetAddress.getByName("192.168.1.20"), 7654),
             (plan.action as SendBootstrapPlan.Action.Direct).route,
+        )
+    }
+
+    @Test
+    fun `viable routes prefer same Wi-Fi LAN before BLE bootstrap routes`() {
+        val peer =
+            peer(
+                lanAddress = "192.168.1.20",
+                lanPort = 7654,
+                bleAddress = "AA:BB:CC:DD:EE:FF",
+                blePsm = 0x1234,
+            )
+
+        val routes = SendBootstrapPlan.viableRoutes(peer)
+
+        assertEquals(
+            listOf(
+                NearbyPeerRoute.Lan(InetAddress.getByName("192.168.1.20"), 7654),
+                NearbyPeerRoute.BleL2cap("AA:BB:CC:DD:EE:FF", 0x1234),
+                NearbyPeerRoute.BleGatt("AA:BB:CC:DD:EE:FF"),
+            ),
+            routes,
         )
     }
 

--- a/app/src/test/kotlin/dev/bluehouse/bada/send/SendBootstrapRetryPolicyTest.kt
+++ b/app/src/test/kotlin/dev/bluehouse/bada/send/SendBootstrapRetryPolicyTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.send
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SendBootstrapRetryPolicyTest {
+    @Test
+    fun `initial connect failure is retryable on a lower-priority route`() {
+        assertTrue(
+            SendBootstrapRetryPolicy.isRetryableBootstrapFailure(
+                "Initial connect failed: failed to connect to /172.17.142.59 (port 53601)",
+            ),
+        )
+    }
+
+    @Test
+    fun `initial handshake timeout is retryable before secure channel exists`() {
+        assertTrue(
+            SendBootstrapRetryPolicy.isRetryableBootstrapFailure(
+                "Initial handshake timed out after 15000ms",
+            ),
+        )
+    }
+
+    @Test
+    fun `protocol and payload failures are not retried as bootstrap failures`() {
+        assertFalse(
+            SendBootstrapRetryPolicy.isRetryableBootstrapFailure(
+                "Expected ConnectionResponse, got PAYLOAD_TRANSFER",
+            ),
+        )
+        assertFalse(
+            SendBootstrapRetryPolicy.isRetryableBootstrapFailure(
+                "Payload stream failed: Broken pipe",
+            ),
+        )
+    }
+}

--- a/app/src/test/kotlin/dev/bluehouse/bada/ui/SendReceiveFragmentSourceTest.kt
+++ b/app/src/test/kotlin/dev/bluehouse/bada/ui/SendReceiveFragmentSourceTest.kt
@@ -21,7 +21,7 @@ class SendReceiveFragmentSourceTest {
     fun `send entry points do not hard gate on wi-fi`() {
         assertFalse(
             "The Send/Receive tab must not require Wi-Fi before launching the file picker; " +
-                "BLE-first routing needs to stay reachable even when Wi-Fi is off.",
+                "BLE routing needs to stay reachable even when Wi-Fi is off.",
             source.contains("ensureWifiEnabled"),
         )
         assertFalse(

--- a/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnection.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnection.kt
@@ -6,6 +6,7 @@
 package dev.bluehouse.bada.protocol.connection
 
 import dev.bluehouse.bada.protocol.medium.MediumRegistry
+import dev.bluehouse.bada.protocol.medium.NearbyMultiplexClientTransport
 import dev.bluehouse.bada.protocol.payload.PayloadProtocolException
 import dev.bluehouse.bada.protocol.transport.ConnectedTransport
 import dev.bluehouse.bada.protocol.transport.EndOfFrameStream
@@ -139,6 +140,12 @@ import java.security.SecureRandom
  *   after the initial transport is open. Closing the transport on this
  *   timeout prevents non-LAN virtual streams from leaving the sender UI
  *   stuck in the pairing state.
+ * @param useNearbyMultiplexInitialTransport When true, the legacy LAN
+ *   socket is first opened as a Nearby multiplex physical pipe and the
+ *   normal OfflineFrame protocol is sent over the accepted virtual
+ *   socket. Production sender paths should leave this disabled unless
+ *   discovery has positively identified a peer that expects multiplexed
+ *   TCP; stock mDNS receivers use the raw LAN shape.
  * @param remoteAcceptanceTimeoutMillis Maximum time to wait after the
  *   IntroductionFrame is sent for the receiver's encrypted
  *   ConnectionResponseFrame. Stock receivers normally answer only after
@@ -168,6 +175,7 @@ public class OutboundConnection private constructor(
     private val qrCodeHandshakeData: ByteArray? = null,
     private val connectTimeoutMillis: Int = DEFAULT_CONNECT_TIMEOUT_MILLIS,
     private val initialHandshakeTimeoutMillis: Long = DEFAULT_INITIAL_HANDSHAKE_TIMEOUT_MILLIS,
+    private val useNearbyMultiplexInitialTransport: Boolean = false,
     private val remoteAcceptanceTimeoutMillis: Long = DEFAULT_REMOTE_ACCEPTANCE_TIMEOUT_MILLIS,
     private val secureRandom: SecureRandom = SecureRandom(),
     private val mediumRegistry: MediumRegistry = MediumRegistry.DefaultWifiLan,
@@ -189,6 +197,7 @@ public class OutboundConnection private constructor(
         qrCodeHandshakeData: ByteArray? = null,
         connectTimeoutMillis: Int = DEFAULT_CONNECT_TIMEOUT_MILLIS,
         initialHandshakeTimeoutMillis: Long = DEFAULT_INITIAL_HANDSHAKE_TIMEOUT_MILLIS,
+        useNearbyMultiplexInitialTransport: Boolean = false,
         remoteAcceptanceTimeoutMillis: Long = DEFAULT_REMOTE_ACCEPTANCE_TIMEOUT_MILLIS,
         secureRandom: SecureRandom = SecureRandom(),
         mediumRegistry: MediumRegistry = MediumRegistry.DefaultWifiLan,
@@ -202,6 +211,7 @@ public class OutboundConnection private constructor(
         qrCodeHandshakeData = qrCodeHandshakeData,
         connectTimeoutMillis = connectTimeoutMillis,
         initialHandshakeTimeoutMillis = initialHandshakeTimeoutMillis,
+        useNearbyMultiplexInitialTransport = useNearbyMultiplexInitialTransport,
         remoteAcceptanceTimeoutMillis = remoteAcceptanceTimeoutMillis,
         secureRandom = secureRandom,
         mediumRegistry = mediumRegistry,
@@ -228,6 +238,7 @@ public class OutboundConnection private constructor(
         qrCodeHandshakeData = qrCodeHandshakeData,
         connectTimeoutMillis = connectTimeoutMillis,
         initialHandshakeTimeoutMillis = initialHandshakeTimeoutMillis,
+        useNearbyMultiplexInitialTransport = false,
         remoteAcceptanceTimeoutMillis = remoteAcceptanceTimeoutMillis,
         secureRandom = secureRandom,
         mediumRegistry = mediumRegistry,
@@ -457,7 +468,25 @@ public class OutboundConnection private constructor(
             // Samsung's UKEY2 server alarm. Best-effort: a misbehaving
             // SocketImpl that rejects this option is non-fatal.
             runCatching { socket.tcpNoDelay = true }
-            socket.asConnectedTransport()
+            val rawTransport = socket.asConnectedTransport()
+            if (!useNearbyMultiplexInitialTransport) {
+                return@withContext rawTransport
+            }
+            val multiplexTransport =
+                NearbyMultiplexClientTransport(
+                    physicalTransport = rawTransport,
+                    requireConnectionResponse = false,
+                    optimisticReadyDelayMillis = NEARBY_MULTIPLEX_OPTIMISTIC_READY_DELAY_MILLIS,
+                    logger = logger,
+                )
+            multiplexTransport.start()
+            val accepted = multiplexTransport.awaitReady(NEARBY_MULTIPLEX_READY_TIMEOUT_MILLIS)
+            if (!accepted) {
+                runCatching { multiplexTransport.close() }
+                throw java.io.IOException("Nearby multiplex socket was not accepted")
+            }
+            logger("step 0: Nearby multiplex virtual socket opened over WIFI_LAN")
+            multiplexTransport
         }
     }
 
@@ -570,6 +599,9 @@ public class OutboundConnection private constructor(
          * unreachable" failures within human attention span.
          */
         public const val DEFAULT_CONNECT_TIMEOUT_MILLIS: Int = 5000
+
+        private const val NEARBY_MULTIPLEX_READY_TIMEOUT_MILLIS: Long = 5_000L
+        private const val NEARBY_MULTIPLEX_OPTIMISTIC_READY_DELAY_MILLIS: Long = 900L
 
         /**
          * Default timeout for the unencrypted ConnectionRequest/UKEY2/

--- a/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnectionDriver.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnectionDriver.kt
@@ -123,34 +123,20 @@ internal class OutboundConnectionDriver(
     @Suppress("ReturnCount")
     suspend fun runLifecycle(): OutboundResult {
         mutableState.value = OutboundConnectionState.Handshaking
-        logger(
-            "step 1: initial transport open medium=${initialTransport.medium} " +
-                "endpointId=$endpointId endpointInfo.size=${endpointInfo.size}",
-        )
-        val transport = FramedConnection(initialTransport).also { framedConnection = it }
 
-        // Step 1: send unencrypted ConnectionRequest. BLE/GATT
-        // bootstraps still carry the legacy Wi-Fi LAN marker because
-        // stock Quick Share validates that shape before it dispatches
-        // the incoming connection. When a local Wi-Fi Direct provider
-        // is registered, advertise WFD in this opening request as well,
-        // then send a post-accept UPGRADE_PATH_REQUEST if the receiver
-        // does not proactively offer Wi-Fi Direct before payload
-        // streaming.
-        val advertisedMediums = advertisedMediumsForInitialTransport()
-        logger("step 1: advertising mediums=$advertisedMediums")
-        transport.sendFrame(
-            OutboundFrames
-                .connectionRequest(
-                    endpointId = endpointId,
-                    endpointInfo = endpointInfo,
-                    supportedMediums = advertisedMediums,
-                ).toByteArray(),
-        )
-        logger("step 1: sent ConnectionRequest, awaiting Ukey2ServerInit")
+        val preSecureTransport =
+            when (val upgrade = openPreSecureTransport()) {
+                is PreUkey2Negotiation.Ready -> upgrade.transport
+                is PreUkey2Negotiation.Failed -> {
+                    val reason = upgrade.reason
+                    mutableState.value = OutboundConnectionState.Failed(reason)
+                    return OutboundResult.Failed(reason)
+                }
+            }
+        logger("step 1: pre-secure active medium=${preSecureTransport.medium}")
 
         val (handshake, peerResponse) =
-            runInitialHandshakeWithTimeout(transport)
+            runInitialHandshakeWithTimeout(preSecureTransport.connection)
                 ?: return initialHandshakeTimedOut()
 
         // Step 3: send our unencrypted ConnectionResponse{ACCEPT}.
@@ -193,14 +179,16 @@ internal class OutboundConnectionDriver(
         logger("step 5: D2D keys derived, PIN=$pin")
 
         // Step 6: SecureChannel takes over.
-        val channel = SecureChannel(transport, sessionKeys, secureRandom).also { secureChannel = it }
+        val channel =
+            SecureChannel(preSecureTransport.connection, sessionKeys, secureRandom)
+                .also { secureChannel = it }
 
         // Step 7: if the receiver offers a higher-bandwidth medium,
         // adopt it before the Nearby Share payload negotiation begins.
         // Peers that stay on Wi-Fi LAN send the first sharing payload;
         // buffer that frame so the existing receive loop sees it.
         val negotiated =
-            when (val negotiation = negotiateBandwidthUpgrade(channel)) {
+            when (val negotiation = negotiateBandwidthUpgrade(channel, preSecureTransport.medium)) {
                 is BandwidthNegotiation.Ready -> negotiation
                 is BandwidthNegotiation.Failed -> {
                     logger("medium-upgrade: ${negotiation.reason}")
@@ -235,7 +223,10 @@ internal class OutboundConnectionDriver(
         // cancel() in that race would crash the peer with Broken pipe.
         onHandshakeComplete()
 
-        return if (requiresWifiDirectUpgradeForBle() && negotiated.medium != Medium.WIFI_DIRECT) {
+        val shouldRunBleWifiDirectLoop =
+            requiresWifiDirectUpgradeForBle(preSecureTransport.medium) &&
+                negotiated.medium != Medium.WIFI_DIRECT
+        return if (shouldRunBleWifiDirectLoop) {
             runBleWifiDirectReceiveLoop(
                 channel = negotiated.channel,
                 fsm = negotiationFsm,
@@ -246,23 +237,91 @@ internal class OutboundConnectionDriver(
         }
     }
 
+    private suspend fun openPreSecureTransport(): PreUkey2Negotiation {
+        logger(
+            "step 1: initial transport open medium=${initialTransport.medium} " +
+                "endpointId=$endpointId endpointInfo.size=${endpointInfo.size}",
+        )
+        val transport = FramedConnection(initialTransport).also { framedConnection = it }
+
+        // BLE/GATT bootstraps still carry the legacy Wi-Fi LAN marker because
+        // stock Quick Share validates that shape before it dispatches the
+        // incoming connection.
+        val advertisedMediums = advertisedMediumsForInitialTransport()
+        logger("step 1: advertising mediums=$advertisedMediums")
+        transport.sendFrame(
+            OutboundFrames
+                .connectionRequest(
+                    endpointId = endpointId,
+                    endpointInfo = endpointInfo,
+                    supportedMediums = advertisedMediums,
+                ).toByteArray(),
+        )
+        logger("step 1: sent ConnectionRequest, probing pre-UKEY2 upgrade")
+
+        return upgradePreUkey2IfOffered(transport)
+    }
+
+    private suspend fun upgradePreUkey2IfOffered(transport: FramedConnection): PreUkey2Negotiation {
+        if (!shouldProbePreUkey2Upgrade()) {
+            return PreUkey2Negotiation.Ready(PreSecureTransport(transport, initialTransport.medium))
+        }
+        logger("medium-upgrade: probing for pre-UKEY2 BLE upgrade offer")
+        return when (
+            val probe =
+                PreUkey2BandwidthUpgrade.receiveOfferProbe(
+                    framedConnection = transport,
+                    timeoutMillis = PRE_UKEY2_UPGRADE_OFFER_WAIT_TIMEOUT_MILLIS,
+                )
+        ) {
+            UpgradeOfferProbe.None -> {
+                logger("medium-upgrade: no pre-UKEY2 upgrade offer; continuing on ${initialTransport.medium}")
+                PreUkey2Negotiation.Ready(PreSecureTransport(transport, initialTransport.medium))
+            }
+            is UpgradeOfferProbe.Other ->
+                PreUkey2Negotiation.Failed(
+                    "Expected pre-UKEY2 upgrade offer, got ${probe.frame.describeFrameType()}",
+                )
+            is UpgradeOfferProbe.Offer ->
+                when (
+                    val upgraded =
+                        PreUkey2BandwidthUpgrade.runClientUpgradeFromOffer(
+                            oldTransport = transport,
+                            offer = probe.frame,
+                            mediumRegistry = mediumRegistry,
+                            endpointId = endpointId,
+                            logger = logger,
+                        )
+                ) {
+                    is PreUkey2UpgradeResult.Ready -> {
+                        framedConnection = upgraded.transport
+                        PreUkey2Negotiation.Ready(PreSecureTransport(upgraded.transport, upgraded.medium))
+                    }
+                    is PreUkey2UpgradeResult.Failed -> PreUkey2Negotiation.Failed(upgraded.reason)
+                }
+        }
+    }
+
     private fun advertisedMediumsForInitialTransport(): Set<Medium> {
         val supportedMediums =
             mediumRegistry.supportedMediumsForCurrentTransport(initialTransport.medium)
-        if (initialTransport.medium != Medium.BLE) return supportedMediums
+        if (!initialTransport.medium.isBleBased()) return supportedMediums
 
         return buildSet {
             add(Medium.WIFI_LAN)
-            add(Medium.BLE)
+            add(initialTransport.medium)
             if (Medium.WIFI_DIRECT in supportedMediums) {
                 add(Medium.WIFI_DIRECT)
             }
         }
     }
 
-    private suspend fun negotiateBandwidthUpgrade(channel: SecureChannel): BandwidthNegotiation {
+    private suspend fun negotiateBandwidthUpgrade(
+        channel: SecureChannel,
+        currentMedium: Medium,
+    ): BandwidthNegotiation {
         val initialWireFrames = mutableListOf<OfflineFrame>()
-        val requiresWifiDirect = requiresWifiDirectUpgradeForBle()
+        val requiresWifiDirect = requiresWifiDirectUpgradeForBle(currentMedium)
         val activeTransport =
             when (
                 val probe =
@@ -276,16 +335,16 @@ internal class OutboundConnectionDriver(
                             },
                     )
             ) {
-                UpgradeOfferProbe.None -> ActiveTransportChannel(channel, initialTransport.medium)
+                UpgradeOfferProbe.None -> ActiveTransportChannel(channel, currentMedium)
                 is UpgradeOfferProbe.Other -> {
                     initialWireFrames += probe.frame
-                    ActiveTransportChannel(channel, initialTransport.medium)
+                    ActiveTransportChannel(channel, currentMedium)
                 }
                 is UpgradeOfferProbe.Offer -> {
                     val transport =
                         BandwidthUpgradeOrchestrator.runClientUpgradeFromOffer(
                             oldChannel = channel,
-                            currentMedium = initialTransport.medium,
+                            currentMedium = currentMedium,
                             offer = probe.frame,
                             mediumRegistry = mediumRegistry,
                             endpointId = endpointId,
@@ -301,12 +360,20 @@ internal class OutboundConnectionDriver(
                     transport.also { secureChannel = it.channel }
                 }
             }
-        return BandwidthNegotiation.Ready(activeTransport.channel, activeTransport.medium, initialWireFrames)
+        return BandwidthNegotiation.Ready(
+            activeTransport.channel,
+            activeTransport.medium,
+            initialWireFrames,
+        )
     }
 
-    private fun requiresWifiDirectUpgradeForBle(): Boolean =
-        initialTransport.medium == Medium.BLE &&
+    private fun shouldProbePreUkey2Upgrade(): Boolean =
+        initialTransport.medium.isBleBased() &&
             Medium.WIFI_DIRECT in mediumRegistry.supportedMediumsForCurrentTransport(initialTransport.medium)
+
+    private fun requiresWifiDirectUpgradeForBle(currentMedium: Medium): Boolean =
+        currentMedium.isBleBased() &&
+            Medium.WIFI_DIRECT in mediumRegistry.supportedMediumsForCurrentTransport(currentMedium)
 
     /**
      * Tear down all owned resources. Safe to call multiple times; each
@@ -1527,6 +1594,7 @@ internal class OutboundConnectionDriver(
             v1.bandwidthUpgradeNegotiation.eventType == expected
 
     private companion object {
+        private const val PRE_UKEY2_UPGRADE_OFFER_WAIT_TIMEOUT_MILLIS: Long = 1_500L
         private const val BLE_WIFI_DIRECT_UPGRADE_TIMEOUT_MILLIS: Long = 12_000L
         private const val BLE_WIFI_DIRECT_POLL_DELAY_MILLIS: Long = 25L
 
@@ -1555,6 +1623,21 @@ internal class OutboundConnectionDriver(
         ) : BandwidthNegotiation
     }
 
+    private data class PreSecureTransport(
+        val connection: FramedConnection,
+        val medium: Medium,
+    )
+
+    private sealed interface PreUkey2Negotiation {
+        data class Ready(
+            val transport: PreSecureTransport,
+        ) : PreUkey2Negotiation
+
+        data class Failed(
+            val reason: String,
+        ) : PreUkey2Negotiation
+    }
+
     private sealed interface BleWifiDirectOutcome {
         data object Continue : BleWifiDirectOutcome
 
@@ -1575,4 +1658,6 @@ internal class OutboundConnectionDriver(
             val reason: String,
         ) : PayloadChannelSelection
     }
+
+    private fun Medium.isBleBased(): Boolean = this == Medium.BLE || this == Medium.BLE_L2CAP
 }

--- a/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnectionDriver.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnectionDriver.kt
@@ -246,7 +246,9 @@ internal class OutboundConnectionDriver(
 
         // BLE/GATT bootstraps still carry the legacy Wi-Fi LAN marker because
         // stock Quick Share validates that shape before it dispatches the
-        // incoming connection.
+        // incoming connection. Same-Wi-Fi LAN, even when the underlying TCP
+        // socket is Nearby-multiplexed, keeps the historical Wi-Fi-only
+        // request shape.
         val advertisedMediums = advertisedMediumsForInitialTransport()
         logger("step 1: advertising mediums=$advertisedMediums")
         transport.sendFrame(
@@ -305,14 +307,18 @@ internal class OutboundConnectionDriver(
     private fun advertisedMediumsForInitialTransport(): Set<Medium> {
         val supportedMediums =
             mediumRegistry.supportedMediumsForCurrentTransport(initialTransport.medium)
-        if (!initialTransport.medium.isBleBased()) return supportedMediums
-
-        return buildSet {
-            add(Medium.WIFI_LAN)
-            add(initialTransport.medium)
-            if (Medium.WIFI_DIRECT in supportedMediums) {
-                add(Medium.WIFI_DIRECT)
-            }
+        return when {
+            initialTransport.medium == Medium.WIFI_LAN ->
+                setOf(Medium.WIFI_LAN)
+            !initialTransport.medium.isBleBased() -> supportedMediums
+            else ->
+                buildSet {
+                    add(Medium.WIFI_LAN)
+                    add(initialTransport.medium)
+                    if (Medium.WIFI_DIRECT in supportedMediums) {
+                        add(Medium.WIFI_DIRECT)
+                    }
+                }
         }
     }
 
@@ -838,8 +844,13 @@ internal class OutboundConnectionDriver(
         logger("medium-upgrade: requested receiver Wi-Fi Direct upgrade before streaming payloads")
         logger("medium-upgrade: waiting for receiver Wi-Fi Direct offer before streaming payloads")
         return when (val probe = pollBleWifiDirectOffer(channel, BLE_WIFI_DIRECT_UPGRADE_TIMEOUT_MILLIS)) {
-            UpgradeOfferProbe.None ->
-                PayloadChannelSelection.Failed("Wi-Fi Direct upgrade was not offered before payload streaming")
+            UpgradeOfferProbe.None -> {
+                logger(
+                    "medium-upgrade: Wi-Fi Direct upgrade was not offered before payload streaming; " +
+                        "continuing on $currentMedium",
+                )
+                PayloadChannelSelection.Ready(channel, currentMedium)
+            }
             is UpgradeOfferProbe.Other ->
                 PayloadChannelSelection.Failed(
                     "Wi-Fi Direct upgrade was required before payload streaming, " +
@@ -1595,7 +1606,7 @@ internal class OutboundConnectionDriver(
 
     private companion object {
         private const val PRE_UKEY2_UPGRADE_OFFER_WAIT_TIMEOUT_MILLIS: Long = 1_500L
-        private const val BLE_WIFI_DIRECT_UPGRADE_TIMEOUT_MILLIS: Long = 12_000L
+        private const val BLE_WIFI_DIRECT_UPGRADE_TIMEOUT_MILLIS: Long = 3_000L
         private const val BLE_WIFI_DIRECT_POLL_DELAY_MILLIS: Long = 25L
 
         /**

--- a/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/OutboundFrames.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/OutboundFrames.kt
@@ -14,6 +14,7 @@ import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.Offl
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OsInfo
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.V1Frame
 import com.google.protobuf.ByteString
+import dev.bluehouse.bada.protocol.endpoint.EndpointInfo
 import dev.bluehouse.bada.protocol.medium.Medium
 
 /**
@@ -73,13 +74,14 @@ internal object OutboundFrames {
         //     — PROTOCOL.md documents stock Android emitting KEEP_ALIVE
         //     every 10 seconds; see KEEP_ALIVE_INTERVAL_MILLIS for the
         //     timeout rationale.
-        //   * endpoint_name is a legacy string field; some forks (older
-        //     Samsung Quick Share) still inspect it. Setting it to the
-        //     empty string keeps modern peers happy and gives legacy peers
-        //     a defined value to read.
+        //   * endpoint_name is a legacy string field; some forks still
+        //     inspect it before parsing endpoint_info. Mirror the visible
+        //     EndpointInfo name when present, and use an empty string only
+        //     for hidden or malformed descriptors.
         //
         // Sort the proto-side enum values so the wire encoding is
         // deterministic for tests and for KAT-style regression detection.
+        val endpointName = legacyEndpointName(endpointInfo)
         val mediumProtoValues =
             supportedMediums
                 .map { it.toConnectionRequestMedium() }
@@ -88,7 +90,7 @@ internal object OutboundFrames {
             ConnectionRequestFrame
                 .newBuilder()
                 .setEndpointId(endpointId)
-                .setEndpointName("")
+                .setEndpointName(endpointName)
                 .setEndpointInfo(ByteString.copyFrom(endpointInfo))
                 .setNonce(nonce)
                 .setMediumMetadata(defaultMediumMetadata(supportedMediums))
@@ -252,5 +254,10 @@ internal object OutboundFrames {
                     .setConnectionResponse(response)
                     .build(),
             ).build()
+    }
+
+    private fun legacyEndpointName(endpointInfo: ByteArray): String {
+        val parsed = EndpointInfo.parse(endpointInfo)
+        return parsed?.deviceName.orEmpty()
     }
 }

--- a/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/PreUkey2BandwidthUpgrade.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/PreUkey2BandwidthUpgrade.kt
@@ -1,0 +1,265 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.protocol.connection
+
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.BandwidthUpgradeNegotiationFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.V1Frame
+import dev.bluehouse.bada.protocol.medium.Medium
+import dev.bluehouse.bada.protocol.medium.MediumRegistry
+import dev.bluehouse.bada.protocol.medium.UpgradePathCredentials
+import dev.bluehouse.bada.protocol.medium.UpgradedTransport
+import dev.bluehouse.bada.protocol.medium.asFramedConnection
+import dev.bluehouse.bada.protocol.transport.FramedConnection
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * Raw bandwidth-upgrade helper for receivers that offer a higher
+ * bandwidth transport before UKEY2 has started.
+ *
+ * The normal [BandwidthUpgradeOrchestrator] runs after SecureChannel is
+ * established. Stock Galaxy receivers can instead send
+ * `UPGRADE_PATH_AVAILABLE` on the BLE bootstrap channel immediately
+ * after `ConnectionRequest`; this helper accepts that raw offer and
+ * returns the upgraded framed transport so UKEY2 can begin there.
+ */
+internal object PreUkey2BandwidthUpgrade {
+    suspend fun receiveOfferProbe(
+        framedConnection: FramedConnection,
+        timeoutMillis: Long,
+    ): UpgradeOfferProbe =
+        withTimeoutOrNull(timeoutMillis) {
+            while (true) {
+                if (framedConnection.hasBufferedInput()) {
+                    val frame = parseRawOfflineFrame(framedConnection, "pre-UKEY2 upgrade probe")
+                    return@withTimeoutOrNull if (
+                        frame.isBandwidthUpgradeEvent(
+                            BandwidthUpgradeNegotiationFrame.EventType.UPGRADE_PATH_AVAILABLE,
+                        )
+                    ) {
+                        UpgradeOfferProbe.Offer(frame)
+                    } else {
+                        UpgradeOfferProbe.Other(frame)
+                    }
+                }
+                delay(POLL_DELAY_MILLIS)
+            }
+            error("unreachable")
+        } ?: UpgradeOfferProbe.None
+
+    @Suppress("ReturnCount")
+    suspend fun runClientUpgradeFromOffer(
+        oldTransport: FramedConnection,
+        offer: OfflineFrame,
+        mediumRegistry: MediumRegistry,
+        endpointId: String,
+        logger: (String) -> Unit,
+    ): PreUkey2UpgradeResult {
+        val credentials =
+            decodeOfferCredentials(offer) ?: run {
+                val reason = "Malformed pre-UKEY2 upgrade offer"
+                logger("medium-upgrade: $reason")
+                return PreUkey2UpgradeResult.Failed(reason)
+            }
+        val expectsClientIntroductionAck =
+            offer.v1.bandwidthUpgradeNegotiation.upgradePathInfo.supportsClientIntroductionAck
+        val provider = mediumRegistry.providerFor(credentials.medium)
+        if (provider == null) {
+            val reason = "No provider for pre-UKEY2 upgrade medium ${credentials.medium}"
+            logger("medium-upgrade: $reason")
+            oldTransport.sendFrame(BandwidthUpgradeFrames.upgradeFailure(credentials.medium).toByteArray())
+            return PreUkey2UpgradeResult.Failed(reason)
+        }
+
+        val transport =
+            withTimeoutOrNull(UPGRADE_TIMEOUT_MILLIS) {
+                provider.adoptUpgrade(credentials)
+            }
+        if (transport == null) {
+            val reason = "Pre-UKEY2 adopt failed for ${credentials.medium}"
+            logger("medium-upgrade: $reason")
+            provider.cancelPendingUpgrade()
+            oldTransport.sendFrame(BandwidthUpgradeFrames.upgradeFailure(credentials.medium).toByteArray())
+            return PreUkey2UpgradeResult.Failed(reason)
+        }
+
+        return runCatching {
+            completeClientUpgrade(
+                oldTransport = oldTransport,
+                transport = transport,
+                credentials = credentials,
+                endpointId = endpointId,
+                expectsClientIntroductionAck = expectsClientIntroductionAck,
+                logger = logger,
+            )
+        }.getOrElse { failure ->
+            val reason =
+                "Pre-UKEY2 upgrade to ${credentials.medium} failed: " +
+                    (failure.message ?: failure::class.simpleName)
+            logger("medium-upgrade: $reason")
+            transport.close()
+            provider.cancelPendingUpgrade()
+            PreUkey2UpgradeResult.Failed(reason)
+        }
+    }
+
+    private suspend fun completeClientUpgrade(
+        oldTransport: FramedConnection,
+        transport: UpgradedTransport,
+        credentials: UpgradePathCredentials,
+        endpointId: String,
+        expectsClientIntroductionAck: Boolean,
+        logger: (String) -> Unit,
+    ): PreUkey2UpgradeResult.Ready {
+        val newFramedConnection = transport.asFramedConnection()
+        newFramedConnection.sendFrame(BandwidthUpgradeFrames.clientIntroduction(endpointId).toByteArray())
+        if (expectsClientIntroductionAck) {
+            receiveRawUpgradeFrame(
+                framedConnection = newFramedConnection,
+                expected = BandwidthUpgradeNegotiationFrame.EventType.CLIENT_INTRODUCTION_ACK,
+                stage = "pre-UKEY2 client raw introduction ack",
+            )
+            logger("medium-upgrade: pre-UKEY2 client received raw CLIENT_INTRODUCTION_ACK")
+        }
+        finishPriorChannel(oldTransport, logger)
+        logger("medium-upgrade: pre-UKEY2 client completed ${credentials.medium}")
+        return PreUkey2UpgradeResult.Ready(newFramedConnection, credentials.medium)
+    }
+
+    private suspend fun finishPriorChannel(
+        oldTransport: FramedConnection,
+        logger: (String) -> Unit,
+    ) {
+        runCatching { oldTransport.sendFrame(BandwidthUpgradeFrames.lastWriteToPriorChannel().toByteArray()) }
+            .onFailure {
+                logger(
+                    "medium-upgrade: failed pre-UKEY2 LAST_WRITE on prior channel: " +
+                        (it.message ?: it::class.simpleName),
+                )
+            }
+        val sawPeerLastWrite =
+            receiveOptionalRawUpgradeEvent(
+                framedConnection = oldTransport,
+                expected = BandwidthUpgradeNegotiationFrame.EventType.LAST_WRITE_TO_PRIOR_CHANNEL,
+                stage = "pre-UKEY2 peer last-write",
+                logger = logger,
+            )
+        if (sawPeerLastWrite) {
+            runCatching { oldTransport.sendFrame(BandwidthUpgradeFrames.safeToClosePriorChannel().toByteArray()) }
+                .onFailure {
+                    logger(
+                        "medium-upgrade: failed pre-UKEY2 SAFE_TO_CLOSE on prior channel: " +
+                            (it.message ?: it::class.simpleName),
+                    )
+                }
+            receiveOptionalRawUpgradeEvent(
+                framedConnection = oldTransport,
+                expected = BandwidthUpgradeNegotiationFrame.EventType.SAFE_TO_CLOSE_PRIOR_CHANNEL,
+                stage = "pre-UKEY2 peer safe-to-close",
+                logger = logger,
+            )
+        }
+        runCatching { oldTransport.close() }
+    }
+
+    private suspend fun receiveOptionalRawUpgradeEvent(
+        framedConnection: FramedConnection,
+        expected: BandwidthUpgradeNegotiationFrame.EventType,
+        stage: String,
+        logger: (String) -> Unit,
+    ): Boolean =
+        withTimeoutOrNull(PRIOR_CHANNEL_DRAIN_MILLIS) {
+            while (true) {
+                if (framedConnection.hasBufferedInput()) {
+                    val frame = parseRawOfflineFrame(framedConnection, stage)
+                    if (frame.isBandwidthUpgradeEvent(expected)) {
+                        return@withTimeoutOrNull true
+                    }
+                    logger(
+                        "medium-upgrade: ignored ${frame.describeUpgradeEvent()} " +
+                            "during $stage",
+                    )
+                }
+                delay(POLL_DELAY_MILLIS)
+            }
+            error("unreachable")
+        } == true
+
+    private suspend fun receiveRawUpgradeFrame(
+        framedConnection: FramedConnection,
+        expected: BandwidthUpgradeNegotiationFrame.EventType,
+        stage: String,
+    ): OfflineFrame {
+        val frame =
+            withTimeoutOrNull(UPGRADE_TIMEOUT_MILLIS) {
+                while (true) {
+                    if (framedConnection.hasBufferedInput()) {
+                        return@withTimeoutOrNull parseRawOfflineFrame(framedConnection, stage)
+                    }
+                    delay(POLL_DELAY_MILLIS)
+                }
+                error("unreachable")
+            } ?: error("Timed out waiting for $stage")
+        checkUpgradeEvent(frame = frame, expected = expected, stage = stage)
+        return frame
+    }
+
+    private suspend fun parseRawOfflineFrame(
+        framedConnection: FramedConnection,
+        stage: String,
+    ): OfflineFrame =
+        try {
+            OfflineFrame.parseFrom(framedConnection.receiveFrame())
+        } catch (e: com.google.protobuf.InvalidProtocolBufferException) {
+            error("Malformed raw OfflineFrame during $stage: ${e.message}")
+        }
+
+    private fun decodeOfferCredentials(frame: OfflineFrame): UpgradePathCredentials? {
+        if (!frame.isBandwidthUpgradeEvent(BandwidthUpgradeNegotiationFrame.EventType.UPGRADE_PATH_AVAILABLE)) {
+            return null
+        }
+        return BandwidthUpgradeFrames.decodeCredentials(frame.v1.bandwidthUpgradeNegotiation.upgradePathInfo)
+    }
+
+    private fun checkUpgradeEvent(
+        frame: OfflineFrame,
+        expected: BandwidthUpgradeNegotiationFrame.EventType,
+        stage: String,
+    ) {
+        if (!frame.isBandwidthUpgradeEvent(expected)) {
+            val actual = frame.describeUpgradeEvent()
+            error("Expected $expected during $stage, got $actual")
+        }
+    }
+
+    private fun OfflineFrame.describeUpgradeEvent(): String =
+        if (hasV1() && v1.type == V1Frame.FrameType.BANDWIDTH_UPGRADE_NEGOTIATION) {
+            v1.bandwidthUpgradeNegotiation.eventType.toString()
+        } else {
+            v1.type.toString()
+        }
+
+    private fun OfflineFrame.isBandwidthUpgradeEvent(expected: BandwidthUpgradeNegotiationFrame.EventType): Boolean =
+        hasV1() &&
+            v1.type == V1Frame.FrameType.BANDWIDTH_UPGRADE_NEGOTIATION &&
+            v1.bandwidthUpgradeNegotiation.eventType == expected
+
+    private const val UPGRADE_TIMEOUT_MILLIS: Long = 30_000L
+    private const val PRIOR_CHANNEL_DRAIN_MILLIS: Long = 500L
+    private const val POLL_DELAY_MILLIS: Long = 10L
+}
+
+internal sealed interface PreUkey2UpgradeResult {
+    data class Ready(
+        val transport: FramedConnection,
+        val medium: Medium,
+    ) : PreUkey2UpgradeResult
+
+    data class Failed(
+        val reason: String,
+    ) : PreUkey2UpgradeResult
+}

--- a/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/medium/NearbyMultiplexClientTransport.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/medium/NearbyMultiplexClientTransport.kt
@@ -1,0 +1,528 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+@file:Suppress("MagicNumber", "TooGenericExceptionCaught")
+
+package dev.bluehouse.bada.protocol.medium
+
+import com.google.location.nearby.mediums.proto.MultiplexFramesProto
+import dev.bluehouse.bada.protocol.transport.ConnectedTransport
+import dev.bluehouse.bada.protocol.transport.EndOfFrameStream
+import dev.bluehouse.bada.protocol.transport.FramedConnection
+import dev.bluehouse.bada.protocol.transport.OversizedFrameException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.withTimeoutOrNull
+import java.io.EOFException
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import java.security.SecureRandom
+
+/**
+ * Sender-side wrapper for Nearby's multiplex socket layer.
+ *
+ * Stock Quick Share may treat the TCP connection discovered through mDNS as
+ * only the physical pipe. In that mode the peer waits for a Multiplex
+ * CONNECTION_REQUEST first, then exposes DATA_FRAME payloads as the normal
+ * OfflineFrame byte stream.
+ */
+internal class NearbyMultiplexClientTransport(
+    private val physicalTransport: ConnectedTransport,
+    private val salt: String = randomMultiplexSalt(),
+    private val requireConnectionResponse: Boolean = true,
+    private val optimisticReadyDelayMillis: Long = 0L,
+    private val logger: (String) -> Unit = {},
+) : ConnectedTransport {
+    private val input = PipedInputStream(INPUT_PIPE_SIZE)
+    private val inputWriter = PipedOutputStream(input)
+    private val ready = CompletableDeferred<Boolean>()
+    private val writeLock = Any()
+    private val saltedHash: ByteArray = NearbyMultiplexFrames.saltedServiceIdHash(salt = salt)
+
+    @Volatile
+    private var closed: Boolean = false
+
+    override val medium: Medium = physicalTransport.medium
+
+    override val inputStream: InputStream = input
+
+    override val outputStream: OutputStream =
+        object : OutputStream() {
+            override fun write(b: Int) {
+                write(byteArrayOf(b.toByte()))
+            }
+
+            override fun write(
+                b: ByteArray,
+                off: Int,
+                len: Int,
+            ) {
+                if (len == 0) return
+                sendPhysicalFrame(
+                    NearbyMultiplexFrames.encodeDataFrame(
+                        saltedServiceIdHash = saltedHash,
+                        data = b.copyOfRange(off, off + len),
+                    ),
+                )
+            }
+
+            override fun flush() {
+                physicalTransport.outputStream.flush()
+            }
+
+            override fun close() {
+                this@NearbyMultiplexClientTransport.close()
+            }
+        }
+
+    fun start() {
+        Thread({ runPump() }, "bada-nearby-multiplex-client").apply {
+            isDaemon = true
+            start()
+        }
+    }
+
+    suspend fun awaitReady(timeoutMillis: Long): Boolean = withTimeoutOrNull(timeoutMillis) { ready.await() } == true
+
+    @Synchronized
+    override fun close() {
+        if (closed) return
+        closed = true
+        if (!ready.isCompleted) ready.complete(false)
+        runCatching {
+            sendPhysicalFrame(
+                NearbyMultiplexFrames.encodeDisconnectionFrame(
+                    saltedServiceIdHash = saltedHash,
+                    serviceIdHashSalt = salt,
+                ),
+            )
+        }
+        runCatching { inputWriter.close() }
+        runCatching { input.close() }
+        runCatching { physicalTransport.close() }
+    }
+
+    private fun runPump() {
+        try {
+            sendConnectionRequest()
+            if (!requireConnectionResponse && !ready.isCompleted) {
+                completeOptimisticReadyAfterDelay()
+            }
+            while (!closed) {
+                val frameBytes = physicalTransport.inputStream.readLengthPrefixedPayload()
+                handleMultiplexFrame(frameBytes)
+            }
+        } catch (_: EndOfFrameStream) {
+            close()
+        } catch (_: EOFException) {
+            close()
+        } catch (io: IOException) {
+            if (!closed) logger("nearby-multiplex: client pump failed: ${io.message ?: io::class.simpleName}")
+            close()
+        } catch (t: Throwable) {
+            if (!closed) logger("nearby-multiplex: client pump crashed: ${t.message ?: t::class.simpleName}")
+            close()
+        }
+    }
+
+    private fun sendConnectionRequest() {
+        sendPhysicalFrame(
+            NearbyMultiplexFrames.encodeConnectionRequestFrame(
+                saltedServiceIdHash = saltedHash,
+                serviceIdHashSalt = salt,
+            ),
+        )
+    }
+
+    private fun completeOptimisticReadyAfterDelay() {
+        if (optimisticReadyDelayMillis <= 0L) {
+            ready.complete(true)
+            logger("nearby-multiplex: optimistic virtual socket opened before CONNECTION_RESPONSE")
+            return
+        }
+        Thread(
+            {
+                runCatching { Thread.sleep(optimisticReadyDelayMillis) }
+                if (!closed && !ready.isCompleted) {
+                    ready.complete(true)
+                    logger("nearby-multiplex: optimistic virtual socket opened after receiver grace")
+                }
+            },
+            "bada-nearby-multiplex-ready",
+        ).apply {
+            isDaemon = true
+            start()
+        }
+    }
+
+    private fun handleMultiplexFrame(frameBytes: ByteArray) {
+        val frame =
+            NearbyMultiplexFrames.parseFrame(frameBytes) ?: run {
+                logger("nearby-multiplex: discarded invalid client frame")
+                close()
+                return
+            }
+        if (
+            !frame.header.saltedServiceIdHash
+                .toByteArray()
+                .contentEquals(saltedHash)
+        ) {
+            logger("nearby-multiplex: discarded client frame for unexpected service hash")
+            return
+        }
+        when (frame.frameType) {
+            MultiplexFramesProto.MultiplexFrame.MultiplexFrameType.CONTROL_FRAME ->
+                handleControlFrame(frame)
+            MultiplexFramesProto.MultiplexFrame.MultiplexFrameType.DATA_FRAME ->
+                feedIncoming(frame.dataFrame.data.toByteArray())
+            else -> Unit
+        }
+    }
+
+    private fun handleControlFrame(frame: MultiplexFramesProto.MultiplexFrame) {
+        when (frame.controlFrame.controlFrameType) {
+            MultiplexFramesProto.MultiplexControlFrame.MultiplexControlFrameType.CONNECTION_RESPONSE -> {
+                val accepted =
+                    frame.controlFrame.connectionResponseFrame.connectionResponseCode ==
+                        MultiplexFramesProto.ConnectionResponseFrame.ConnectionResponseCode.CONNECTION_ACCEPTED
+                if (!ready.isCompleted) ready.complete(accepted)
+                if (!accepted) {
+                    logger("nearby-multiplex: peer rejected virtual socket")
+                    close()
+                }
+            }
+            MultiplexFramesProto.MultiplexControlFrame.MultiplexControlFrameType.DISCONNECTION -> close()
+            else -> Unit
+        }
+    }
+
+    private fun feedIncoming(bytes: ByteArray) {
+        if (closed) return
+        try {
+            inputWriter.write(bytes)
+            inputWriter.flush()
+        } catch (io: IOException) {
+            logger("nearby-multiplex: client virtual input closed: ${io.message ?: io::class.simpleName}")
+            close()
+        }
+    }
+
+    private fun sendPhysicalFrame(frameBytes: ByteArray) {
+        synchronized(writeLock) {
+            physicalTransport.outputStream.write(NearbyMultiplexFrames.encodeLengthPrefixed(frameBytes))
+            physicalTransport.outputStream.flush()
+        }
+    }
+
+    private companion object {
+        private const val INPUT_PIPE_SIZE: Int = 1024 * 1024
+    }
+}
+
+/**
+ * Receiver-side probe for a Wi-Fi LAN physical socket.
+ *
+ * It consumes exactly one length-prefixed physical frame. If that frame is a
+ * valid Nearby multiplex CONNECTION_REQUEST, the returned transport is the
+ * accepted virtual socket. Otherwise the original bytes are preserved and the
+ * returned transport behaves like the raw socket that older Bada/NearDrop
+ * peers expect.
+ */
+internal fun probeNearbyMultiplexServerTransport(
+    physicalTransport: ConnectedTransport,
+    logger: (String) -> Unit = {},
+): ConnectedTransport {
+    val firstFrame = physicalTransport.inputStream.readLengthPrefixedFrame()
+    val parsed = NearbyMultiplexFrames.parseFrame(firstFrame.payload)
+    val control = parsed?.controlFrame
+    if (
+        parsed?.frameType != MultiplexFramesProto.MultiplexFrame.MultiplexFrameType.CONTROL_FRAME ||
+        control?.controlFrameType !=
+        MultiplexFramesProto.MultiplexControlFrame.MultiplexControlFrameType.CONNECTION_REQUEST
+    ) {
+        logger("nearby-multiplex: LAN socket using raw Nearby stream")
+        return PrebufferedConnectedTransport(physicalTransport, firstFrame.originalBytes)
+    }
+
+    val salt = parsed.header.serviceIdHashSalt
+    val saltedHash = parsed.header.saltedServiceIdHash.toByteArray()
+    val expected = NearbyMultiplexFrames.saltedServiceIdHash(salt = salt)
+    val response =
+        if (saltedHash.contentEquals(expected)) {
+            MultiplexFramesProto.ConnectionResponseFrame.ConnectionResponseCode.CONNECTION_ACCEPTED
+        } else {
+            MultiplexFramesProto.ConnectionResponseFrame.ConnectionResponseCode.NOT_LISTENING
+        }
+    physicalTransport.outputStream.write(
+        NearbyMultiplexFrames.encodeLengthPrefixed(
+            NearbyMultiplexFrames.encodeConnectionResponseFrame(
+                saltedServiceIdHash = saltedHash,
+                serviceIdHashSalt = salt,
+                responseCode = response,
+            ),
+        ),
+    )
+    physicalTransport.outputStream.flush()
+    if (response != MultiplexFramesProto.ConnectionResponseFrame.ConnectionResponseCode.CONNECTION_ACCEPTED) {
+        throw IOException("Nearby multiplex service hash did not match")
+    }
+
+    logger("nearby-multiplex: LAN socket using multiplex stream")
+    return NearbyMultiplexServerTransport(
+        physicalTransport = physicalTransport,
+        saltedHash = saltedHash,
+        salt = salt,
+        logger = logger,
+    ).also { it.start() }
+}
+
+private class NearbyMultiplexServerTransport(
+    private val physicalTransport: ConnectedTransport,
+    private val saltedHash: ByteArray,
+    private val salt: String,
+    private val logger: (String) -> Unit,
+) : ConnectedTransport {
+    private val input = PipedInputStream(INPUT_PIPE_SIZE)
+    private val inputWriter = PipedOutputStream(input)
+    private val writeLock = Any()
+
+    @Volatile
+    private var closed: Boolean = false
+
+    override val medium: Medium = physicalTransport.medium
+
+    override val inputStream: InputStream = input
+
+    override val outputStream: OutputStream =
+        object : OutputStream() {
+            override fun write(b: Int) {
+                write(byteArrayOf(b.toByte()))
+            }
+
+            override fun write(
+                b: ByteArray,
+                off: Int,
+                len: Int,
+            ) {
+                if (len == 0) return
+                sendPhysicalFrame(
+                    NearbyMultiplexFrames.encodeDataFrame(
+                        saltedServiceIdHash = saltedHash,
+                        data = b.copyOfRange(off, off + len),
+                    ),
+                )
+            }
+
+            override fun flush() {
+                physicalTransport.outputStream.flush()
+            }
+
+            override fun close() {
+                this@NearbyMultiplexServerTransport.close()
+            }
+        }
+
+    fun start() {
+        Thread({ runPump() }, "bada-nearby-multiplex-server").apply {
+            isDaemon = true
+            start()
+        }
+    }
+
+    @Synchronized
+    override fun close() {
+        if (closed) return
+        closed = true
+        runCatching {
+            sendPhysicalFrame(
+                NearbyMultiplexFrames.encodeDisconnectionFrame(
+                    saltedServiceIdHash = saltedHash,
+                    serviceIdHashSalt = salt,
+                ),
+            )
+        }
+        runCatching { inputWriter.close() }
+        runCatching { input.close() }
+        runCatching { physicalTransport.close() }
+    }
+
+    private fun runPump() {
+        try {
+            while (!closed) {
+                handleMultiplexFrame(physicalTransport.inputStream.readLengthPrefixedPayload())
+            }
+        } catch (_: EndOfFrameStream) {
+            close()
+        } catch (_: EOFException) {
+            close()
+        } catch (io: IOException) {
+            if (!closed) logger("nearby-multiplex: server pump failed: ${io.message ?: io::class.simpleName}")
+            close()
+        } catch (t: Throwable) {
+            if (!closed) logger("nearby-multiplex: server pump crashed: ${t.message ?: t::class.simpleName}")
+            close()
+        }
+    }
+
+    private fun handleMultiplexFrame(frameBytes: ByteArray) {
+        val frame =
+            NearbyMultiplexFrames.parseFrame(frameBytes) ?: run {
+                logger("nearby-multiplex: discarded invalid server frame")
+                close()
+                return
+            }
+        if (
+            !frame.header.saltedServiceIdHash
+                .toByteArray()
+                .contentEquals(saltedHash)
+        ) {
+            logger("nearby-multiplex: discarded server frame for unexpected service hash")
+            return
+        }
+        when (frame.frameType) {
+            MultiplexFramesProto.MultiplexFrame.MultiplexFrameType.CONTROL_FRAME ->
+                if (
+                    frame.controlFrame.controlFrameType ==
+                    MultiplexFramesProto.MultiplexControlFrame.MultiplexControlFrameType.DISCONNECTION
+                ) {
+                    close()
+                }
+            MultiplexFramesProto.MultiplexFrame.MultiplexFrameType.DATA_FRAME ->
+                feedIncoming(frame.dataFrame.data.toByteArray())
+            else -> Unit
+        }
+    }
+
+    private fun feedIncoming(bytes: ByteArray) {
+        if (closed) return
+        try {
+            inputWriter.write(bytes)
+            inputWriter.flush()
+        } catch (io: IOException) {
+            logger("nearby-multiplex: server virtual input closed: ${io.message ?: io::class.simpleName}")
+            close()
+        }
+    }
+
+    private fun sendPhysicalFrame(frameBytes: ByteArray) {
+        synchronized(writeLock) {
+            physicalTransport.outputStream.write(NearbyMultiplexFrames.encodeLengthPrefixed(frameBytes))
+            physicalTransport.outputStream.flush()
+        }
+    }
+
+    private companion object {
+        private const val INPUT_PIPE_SIZE: Int = 1024 * 1024
+    }
+}
+
+private class PrebufferedConnectedTransport(
+    private val physicalTransport: ConnectedTransport,
+    prebufferedBytes: ByteArray,
+) : ConnectedTransport {
+    override val medium: Medium = physicalTransport.medium
+
+    override val inputStream: InputStream = PrebufferedInputStream(prebufferedBytes, physicalTransport.inputStream)
+
+    override val outputStream: OutputStream = physicalTransport.outputStream
+
+    override fun close() {
+        physicalTransport.close()
+    }
+}
+
+private class PrebufferedInputStream(
+    private val prebufferedBytes: ByteArray,
+    private val delegate: InputStream,
+) : InputStream() {
+    private var offset: Int = 0
+
+    override fun read(): Int {
+        if (offset < prebufferedBytes.size) {
+            return prebufferedBytes[offset++].toInt() and BYTE_MASK
+        }
+        return delegate.read()
+    }
+
+    override fun read(
+        b: ByteArray,
+        off: Int,
+        len: Int,
+    ): Int {
+        if (len == 0) return 0
+        return if (offset >= prebufferedBytes.size) {
+            delegate.read(b, off, len)
+        } else {
+            val count = minOf(len, prebufferedBytes.size - offset)
+            prebufferedBytes.copyInto(b, destinationOffset = off, startIndex = offset, endIndex = offset + count)
+            offset += count
+            count
+        }
+    }
+
+    override fun available(): Int = (prebufferedBytes.size - offset) + delegate.available()
+
+    override fun close() {
+        delegate.close()
+    }
+
+    private companion object {
+        private const val BYTE_MASK: Int = 0xFF
+    }
+}
+
+private data class LengthPrefixedFrame(
+    val payload: ByteArray,
+    val originalBytes: ByteArray,
+)
+
+private fun InputStream.readLengthPrefixedPayload(): ByteArray = readLengthPrefixedFrame().payload
+
+private fun InputStream.readLengthPrefixedFrame(): LengthPrefixedFrame {
+    val header = readHeaderBytes()
+    val length = NearbyMultiplexFrames.decodeLength(header) ?: throw EOFException("missing length prefix")
+    if (length <= 0 || length >= FramedConnection.SANE_FRAME_LENGTH) {
+        throw OversizedFrameException(length)
+    }
+    val payload = readExactly(length)
+    return LengthPrefixedFrame(payload = payload, originalBytes = header + payload)
+}
+
+private fun InputStream.readHeaderBytes(): ByteArray {
+    val header = ByteArray(NearbyMultiplexFrames.LENGTH_PREFIX_BYTES)
+    var read = 0
+    while (read < header.size) {
+        val n = read(header, read, header.size - read)
+        if (n < 0) {
+            if (read == 0) throw EndOfFrameStream()
+            throw EOFException("Stream closed mid-header after $read of ${header.size} bytes")
+        }
+        read += n
+    }
+    return header
+}
+
+private fun InputStream.readExactly(length: Int): ByteArray {
+    val buffer = ByteArray(length)
+    var read = 0
+    while (read < length) {
+        val n = read(buffer, read, length - read)
+        if (n < 0) {
+            throw EOFException("Stream closed mid-frame after $read of $length payload bytes")
+        }
+        read += n
+    }
+    return buffer
+}
+
+private fun randomMultiplexSalt(): String {
+    val bytes = ByteArray(SALT_BYTES)
+    SecureRandom().nextBytes(bytes)
+    return bytes.joinToString("") { "%02x".format(it) }
+}
+
+private const val SALT_BYTES: Int = 8

--- a/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/server/TcpReceiverServer.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/server/TcpReceiverServer.kt
@@ -7,9 +7,12 @@ package dev.bluehouse.bada.protocol.server
 
 import dev.bluehouse.bada.protocol.connection.InboundConnection
 import dev.bluehouse.bada.protocol.connection.InboundResult
+import dev.bluehouse.bada.protocol.medium.Medium
 import dev.bluehouse.bada.protocol.medium.MediumRegistry
+import dev.bluehouse.bada.protocol.medium.probeNearbyMultiplexServerTransport
 import dev.bluehouse.bada.protocol.payload.FileDestinationFactory
 import dev.bluehouse.bada.protocol.transport.ConnectedTransport
+import dev.bluehouse.bada.protocol.transport.EndOfFrameStream
 import dev.bluehouse.bada.protocol.transport.asConnectedTransport
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -450,15 +453,37 @@ public class TcpReceiverServer(
             activeTransports[connectionId] = transport
         }
 
-        val inbound =
-            InboundConnection(
-                transport = transport,
-                secureRandom = secureRandomProvider(),
-                mediumRegistry = mediumRegistry,
-                logger = logger,
-            )
-
         internalScope.launch {
+            val acceptedTransport =
+                try {
+                    prepareAcceptedTransport(transport)
+                } catch (cancel: CancellationException) {
+                    runCatching { transport.close() }
+                    throw cancel
+                } catch (
+                    @Suppress("TooGenericExceptionCaught") e: Throwable,
+                ) {
+                    logger("tcp: failed to prepare accepted transport: ${e.message ?: e::class.simpleName}")
+                    runCatching { transport.close() }
+                    synchronized(connectionMutexesLock) {
+                        connectionMutexes.remove(connectionId)
+                        activeTransports.remove(connectionId)
+                    }
+                    return@launch
+                }
+
+            synchronized(connectionMutexesLock) {
+                activeTransports[connectionId] = acceptedTransport
+            }
+
+            val inbound =
+                InboundConnection(
+                    transport = acceptedTransport,
+                    secureRandom = secureRandomProvider(),
+                    mediumRegistry = mediumRegistry,
+                    logger = logger,
+                )
+
             // Emit the active connection BEFORE invoking run() so
             // subscribers can race to attach to its state flow before
             // the first state transition happens.
@@ -474,7 +499,7 @@ public class TcpReceiverServer(
                     // was externally cancelled. Make sure the socket is
                     // closed even though InboundConnection.run already
                     // does this in its finally block -- belt and braces.
-                    runCatching { transport.close() }
+                    runCatching { acceptedTransport.close() }
                     throw cancel
                 } catch (
                     @Suppress("TooGenericExceptionCaught") e: Throwable,
@@ -486,7 +511,7 @@ public class TcpReceiverServer(
                     // supervisor (it would not cancel siblings, but
                     // would leak as an UnhandledCoroutineExceptionHandler
                     // log).
-                    runCatching { transport.close() }
+                    runCatching { acceptedTransport.close() }
                     @Suppress("UnsafeCallOnNullableType")
                     InboundResult.Failed("Unexpected ${e::class.simpleName}: ${e.message ?: ""}")
                 } finally {
@@ -499,6 +524,17 @@ public class TcpReceiverServer(
             mutableResults.tryEmit(InboundConnectionCompletion(connectionId, inbound, result))
         }
     }
+
+    private fun prepareAcceptedTransport(transport: ConnectedTransport): ConnectedTransport =
+        if (transport.medium == Medium.WIFI_LAN) {
+            try {
+                probeNearbyMultiplexServerTransport(transport, logger)
+            } catch (_: EndOfFrameStream) {
+                transport
+            }
+        } else {
+            transport
+        }
 
     private companion object {
         /**

--- a/core-protocol/src/test/kotlin/dev/bluehouse/bada/protocol/connection/ConnectionRequestMediumsTest.kt
+++ b/core-protocol/src/test/kotlin/dev/bluehouse/bada/protocol/connection/ConnectionRequestMediumsTest.kt
@@ -10,6 +10,8 @@ import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.Conn
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.EndpointType
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.MediumMetadata
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame
+import dev.bluehouse.bada.protocol.endpoint.DeviceType
+import dev.bluehouse.bada.protocol.endpoint.EndpointInfo
 import dev.bluehouse.bada.protocol.medium.Medium
 import org.junit.jupiter.api.Test
 
@@ -95,6 +97,24 @@ class ConnectionRequestMediumsTest {
         assertThat(req.connectionsDevice.endpointId).isEqualTo("XYZW")
         assertThat(req.connectionsDevice.endpointType).isEqualTo(EndpointType.CONNECTIONS_ENDPOINT)
         assertThat(req.connectionsDevice.endpointInfo.toByteArray()).isEqualTo(endpointInfo)
+    }
+
+    @Test
+    fun `visible EndpointInfo name is mirrored into legacy endpoint_name`() {
+        val endpointInfo =
+            EndpointInfo(
+                version = 1,
+                hidden = false,
+                deviceType = DeviceType.PHONE,
+                reserved = false,
+                metadata = ByteArray(EndpointInfo.METADATA_LEN),
+                deviceName = "Bada177Lab",
+            ).serialize()
+
+        val req = parseRequest(OutboundFrames.connectionRequest("XYZW", endpointInfo))
+
+        assertThat(req.endpointName).isEqualTo("Bada177Lab")
+        assertThat(req.endpointInfo.toByteArray()).isEqualTo(endpointInfo)
     }
 
     @Test

--- a/core-protocol/src/test/kotlin/dev/bluehouse/bada/protocol/connection/InboundConnectionTest.kt
+++ b/core-protocol/src/test/kotlin/dev/bluehouse/bada/protocol/connection/InboundConnectionTest.kt
@@ -10,10 +10,13 @@ import com.google.common.truth.Truth.assertThat
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.ConnectionRequestFrame
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.V1Frame
+import com.google.protobuf.ByteString
 import dev.bluehouse.bada.protocol.crypto.D2DKeyDerivation
 import dev.bluehouse.bada.protocol.crypto.D2DRole
 import dev.bluehouse.bada.protocol.crypto.pin.PinDerivation
 import dev.bluehouse.bada.protocol.crypto.securemessage.SecureChannel
+import dev.bluehouse.bada.protocol.endpoint.DeviceType
+import dev.bluehouse.bada.protocol.endpoint.EndpointInfo
 import dev.bluehouse.bada.protocol.payload.FileDestinationFactory
 import dev.bluehouse.bada.protocol.payload.PayloadAssembler
 import dev.bluehouse.bada.protocol.payload.PayloadEvent
@@ -55,6 +58,7 @@ import java.security.SecureRandom
  * payload assembler. This is the architectural-level test the issue
  * calls for: the loopback proves the pieces tie together correctly.
  */
+@Suppress("LargeClass")
 class InboundConnectionTest {
     private lateinit var serverSocket: ServerSocket
     private val openedSockets = mutableListOf<Socket>()
@@ -81,6 +85,16 @@ class InboundConnectionTest {
             InboundConnectionState.Rejected -> true
             else -> false
         }
+
+    private fun customEndpointInfo(name: String): EndpointInfo =
+        EndpointInfo(
+            version = 1,
+            hidden = false,
+            deviceType = DeviceType.PHONE,
+            reserved = false,
+            metadata = ByteArray(EndpointInfo.METADATA_LEN) { index -> (index + 1).toByte() },
+            deviceName = name,
+        )
 
     /** Opens a loopback `Socket` pair: returns (sender-side, receiver-side). */
     private fun connectedSocketPair(): Pair<Socket, Socket> {
@@ -378,6 +392,53 @@ class InboundConnectionTest {
                     as InboundConnectionState.WaitingForUserConsent
             assertThat(consentState.metadata.pin.length).isEqualTo(TransferMetadata.PIN_LENGTH)
             assertThat(consentState.metadata.items).hasSize(1)
+        }
+
+    @Test
+    fun `same Wi-Fi inbound consent surfaces customized Bada sender device name`() =
+        runTest(timeout = kotlin.time.Duration.parse("30s")) {
+            val (clientSocket, serverSocket) = connectedSocketPair()
+            val factory = InMemoryFactory()
+            val rand = SecureRandom("inbound-lan-custom-name".toByteArray())
+            val inbound = InboundConnection(serverSocket, secureRandom = rand)
+            val senderName = "BadaSameWifi"
+            val textBytes = "hello from custom Bada".toByteArray()
+            val introduction =
+                IntroductionFrame
+                    .newBuilder()
+                    .addTextMetadata(
+                        Protocol.TextMetadata
+                            .newBuilder()
+                            .setTextTitle("clip")
+                            .setPayloadId(0x5151L)
+                            .setSize(textBytes.size.toLong())
+                            .setType(Protocol.TextMetadata.Type.TEXT)
+                            .build(),
+                    ).build()
+
+            coroutineScope {
+                val receiverJob = async { inbound.run(factory) }
+
+                launch {
+                    val consentState =
+                        inbound.state.first {
+                            it is InboundConnectionState.WaitingForUserConsent
+                        } as InboundConnectionState.WaitingForUserConsent
+                    assertThat(consentState.metadata.sourceDeviceName).isEqualTo(senderName)
+                    inbound.submitUserConsent(accepted = true)
+                }
+
+                runSyntheticSender(
+                    socket = clientSocket,
+                    introduction = introduction,
+                    files = emptyMap(),
+                    texts = mapOf(0x5151L to textBytes),
+                    secureRandom = SecureRandom("sender-lan-custom-name".toByteArray()),
+                    endpointInfo = customEndpointInfo(senderName).serialize(),
+                )
+
+                assertThat(receiverJob.await()).isInstanceOf(InboundResult.Completed::class.java)
+            }
         }
 
     @Test
@@ -795,8 +856,17 @@ class InboundConnectionTest {
         files: Map<Long, ByteArray>,
         texts: Map<Long, ByteArray>,
         secureRandom: SecureRandom,
+        endpointInfo: ByteArray = ByteArray(0),
     ) {
         val transport = FramedConnection(socket)
+        val requestBuilder =
+            ConnectionRequestFrame
+                .newBuilder()
+                .setEndpointId("ABCD")
+                .setEndpointName("test-sender")
+        if (endpointInfo.isNotEmpty()) {
+            requestBuilder.setEndpointInfo(ByteString.copyFrom(endpointInfo))
+        }
 
         // Step 1: send unencrypted ConnectionRequest.
         val connReq =
@@ -807,13 +877,8 @@ class InboundConnectionTest {
                     V1Frame
                         .newBuilder()
                         .setType(V1Frame.FrameType.CONNECTION_REQUEST)
-                        .setConnectionRequest(
-                            ConnectionRequestFrame
-                                .newBuilder()
-                                .setEndpointId("ABCD")
-                                .setEndpointName("test-sender")
-                                .build(),
-                        ).build(),
+                        .setConnectionRequest(requestBuilder.build())
+                        .build(),
                 ).build()
         transport.sendFrame(connReq.toByteArray())
 

--- a/core-protocol/src/test/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnectionTest.kt
+++ b/core-protocol/src/test/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnectionTest.kt
@@ -11,12 +11,15 @@ import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.Medi
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.PayloadTransferFrame.PayloadHeader
 import com.google.security.cryptauth.lib.securegcm.UkeyProto.Ukey2Message
+import dev.bluehouse.bada.protocol.endpoint.DeviceType
+import dev.bluehouse.bada.protocol.endpoint.EndpointInfo
 import dev.bluehouse.bada.protocol.medium.Medium
 import dev.bluehouse.bada.protocol.medium.MediumLadder
 import dev.bluehouse.bada.protocol.medium.MediumProvider
 import dev.bluehouse.bada.protocol.medium.MediumRegistry
 import dev.bluehouse.bada.protocol.medium.UpgradePathCredentials
 import dev.bluehouse.bada.protocol.medium.UpgradedTransport
+import dev.bluehouse.bada.protocol.medium.probeNearbyMultiplexServerTransport
 import dev.bluehouse.bada.protocol.payload.FileDestinationFactory
 import dev.bluehouse.bada.protocol.transport.ConnectedTransport
 import dev.bluehouse.bada.protocol.transport.FramedConnection
@@ -233,6 +236,16 @@ class OutboundConnectionTest {
     ) : MediumProvider {
         override fun isSupported(): Boolean = true
     }
+
+    private fun customEndpointInfo(name: String = "Bada177Lab"): EndpointInfo =
+        EndpointInfo(
+            version = 1,
+            hidden = false,
+            deviceType = DeviceType.PHONE,
+            reserved = false,
+            metadata = ByteArray(EndpointInfo.METADATA_LEN) { index -> (index + 1).toByte() },
+            deviceName = name,
+        )
 
     /** Build a [FileSource] backed by an in-memory byte array. */
     private fun bytesSource(
@@ -600,6 +613,70 @@ class OutboundConnectionTest {
         }
 
     @Test
+    fun `preconnected BLE bootstrap streams payloads when Wi-Fi Direct offer never arrives`() =
+        runBlocking {
+            withTimeout(WALLCLOCK_TIMEOUT_MS) {
+                val (client, server) = connectedSocketPair()
+                val factory = InMemoryFactory()
+                val logs = mutableListOf<String>()
+                val outbound =
+                    OutboundConnection(
+                        transport = client.asConnectedTransport(Medium.BLE),
+                        secureRandom = SecureRandom("outbound-ble-bootstrap-no-direct-offer".toByteArray()),
+                        mediumRegistry =
+                            MediumRegistry(
+                                providers =
+                                    listOf(
+                                        MediumRegistry.DefaultWifiLan.providerFor(Medium.WIFI_LAN)!!,
+                                        SupportedProvider(Medium.WIFI_DIRECT),
+                                        SupportedProvider(Medium.BLE),
+                                    ),
+                                ladder = MediumLadder(listOf(Medium.WIFI_DIRECT, Medium.WIFI_LAN, Medium.BLE)),
+                            ),
+                        logger = logs::add,
+                    )
+                val inbound =
+                    InboundConnection(
+                        transport = server.asConnectedTransport(Medium.BLE),
+                        secureRandom = SecureRandom("inbound-ble-bootstrap-no-direct-offer".toByteArray()),
+                        mediumRegistry =
+                            MediumRegistry(
+                                providers = listOf(SupportedProvider(Medium.BLE)),
+                                ladder = MediumLadder(listOf(Medium.WIFI_DIRECT, Medium.WIFI_LAN, Medium.BLE)),
+                            ),
+                    )
+
+                val fileBytes = ByteArray(768) { (it xor 0x55).toByte() }
+                val payloadId = 0x5156L
+                val files = listOf(bytesSource("ble-no-direct-offer.bin", fileBytes, payloadId))
+
+                coroutineScope {
+                    val outboundJob = async { outbound.run(files) }
+
+                    launch {
+                        inbound.state.first { it is InboundConnectionState.WaitingForUserConsent }
+                        inbound.submitUserConsent(accepted = true)
+                    }
+
+                    val inboundResult = inbound.run(factory)
+                    val outboundResult = outboundJob.await()
+
+                    assertThat(outboundResult).isEqualTo(OutboundResult.Completed)
+                    assertThat(inboundResult).isInstanceOf(InboundResult.Completed::class.java)
+                }
+
+                assertThat(factory.output[payloadId]?.toByteArray()).isEqualTo(fileBytes)
+                assertThat(outbound.state.value).isEqualTo(OutboundConnectionState.Completed)
+                assertThat(inbound.activeMedium.value).isEqualTo(Medium.BLE)
+                assertThat(logs)
+                    .contains(
+                        "medium-upgrade: Wi-Fi Direct upgrade was not offered before payload streaming; " +
+                            "continuing on BLE",
+                    )
+            }
+        }
+
+    @Test
     fun `preconnected BLE bootstrap consumes pre-UKEY2 Wi-Fi Direct offer before UKEY2`() =
         runBlocking {
             withTimeout(WALLCLOCK_TIMEOUT_MS) {
@@ -713,9 +790,11 @@ class OutboundConnectionTest {
             withTimeout(WALLCLOCK_TIMEOUT_MS) {
                 val (client, server) = connectedSocketPair()
                 val directUpgradePair = LoopbackUpgradePair(Medium.WIFI_DIRECT)
+                val endpointInfo = customEndpointInfo("Bada177Lab")
                 val outbound =
                     OutboundConnection(
                         transport = client.asConnectedTransport(Medium.BLE),
+                        endpointInfo = endpointInfo.serialize(),
                         secureRandom = SecureRandom("outbound-ble-bootstrap-request".toByteArray()),
                         mediumRegistry =
                             MediumRegistry(
@@ -746,6 +825,10 @@ class OutboundConnectionTest {
                                 Medium.WIFI_LAN.wireNumber,
                                 Medium.WIFI_DIRECT.wireNumber,
                             ).inOrder()
+                        assertThat(EndpointInfo.parse(request.endpointInfo.toByteArray()))
+                            .isEqualTo(endpointInfo)
+                        assertThat(EndpointInfo.parse(request.connectionsDevice.endpointInfo.toByteArray()))
+                            .isEqualTo(endpointInfo)
                         assertThat(request.mediumMetadata.supportedWifiDirectAuthTypesList)
                             .containsExactly(MediumMetadata.WifiDirectAuthType.WIFI_DIRECT_WITH_PASSWORD)
                         assertThat(request.mediumMetadata.hasMediumRole()).isFalse()
@@ -757,6 +840,130 @@ class OutboundConnectionTest {
                     runCatching { wire.close() }
                     directUpgradePair.close()
                 }
+            }
+        }
+
+    @Test
+    fun `same Wi-Fi raw LAN bootstrap advertises LAN only and preserves custom sender device name`() =
+        runBlocking {
+            withTimeout(WALLCLOCK_TIMEOUT_MS) {
+                val (client, server) = connectedSocketPair()
+                val endpointInfo = customEndpointInfo("BadaSameWifi")
+                val logs = mutableListOf<String>()
+                val registry =
+                    MediumRegistry(
+                        providers =
+                            listOf(
+                                MediumRegistry.DefaultWifiLan.providerFor(Medium.WIFI_LAN)!!,
+                                SupportedProvider(Medium.WIFI_DIRECT),
+                                SupportedProvider(Medium.WIFI_HOTSPOT),
+                                SupportedProvider(Medium.BLE),
+                                SupportedProvider(Medium.BLE_L2CAP),
+                            ),
+                    )
+                val outbound =
+                    OutboundConnection(
+                        transport = client.asConnectedTransport(Medium.WIFI_LAN),
+                        endpointInfo = endpointInfo.serialize(),
+                        secureRandom = SecureRandom("outbound-lan-custom-name-request".toByteArray()),
+                        mediumRegistry = registry,
+                        logger = logs::add,
+                        initialHandshakeTimeoutMillis = SHORT_INITIAL_HANDSHAKE_TIMEOUT_MS,
+                    )
+                val wire = FramedConnection(server.asConnectedTransport(Medium.WIFI_LAN))
+
+                try {
+                    coroutineScope {
+                        val outboundJob = async { outbound.run(emptyList()) }
+                        val request =
+                            OfflineFrame
+                                .parseFrom(wire.receiveFrame())
+                                .v1
+                                .connectionRequest
+
+                        assertThat(request.mediumsList.map { it.number })
+                            .containsExactly(Medium.WIFI_LAN.wireNumber)
+                        assertThat(EndpointInfo.parse(request.endpointInfo.toByteArray()))
+                            .isEqualTo(endpointInfo)
+                        assertThat(EndpointInfo.parse(request.connectionsDevice.endpointInfo.toByteArray()))
+                            .isEqualTo(endpointInfo)
+
+                        wire.close()
+                        assertThat(outboundJob.await()).isInstanceOf(OutboundResult.Failed::class.java)
+                    }
+
+                    assertThat(logs).doesNotContain("medium-upgrade: probing for pre-UKEY2 BLE upgrade offer")
+                    assertThat(logs).contains("step 1: advertising mediums=[WIFI_LAN]")
+                } finally {
+                    runCatching { wire.close() }
+                }
+            }
+        }
+
+    @Test
+    fun `same Wi-Fi multiplex LAN bootstrap advertises Wi-Fi only and preserves custom sender device name`() =
+        runBlocking {
+            withTimeout(WALLCLOCK_TIMEOUT_MS) {
+                val (port, accept) = listenAndAcceptInBackground()
+                val endpointInfo = customEndpointInfo("BadaSameWifi")
+                val logs = mutableListOf<String>()
+                val registry =
+                    MediumRegistry(
+                        providers =
+                            listOf(
+                                MediumRegistry.DefaultWifiLan.providerFor(Medium.WIFI_LAN)!!,
+                                SupportedProvider(Medium.WIFI_DIRECT),
+                                SupportedProvider(Medium.WIFI_HOTSPOT),
+                                SupportedProvider(Medium.BLE),
+                                SupportedProvider(Medium.BLE_L2CAP),
+                            ),
+                    )
+                val outbound =
+                    OutboundConnection(
+                        targetAddress = InetAddress.getLoopbackAddress(),
+                        port = port,
+                        endpointInfo = endpointInfo.serialize(),
+                        secureRandom = SecureRandom("outbound-lan-multiplex-request".toByteArray()),
+                        mediumRegistry = registry,
+                        logger = logs::add,
+                        useNearbyMultiplexInitialTransport = true,
+                        initialHandshakeTimeoutMillis = SHORT_INITIAL_HANDSHAKE_TIMEOUT_MS,
+                    )
+
+                coroutineScope {
+                    val outboundJob = async { outbound.run(emptyList()) }
+                    val physical = accept().asConnectedTransport(Medium.WIFI_LAN)
+                    val virtual =
+                        withContext(Dispatchers.IO) {
+                            probeNearbyMultiplexServerTransport(physical, logs::add)
+                        }
+                    val wire = FramedConnection(virtual)
+                    try {
+                        val request =
+                            OfflineFrame
+                                .parseFrom(wire.receiveFrame())
+                                .v1
+                                .connectionRequest
+
+                        assertThat(request.mediumsList.map { it.number })
+                            .containsExactly(
+                                Medium.WIFI_LAN.wireNumber,
+                            ).inOrder()
+                        assertThat(EndpointInfo.parse(request.endpointInfo.toByteArray()))
+                            .isEqualTo(endpointInfo)
+                        assertThat(EndpointInfo.parse(request.connectionsDevice.endpointInfo.toByteArray()))
+                            .isEqualTo(endpointInfo)
+
+                        wire.close()
+                        assertThat(outboundJob.await()).isInstanceOf(OutboundResult.Failed::class.java)
+                    } finally {
+                        runCatching { wire.close() }
+                    }
+                }
+
+                assertThat(logs).contains("step 0: Nearby multiplex virtual socket opened over WIFI_LAN")
+                assertThat(logs).contains("step 1: advertising mediums=[WIFI_LAN]")
+                assertThat(logs).contains("nearby-multiplex: LAN socket using multiplex stream")
             }
         }
 

--- a/core-protocol/src/test/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnectionTest.kt
+++ b/core-protocol/src/test/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnectionTest.kt
@@ -6,9 +6,11 @@
 package dev.bluehouse.bada.protocol.connection
 
 import com.google.common.truth.Truth.assertThat
+import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.BandwidthUpgradeNegotiationFrame
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.MediumMetadata
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.OfflineFrame
 import com.google.location.nearby.connections.proto.OfflineWireFormatsProto.PayloadTransferFrame.PayloadHeader
+import com.google.security.cryptauth.lib.securegcm.UkeyProto.Ukey2Message
 import dev.bluehouse.bada.protocol.medium.Medium
 import dev.bluehouse.bada.protocol.medium.MediumLadder
 import dev.bluehouse.bada.protocol.medium.MediumProvider
@@ -519,6 +521,7 @@ class OutboundConnectionTest {
                 val factory = InMemoryFactory()
                 val directUpgradePair = LoopbackUpgradePair(Medium.WIFI_DIRECT)
                 val hotspotUpgradePair = LoopbackUpgradePair(Medium.WIFI_HOTSPOT)
+                val logs = mutableListOf<String>()
                 val ladder =
                     MediumLadder(
                         listOf(
@@ -544,6 +547,7 @@ class OutboundConnectionTest {
                                     ),
                                 ladder = ladder,
                             ),
+                        logger = logs::add,
                     )
 
                 val fileBytes = ByteArray(1024) { (it and 0x7F).toByte() }
@@ -586,9 +590,119 @@ class OutboundConnectionTest {
 
                     assertThat(factory.output[payloadId]?.toByteArray()).isEqualTo(fileBytes)
                     assertThat(outbound.state.value).isEqualTo(OutboundConnectionState.Completed)
+                    assertThat(logs)
+                        .contains("medium-upgrade: no pre-UKEY2 upgrade offer; continuing on BLE")
                 } finally {
                     directUpgradePair.close()
                     hotspotUpgradePair.close()
+                }
+            }
+        }
+
+    @Test
+    fun `preconnected BLE bootstrap consumes pre-UKEY2 Wi-Fi Direct offer before UKEY2`() =
+        runBlocking {
+            withTimeout(WALLCLOCK_TIMEOUT_MS) {
+                val (client, server) = connectedSocketPair()
+                val directUpgradePair = LoopbackUpgradePair(Medium.WIFI_DIRECT)
+                val endpointId = "ABCD"
+                val logs = mutableListOf<String>()
+                val outbound =
+                    OutboundConnection(
+                        transport = client.asConnectedTransport(Medium.BLE),
+                        endpointId = endpointId,
+                        secureRandom = SecureRandom("outbound-ble-pre-ukey2-direct".toByteArray()),
+                        mediumRegistry =
+                            MediumRegistry(
+                                providers =
+                                    listOf(
+                                        MediumRegistry.DefaultWifiLan.providerFor(Medium.WIFI_LAN)!!,
+                                        directUpgradePair.clientProvider,
+                                        SupportedProvider(Medium.BLE),
+                                    ),
+                                ladder = MediumLadder(listOf(Medium.WIFI_DIRECT, Medium.WIFI_LAN, Medium.BLE)),
+                            ),
+                        logger = logs::add,
+                    )
+                val oldWire = FramedConnection(server.asConnectedTransport(Medium.BLE))
+
+                try {
+                    coroutineScope {
+                        val outboundJob = async { outbound.run(emptyList()) }
+                        val request =
+                            OfflineFrame
+                                .parseFrom(oldWire.receiveFrame())
+                                .v1
+                                .connectionRequest
+
+                        assertThat(request.endpointId).isEqualTo(endpointId)
+                        oldWire.sendFrame(
+                            BandwidthUpgradeFrames
+                                .upgradePathAvailable(UpgradePathCredentials.Generic(Medium.WIFI_DIRECT))
+                                .toByteArray(),
+                        )
+
+                        val upgradedWire = FramedConnection(directUpgradePair.serverProvider.acceptUpgrade()!!)
+                        val clientIntro = OfflineFrame.parseFrom(upgradedWire.receiveFrame())
+                        assertThat(clientIntro.v1.bandwidthUpgradeNegotiation.eventType)
+                            .isEqualTo(BandwidthUpgradeNegotiationFrame.EventType.CLIENT_INTRODUCTION)
+                        assertThat(clientIntro.v1.bandwidthUpgradeNegotiation.clientIntroduction.endpointId)
+                            .isEqualTo(endpointId)
+                        upgradedWire.sendFrame(BandwidthUpgradeFrames.clientIntroductionAck().toByteArray())
+                        completeRawPriorChannelClose(oldWire)
+
+                        val ukey2ClientInit = Ukey2Message.parseFrom(upgradedWire.receiveFrame())
+                        assertThat(ukey2ClientInit.messageType).isEqualTo(Ukey2Message.Type.CLIENT_INIT)
+
+                        upgradedWire.close()
+                        assertThat(outboundJob.await()).isInstanceOf(OutboundResult.Failed::class.java)
+                    }
+
+                    assertThat(logs).contains("medium-upgrade: pre-UKEY2 client completed WIFI_DIRECT")
+                } finally {
+                    runCatching { oldWire.close() }
+                    directUpgradePair.close()
+                }
+            }
+        }
+
+    @Test
+    fun `preconnected BLE bootstrap times out when pre-UKEY2 peer stays silent`() =
+        runBlocking {
+            withTimeout(WALLCLOCK_TIMEOUT_MS) {
+                val (client, server) = connectedSocketPair()
+                val directUpgradePair = LoopbackUpgradePair(Medium.WIFI_DIRECT)
+                val outbound =
+                    OutboundConnection(
+                        transport = client.asConnectedTransport(Medium.BLE),
+                        secureRandom = SecureRandom("outbound-ble-pre-ukey2-silent".toByteArray()),
+                        mediumRegistry =
+                            MediumRegistry(
+                                providers =
+                                    listOf(
+                                        MediumRegistry.DefaultWifiLan.providerFor(Medium.WIFI_LAN)!!,
+                                        directUpgradePair.clientProvider,
+                                        SupportedProvider(Medium.BLE),
+                                    ),
+                                ladder = MediumLadder(listOf(Medium.WIFI_DIRECT, Medium.WIFI_LAN, Medium.BLE)),
+                            ),
+                        initialHandshakeTimeoutMillis = SHORT_INITIAL_HANDSHAKE_TIMEOUT_MS,
+                    )
+                val oldWire = FramedConnection(server.asConnectedTransport(Medium.BLE))
+
+                try {
+                    coroutineScope {
+                        val outboundJob = async { outbound.run(emptyList()) }
+                        assertThat(OfflineFrame.parseFrom(oldWire.receiveFrame()).isConnectionRequest()).isTrue()
+                        val result = outboundJob.await()
+
+                        assertThat(result).isInstanceOf(OutboundResult.Failed::class.java)
+                        assertThat((result as OutboundResult.Failed).reason)
+                            .contains("Initial handshake timed out")
+                    }
+                } finally {
+                    runCatching { oldWire.close() }
+                    directUpgradePair.close()
                 }
             }
         }
@@ -645,6 +759,20 @@ class OutboundConnectionTest {
                 }
             }
         }
+
+    private suspend fun completeRawPriorChannelClose(oldWire: FramedConnection) {
+        val clientLastWrite = OfflineFrame.parseFrom(oldWire.receiveFrame())
+        assertThat(clientLastWrite.v1.bandwidthUpgradeNegotiation.eventType)
+            .isEqualTo(BandwidthUpgradeNegotiationFrame.EventType.LAST_WRITE_TO_PRIOR_CHANNEL)
+
+        oldWire.sendFrame(BandwidthUpgradeFrames.lastWriteToPriorChannel().toByteArray())
+
+        val clientSafeToClose = OfflineFrame.parseFrom(oldWire.receiveFrame())
+        assertThat(clientSafeToClose.v1.bandwidthUpgradeNegotiation.eventType)
+            .isEqualTo(BandwidthUpgradeNegotiationFrame.EventType.SAFE_TO_CLOSE_PRIOR_CHANNEL)
+
+        oldWire.sendFrame(BandwidthUpgradeFrames.safeToClosePriorChannel().toByteArray())
+    }
 
     @Test
     fun `reject path - peer rejects and sender surfaces Rejected`() =

--- a/core-protocol/src/test/kotlin/dev/bluehouse/bada/protocol/medium/NearbyMultiplexTransportTest.kt
+++ b/core-protocol/src/test/kotlin/dev/bluehouse/bada/protocol/medium/NearbyMultiplexTransportTest.kt
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.protocol.medium
+
+import com.google.common.truth.Truth.assertThat
+import dev.bluehouse.bada.protocol.transport.asConnectedTransport
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import java.io.InputStream
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.Socket
+
+class NearbyMultiplexTransportTest {
+    private lateinit var serverSocket: ServerSocket
+    private val openedSockets = mutableListOf<Socket>()
+
+    @AfterEach
+    fun tearDown() {
+        openedSockets.forEach { runCatching { it.close() } }
+        if (::serverSocket.isInitialized) {
+            runCatching { serverSocket.close() }
+        }
+    }
+
+    @Test
+    fun `client and server exchange virtual bytes over multiplexed physical socket`() =
+        runBlocking {
+            withTimeout(WALLCLOCK_TIMEOUT_MS) {
+                val (clientSocket, serverSocket) = connectedSocketPair()
+                val serverDeferred =
+                    async(Dispatchers.IO) {
+                        probeNearbyMultiplexServerTransport(serverSocket.asConnectedTransport(Medium.WIFI_LAN))
+                    }
+                val client =
+                    NearbyMultiplexClientTransport(
+                        physicalTransport = clientSocket.asConnectedTransport(Medium.WIFI_LAN),
+                        salt = "client-salt",
+                    )
+                client.start()
+
+                assertThat(client.awaitReady(CONNECTION_READY_TIMEOUT_MS)).isTrue()
+                val server = serverDeferred.await()
+
+                client.outputStream.write("hello".toByteArray(Charsets.UTF_8))
+                client.outputStream.flush()
+                assertThat(server.inputStream.readExactly(5).decodeToString()).isEqualTo("hello")
+
+                server.outputStream.write("world".toByteArray(Charsets.UTF_8))
+                server.outputStream.flush()
+                assertThat(client.inputStream.readExactly(5).decodeToString()).isEqualTo("world")
+
+                client.close()
+                server.close()
+            }
+        }
+
+    @Test
+    fun `optimistic client sends virtual bytes before connection response`() =
+        runBlocking {
+            withTimeout(WALLCLOCK_TIMEOUT_MS) {
+                val (clientSocket, serverSocket) = connectedSocketPair()
+                val client =
+                    NearbyMultiplexClientTransport(
+                        physicalTransport = clientSocket.asConnectedTransport(Medium.WIFI_LAN),
+                        salt = "client-salt",
+                        requireConnectionResponse = false,
+                    )
+                client.start()
+
+                assertThat(client.awaitReady(CONNECTION_READY_TIMEOUT_MS)).isTrue()
+                client.outputStream.write("early".toByteArray(Charsets.UTF_8))
+                client.outputStream.flush()
+
+                val serverInput = serverSocket.getInputStream()
+                val request =
+                    NearbyMultiplexFrames.parseFrame(
+                        serverInput.readLengthPrefixedPayloadForTest(),
+                    )
+                val data =
+                    NearbyMultiplexFrames.parseFrame(
+                        serverInput.readLengthPrefixedPayloadForTest(),
+                    )
+
+                assertThat(request?.controlFrame?.controlFrameType)
+                    .isEqualTo(
+                        com.google.location.nearby.mediums.proto.MultiplexFramesProto
+                            .MultiplexControlFrame
+                            .MultiplexControlFrameType
+                            .CONNECTION_REQUEST,
+                    )
+                assertThat(
+                    data
+                        ?.dataFrame
+                        ?.data
+                        ?.toByteArray()
+                        ?.decodeToString(),
+                ).isEqualTo("early")
+                assertThat(data?.header?.hasServiceIdHashSalt()).isFalse()
+
+                client.close()
+            }
+        }
+
+    @Test
+    fun `optimistic client waits receiver grace before opening virtual socket`() =
+        runBlocking {
+            withTimeout(WALLCLOCK_TIMEOUT_MS) {
+                val (clientSocket, serverSocket) = connectedSocketPair()
+                val client =
+                    NearbyMultiplexClientTransport(
+                        physicalTransport = clientSocket.asConnectedTransport(Medium.WIFI_LAN),
+                        salt = "client-salt",
+                        requireConnectionResponse = false,
+                        optimisticReadyDelayMillis = 200L,
+                    )
+                client.start()
+
+                val request =
+                    NearbyMultiplexFrames.parseFrame(
+                        serverSocket.getInputStream().readLengthPrefixedPayloadForTest(),
+                    )
+                assertThat(request?.controlFrame?.controlFrameType)
+                    .isEqualTo(
+                        com.google.location.nearby.mediums.proto.MultiplexFramesProto
+                            .MultiplexControlFrame
+                            .MultiplexControlFrameType
+                            .CONNECTION_REQUEST,
+                    )
+                assertThat(client.awaitReady(50L)).isFalse()
+                assertThat(client.awaitReady(CONNECTION_READY_TIMEOUT_MS)).isTrue()
+
+                client.close()
+            }
+        }
+
+    @Test
+    fun `server probe preserves first raw Nearby frame when peer is not multiplexed`() =
+        runBlocking {
+            withTimeout(WALLCLOCK_TIMEOUT_MS) {
+                val (clientSocket, serverSocket) = connectedSocketPair()
+                val serverDeferred =
+                    async(Dispatchers.IO) {
+                        probeNearbyMultiplexServerTransport(serverSocket.asConnectedTransport(Medium.WIFI_LAN))
+                    }
+                val payload = byteArrayOf(0x08, 0x01, 0x10, 0x02)
+                val framed = NearbyMultiplexFrames.encodeLengthPrefixed(payload)
+                withContext(Dispatchers.IO) {
+                    clientSocket.getOutputStream().write(framed)
+                    clientSocket.getOutputStream().flush()
+                }
+
+                val server = serverDeferred.await()
+                assertThat(server.inputStream.readExactly(framed.size)).isEqualTo(framed)
+
+                server.outputStream.write("ack".toByteArray(Charsets.UTF_8))
+                server.outputStream.flush()
+                assertThat(clientSocket.getInputStream().readExactly(3).decodeToString()).isEqualTo("ack")
+
+                server.close()
+            }
+        }
+
+    private fun connectedSocketPair(): Pair<Socket, Socket> {
+        serverSocket = ServerSocket(0, 0, InetAddress.getLoopbackAddress())
+        val client = Socket(InetAddress.getLoopbackAddress(), serverSocket.localPort)
+        val server = serverSocket.accept()
+        openedSockets += client
+        openedSockets += server
+        return client to server
+    }
+
+    private fun InputStream.readExactly(length: Int): ByteArray {
+        val out = ByteArray(length)
+        var offset = 0
+        while (offset < length) {
+            val read = read(out, offset, length - offset)
+            check(read >= 0) { "stream closed after $offset of $length bytes" }
+            offset += read
+        }
+        return out
+    }
+
+    private fun InputStream.readLengthPrefixedPayloadForTest(): ByteArray {
+        val header = readExactly(NearbyMultiplexFrames.LENGTH_PREFIX_BYTES)
+        val length = requireNotNull(NearbyMultiplexFrames.decodeLength(header))
+        return readExactly(length)
+    }
+
+    private companion object {
+        private const val CONNECTION_READY_TIMEOUT_MS: Long = 1_000L
+        private const val WALLCLOCK_TIMEOUT_MS: Long = 5_000L
+    }
+}

--- a/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/Discovery.kt
+++ b/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/Discovery.kt
@@ -6,7 +6,10 @@
 package dev.bluehouse.bada.discovery
 
 import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
 import android.net.nsd.NsdManager
+import android.net.wifi.WifiManager
 import dev.bluehouse.bada.protocol.endpoint.Base64Url
 import dev.bluehouse.bada.protocol.endpoint.EndpointInfo
 import kotlinx.coroutines.Dispatchers
@@ -19,6 +22,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import java.io.IOException
+import java.net.Inet4Address
 import java.net.InetAddress
 import java.net.NetworkInterface
 import java.util.concurrent.atomic.AtomicBoolean
@@ -70,6 +74,7 @@ public class Discovery internal constructor(
      */
     private val instanceEndpointIdProvider: (() -> ByteArray?)? = null,
     private val localAddressProvider: () -> Set<InetAddress> = ::localInterfaceAddresses,
+    private val wifiFrequencyProvider: () -> Int? = { null },
     /**
      * When `true`, the browse path drops any record whose mDNS instance
      * name matches one currently advertised by this process — that is,
@@ -89,6 +94,8 @@ public class Discovery internal constructor(
         registrar = AndroidNsdRegistrar(systemNsdManager(context)),
         browser = AndroidNsdBrowser(systemNsdManager(context)),
         networkWatcherFactory = AndroidNetworkWatcherFactory(context.applicationContext),
+        localAddressProvider = { localWifiInterfaceAddresses(context.applicationContext) },
+        wifiFrequencyProvider = { currentWifiFrequency(context.applicationContext) },
     )
 
     /**
@@ -103,6 +110,8 @@ public class Discovery internal constructor(
         browser = AndroidNsdBrowser(systemNsdManager(context)),
         networkWatcherFactory = AndroidNetworkWatcherFactory(context.applicationContext),
         instanceEndpointIdProvider = instanceEndpointIdProvider,
+        localAddressProvider = { localWifiInterfaceAddresses(context.applicationContext) },
+        wifiFrequencyProvider = { currentWifiFrequency(context.applicationContext) },
     )
 
     /**
@@ -164,14 +173,13 @@ public class Discovery internal constructor(
         // base64 alphabet is a strict subset of ASCII so the bytes
         // round-trip cleanly through any String/byte[] mDNS attribute
         // bridge on the platform.
-        val encodedEndpointInfo =
-            Base64Url.encode(endpointInfo.serialize()).toByteArray(Charsets.US_ASCII)
-        val attributes = mapOf(QuickShareMdns.TXT_KEY_ENDPOINT_INFO to encodedEndpointInfo)
+        val attributes = buildAdvertiseAttributes(endpointInfo)
 
         Log.i(
             TAG,
             "advertise: starting publish instance=$instanceName " +
-                "endpointId=${instanceEndpointId?.toAsciiLabel() ?: "-"} port=$port",
+                "endpointId=${instanceEndpointId?.toAsciiLabel() ?: "-"} port=$port " +
+                "txtKeys=${attributes.keys.sorted()}",
         )
 
         return try {
@@ -373,6 +381,20 @@ public class Discovery internal constructor(
         return addresses.any(localAddresses::contains)
     }
 
+    private fun buildAdvertiseAttributes(endpointInfo: EndpointInfo): Map<String, ByteArray> {
+        val encodedEndpointInfo =
+            Base64Url.encode(endpointInfo.serialize()).toByteArray(Charsets.US_ASCII)
+        val attributes =
+            linkedMapOf(QuickShareMdns.TXT_KEY_ENDPOINT_INFO to encodedEndpointInfo)
+        firstAdvertisableIpv4Address(localAddressProvider())?.hostAddress?.let { hostAddress ->
+            attributes[QuickShareMdns.TXT_KEY_IPV4_ADDRESS] = hostAddress.toByteArray(Charsets.US_ASCII)
+        }
+        wifiFrequencyProvider()?.takeIf { it > 0 }?.let { frequency ->
+            attributes[QuickShareMdns.TXT_KEY_WIFI_FREQUENCY] = frequency.toString().toByteArray(Charsets.US_ASCII)
+        }
+        return attributes
+    }
+
     /**
      * Render a TXT record as a single-line `k1=v1, k2=v2, ...` string
      * for diagnostic logging. Values are tried as ASCII first (so Quick
@@ -473,6 +495,7 @@ public class Discovery internal constructor(
          * [NsdRegistrar] / [NsdBrowser] fakes. The public constructor
          * remains the only path that consumes a [Context].
          */
+        @Suppress("LongParameterList")
         @JvmStatic
         internal fun forTesting(
             registrar: NsdRegistrar,
@@ -481,6 +504,7 @@ public class Discovery internal constructor(
             filterSelfPublishedInstances: Boolean = false,
             instanceEndpointIdProvider: (() -> ByteArray?)? = null,
             localAddressProvider: () -> Set<InetAddress> = { emptySet() },
+            wifiFrequencyProvider: () -> Int? = { null },
         ): Discovery =
             Discovery(
                 registrar = registrar,
@@ -489,10 +513,37 @@ public class Discovery internal constructor(
                 filterSelfPublishedInstances = filterSelfPublishedInstances,
                 instanceEndpointIdProvider = instanceEndpointIdProvider,
                 localAddressProvider = localAddressProvider,
+                wifiFrequencyProvider = wifiFrequencyProvider,
             )
 
         private fun systemNsdManager(context: Context): NsdManager =
             context.applicationContext.getSystemService(Context.NSD_SERVICE) as NsdManager
+
+        @Suppress("DEPRECATION")
+        private fun localWifiInterfaceAddresses(context: Context): Set<InetAddress> {
+            val cm =
+                context.applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+            val wifiNetworks =
+                cm.allNetworks
+                    .asSequence()
+                    .filter { network ->
+                        cm.getNetworkCapabilities(network)?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true
+                    }
+            return wifiNetworks
+                .mapNotNull { network -> cm.getLinkProperties(network) }
+                .flatMap { linkProperties -> linkProperties.linkAddresses.asSequence() }
+                .map { linkAddress -> linkAddress.address }
+                .toSet()
+        }
+
+        @Suppress("DEPRECATION")
+        private fun currentWifiFrequency(context: Context): Int? =
+            runCatching {
+                val wifiManager =
+                    context.applicationContext.getSystemService(Context.WIFI_SERVICE) as? WifiManager
+                        ?: return null
+                wifiManager.connectionInfo?.frequency?.takeIf { it > 0 }
+            }.getOrNull()
 
         private fun localInterfaceAddresses(): Set<InetAddress> {
             val interfaces = NetworkInterface.getNetworkInterfaces() ?: return emptySet()
@@ -510,6 +561,14 @@ public class Discovery internal constructor(
         internal const val DEFAULT_ADVERTISE_REGISTER_TIMEOUT_MILLIS: Long = 2_000L
     }
 }
+
+private fun firstAdvertisableIpv4Address(addresses: Set<InetAddress>): Inet4Address? =
+    addresses
+        .asSequence()
+        .filterIsInstance<Inet4Address>()
+        .filterNot { it.isAnyLocalAddress || it.isLoopbackAddress || it.isLinkLocalAddress || it.isMulticastAddress }
+        .sortedBy(InetAddress::getHostAddress)
+        .firstOrNull()
 
 private fun ByteArray.toAsciiLabel(): String = String(this, Charsets.US_ASCII)
 

--- a/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/NearbyPeer.kt
+++ b/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/NearbyPeer.kt
@@ -62,31 +62,17 @@ public data class NearbyPeer(
     /**
      * Select the initial-control route.
      *
-     * LAN remains first priority to preserve the pre-#137 behaviour when
+     * LAN remains first priority to preserve the direct same-Wi-Fi path when
      * a peer is already reachable by mDNS + TCP. BLE L2CAP is the preferred
      * off-LAN bootstrap path when the receiver advertises a PSM. A visible
-     * BLE receiver without a PSM is only a GATT bootstrap candidate after
-     * the GATT advertisement-slot probe verifies the service; header-only
-     * and raw scan-result-only BLE observations remain discovery metadata
-     * until another route confirms a transport.
+     * BLE receiver without a PSM is only a GATT bootstrap candidate after the
+     * GATT advertisement-slot probe verifies the service; header-only and raw
+     * scan-result-only BLE observations remain discovery metadata until
+     * another route confirms a transport.
      */
     public fun preferredRoute(): NearbyPeerRoute? {
         if (endpointInfo == null) {
             return null
-        }
-        // BLE-first preference. See [SendBootstrapPlan.directRoute] for
-        // the rationale: BLE bypasses the AP and remains reachable on
-        // Wi-Fi networks that drop peer-to-peer LAN frames, so we'd
-        // rather pay the brief BLE setup latency than fail with
-        // EHOSTUNREACH on isolated SSIDs.
-        val ble = bleAdvertisement
-        val bleAddress = ble?.advertiserAddress
-        val l2capPsm = ble?.l2capPsm
-        if (bleAddress != null && l2capPsm != null) {
-            return NearbyPeerRoute.BleL2cap(macAddress = bleAddress, psm = l2capPsm)
-        }
-        if (bleAddress != null && ble.gattConnectable) {
-            return NearbyPeerRoute.BleGatt(macAddress = bleAddress)
         }
         val lan = lanEndpoint
         val primaryAddress = lan?.primaryAddress()
@@ -95,6 +81,15 @@ public data class NearbyPeer(
                 address = primaryAddress,
                 port = lan.port,
             )
+        }
+        val ble = bleAdvertisement
+        val bleAddress = ble?.advertiserAddress
+        val l2capPsm = ble?.l2capPsm
+        if (bleAddress != null && l2capPsm != null) {
+            return NearbyPeerRoute.BleL2cap(macAddress = bleAddress, psm = l2capPsm)
+        }
+        if (bleAddress != null && ble.gattConnectable) {
+            return NearbyPeerRoute.BleGatt(macAddress = bleAddress)
         }
         if (UserFacingMediumFeatures.BLUETOOTH_CLASSIC_USER_FACING_ENABLED) {
             val bluetooth = bluetoothEndpoint

--- a/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/NetworkChangeWatcher.kt
+++ b/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/NetworkChangeWatcher.kt
@@ -18,9 +18,9 @@ import java.util.concurrent.atomic.AtomicBoolean
  *
  * Quick Share peers cache mDNS service records keyed by the publishing
  * IP address; when the device moves to a new Wi-Fi network the JmDNS
- * instance is now bound to a stale interface and any further
+ * registration is now bound to a stale interface and any further
  * advertisements would be silently invisible to peers on the new
- * network. Re-creating the JmDNS instance on `onAvailable` /
+ * network. Re-creating the NSD registration on `onAvailable` /
  * `onLost` puts the advertisement back on the wire with the correct
  * source address.
  *
@@ -36,6 +36,10 @@ internal class NetworkChangeWatcher(
 ) : NetworkWatcher {
     private val cm: ConnectivityManager =
         context.applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+    private val networkTracker =
+        NetworkChangeTracker(
+            initialNetworks = currentWifiNetworks(),
+        )
 
     // Restrict the callback to Wi-Fi only — cellular changes are not
     // relevant for Quick Share LAN discovery and would just churn the
@@ -49,7 +53,9 @@ internal class NetworkChangeWatcher(
     private val callback =
         object : ConnectivityManager.NetworkCallback() {
             override fun onAvailable(network: Network) {
-                onChanged()
+                if (networkTracker.recordAvailable(network)) {
+                    onChanged()
+                }
             }
 
             override fun onLost(network: Network) {
@@ -57,7 +63,9 @@ internal class NetworkChangeWatcher(
                 // instance just goes silent); but firing the callback lets
                 // the consumer release any per-network resources. The
                 // following `onAvailable` will rebuild things.
-                onChanged()
+                if (networkTracker.recordLost(network)) {
+                    onChanged()
+                }
             }
         }
 
@@ -87,4 +95,40 @@ internal class NetworkChangeWatcher(
             }
         }
     }
+
+    @Suppress("DEPRECATION")
+    private fun currentWifiNetworks(): Set<Network> =
+        cm.allNetworks
+            .filter(::isWifiNetwork)
+            .toSet()
+
+    private fun isWifiNetwork(network: Network): Boolean =
+        cm.getNetworkCapabilities(network)?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true
+}
+
+/**
+ * Tracks Wi-Fi networks known before registering the platform callback.
+ *
+ * `ConnectivityManager.registerNetworkCallback` immediately invokes
+ * `onAvailable` for already-satisfied networks. Treating that as a real
+ * network change tears down a fresh mDNS publish right after startup, which
+ * can leave the receiver BLE-visible but LAN-unresolvable if the second NSD
+ * registration times out. This tracker suppresses those initial echoes while
+ * still forwarding genuine later availability/loss transitions.
+ */
+internal class NetworkChangeTracker<T>(
+    initialNetworks: Set<T>,
+) {
+    private val lock = Object()
+    private val knownNetworks: MutableSet<T> = initialNetworks.toMutableSet()
+
+    fun recordAvailable(network: T): Boolean =
+        synchronized(lock) {
+            knownNetworks.add(network)
+        }
+
+    fun recordLost(network: T): Boolean =
+        synchronized(lock) {
+            knownNetworks.remove(network)
+        }
 }

--- a/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/QuickShareMdns.kt
+++ b/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/QuickShareMdns.kt
@@ -68,6 +68,27 @@ public object QuickShareMdns {
     public const val TXT_KEY_ENDPOINT_INFO: String = "n"
 
     /**
+     * TXT-record key carrying the peer's dotted-decimal IPv4 address.
+     *
+     * Stock Android Quick Share publishes this alongside `n=`. Samsung's
+     * sender UI can surface a BLE-correlated peer by name while still leaving
+     * the Wi-Fi-LAN connection candidate unresolved unless this value is
+     * present in the mDNS record.
+     */
+    public const val TXT_KEY_IPV4_ADDRESS: String = "IPv4"
+
+    /**
+     * TXT-record key carrying the Wi-Fi channel frequency in MHz.
+     *
+     * Stock Quick Share records include this as `f=<frequency>`. Samsung's
+     * stack already correlates our BLE advertisement by name, but its LAN
+     * resolver ignores mDNS candidates that do not look like the stock
+     * Wi-Fi-LAN metadata shape, so advertise the same optional hint when the
+     * platform exposes it.
+     */
+    public const val TXT_KEY_WIFI_FREQUENCY: String = "f"
+
+    /**
      * Alphabet used when generating the random 4-byte endpoint ID portion of
      * the service-instance name. Restricting to alphanumeric ASCII keeps the
      * raw bytes safely round-trippable through every URL-safe-base64

--- a/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/ble/BleQuickShareAdvertiser.kt
+++ b/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/ble/BleQuickShareAdvertiser.kt
@@ -22,6 +22,7 @@ import android.os.ParcelUuid
 import androidx.annotation.RequiresApi
 import androidx.annotation.RequiresPermission
 import androidx.core.content.ContextCompat
+import dev.bluehouse.bada.protocol.endpoint.BleAdvertisement
 import dev.bluehouse.bada.protocol.endpoint.BleAdvertisementHeader
 import dev.bluehouse.bada.protocol.endpoint.BleServiceData
 import dev.bluehouse.bada.protocol.endpoint.DctAdvertisement
@@ -50,7 +51,7 @@ import dev.bluehouse.bada.discovery.diagnostics.DiagnosticLog as Log
  * The primary service-data payload is built as a compact BLE v2 GATT
  * advertisement header in `:core-protocol` (pure-JVM, KAT-tested). Stock
  * Samsung senders read the visible receiver identity from GATT slot zero,
- * where Bada publishes a second-profile fast advertisement:
+ * where Bada publishes a standard GATT-slot advertisement:
  *
  * ```text
  * [ header | bloom_filter | advertisement_hash | psm=0 ]
@@ -58,13 +59,11 @@ import dev.bluehouse.bada.discovery.diagnostics.DiagnosticLog as Log
  *
  * Vivo/OriginOS devices can run Google Play services' own Nearby GATT
  * provider beside Bada. The regular `0xFEF3` slot service therefore
- * must stay published, and slot zero must advertise the second-profile socket
- * so Samsung resolves the selected peer into Bada instead of Google's
- * coresident regular profile. The connectable extended payload carries the
- * visible receiver name only. Do not append the RX instant-connection extra
- * field here: on One UI 8.0.5 it promotes the tap into a separate
- * Mosey/link-local path on port 8770, bypassing Bada's BLE GATT
- * bootstrap server.
+ * must stay published, and the primary advertisement header's slot hash must
+ * match the same standard non-fast slot zero bytes that the GATT server
+ * exposes. The connectable extended payload carries the visible receiver name
+ * plus Nearby's RX instant-connection extra field so Samsung can resolve a
+ * visible share-sheet row into Bada's GATT socket.
  *
  * Bada does not submit the optional DCT (`0xFC73`) advertisement in
  * receiver mode. Samsung ShareLive was observed to probe the DCT advertiser
@@ -637,10 +636,11 @@ public object DefaultPayloadFactory : PayloadFactory {
         endpointInfo: EndpointInfo,
     ): ByteArray {
         val gattAdvertisement =
-            BleServiceData.encodeFramed(
+            BleAdvertisement.encodeGattAdvertisement(
                 endpointId = endpointId,
                 endpointInfo = endpointInfo,
-                secondProfile = true,
+                psm = 0,
+                secondProfile = false,
             )
         return BleAdvertisementHeader.encodeSingleSlot(
             serviceId = NearbyServiceId.VALUE,
@@ -674,12 +674,19 @@ public object DefaultVisiblePayloadFactory : OptionalPayloadFactory {
     ): ByteArray? {
         if (endpointInfo.hidden || endpointInfo.deviceName == null) return null
         val activePsm = BleDctPsmHolder.currentPsm?.takeIf { it != DctAdvertisement.DEFAULT_PSM }
+        val rxAdvertisement =
+            BleAdvertisement.encodeGattAdvertisement(
+                endpointId = endpointId,
+                endpointInfo = endpointInfo,
+                psm = activePsm ?: 0,
+                secondProfile = false,
+            )
         return BleServiceData.encodeFramedWithExtraFields(
             endpointId = endpointId,
             endpointInfo = endpointInfo,
             psm = activePsm,
-            rxInstantConnectionAdvertisement = null,
-            secondProfile = true,
+            rxInstantConnectionAdvertisement = rxAdvertisement,
+            secondProfile = false,
         )
     }
 }

--- a/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/bootstrap/BleGattInitialControlClient.kt
+++ b/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/bootstrap/BleGattInitialControlClient.kt
@@ -55,8 +55,8 @@ import java.util.concurrent.atomic.AtomicReference
  * Sender-side BLE GATT initial-control client for stock Quick Share receivers.
  *
  * Nearby's BLE v2 path first opens a small Weave-over-GATT socket on the
- * connectable `0xFEF3` advertiser, then wraps the normal Nearby multiplex
- * socket inside that stream. This client performs that bootstrap and exposes
+ * connectable `0xFEF3` advertiser, then carries the normal Nearby stream
+ * inside that physical socket. This client performs that bootstrap and exposes
  * the accepted virtual socket as a [ConnectedTransport] for the existing
  * outbound protocol driver. Timing delays, slot reads, and retries here are
  * compatibility residue from real-device probing. Samsung can log

--- a/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/bootstrap/BleGattInitialControlServer.kt
+++ b/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/bootstrap/BleGattInitialControlServer.kt
@@ -27,6 +27,7 @@ import androidx.annotation.RequiresPermission
 import androidx.core.content.ContextCompat
 import com.google.location.nearby.mediums.proto.BleFramesProto
 import com.google.location.nearby.mediums.proto.MultiplexFramesProto
+import dev.bluehouse.bada.protocol.endpoint.BleAdvertisement
 import dev.bluehouse.bada.protocol.endpoint.BleServiceData
 import dev.bluehouse.bada.protocol.endpoint.EndpointInfo
 import dev.bluehouse.bada.protocol.endpoint.NearbyServiceId
@@ -530,17 +531,18 @@ public class BleGattInitialControlServer(
             endpointInfo: EndpointInfo,
             endpointId: ByteArray,
         ): List<GattCharacteristicSpec> {
-            // The second-profile frame type (0x4B) was originally meant
-            // to disambiguate when GMS owns the first 0xFEF3 GATT
-            // profile. On stock Galaxy senders the bit is not recognised
-            // and the receiver gets filtered out of the share-target
-            // list, so we publish the standard 0x4A frame type and the
-            // Weave chars under the same standard 0xFEF3 UUID instead.
+            // Stock Nearby GATT slots use the non-fast Mediums wrapper:
+            // header + service-id hash + 4-byte data length + endpoint
+            // advertisement + token. Extended scan results may carry the
+            // compact fast wrapper, but Samsung expects slot zero to be
+            // regular so it can resolve a visible row into a connectable
+            // Nearby socket capability.
             val visibleAdvertisement =
                 runCatching {
-                    BleServiceData.encodeFramed(
+                    BleAdvertisement.encodeGattAdvertisement(
                         endpointId = endpointId,
                         endpointInfo = endpointInfo,
+                        psm = 0,
                         secondProfile = false,
                     )
                 }.getOrDefault(ByteArray(0))
@@ -883,6 +885,10 @@ internal class BleMultiplexBridge(
                 val salt = frame.header.serviceIdHashSalt
                 val saltedHash = frame.header.saltedServiceIdHash.toByteArray()
                 val expected = NearbyMultiplexFrames.saltedServiceIdHash(salt = salt)
+                Log.w(
+                    tag,
+                    "BLE socket multiplex CONNECTION_REQUEST hashMatches=${saltedHash.contentEquals(expected)}",
+                )
                 val response =
                     if (saltedHash.contentEquals(expected)) {
                         ensureVirtualTransport(saltedHash, salt)
@@ -913,6 +919,10 @@ internal class BleMultiplexBridge(
     private fun handleDataFrame(frame: MultiplexFramesProto.MultiplexFrame) {
         val salt = frame.header.serviceIdHashSalt
         val saltedHash = frame.header.saltedServiceIdHash.toByteArray()
+        Log.w(
+            tag,
+            "BLE socket multiplex DATA_FRAME bytes=${frame.dataFrame.data.size()} virtual=${virtualTransport != null}",
+        )
         val transport = virtualTransport ?: ensureVirtualTransport(saltedHash, salt)
         transport.feedIncoming(frame.dataFrame.data.toByteArray())
     }

--- a/discovery-android/src/test/kotlin/dev/bluehouse/bada/discovery/DiscoveryAdvertiseTest.kt
+++ b/discovery-android/src/test/kotlin/dev/bluehouse/bada/discovery/DiscoveryAdvertiseTest.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.delay
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.io.IOException
+import java.net.InetAddress
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
@@ -230,6 +231,120 @@ class DiscoveryAdvertiseTest {
     }
 
     @Test
+    fun `same Wi-Fi mDNS advertisement preserves customized Bada receiver name`() {
+        val countingRegistrar = CountingNsdRegistrar()
+        val discovery =
+            Discovery.forTesting(
+                registrar = countingRegistrar,
+                browser = NoopNsdBrowser,
+            )
+        val endpointInfo = sampleEndpointInfo(deviceName = "BadaSameWifi")
+        val handle = discovery.advertise(endpointInfo, port = 51_002)
+        try {
+            val attrs = countingRegistrar.lastRegisteredAttrs.get()
+            val encodedBytes = requireNotNull(attrs[QuickShareMdns.TXT_KEY_ENDPOINT_INFO])
+            val encoded = String(encodedBytes, Charsets.US_ASCII)
+            val decoded = requireNotNull(Base64Url.decode(encoded))
+            val parsed = EndpointInfo.parse(decoded)
+
+            assertThat(parsed).isEqualTo(endpointInfo)
+            assertThat(parsed!!.deviceName).isEqualTo("BadaSameWifi")
+        } finally {
+            handle.close()
+        }
+    }
+
+    @Test
+    fun `advertise includes IPv4 TXT key from local Wi-Fi address provider`() {
+        val countingRegistrar = CountingNsdRegistrar()
+        val discovery =
+            Discovery.forTesting(
+                registrar = countingRegistrar,
+                browser = NoopNsdBrowser,
+                localAddressProvider = {
+                    setOf(
+                        InetAddress.getByName("127.0.0.1"),
+                        InetAddress.getByName("172.17.142.9"),
+                        InetAddress.getByName("fe80::1"),
+                    )
+                },
+            )
+
+        val handle = discovery.advertise(sampleEndpointInfo(deviceName = "BadaSameWifi"), port = 51_003)
+        try {
+            val attrs = countingRegistrar.lastRegisteredAttrs.get()
+            assertThat(String(attrs[QuickShareMdns.TXT_KEY_IPV4_ADDRESS]!!, Charsets.US_ASCII))
+                .isEqualTo("172.17.142.9")
+        } finally {
+            handle.close()
+        }
+    }
+
+    @Test
+    fun `advertise omits IPv4 TXT key when no usable local IPv4 exists`() {
+        val countingRegistrar = CountingNsdRegistrar()
+        val discovery =
+            Discovery.forTesting(
+                registrar = countingRegistrar,
+                browser = NoopNsdBrowser,
+                localAddressProvider = {
+                    setOf(
+                        InetAddress.getByName("127.0.0.1"),
+                        InetAddress.getByName("169.254.10.20"),
+                        InetAddress.getByName("fe80::1"),
+                    )
+                },
+            )
+
+        val handle = discovery.advertise(sampleEndpointInfo(), port = 51_004)
+        try {
+            val attrs = countingRegistrar.lastRegisteredAttrs.get()
+            assertThat(attrs).doesNotContainKey(QuickShareMdns.TXT_KEY_IPV4_ADDRESS)
+        } finally {
+            handle.close()
+        }
+    }
+
+    @Test
+    fun `advertise includes Wi-Fi frequency TXT key from provider`() {
+        val countingRegistrar = CountingNsdRegistrar()
+        val discovery =
+            Discovery.forTesting(
+                registrar = countingRegistrar,
+                browser = NoopNsdBrowser,
+                wifiFrequencyProvider = { 5240 },
+            )
+
+        val handle = discovery.advertise(sampleEndpointInfo(deviceName = "BadaSameWifi"), port = 51_005)
+        try {
+            val attrs = countingRegistrar.lastRegisteredAttrs.get()
+            assertThat(String(attrs[QuickShareMdns.TXT_KEY_WIFI_FREQUENCY]!!, Charsets.US_ASCII))
+                .isEqualTo("5240")
+        } finally {
+            handle.close()
+        }
+    }
+
+    @Test
+    fun `advertise omits Wi-Fi frequency TXT key when provider has no usable frequency`() {
+        val countingRegistrar = CountingNsdRegistrar()
+        val discovery =
+            Discovery.forTesting(
+                registrar = countingRegistrar,
+                browser = NoopNsdBrowser,
+                wifiFrequencyProvider = { 0 },
+            )
+
+        val handle = discovery.advertise(sampleEndpointInfo(), port = 51_006)
+        try {
+            val attrs = countingRegistrar.lastRegisteredAttrs.get()
+            assertThat(attrs).doesNotContainKey(QuickShareMdns.TXT_KEY_WIFI_FREQUENCY)
+        } finally {
+            handle.close()
+        }
+    }
+
+    @Test
     fun `advertise can reuse a caller supplied endpoint ID in the instance name`() {
         val requestedNames = mutableListOf<String>()
         val endpointId = "WvMg".toByteArray(Charsets.US_ASCII)
@@ -255,7 +370,7 @@ class DiscoveryAdvertiseTest {
         }
     }
 
-    private fun sampleEndpointInfo(): EndpointInfo =
+    private fun sampleEndpointInfo(deviceName: String = "Test Device"): EndpointInfo =
         EndpointInfo(
             version = 1,
             hidden = false,
@@ -264,7 +379,7 @@ class DiscoveryAdvertiseTest {
             // Fill metadata with a full 0x00..0xFF round-trip pattern so
             // a regression that mangles high-bit bytes shows up.
             metadata = ByteArray(EndpointInfo.METADATA_LEN) { (it * 17).toByte() },
-            deviceName = "Test Device",
+            deviceName = deviceName,
             tlvRecords = emptyList(),
         )
 

--- a/discovery-android/src/test/kotlin/dev/bluehouse/bada/discovery/NearbyPeerDiscoveryTest.kt
+++ b/discovery-android/src/test/kotlin/dev/bluehouse/bada/discovery/NearbyPeerDiscoveryTest.kt
@@ -236,6 +236,68 @@ class NearbyPeerDiscoveryTest {
         }
 
     @Test
+    fun `same Wi-Fi LAN is preferred after peer also advertises BLE bootstrap`() =
+        runTest {
+            val lanEvents = MutableSharedFlow<DiscoveryEvent>()
+            val bleEvents = MutableSharedFlow<BleFastAdvertisementScanner.Observation>()
+            val bluetoothEvents = MutableSharedFlow<BluetoothClassicPeerScanner.Observation>()
+            val discovery =
+                NearbyPeerDiscovery.forTesting(
+                    lanEvents = lanEvents,
+                    bleEvents = bleEvents,
+                    bluetoothEvents = bluetoothEvents,
+                )
+            val seen = mutableListOf<NearbyPeerEvent>()
+            val collector =
+                backgroundScope.launch {
+                    discovery.browse().collect { seen += it }
+                }
+            runCurrent()
+
+            val endpointInfo = endpointInfo(name = "Bada177Lab")
+            bleEvents.emit(
+                BleFastAdvertisementScanner.Observation(
+                    endpointId = "B177",
+                    endpointInfo = endpointInfo,
+                    advertiserAddress = "77:88:99:AA:BB:CC",
+                    rssi = -47,
+                    l2capPsm = 0x1234,
+                    gattConnectable = true,
+                ),
+            )
+            lanEvents.emit(
+                DiscoveryEvent.Resolved(
+                    DiscoveredService(
+                        instanceName = "instance-bada177",
+                        endpointId = "B177".toByteArray(Charsets.US_ASCII),
+                        addresses = listOf(InetAddress.getByName("192.168.1.77")),
+                        port = 54321,
+                        endpointInfo = endpointInfo,
+                    ),
+                ),
+            )
+            runCurrent()
+
+            val resolved = seen.last() as NearbyPeerEvent.Resolved
+            assertThat(resolved.peer.displayName()).isEqualTo("Bada177Lab")
+            assertThat(resolved.peer.candidateMediums).containsExactly(
+                Medium.WIFI_LAN,
+                Medium.BLE,
+                Medium.BLE_L2CAP,
+            )
+            assertThat(resolved.peer.preferredRoute()).isEqualTo(
+                NearbyPeerRoute.Lan(
+                    address = InetAddress.getByName("192.168.1.77"),
+                    port = 54321,
+                ),
+            )
+            assertThat(resolved.peer.lanEndpoint?.primaryAddress()).isEqualTo(InetAddress.getByName("192.168.1.77"))
+            assertThat(resolved.peer.lanEndpoint?.port).isEqualTo(54321)
+
+            collector.cancel()
+        }
+
+    @Test
     fun `verified BLE GATT route ignores visibility bit`() =
         runTest {
             val lanEvents = MutableSharedFlow<DiscoveryEvent>()

--- a/discovery-android/src/test/kotlin/dev/bluehouse/bada/discovery/NetworkChangeWatcherTest.kt
+++ b/discovery-android/src/test/kotlin/dev/bluehouse/bada/discovery/NetworkChangeWatcherTest.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.discovery
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class NetworkChangeWatcherTest {
+    @Test
+    fun `initial available Wi-Fi callback is suppressed`() {
+        val tracker = NetworkChangeTracker(initialNetworks = setOf("home-wifi"))
+
+        assertThat(tracker.recordAvailable("home-wifi")).isFalse()
+    }
+
+    @Test
+    fun `new Wi-Fi availability is reported once`() {
+        val tracker = NetworkChangeTracker(initialNetworks = emptySet<String>())
+
+        assertThat(tracker.recordAvailable("home-wifi")).isTrue()
+        assertThat(tracker.recordAvailable("home-wifi")).isFalse()
+    }
+
+    @Test
+    fun `known Wi-Fi loss is reported once`() {
+        val tracker = NetworkChangeTracker(initialNetworks = setOf("home-wifi"))
+
+        assertThat(tracker.recordLost("home-wifi")).isTrue()
+        assertThat(tracker.recordLost("home-wifi")).isFalse()
+    }
+}

--- a/discovery-android/src/test/kotlin/dev/bluehouse/bada/discovery/ble/BleQuickShareAdvertiserTest.kt
+++ b/discovery-android/src/test/kotlin/dev/bluehouse/bada/discovery/ble/BleQuickShareAdvertiserTest.kt
@@ -12,6 +12,7 @@ import dev.bluehouse.bada.protocol.endpoint.BleAdvertisementHeader
 import dev.bluehouse.bada.protocol.endpoint.BleServiceData
 import dev.bluehouse.bada.protocol.endpoint.DeviceType
 import dev.bluehouse.bada.protocol.endpoint.EndpointInfo
+import dev.bluehouse.bada.protocol.endpoint.NearbyServiceId
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
@@ -97,7 +98,7 @@ class BleQuickShareAdvertiserTest {
     }
 
     @Test
-    fun `start exposes visible EndpointInfo without RX instant extra field`() {
+    fun `start exposes visible EndpointInfo with RX instant connection advertisement`() {
         val gate = RecordingGate(failOnStart = false)
         val advertiser =
             BleQuickShareAdvertiser.forTesting(
@@ -131,12 +132,17 @@ class BleQuickShareAdvertiserTest {
 
         assertThat(visiblePayload).isNotNull()
         val visibleAdvertisement = BleAdvertisement.parse(visiblePayload!!)!!
-        assertThat(visibleAdvertisement.secondProfile).isTrue()
+        assertThat(visibleAdvertisement.secondProfile).isFalse()
         val visibleInfo = BleServiceData.parse(visiblePayload)!!.endpointInfo
         assertThat(visibleInfo.hidden).isFalse()
         assertThat(visibleInfo.deviceName).isEqualTo("Bada")
         assertThat(BleServiceData.parsePsmExtraField(visiblePayload)).isNull()
-        assertThat(visibleAdvertisement.rxInstantConnectionAdvertisement).isEmpty()
+        val rxAdvertisement = BleAdvertisement.parse(visibleAdvertisement.rxInstantConnectionAdvertisement)
+        assertThat(rxAdvertisement).isNotNull()
+        assertThat(rxAdvertisement!!.fastAdvertisement).isFalse()
+        assertThat(rxAdvertisement.secondProfile).isFalse()
+        assertThat(rxAdvertisement.serviceIdHash).isEqualTo(NearbyServiceId.hashPrefix)
+        assertThat(BleServiceData.parse(rxAdvertisement.data)!!.endpointInfo).isEqualTo(info)
         assertThat(visiblePayload.size).isGreaterThan(27)
     }
 
@@ -164,7 +170,10 @@ class BleQuickShareAdvertiserTest {
             assertThat(BleServiceData.parsePsmExtraField(call.visiblePayload!!)).isEqualTo(0x1234)
             val visibleAdvertisement = BleAdvertisement.parse(call.visiblePayload!!)!!
             assertThat(visibleAdvertisement.psm).isEqualTo(0x1234)
-            assertThat(visibleAdvertisement.rxInstantConnectionAdvertisement).isEmpty()
+            assertThat(visibleAdvertisement.secondProfile).isFalse()
+            val rxAdvertisement = BleAdvertisement.parse(visibleAdvertisement.rxInstantConnectionAdvertisement)
+            assertThat(rxAdvertisement).isNotNull()
+            assertThat(rxAdvertisement!!.psm).isEqualTo(0x1234)
         } finally {
             BleDctPsmHolder.clear()
         }

--- a/discovery-android/src/test/kotlin/dev/bluehouse/bada/discovery/bootstrap/BleGattInitialControlServerTest.kt
+++ b/discovery-android/src/test/kotlin/dev/bluehouse/bada/discovery/bootstrap/BleGattInitialControlServerTest.kt
@@ -7,6 +7,7 @@
 package dev.bluehouse.bada.discovery.bootstrap
 
 import com.google.common.truth.Truth.assertThat
+import dev.bluehouse.bada.protocol.endpoint.BleAdvertisement
 import dev.bluehouse.bada.protocol.endpoint.BleServiceData
 import dev.bluehouse.bada.protocol.endpoint.DeviceType
 import dev.bluehouse.bada.protocol.endpoint.EndpointInfo
@@ -55,8 +56,9 @@ class BleGattInitialControlServerTest {
             ).value
         assertThat(slotValue)
             .isNotNull()
-        assertThat(slotValue[0].toInt() and 0xFF)
-            .isEqualTo(BleServiceData.FRAME_TYPE_FAST_ADVERTISEMENT)
+        val advertisement = BleAdvertisement.parse(slotValue)
+        assertThat(advertisement).isNotNull()
+        assertThat(advertisement!!.fastAdvertisement).isFalse()
     }
 
     @Test
@@ -82,16 +84,40 @@ class BleGattInitialControlServerTest {
             .doesNotContain(BleGattInitialControlServer.GATT_SLOT_0_UUID)
     }
 
+    @Test
+    fun `advertisement slot preserves customized Bada receiver name`() {
+        val endpointInfo = sampleEndpointInfo(deviceName = "Bada177Lab")
+        val serviceSpecs =
+            BleGattInitialControlServer.buildServiceSpecs(
+                endpointInfo = endpointInfo,
+                endpointId = "2xLU".toByteArray(StandardCharsets.US_ASCII),
+                publishAdvertisementSlotService = true,
+            )
+
+        val slotValue =
+            requireNotNull(
+                serviceSpecs
+                    .single()
+                    .characteristics
+                    .firstOrNull { it.uuid == BleGattInitialControlServer.GATT_SLOT_0_UUID },
+            ).value
+        val advertisement = requireNotNull(BleAdvertisement.parse(slotValue))
+        val parsed = requireNotNull(BleServiceData.parse(advertisement.data))
+
+        assertThat(String(parsed.endpointId, StandardCharsets.US_ASCII)).isEqualTo("2xLU")
+        assertThat(parsed.endpointInfo).isEqualTo(endpointInfo)
+    }
+
     private fun BleGattInitialControlServer.Companion.GattServiceSpec.characteristicUuids() =
         characteristics.map { it.uuid }
 
-    private fun sampleEndpointInfo(): EndpointInfo =
+    private fun sampleEndpointInfo(deviceName: String = "Bada"): EndpointInfo =
         EndpointInfo(
             version = 1,
             hidden = false,
             deviceType = DeviceType.PHONE,
             reserved = false,
             metadata = ByteArray(EndpointInfo.METADATA_LEN) { index -> index.toByte() },
-            deviceName = "Bada",
+            deviceName = deviceName,
         )
 }


### PR DESCRIPTION
## Summary
- Add a pre-UKEY2 raw bandwidth-upgrade probe for BLE/BLE_L2CAP sender bootstraps.
- Adopt receiver WFD offers before UKEY2, then run the normal secure handshake on the upgraded transport.
- Keep stock Samsung sender paths on raw Nearby over BLE GATT / mDNS LAN, while preserving receiver-side multiplex tolerance.
- Publish same-Wi-Fi mDNS metadata (`IPv4`, `f`, customized receiver name) and keep sender fallback behavior bounded to bootstrap failures.

## Verification
- `./gradlew --no-daemon staticAnalysis :core-protocol:test :discovery-android:testDebugUnitTest :app:testDebugUnitTest :app:assembleDebug`

## Device Debug Loop
- Installed `app/build/outputs/apk/debug/app-debug.apk` on vivo `V2547A` after clearing the OriginOS Security Care prompt.
- Both devices were on `HomeAP_5Ghz`; Samsung mobile data was disabled for same-Wi-Fi isolation and Quick Share `Share with Apple devices` was off.
- Customized Bada advertised name persisted as `Bada177Lab`.
- Forward regression: Bada/vivo -> Samsung `SM-F966N` over same-Wi-Fi LAN, `pr178-forward-multiplex.bin` 65,536 bytes. Samsung showed `Bada177Lab wants to share`, completed with `1 file received from Bada177Lab`, and wrote `/sdcard/Download/Quick Share/pr178-forward-multiplex.bin` at 65,536 bytes.
- Reverse regression: Samsung `SM-F966N` -> Bada/vivo over same-Wi-Fi LAN, `pr178-reverse.bin` 65,536 bytes. Samsung showed `Bada177Lab` as `Sent`; vivo accepted `Kyujin's Z Fold7 wants to share files` and wrote `/sdcard/Download/pr178-reverse (1).bin` at 65,536 bytes.

Addresses #177