### PR TITLE
feat: Quick Settings tile to toggle receiver discoverability

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -333,6 +333,34 @@
             android:theme="@style/Theme.Bada.ConsentDialog"
             android:label="@string/consent_activity_label" />
 
+        <!--
+          Quick Settings tile: toggles the receiver's "always visible"
+          override straight from the system Quick Settings panel so the
+          user can make this device discoverable to nearby Quick Share
+          senders without opening the app.
+
+          Required by the platform: exported=true plus the
+          BIND_QUICK_SETTINGS_TILE permission (only system_server, which
+          binds the tile, holds it) and the QS_TILE action filter. The
+          icon must be a 24dp solid-white VectorDrawable.
+
+          TOGGLEABLE_TILE marks this as a two-state on/off switch for
+          accessibility and so the OS understands the tile's behavior.
+        -->
+        <service
+            android:name=".tile.BadaQuickShareTileService"
+            android:exported="true"
+            android:icon="@drawable/ic_qs_bada_visible"
+            android:label="@string/qs_tile_label"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.TOGGLEABLE_TILE"
+                android:value="true" />
+        </service>
+
     </application>
 
 </manifest>

--- a/app/src/main/kotlin/dev/bluehouse/bada/tile/BadaQuickShareTileService.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/tile/BadaQuickShareTileService.kt
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.tile
+
+import android.app.PendingIntent
+import android.content.Intent
+import android.graphics.drawable.Icon
+import android.os.Build
+import android.service.quicksettings.Tile
+import android.service.quicksettings.TileService
+import android.util.Log
+import dev.bluehouse.bada.MainActivity
+import dev.bluehouse.bada.R
+import dev.bluehouse.bada.onboarding.PermissionRequirements
+import dev.bluehouse.bada.service.receiver.MdnsVisibilityOverrideHolder
+import dev.bluehouse.bada.service.receiver.ReceiverForegroundService
+
+/**
+ * Quick Settings tile that turns Bada "on" — i.e. forces the receiver to
+ * be discoverable to nearby Quick Share senders — straight from the
+ * system Quick Settings panel, without opening the app.
+ *
+ * Tapping the tile toggles the same process-wide
+ * [MdnsVisibilityOverrideHolder] "always visible" override that the
+ * in-app Send/Receive pill drives (see `SendReceiveFragment`), and brings
+ * the [ReceiverForegroundService] up/down to back it. ON publishes the
+ * mDNS + BLE fast advertisement unconditionally; OFF clears the override
+ * and stops the receiver.
+ *
+ * State model: the tile mirrors [MdnsVisibilityOverrideHolder.isActive].
+ * The override lives in memory only and resets on process death, so a
+ * cold Quick Settings panel correctly shows the tile OFF (nothing is
+ * actually advertising). [onStartListening] re-syncs every time the panel
+ * opens, which keeps the tile consistent with the in-app pill even though
+ * one cannot change the override while the other is on screen.
+ *
+ * This is a standard (listening) tile rather than an active tile: the
+ * override has no cross-module way to push `requestListeningState`, and
+ * re-reading the holder in [onStartListening] is enough for eventual
+ * consistency.
+ */
+internal class BadaQuickShareTileService : TileService() {
+    /**
+     * Fires each time the Quick Settings panel becomes visible. Re-read
+     * the current override so the tile reflects state changed elsewhere
+     * (the in-app pill, or a process restart that reset the override).
+     */
+    override fun onStartListening() {
+        super.onStartListening()
+        syncTile()
+    }
+
+    override fun onClick() {
+        super.onClick()
+        if (MdnsVisibilityOverrideHolder.isActive) {
+            turnOff()
+        } else {
+            turnOn()
+        }
+        syncTile()
+    }
+
+    private fun turnOn() {
+        // Being discoverable needs the mandatory discovery permission
+        // (NEARBY_WIFI_DEVICES on API 33+). If it isn't granted yet,
+        // toggling the override would light up a switch that can never
+        // actually advertise — so bounce the user into the app instead,
+        // which routes to the permissions onboarding. This mirrors
+        // MainActivity's own service-start gate.
+        if (!PermissionRequirements.allGranted(this) &&
+            !PermissionRequirements.onlyOptionalMissing(this)
+        ) {
+            openApp()
+            return
+        }
+
+        MdnsVisibilityOverrideHolder.setAlwaysVisible(true)
+        try {
+            ReceiverForegroundService.start(this)
+        } catch (e: IllegalStateException) {
+            // Android 12+ forbids most background foreground-service
+            // starts; ForegroundServiceStartNotAllowedException (API 31+)
+            // extends IllegalStateException, and a Quick Settings tap is
+            // NOT one of the platform's documented start exemptions. When
+            // Bada is fully backgrounded the start can therefore be
+            // rejected. Fall back to opening the app: MainActivity starts
+            // the receiver from a visible (exempt) context, and the
+            // override we just set makes the gate advertise immediately.
+            Log.w(TAG, "Foreground-service start from tile rejected; opening app instead", e)
+            openApp()
+        }
+    }
+
+    private fun turnOff() {
+        MdnsVisibilityOverrideHolder.setAlwaysVisible(false)
+        // stop() delivers ACTION_STOP through startService to the
+        // already-running service. Re-delivering to a running service is
+        // allowed from the background, so this needs no FGS-start handling.
+        ReceiverForegroundService.stop(this)
+    }
+
+    /**
+     * Push the current override state onto the tile. Safe to call from
+     * any callback; no-ops if the platform has not handed us a [Tile]
+     * yet (e.g. before the service is fully bound).
+     */
+    private fun syncTile() {
+        val tile = qsTile ?: return
+        val active = MdnsVisibilityOverrideHolder.isActive
+        tile.state = if (active) Tile.STATE_ACTIVE else Tile.STATE_INACTIVE
+        tile.label = getString(R.string.qs_tile_label)
+        tile.icon = Icon.createWithResource(this, R.drawable.ic_qs_bada_visible)
+        val statusRes = if (active) R.string.qs_tile_subtitle_on else R.string.qs_tile_subtitle_off
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            tile.subtitle = getString(statusRes)
+        }
+        tile.contentDescription =
+            getString(
+                if (active) R.string.qs_tile_content_desc_on else R.string.qs_tile_content_desc_off,
+            )
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            tile.stateDescription = getString(statusRes)
+        }
+        tile.updateTile()
+    }
+
+    /**
+     * Collapse the panel and bring up [MainActivity]. Used both when a
+     * mandatory permission is missing (MainActivity routes to onboarding)
+     * and as the fallback when a background foreground-service start is
+     * rejected.
+     *
+     * API 34 made [startActivityAndCollapse] with a bare `Intent` throw;
+     * the `PendingIntent` overload it added is the supported path there,
+     * while older platforms still take the `Intent` form.
+     */
+    private fun openApp() {
+        val intent =
+            Intent(this, MainActivity::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            val pending =
+                PendingIntent.getActivity(
+                    this,
+                    0,
+                    intent,
+                    PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+                )
+            startActivityAndCollapse(pending)
+        } else {
+            @Suppress("DEPRECATION")
+            startActivityAndCollapse(intent)
+        }
+    }
+
+    private companion object {
+        const val TAG = "BadaQsTile"
+    }
+}

