### PR TITLE
feat: prompt for full-screen-intent so background transfers pop the PIN

### DIFF
--- a/app/src/main/kotlin/dev/bluehouse/bada/MainActivity.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/MainActivity.kt
@@ -26,6 +26,8 @@ import com.google.android.material.bottomnavigation.BottomNavigationView
 import dev.bluehouse.bada.battery.BatteryOptimizationOemHelper
 import dev.bluehouse.bada.battery.BatteryOptimizationPreferences
 import dev.bluehouse.bada.bugreport.BugReportFlowSupport
+import dev.bluehouse.bada.consent.FullScreenIntentPermission
+import dev.bluehouse.bada.consent.FullScreenIntentPreferences
 import dev.bluehouse.bada.onboarding.PermissionRequirements
 import dev.bluehouse.bada.onboarding.PermissionsOnboardingActivity
 import dev.bluehouse.bada.service.receiver.ReceiverForegroundService
@@ -83,6 +85,14 @@ class MainActivity : AppCompatActivity() {
     private var batteryDialogShownThisSession: Boolean = false
 
     /**
+     * Session latch for the full-screen-intent first-launch prompt,
+     * mirroring [batteryDialogShownThisSession]. Survives configuration
+     * changes via `savedInstanceState`; a fresh cold start clears it and
+     * the dialog re-evaluates against [FullScreenIntentPreferences].
+     */
+    private var fsiDialogShownThisSession: Boolean = false
+
+    /**
      * Shake-to-report bug flow (#166). Lives at the activity level
      * because the support class registers a process-lifetime
      * SensorEventListener, hooks the activity's
@@ -106,6 +116,7 @@ class MainActivity : AppCompatActivity() {
         savedInstanceState?.let {
             onboardingLaunched = it.getBoolean(STATE_ONBOARDING_LAUNCHED, false)
             batteryDialogShownThisSession = it.getBoolean(STATE_BATTERY_DIALOG_SHOWN, false)
+            fsiDialogShownThisSession = it.getBoolean(STATE_FSI_DIALOG_SHOWN, false)
         }
 
         val toolbar = findViewById<MaterialToolbar>(R.id.main_toolbar)
@@ -239,6 +250,7 @@ class MainActivity : AppCompatActivity() {
         super.onSaveInstanceState(outState)
         outState.putBoolean(STATE_ONBOARDING_LAUNCHED, onboardingLaunched)
         outState.putBoolean(STATE_BATTERY_DIALOG_SHOWN, batteryDialogShownThisSession)
+        outState.putBoolean(STATE_FSI_DIALOG_SHOWN, fsiDialogShownThisSession)
     }
 
     override fun onStart() {
@@ -273,13 +285,15 @@ class MainActivity : AppCompatActivity() {
         // internally and gracefully no-op rather than crash.
         ReceiverForegroundService.start(this)
 
-        // Battery-exemption prompt (#47, dialog form). Replaces the
-        // banner that previously lived inline in SendReceiveFragment.
-        // The session latch keeps the dialog from re-raising on
-        // returns from CreditActivity / system Settings; the prefs
-        // dismissal keeps it from re-raising on cold starts after
-        // the user has chosen Skip or Open Settings once.
-        maybeShowBatteryOptimizationDialog()
+        // First-launch prompts (#47 battery, full-screen-intent). Show at
+        // most one per onStart so the user never faces stacked dialogs:
+        // the battery exemption takes priority, and the full-screen-intent
+        // prompt only raises when the battery one did not. Each is gated
+        // by its own session latch + persisted dismissal flag, so the
+        // skipped one still gets its turn on a later cold start.
+        if (!maybeShowBatteryOptimizationDialog()) {
+            maybeShowFullScreenIntentDialog()
+        }
     }
 
     /**
@@ -305,11 +319,11 @@ class MainActivity : AppCompatActivity() {
      *                             will re-prompt.
      */
     @Suppress("ReturnCount")
-    private fun maybeShowBatteryOptimizationDialog() {
-        if (batteryDialogShownThisSession) return
-        if (BatteryOptimizationPreferences.from(this).hasBeenDismissed()) return
-        if (BatteryOptimizationOemHelper.isAlreadyExempt(this)) return
-        if (BatteryOptimizationOemHelper.intentsForCurrentDevice(this).isEmpty()) return
+    private fun maybeShowBatteryOptimizationDialog(): Boolean {
+        if (batteryDialogShownThisSession) return false
+        if (BatteryOptimizationPreferences.from(this).hasBeenDismissed()) return false
+        if (BatteryOptimizationOemHelper.isAlreadyExempt(this)) return false
+        if (BatteryOptimizationOemHelper.intentsForCurrentDevice(this).isEmpty()) return false
 
         batteryDialogShownThisSession = true
 
@@ -327,12 +341,56 @@ class MainActivity : AppCompatActivity() {
                     .show()
             }.setCancelable(true)
             .show()
+        return true
+    }
+
+    /**
+     * Raise the full-screen-intent first-launch prompt at most once per
+     * MainActivity instance. Only relevant on Android 14+, where
+     * `USE_FULL_SCREEN_INTENT` became a special access that is
+     * auto-denied for non-calendar/alarm apps — without it the
+     * incoming-transfer consent prompt cannot pop full-screen while Bada
+     * is backgrounded and degrades to a heads-up notification.
+     *
+     * Gated identically to the battery prompt: session latch + persisted
+     * dismissal. Only shows when the access is actually requestable
+     * (API 34+ and not yet granted).
+     *
+     * Open Settings → route to the system page and mark dismissed.
+     * Skip → mark dismissed and Toast that it lives in the Settings tab.
+     *
+     * @return true when the dialog was shown this call.
+     */
+    @Suppress("ReturnCount")
+    private fun maybeShowFullScreenIntentDialog(): Boolean {
+        if (fsiDialogShownThisSession) return false
+        if (FullScreenIntentPreferences.from(this).hasBeenDismissed()) return false
+        if (!FullScreenIntentPermission.isRequestable(this)) return false
+
+        fsiDialogShownThisSession = true
+
+        AlertDialog
+            .Builder(this)
+            .setTitle(R.string.settings_fsi_title)
+            .setMessage(R.string.fsi_dialog_body)
+            .setPositiveButton(R.string.settings_fsi_open) { _, _ ->
+                FullScreenIntentPermission.openSettings(this)
+                FullScreenIntentPreferences.from(this).markDismissed()
+            }.setNegativeButton(R.string.main_battery_banner_skip) { _, _ ->
+                FullScreenIntentPreferences.from(this).markDismissed()
+                Toast
+                    .makeText(this, R.string.fsi_dialog_skip_toast, Toast.LENGTH_LONG)
+                    .show()
+            }.setCancelable(true)
+            .show()
+        return true
     }
 
     internal companion object {
         private const val TAG = "BadaMain"
         private const val STATE_ONBOARDING_LAUNCHED = "bada.main.onboardingLaunched"
         private const val STATE_BATTERY_DIALOG_SHOWN = "bada.main.batteryDialogShown"
+        private const val STATE_FSI_DIALOG_SHOWN = "bada.main.fsiDialogShown"
 
         // Bottom-nav icon scale on press (matches vivo native).
         private const val PRESSED_ICON_SCALE = 0.85f

--- a/app/src/main/kotlin/dev/bluehouse/bada/consent/FullScreenIntentPermission.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/consent/FullScreenIntentPermission.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.consent
+
+import android.app.NotificationManager
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.provider.Settings
+import android.util.Log
+import androidx.core.content.getSystemService
+
+/**
+ * Helpers for the `USE_FULL_SCREEN_INTENT` special app access that the
+ * incoming-transfer consent popup (#22) relies on to raise
+ * [ConsentTrampolineActivity] over the lock screen / other apps when a
+ * transfer arrives while Bada is in the background.
+ *
+ * Android 14 (API 34) turned `USE_FULL_SCREEN_INTENT` from an
+ * install-time grant into a special app access that is auto-denied for
+ * everything except the default calendar / alarm apps. When it is not
+ * granted, `ConsentNotification`'s `setFullScreenIntent(...)` silently
+ * degrades to a heads-up notification: the PIN and Accept / Reject
+ * actions are still shown, but the full-screen prompt no longer pops
+ * automatically. This helper lets the app detect that state and route
+ * the user to the system page that toggles it.
+ *
+ * On API <= 33 the permission is granted at install time, so
+ * [isApplicable] is false (nothing to ask for) and [isGranted] is always
+ * true.
+ */
+internal object FullScreenIntentPermission {
+    /**
+     * True when the platform will honour a full-screen intent for this
+     * app. Always true below API 34 (install-time grant); on API 34+ it
+     * reflects [NotificationManager.canUseFullScreenIntent].
+     */
+    @Suppress("ReturnCount")
+    fun isGranted(context: Context): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) return true
+        val notificationManager = context.getSystemService<NotificationManager>() ?: return false
+        return notificationManager.canUseFullScreenIntent()
+    }
+
+    /**
+     * True on API 34+ regardless of grant state — i.e. the special
+     * access exists as a user-grantable toggle on this device. The
+     * Settings tab uses this to decide whether to show the row at all;
+     * the concept does not exist below API 34.
+     */
+    fun isApplicable(): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
+
+    /**
+     * True only when the access both exists (API 34+) AND is not
+     * currently granted. Used to decide whether to surface the
+     * first-launch prompt — there is nothing to ask for otherwise.
+     */
+    fun isRequestable(context: Context): Boolean = isApplicable() && !isGranted(context)
+
+    /**
+     * Open the system "Full screen notifications" special-access page
+     * for this app. Falls back to the app's notification settings, then
+     * the app details page, if the dedicated action is unavailable on
+     * the device. Logs and returns on a fully unresolvable device rather
+     * than throwing.
+     */
+    fun openSettings(context: Context) {
+        val packageUri = Uri.fromParts("package", context.packageName, null)
+        val candidates =
+            buildList {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                    add(
+                        Intent(Settings.ACTION_MANAGE_APP_USE_FULL_SCREEN_INTENT, packageUri)
+                            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+                    )
+                }
+                add(
+                    Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
+                        .putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
+                        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+                )
+                add(
+                    Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS, packageUri)
+                        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+                )
+            }
+        for (intent in candidates) {
+            try {
+                context.startActivity(intent)
+                return
+            } catch (e: ActivityNotFoundException) {
+                Log.w(TAG, "Full-screen-intent settings not launchable: ${intent.action}", e)
+            }
+        }
+    }
+
+    private const val TAG = "BadaFsi"
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/consent/FullScreenIntentPreferences.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/consent/FullScreenIntentPreferences.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.consent
+
+import android.content.Context
+import android.content.SharedPreferences
+
+/**
+ * "Shown once" flag for the full-screen-intent first-launch prompt,
+ * mirroring [dev.bluehouse.bada.battery.BatteryOptimizationPreferences].
+ *
+ * The dialog raised by `MainActivity` asks the user to grant the
+ * `USE_FULL_SCREEN_INTENT` special access (Android 14+) so background
+ * transfer consent prompts can pop full-screen. Once the user taps Skip
+ * or Open Settings, [markDismissed] keeps the one-time dialog from
+ * re-raising on later cold starts. The Settings-tab row stays available
+ * regardless, so the user can revisit the access without clearing app
+ * data.
+ */
+internal class FullScreenIntentPreferences(
+    private val prefs: SharedPreferences,
+) {
+    /**
+     * True once the user has tapped Skip or successfully reached the
+     * system full-screen-notifications page from the first-launch
+     * dialog. The dialog stays hidden in either case.
+     */
+    fun hasBeenDismissed(): Boolean = prefs.getBoolean(KEY_DISMISSED, false)
+
+    /** Marks the prompt as handled. Idempotent after the first commit. */
+    fun markDismissed() {
+        prefs.edit().putBoolean(KEY_DISMISSED, true).apply()
+    }
+
+    internal companion object {
+        internal const val PREFS_NAME = "bada.full_screen_intent"
+
+        private const val KEY_DISMISSED = "full_screen_intent_prompt_dismissed"
+
+        fun from(context: Context): FullScreenIntentPreferences =
+            FullScreenIntentPreferences(
+                context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE),
+            )
+    }
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/ui/SettingsFragment.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/ui/SettingsFragment.kt
@@ -21,6 +21,7 @@ import dev.bluehouse.bada.MainActivity
 import dev.bluehouse.bada.R
 import dev.bluehouse.bada.battery.BatteryOptimizationOemHelper
 import dev.bluehouse.bada.bugreport.BugReportPreferences