--- a/app/src/main/res/drawable/ic_qs_bada_visible.xml
+++ b/app/src/main/res/drawable/ic_qs_bada_visible.xml
@@ -1,0 +1,22 @@
+<!--
+  Quick Settings tile icon. Per the platform guidance the tile icon
+  must be a 24x24dp solid-white VectorDrawable on a transparent
+  background; Quick Settings tints it for the active / inactive states
+  itself, so the source paths are pure white.
+
+  Glyph is the Material "wifi_tethering" broadcast mark — a centre dot
+  radiating concentric arcs — which reads as "this device is
+  discoverable / broadcasting to nearby peers", matching what toggling
+  the tile actually does (force the receiver's always-visible mDNS/BLE
+  advertisement).
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFFFF">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,11c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2zM18,13c0,-3.31 -2.69,-6 -6,-6s-6,2.69 -6,6c0,2.22 1.21,4.15 3,5.19l1,-1.74c-1.19,-0.7 -2,-1.97 -2,-3.45 0,-2.21 1.79,-4 4,-4s4,1.79 4,4c0,1.48 -0.81,2.75 -2,3.45l1,1.74c1.79,-1.04 3,-2.97 3,-5.19zM12,3C6.48,3 2,7.48 2,13c0,3.7 2.01,6.92 4.99,8.65l1,-1.73C5.61,18.53 4,15.96 4,13c0,-4.42 3.58,-8 8,-8s8,3.58 8,8c0,2.96 -1.61,5.53 -4,6.92l1,1.73c2.98,-1.73 4.99,-4.95 4.99,-8.65C22,7.48 17.52,3 12,3z" />
+</vector>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -300,4 +300,11 @@
     <string name="consent_state_close">닫기</string>
     <string name="consent_state_view_image_unavailable">이 이미지를 열 수 있는 앱이 없습니다.</string>
 