+import dev.bluehouse.bada.consent.FullScreenIntentPermission
 import dev.bluehouse.bada.service.downloads.SaveLocationDisplayName
 import dev.bluehouse.bada.service.downloads.SaveLocationPreferences
 import dev.bluehouse.bada.service.receiver.AdvertisedDeviceNames
@@ -117,6 +118,10 @@ internal class SettingsFragment : Fragment(R.layout.fragment_settings) {
             MainActivity.openBatterySettings(requireContext())
         }
 
+        view.findViewById<Button>(R.id.settings_fsi_open).setOnClickListener {
+            FullScreenIntentPermission.openSettings(requireContext())
+        }
+
         val bugReportSwitch = view.findViewById<SwitchCompat>(R.id.main_bug_report_switch)
         val bugReportPreferences = BugReportPreferences.from(requireContext())
         bugReportSwitch.isChecked = bugReportPreferences.isShakeToReportEnabled()
@@ -135,11 +140,17 @@ internal class SettingsFragment : Fragment(R.layout.fragment_settings) {
         refreshSaveLocationLabel()
         refreshAdvertisedNameSection()
         refreshBatteryStatus()
+        refreshFullScreenIntentSection()
         refreshBugReportSwitch()
     }
 
     override fun onResume() {
         super.onResume()
+        // Full-screen-intent access is toggled on a system Settings page
+        // that, like the battery overlay, can dismiss without fully
+        // stopping this activity on some OEM ROMs. Re-check on resume so
+        // the status line flips immediately after the user grants it.
+        refreshFullScreenIntentSection()
         // Re-check the battery-optimization exemption on every resume.
         // The platform's `ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS`
         // dialog is a translucent overlay on some OEM ROMs (vivo
@@ -183,6 +194,30 @@ internal class SettingsFragment : Fragment(R.layout.fragment_settings) {
                 getString(R.string.settings_battery_status_exempt)
             } else {
                 getString(R.string.settings_battery_status_not_exempt)
+            }
+    }
+
+    /**
+     * Show the full-screen-alerts card only on Android 14+ (where
+     * `USE_FULL_SCREEN_INTENT` is a grantable special access) and reflect
+     * the current grant state in its status line. On older platforms the
+     * permission is install-time, so the whole card stays hidden.
+     */
+    @Suppress("ReturnCount")
+    private fun refreshFullScreenIntentSection() {
+        val v = view ?: return
+        val card = v.findViewById<View>(R.id.settings_fsi_card) ?: return
+        if (!FullScreenIntentPermission.isApplicable()) {
+            card.visibility = View.GONE
+            return
+        }
+        card.visibility = View.VISIBLE
+        val status = v.findViewById<TextView>(R.id.settings_fsi_status) ?: return
+        status.text =
+            if (FullScreenIntentPermission.isGranted(requireContext())) {
+                getString(R.string.settings_fsi_status_granted)
+            } else {
+                getString(R.string.settings_fsi_status_not_granted)
             }
     }
 

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -275,6 +275,62 @@
 
         </LinearLayout>
 