+    <!-- Quick Settings tile. `qs_tile_label` ("Bada") is a proper noun
+         and intentionally NOT overridden here. -->
+    <string name="qs_tile_subtitle_on">검색 가능</string>
+    <string name="qs_tile_subtitle_off">꺼짐</string>
+    <string name="qs_tile_content_desc_on">근처 기기에서 Bada를 검색할 수 있습니다</string>
+    <string name="qs_tile_content_desc_off">Bada를 검색할 수 없습니다</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -442,4 +442,19 @@
       survives string formatting unchanged.
     -->
     <string name="transfer_progress_percent">%1$d%%</string>
+
+    <!--
+      Quick Settings tile (BadaQuickShareTileService). Toggles the
+      receiver's "always visible" override from the system Quick Settings
+      panel. `qs_tile_label` is also the tile's manifest android:label
+      (shown in the Quick Settings edit tray) — keep it under ~18 chars
+      and untranslated (proper noun). The subtitle/state strings render
+      under the tile label on API 29+; the content descriptions back
+      TalkBack on every API level.
+    -->
+    <string name="qs_tile_label">Bada</string>
+    <string name="qs_tile_subtitle_on">Discoverable</string>
+    <string name="qs_tile_subtitle_off">Off</string>
+    <string name="qs_tile_content_desc_on">Bada is discoverable to nearby devices</string>
+    <string name="qs_tile_content_desc_off">Bada is not discoverable</string>
 </resources>


### PR DESCRIPTION
## Summary

Adds `BadaQuickShareTileService`, a Quick Settings tile that makes the device discoverable to nearby Quick Share senders straight from the system Quick Settings panel — no need to open the app.

Tapping the tile toggles the same process-wide `MdnsVisibilityOverrideHolder` "always visible" override that the in-app Send/Receive pill drives, and brings `ReceiverForegroundService` up/down to back it. ON publishes mDNS + the BLE fast advertisement unconditionally; OFF clears the override and stops the receiver.

## Details

- **State model:** the tile mirrors `MdnsVisibilityOverrideHolder.isActive`; `onStartListening` re-syncs each time the panel opens (standard listening tile).
- **Background FGS-start handling:** a Quick Settings tap is **not** on the platform's foreground-service start-from-background exemption list, so when the app is backgrounded `startForegroundService` can throw `ForegroundServiceStartNotAllowedException`. The tile catches it and falls back to opening `MainActivity`, which starts the receiver from a visible (exempt) context; the override set beforehand makes the gate advertise immediately.
- **Permission gate:** if the mandatory discovery permission is missing, the tile routes the user into the app (onboarding) instead of toggling a switch that can't advertise.
- **API 34:** uses the `startActivityAndCollapse(PendingIntent)` form on API 34+, the `Intent` form below.
- Manifest `<service>` with `BIND_QUICK_SETTINGS_TILE`, `QS_TILE` intent-filter, 24dp white vector icon, and `TOGGLEABLE_TILE` metadata. Strings added to `values` + `values-ko` (Japanese follow-up after the i18n branch merges).

## Testing
- `:app:assembleDebug`, `:app:ktlintCheck`, `:app:detekt` pass.
- Verified on a vivo device (Android 16): foreground direct-start path and background fallback path (`ForegroundServiceStartNotAllowedException` → open-app → receiver starts, gate publishes with `overrideOn=true`).