+        <!-- ============ Card: Full-screen transfer alerts (API 34+) ============
+             Hidden by default; SettingsFragment makes it visible only on
+             Android 14+, where USE_FULL_SCREEN_INTENT became a grantable
+             special access. Lets the consent PIN prompt pop full-screen
+             over other apps / the lock screen when a transfer arrives
+             while Bada is in the background. -->
+        <LinearLayout
+            android:id="@+id/settings_fsi_card"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:background="@drawable/settings_card_background"
+            android:orientation="vertical"
+            android:padding="20dp"
+            android:visibility="gone">
+
+            <TextView
+                android:id="@+id/settings_fsi_title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/settings_fsi_title"
+                android:textAppearance="@style/TextAppearance.AppCompat.Subhead"
+                android:textColor="?android:attr/textColorPrimary"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/settings_fsi_subtitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:text="@string/settings_fsi_subtitle"
+                android:textAppearance="@style/TextAppearance.AppCompat.Small"
+                android:textColor="?android:attr/textColorSecondary" />
+
+            <TextView
+                android:id="@+id/settings_fsi_status"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:background="@drawable/qr_url_background"
+                android:paddingHorizontal="12dp"
+                android:paddingVertical="10dp"
+                android:textAppearance="@style/TextAppearance.AppCompat.Body2"
+                android:textColor="?android:attr/textColorPrimary"
+                android:textIsSelectable="true"
+                tools:text="Currently: full-screen alerts not allowed" />
+
+            <Button
+                android:id="@+id/settings_fsi_open"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:text="@string/settings_fsi_open" />
+
+        </LinearLayout>
+
         <!-- ============ Card 4: Shake-to-report bug ============ -->
         <!--
           Switch row: title and Switch share a horizontal row so

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -129,6 +129,15 @@
     <string name="settings_battery_status_not_exempt">현재: 제외되지 않음. 백그라운드에서 수신이 중단될 수 있습니다</string>
     <string name="settings_battery_open">배터리 설정 열기</string>
 
+    <!-- Settings tab "전체 화면 수신 알림" row + first-launch dialog (Android 14+). -->
+    <string name="settings_fsi_title">전체 화면 수신 알림</string>
+    <string name="settings_fsi_subtitle">전체 화면 알림을 허용하면 Bada가 백그라운드에 있을 때 수신 요청이 와도 다른 앱 위나 잠금 화면에서 PIN이 바로 표시됩니다. 허용하지 않아도 알림을 눌러 PIN을 확인할 수 있습니다.</string>
+    <string name="settings_fsi_status_granted">현재: 전체 화면 알림 허용됨</string>
+    <string name="settings_fsi_status_not_granted">현재: 허용되지 않음. PIN 요청이 알림으로 표시됩니다</string>
+    <string name="settings_fsi_open">알림 설정 열기</string>
+    <string name="fsi_dialog_body">Bada가 백그라운드에 있을 때 수신 요청이 오면, 화면 위로 PIN 요청을 띄우기 위해 전체 화면 알림 권한이 필요합니다. 허용하지 않으면 요청이 일반 알림으로 도착하며, 눌러서 열 수 있습니다. 설정을 열어 허용하거나, 나중에 설정 탭에서 처리하려면 건너뛰세요.</string>
+    <string name="fsi_dialog_skip_toast">설정에서 변경할 수 있습니다.</string>
+
     <!-- Permissions onboarding (#26 + #31). -->
     <string name="onboarding_title">앱 권한</string>
     <string name="onboarding_intro">Quick Share는 로컬 Wi-Fi 네트워크에서 근처 기기를 검색하고, 근처 Quick Share 수신기를 깨우는 짧은 Bluetooth Low Energy 신호를 송수신하며, 전송 상태를 알리기 위해 몇 가지 Android 권한이 필요합니다. 아래에서 각 권한이 어떻게 사용되는지 확인할 수 있습니다.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -185,6 +185,22 @@
     <string name="settings_battery_status_not_exempt">Currently: not exempt — receiving may stop in the background</string>
     <string name="settings_battery_open">Open battery settings</string>
 
+    <!-- Settings tab "Full-screen transfer alerts" row + first-launch
+         dialog (Android 14+). On API 34+ USE_FULL_SCREEN_INTENT is a
+         special access that is auto-denied; without it the incoming
+         consent prompt (with the PIN) cannot pop full-screen over other
+         apps / the lock screen while Bada is in the background and
+         degrades to a heads-up notification. The row and dialog route
+         the user to the system page that grants it. The row is hidden
+         entirely below API 34, where the permission is install-time. -->
+    <string name="settings_fsi_title">Full-screen transfer alerts</string>
+    <string name="settings_fsi_subtitle">Allow full-screen notifications so an incoming transfer can show its PIN over other apps and on the lock screen when Bada is in the background. Without it, you still get a notification you can tap to see the PIN.</string>
+    <string name="settings_fsi_status_granted">Currently: full-screen alerts allowed</string>
+    <string name="settings_fsi_status_not_granted">Currently: not allowed — the PIN prompt arrives as a notification instead</string>
+    <string name="settings_fsi_open">Open notification settings</string>
+    <string name="fsi_dialog_body">When a transfer arrives while Bada is in the background, Android needs the full-screen notification permission to pop the PIN prompt over your screen. Without it, the prompt arrives as a regular notification you tap to open. Open settings to allow it, or Skip to handle it later from the Settings tab.</string>
+    <string name="fsi_dialog_skip_toast">You can change this from Settings.</string>
+
     <!-- Permissions onboarding (#26 + #31). -->
     <string name="onboarding_title">App permissions</string>
     <string name="onboarding_intro">Quick Share needs a small set of Android permissions to discover nearby devices over your local Wi-Fi network, to broadcast and listen for short Bluetooth Low Energy pulses that wake nearby Quick Share receivers, and to keep you informed about transfers. Each permission below explains exactly what it is used for.</string>


### PR DESCRIPTION
## Summary

Lets the incoming-transfer consent prompt (`ConsentTrampolineActivity`, with the PIN) pop full-screen over other apps / the lock screen when a transfer arrives while Bada is in the **background**.

The consent flow already attaches a full-screen intent to the consent notification, but on **Android 14+** `USE_FULL_SCREEN_INTENT` became a special access that is auto-denied for non-calendar/alarm apps. Without it the full-screen popup silently degrades to a heads-up notification. This PR adds the missing piece: detecting the grant state and routing the user to grant it.

## Details

- **`FullScreenIntentPermission`** — `canUseFullScreenIntent()` check (always true below API 34, where it's install-time) and a settings route (`ACTION_MANAGE_APP_USE_FULL_SCREEN_INTENT`, with notification-settings / app-details fallbacks).
- **First-launch dialog** in `MainActivity`, chained *after* the battery-optimization prompt so dialogs never stack; gated by a session latch + persisted dismissal flag (`FullScreenIntentPreferences`), and only when the access is actually requestable (API 34+ and not granted).
- **Settings-tab row** showing the current grant status with a button to the system page. Hidden entirely below API 34, where the permission is install-time.
- No changes to the consent notification itself — it already sets the full-screen intent, so granting the access is all that's needed for the popup to fire.

Strings added to `values` + `values-ko` (Japanese follow-up after the i18n branch merges).

## Testing
- `:app:assembleDebug`, `:app:ktlintCheck`, `:app:detekt` pass.
- Verified on a vivo device (Android 16): app builds/installs; the Settings row and first-launch prompt only surface when the access is ungranted on API 34+.