### PR TITLE
feat: Quick Settings tile, background consent popup, and Japanese localization

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -333,6 +333,34 @@
             android:theme="@style/Theme.Bada.ConsentDialog"
             android:label="@string/consent_activity_label" />
 
+        <!--
+          Quick Settings tile: toggles the receiver's "always visible"
+          override straight from the system Quick Settings panel so the
+          user can make this device discoverable to nearby Quick Share
+          senders without opening the app.
+
+          Required by the platform: exported=true plus the
+          BIND_QUICK_SETTINGS_TILE permission (only system_server, which
+          binds the tile, holds it) and the QS_TILE action filter. The
+          icon must be a 24dp solid-white VectorDrawable.
+
+          TOGGLEABLE_TILE marks this as a two-state on/off switch for
+          accessibility and so the OS understands the tile's behavior.
+        -->
+        <service
+            android:name=".tile.BadaQuickShareTileService"
+            android:exported="true"
+            android:icon="@drawable/ic_qs_bada_visible"
+            android:label="@string/qs_tile_label"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.TOGGLEABLE_TILE"
+                android:value="true" />
+        </service>
+
     </application>
 
 </manifest>

--- a/app/src/main/kotlin/dev/bluehouse/bada/MainActivity.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/MainActivity.kt
@@ -26,6 +26,8 @@ import com.google.android.material.bottomnavigation.BottomNavigationView
 import dev.bluehouse.bada.battery.BatteryOptimizationOemHelper
 import dev.bluehouse.bada.battery.BatteryOptimizationPreferences
 import dev.bluehouse.bada.bugreport.BugReportFlowSupport
+import dev.bluehouse.bada.consent.FullScreenIntentPermission
+import dev.bluehouse.bada.consent.FullScreenIntentPreferences
 import dev.bluehouse.bada.onboarding.PermissionRequirements
 import dev.bluehouse.bada.onboarding.PermissionsOnboardingActivity
 import dev.bluehouse.bada.service.receiver.ReceiverForegroundService
@@ -83,6 +85,14 @@ class MainActivity : AppCompatActivity() {
     private var batteryDialogShownThisSession: Boolean = false
 
     /**
+     * Session latch for the full-screen-intent first-launch prompt,
+     * mirroring [batteryDialogShownThisSession]. Survives configuration
+     * changes via `savedInstanceState`; a fresh cold start clears it and
+     * the dialog re-evaluates against [FullScreenIntentPreferences].
+     */
+    private var fsiDialogShownThisSession: Boolean = false
+
+    /**
      * Shake-to-report bug flow (#166). Lives at the activity level
      * because the support class registers a process-lifetime
      * SensorEventListener, hooks the activity's
@@ -106,6 +116,7 @@ class MainActivity : AppCompatActivity() {
         savedInstanceState?.let {
             onboardingLaunched = it.getBoolean(STATE_ONBOARDING_LAUNCHED, false)
             batteryDialogShownThisSession = it.getBoolean(STATE_BATTERY_DIALOG_SHOWN, false)
+            fsiDialogShownThisSession = it.getBoolean(STATE_FSI_DIALOG_SHOWN, false)
         }
 
         val toolbar = findViewById<MaterialToolbar>(R.id.main_toolbar)
@@ -239,6 +250,7 @@ class MainActivity : AppCompatActivity() {
         super.onSaveInstanceState(outState)
         outState.putBoolean(STATE_ONBOARDING_LAUNCHED, onboardingLaunched)
         outState.putBoolean(STATE_BATTERY_DIALOG_SHOWN, batteryDialogShownThisSession)
+        outState.putBoolean(STATE_FSI_DIALOG_SHOWN, fsiDialogShownThisSession)
     }
 
     override fun onStart() {
@@ -273,13 +285,15 @@ class MainActivity : AppCompatActivity() {
         // internally and gracefully no-op rather than crash.
         ReceiverForegroundService.start(this)
 
-        // Battery-exemption prompt (#47, dialog form). Replaces the
-        // banner that previously lived inline in SendReceiveFragment.
-        // The session latch keeps the dialog from re-raising on
-        // returns from CreditActivity / system Settings; the prefs
-        // dismissal keeps it from re-raising on cold starts after
-        // the user has chosen Skip or Open Settings once.
-        maybeShowBatteryOptimizationDialog()
+        // First-launch prompts (#47 battery, full-screen-intent). Show at
+        // most one per onStart so the user never faces stacked dialogs:
+        // the battery exemption takes priority, and the full-screen-intent
+        // prompt only raises when the battery one did not. Each is gated
+        // by its own session latch + persisted dismissal flag, so the
+        // skipped one still gets its turn on a later cold start.
+        if (!maybeShowBatteryOptimizationDialog()) {
+            maybeShowFullScreenIntentDialog()
+        }
     }
 
     /**
@@ -305,11 +319,11 @@ class MainActivity : AppCompatActivity() {
      *                             will re-prompt.
      */
     @Suppress("ReturnCount")
-    private fun maybeShowBatteryOptimizationDialog() {
-        if (batteryDialogShownThisSession) return
-        if (BatteryOptimizationPreferences.from(this).hasBeenDismissed()) return
-        if (BatteryOptimizationOemHelper.isAlreadyExempt(this)) return
-        if (BatteryOptimizationOemHelper.intentsForCurrentDevice(this).isEmpty()) return
+    private fun maybeShowBatteryOptimizationDialog(): Boolean {
+        if (batteryDialogShownThisSession) return false
+        if (BatteryOptimizationPreferences.from(this).hasBeenDismissed()) return false
+        if (BatteryOptimizationOemHelper.isAlreadyExempt(this)) return false
+        if (BatteryOptimizationOemHelper.intentsForCurrentDevice(this).isEmpty()) return false
 
         batteryDialogShownThisSession = true
 
@@ -327,12 +341,56 @@ class MainActivity : AppCompatActivity() {
                     .show()
             }.setCancelable(true)
             .show()
+        return true
+    }
+
+    /**
+     * Raise the full-screen-intent first-launch prompt at most once per
+     * MainActivity instance. Only relevant on Android 14+, where
+     * `USE_FULL_SCREEN_INTENT` became a special access that is
+     * auto-denied for non-calendar/alarm apps — without it the
+     * incoming-transfer consent prompt cannot pop full-screen while Bada
+     * is backgrounded and degrades to a heads-up notification.
+     *
+     * Gated identically to the battery prompt: session latch + persisted
+     * dismissal. Only shows when the access is actually requestable
+     * (API 34+ and not yet granted).
+     *
+     * Open Settings → route to the system page and mark dismissed.
+     * Skip → mark dismissed and Toast that it lives in the Settings tab.
+     *
+     * @return true when the dialog was shown this call.
+     */
+    @Suppress("ReturnCount")
+    private fun maybeShowFullScreenIntentDialog(): Boolean {
+        if (fsiDialogShownThisSession) return false
+        if (FullScreenIntentPreferences.from(this).hasBeenDismissed()) return false
+        if (!FullScreenIntentPermission.isRequestable(this)) return false
+
+        fsiDialogShownThisSession = true
+
+        AlertDialog
+            .Builder(this)
+            .setTitle(R.string.settings_fsi_title)
+            .setMessage(R.string.fsi_dialog_body)
+            .setPositiveButton(R.string.settings_fsi_open) { _, _ ->
+                FullScreenIntentPermission.openSettings(this)
+                FullScreenIntentPreferences.from(this).markDismissed()
+            }.setNegativeButton(R.string.main_battery_banner_skip) { _, _ ->
+                FullScreenIntentPreferences.from(this).markDismissed()
+                Toast
+                    .makeText(this, R.string.fsi_dialog_skip_toast, Toast.LENGTH_LONG)
+                    .show()
+            }.setCancelable(true)
+            .show()
+        return true
     }
 
     internal companion object {
         private const val TAG = "BadaMain"
         private const val STATE_ONBOARDING_LAUNCHED = "bada.main.onboardingLaunched"
         private const val STATE_BATTERY_DIALOG_SHOWN = "bada.main.batteryDialogShown"
+        private const val STATE_FSI_DIALOG_SHOWN = "bada.main.fsiDialogShown"
 
         // Bottom-nav icon scale on press (matches vivo native).
         private const val PRESSED_ICON_SCALE = 0.85f

--- a/app/src/main/kotlin/dev/bluehouse/bada/consent/FullScreenIntentPermission.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/consent/FullScreenIntentPermission.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.consent
+
+import android.app.NotificationManager
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.provider.Settings
+import android.util.Log
+import androidx.core.content.getSystemService
+
+/**
+ * Helpers for the `USE_FULL_SCREEN_INTENT` special app access that the
+ * incoming-transfer consent popup (#22) relies on to raise
+ * [ConsentTrampolineActivity] over the lock screen / other apps when a
+ * transfer arrives while Bada is in the background.
+ *
+ * Android 14 (API 34) turned `USE_FULL_SCREEN_INTENT` from an
+ * install-time grant into a special app access that is auto-denied for
+ * everything except the default calendar / alarm apps. When it is not
+ * granted, `ConsentNotification`'s `setFullScreenIntent(...)` silently
+ * degrades to a heads-up notification: the PIN and Accept / Reject
+ * actions are still shown, but the full-screen prompt no longer pops
+ * automatically. This helper lets the app detect that state and route
+ * the user to the system page that toggles it.
+ *
+ * On API <= 33 the permission is granted at install time, so
+ * [isApplicable] is false (nothing to ask for) and [isGranted] is always
+ * true.
+ */
+internal object FullScreenIntentPermission {
+    /**
+     * True when the platform will honour a full-screen intent for this
+     * app. Always true below API 34 (install-time grant); on API 34+ it
+     * reflects [NotificationManager.canUseFullScreenIntent].
+     */
+    @Suppress("ReturnCount")
+    fun isGranted(context: Context): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) return true
+        val notificationManager = context.getSystemService<NotificationManager>() ?: return false
+        return notificationManager.canUseFullScreenIntent()
+    }
+
+    /**
+     * True on API 34+ regardless of grant state — i.e. the special
+     * access exists as a user-grantable toggle on this device. The
+     * Settings tab uses this to decide whether to show the row at all;
+     * the concept does not exist below API 34.
+     */
+    fun isApplicable(): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
+
+    /**
+     * True only when the access both exists (API 34+) AND is not
+     * currently granted. Used to decide whether to surface the
+     * first-launch prompt — there is nothing to ask for otherwise.
+     */
+    fun isRequestable(context: Context): Boolean = isApplicable() && !isGranted(context)
+
+    /**
+     * Open the system "Full screen notifications" special-access page
+     * for this app. Falls back to the app's notification settings, then
+     * the app details page, if the dedicated action is unavailable on
+     * the device. Logs and returns on a fully unresolvable device rather
+     * than throwing.
+     */
+    fun openSettings(context: Context) {
+        val packageUri = Uri.fromParts("package", context.packageName, null)
+        val candidates =
+            buildList {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                    add(
+                        Intent(Settings.ACTION_MANAGE_APP_USE_FULL_SCREEN_INTENT, packageUri)
+                            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+                    )
+                }
+                add(
+                    Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
+                        .putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
+                        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+                )
+                add(
+                    Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS, packageUri)
+                        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+                )
+            }
+        for (intent in candidates) {
+            try {
+                context.startActivity(intent)
+                return
+            } catch (e: ActivityNotFoundException) {
+                Log.w(TAG, "Full-screen-intent settings not launchable: ${intent.action}", e)
+            }
+        }
+    }
+
+    private const val TAG = "BadaFsi"
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/consent/FullScreenIntentPreferences.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/consent/FullScreenIntentPreferences.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.consent
+
+import android.content.Context
+import android.content.SharedPreferences
+
+/**
+ * "Shown once" flag for the full-screen-intent first-launch prompt,
+ * mirroring [dev.bluehouse.bada.battery.BatteryOptimizationPreferences].
+ *
+ * The dialog raised by `MainActivity` asks the user to grant the
+ * `USE_FULL_SCREEN_INTENT` special access (Android 14+) so background
+ * transfer consent prompts can pop full-screen. Once the user taps Skip
+ * or Open Settings, [markDismissed] keeps the one-time dialog from
+ * re-raising on later cold starts. The Settings-tab row stays available
+ * regardless, so the user can revisit the access without clearing app
+ * data.
+ */
+internal class FullScreenIntentPreferences(
+    private val prefs: SharedPreferences,
+) {
+    /**
+     * True once the user has tapped Skip or successfully reached the
+     * system full-screen-notifications page from the first-launch
+     * dialog. The dialog stays hidden in either case.
+     */
+    fun hasBeenDismissed(): Boolean = prefs.getBoolean(KEY_DISMISSED, false)
+
+    /** Marks the prompt as handled. Idempotent after the first commit. */
+    fun markDismissed() {
+        prefs.edit().putBoolean(KEY_DISMISSED, true).apply()
+    }
+
+    internal companion object {
+        internal const val PREFS_NAME = "bada.full_screen_intent"
+
+        private const val KEY_DISMISSED = "full_screen_intent_prompt_dismissed"
+
+        fun from(context: Context): FullScreenIntentPreferences =
+            FullScreenIntentPreferences(
+                context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE),
+            )
+    }
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/tile/BadaQuickShareTileService.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/tile/BadaQuickShareTileService.kt
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.tile
+
+import android.app.PendingIntent
+import android.content.Intent
+import android.graphics.drawable.Icon
+import android.os.Build
+import android.service.quicksettings.Tile
+import android.service.quicksettings.TileService
+import android.util.Log
+import dev.bluehouse.bada.MainActivity
+import dev.bluehouse.bada.R
+import dev.bluehouse.bada.onboarding.PermissionRequirements
+import dev.bluehouse.bada.service.receiver.MdnsVisibilityOverrideHolder
+import dev.bluehouse.bada.service.receiver.ReceiverForegroundService
+
+/**
+ * Quick Settings tile that turns Bada "on" — i.e. forces the receiver to
+ * be discoverable to nearby Quick Share senders — straight from the
+ * system Quick Settings panel, without opening the app.
+ *
+ * Tapping the tile toggles the same process-wide
+ * [MdnsVisibilityOverrideHolder] "always visible" override that the
+ * in-app Send/Receive pill drives (see `SendReceiveFragment`), and brings
+ * the [ReceiverForegroundService] up/down to back it. ON publishes the
+ * mDNS + BLE fast advertisement unconditionally; OFF clears the override
+ * and stops the receiver.
+ *
+ * State model: the tile mirrors [MdnsVisibilityOverrideHolder.isActive].
+ * The override lives in memory only and resets on process death, so a
+ * cold Quick Settings panel correctly shows the tile OFF (nothing is
+ * actually advertising). [onStartListening] re-syncs every time the panel
+ * opens, which keeps the tile consistent with the in-app pill even though
+ * one cannot change the override while the other is on screen.
+ *
+ * This is a standard (listening) tile rather than an active tile: the
+ * override has no cross-module way to push `requestListeningState`, and
+ * re-reading the holder in [onStartListening] is enough for eventual
+ * consistency.
+ */
+internal class BadaQuickShareTileService : TileService() {
+    /**
+     * Fires each time the Quick Settings panel becomes visible. Re-read
+     * the current override so the tile reflects state changed elsewhere
+     * (the in-app pill, or a process restart that reset the override).
+     */
+    override fun onStartListening() {
+        super.onStartListening()
+        syncTile()
+    }
+
+    override fun onClick() {
+        super.onClick()
+        if (MdnsVisibilityOverrideHolder.isActive) {
+            turnOff()
+        } else {
+            turnOn()
+        }
+        syncTile()
+    }
+
+    private fun turnOn() {
+        // Being discoverable needs the mandatory discovery permission
+        // (NEARBY_WIFI_DEVICES on API 33+). If it isn't granted yet,
+        // toggling the override would light up a switch that can never
+        // actually advertise — so bounce the user into the app instead,
+        // which routes to the permissions onboarding. This mirrors
+        // MainActivity's own service-start gate.
+        if (!PermissionRequirements.allGranted(this) &&
+            !PermissionRequirements.onlyOptionalMissing(this)
+        ) {
+            openApp()
+            return
+        }
+
+        MdnsVisibilityOverrideHolder.setAlwaysVisible(true)
+        try {
+            ReceiverForegroundService.start(this)
+        } catch (e: IllegalStateException) {
+            // Android 12+ forbids most background foreground-service
+            // starts; ForegroundServiceStartNotAllowedException (API 31+)
+            // extends IllegalStateException, and a Quick Settings tap is
+            // NOT one of the platform's documented start exemptions. When
+            // Bada is fully backgrounded the start can therefore be
+            // rejected. Fall back to opening the app: MainActivity starts
+            // the receiver from a visible (exempt) context, and the
+            // override we just set makes the gate advertise immediately.
+            Log.w(TAG, "Foreground-service start from tile rejected; opening app instead", e)
+            openApp()
+        }
+    }
+
+    private fun turnOff() {
+        MdnsVisibilityOverrideHolder.setAlwaysVisible(false)
+        // stop() delivers ACTION_STOP through startService to the
+        // already-running service. Re-delivering to a running service is
+        // allowed from the background, so this needs no FGS-start handling.
+        ReceiverForegroundService.stop(this)
+    }
+
+    /**
+     * Push the current override state onto the tile. Safe to call from
+     * any callback; no-ops if the platform has not handed us a [Tile]
+     * yet (e.g. before the service is fully bound).
+     */
+    private fun syncTile() {
+        val tile = qsTile ?: return
+        val active = MdnsVisibilityOverrideHolder.isActive
+        tile.state = if (active) Tile.STATE_ACTIVE else Tile.STATE_INACTIVE
+        tile.label = getString(R.string.qs_tile_label)
+        tile.icon = Icon.createWithResource(this, R.drawable.ic_qs_bada_visible)
+        val statusRes = if (active) R.string.qs_tile_subtitle_on else R.string.qs_tile_subtitle_off
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            tile.subtitle = getString(statusRes)
+        }
+        tile.contentDescription =
+            getString(
+                if (active) R.string.qs_tile_content_desc_on else R.string.qs_tile_content_desc_off,
+            )
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            tile.stateDescription = getString(statusRes)
+        }
+        tile.updateTile()
+    }
+
+    /**
+     * Collapse the panel and bring up [MainActivity]. Used both when a
+     * mandatory permission is missing (MainActivity routes to onboarding)
+     * and as the fallback when a background foreground-service start is
+     * rejected.
+     *
+     * API 34 made [startActivityAndCollapse] with a bare `Intent` throw;
+     * the `PendingIntent` overload it added is the supported path there,
+     * while older platforms still take the `Intent` form.
+     */
+    private fun openApp() {
+        val intent =
+            Intent(this, MainActivity::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            val pending =
+                PendingIntent.getActivity(
+                    this,
+                    0,
+                    intent,
+                    PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+                )
+            startActivityAndCollapse(pending)
+        } else {
+            @Suppress("DEPRECATION")
+            startActivityAndCollapse(intent)
+        }
+    }
+
+    private companion object {
+        const val TAG = "BadaQsTile"
+    }
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/ui/SettingsFragment.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/ui/SettingsFragment.kt
@@ -21,6 +21,7 @@ import dev.bluehouse.bada.MainActivity
 import dev.bluehouse.bada.R
 import dev.bluehouse.bada.battery.BatteryOptimizationOemHelper
 import dev.bluehouse.bada.bugreport.BugReportPreferences
+import dev.bluehouse.bada.consent.FullScreenIntentPermission
 import dev.bluehouse.bada.service.downloads.SaveLocationDisplayName
 import dev.bluehouse.bada.service.downloads.SaveLocationPreferences
 import dev.bluehouse.bada.service.receiver.AdvertisedDeviceNames
@@ -117,6 +118,10 @@ internal class SettingsFragment : Fragment(R.layout.fragment_settings) {
             MainActivity.openBatterySettings(requireContext())
         }
 
+        view.findViewById<Button>(R.id.settings_fsi_open).setOnClickListener {
+            FullScreenIntentPermission.openSettings(requireContext())
+        }
+
         val bugReportSwitch = view.findViewById<SwitchCompat>(R.id.main_bug_report_switch)
         val bugReportPreferences = BugReportPreferences.from(requireContext())
         bugReportSwitch.isChecked = bugReportPreferences.isShakeToReportEnabled()
@@ -135,11 +140,17 @@ internal class SettingsFragment : Fragment(R.layout.fragment_settings) {
         refreshSaveLocationLabel()
         refreshAdvertisedNameSection()
         refreshBatteryStatus()
+        refreshFullScreenIntentSection()
         refreshBugReportSwitch()
     }
 
     override fun onResume() {
         super.onResume()
+        // Full-screen-intent access is toggled on a system Settings page
+        // that, like the battery overlay, can dismiss without fully
+        // stopping this activity on some OEM ROMs. Re-check on resume so
+        // the status line flips immediately after the user grants it.
+        refreshFullScreenIntentSection()
         // Re-check the battery-optimization exemption on every resume.
         // The platform's `ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS`
         // dialog is a translucent overlay on some OEM ROMs (vivo
@@ -183,6 +194,30 @@ internal class SettingsFragment : Fragment(R.layout.fragment_settings) {
                 getString(R.string.settings_battery_status_exempt)
             } else {
                 getString(R.string.settings_battery_status_not_exempt)
+            }
+    }
+
+    /**
+     * Show the full-screen-alerts card only on Android 14+ (where
+     * `USE_FULL_SCREEN_INTENT` is a grantable special access) and reflect
+     * the current grant state in its status line. On older platforms the
+     * permission is install-time, so the whole card stays hidden.
+     */
+    @Suppress("ReturnCount")
+    private fun refreshFullScreenIntentSection() {
+        val v = view ?: return
+        val card = v.findViewById<View>(R.id.settings_fsi_card) ?: return
+        if (!FullScreenIntentPermission.isApplicable()) {
+            card.visibility = View.GONE
+            return
+        }
+        card.visibility = View.VISIBLE
+        val status = v.findViewById<TextView>(R.id.settings_fsi_status) ?: return
+        status.text =
+            if (FullScreenIntentPermission.isGranted(requireContext())) {
+                getString(R.string.settings_fsi_status_granted)
+            } else {
+                getString(R.string.settings_fsi_status_not_granted)
             }
     }
 

--- a/app/src/main/res/drawable/ic_qs_bada_visible.xml
+++ b/app/src/main/res/drawable/ic_qs_bada_visible.xml
@@ -1,0 +1,22 @@
+<!--
+  Quick Settings tile icon. Per the platform guidance the tile icon
+  must be a 24x24dp solid-white VectorDrawable on a transparent
+  background; Quick Settings tints it for the active / inactive states
+  itself, so the source paths are pure white.
+
+  Glyph is the Material "wifi_tethering" broadcast mark — a centre dot
+  radiating concentric arcs — which reads as "this device is
+  discoverable / broadcasting to nearby peers", matching what toggling
+  the tile actually does (force the receiver's always-visible mDNS/BLE
+  advertisement).
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFFFF">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,11c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2zM18,13c0,-3.31 -2.69,-6 -6,-6s-6,2.69 -6,6c0,2.22 1.21,4.15 3,5.19l1,-1.74c-1.19,-0.7 -2,-1.97 -2,-3.45 0,-2.21 1.79,-4 4,-4s4,1.79 4,4c0,1.48 -0.81,2.75 -2,3.45l1,1.74c1.79,-1.04 3,-2.97 3,-5.19zM12,3C6.48,3 2,7.48 2,13c0,3.7 2.01,6.92 4.99,8.65l1,-1.73C5.61,18.53 4,15.96 4,13c0,-4.42 3.58,-8 8,-8s8,3.58 8,8c0,2.96 -1.61,5.53 -4,6.92l1,1.73c2.98,-1.73 4.99,-4.95 4.99,-8.65C22,7.48 17.52,3 12,3z" />
+</vector>

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -275,6 +275,62 @@
 
         </LinearLayout>
 
+        <!-- ============ Card: Full-screen transfer alerts (API 34+) ============
+             Hidden by default; SettingsFragment makes it visible only on
+             Android 14+, where USE_FULL_SCREEN_INTENT became a grantable
+             special access. Lets the consent PIN prompt pop full-screen
+             over other apps / the lock screen when a transfer arrives
+             while Bada is in the background. -->
+        <LinearLayout
+            android:id="@+id/settings_fsi_card"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:background="@drawable/settings_card_background"
+            android:orientation="vertical"
+            android:padding="20dp"
+            android:visibility="gone">
+
+            <TextView
+                android:id="@+id/settings_fsi_title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/settings_fsi_title"
+                android:textAppearance="@style/TextAppearance.AppCompat.Subhead"
+                android:textColor="?android:attr/textColorPrimary"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/settings_fsi_subtitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:text="@string/settings_fsi_subtitle"
+                android:textAppearance="@style/TextAppearance.AppCompat.Small"
+                android:textColor="?android:attr/textColorSecondary" />
+
+            <TextView
+                android:id="@+id/settings_fsi_status"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:background="@drawable/qr_url_background"
+                android:paddingHorizontal="12dp"
+                android:paddingVertical="10dp"
+                android:textAppearance="@style/TextAppearance.AppCompat.Body2"
+                android:textColor="?android:attr/textColorPrimary"
+                android:textIsSelectable="true"
+                tools:text="Currently: full-screen alerts not allowed" />
+
+            <Button
+                android:id="@+id/settings_fsi_open"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:text="@string/settings_fsi_open" />
+
+        </LinearLayout>
+
         <!-- ============ Card 4: Shake-to-report bug ============ -->
         <!--
           Switch row: title and Switch share a horizontal row so

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -46,7 +46,7 @@
     <string name="credit_kevin_desc">マイルが足りません</string>
     <!-- YEONFEEL's tagline (Japanese rendering of the Korean source
          "아무도 알지 못하는 세상을 걷는 법"). -->
-    <string name="credit_yeonfeel_desc">誰も知らない世界の歩き方</string>
+    <string name="credit_yeonfeel_desc">だれもが識らない世界の歩き方</string>
     <!-- Credit screen, QA section. -->
     <string name="credit_chiyak_qa_desc">コンサートのチケットが買いたいです</string>
     <string name="credit_parami_desc">毎日感謝の祈りを捧げよう</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,0 +1,284 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Japanese (`ja`) string overrides. The Android resource system
+  picks this file for any device whose primary locale resolves to
+  Japanese (`ja`, `ja-rJP`); every other locale falls back to the
+  canonical English copy in `values/strings.xml`.
+
+  Pairing additions: when adding a new translatable string, add the
+  English copy in `values/strings.xml` first, then the Japanese
+  rendering here. Keep the resource name identical between both
+  files. Format placeholders (%1$s, %1$d, %%, etc.) and escaped
+  glyphs are preserved verbatim — translators only adjust the
+  surrounding prose.
+
+  A small set of strings is intentionally NOT translated, matching
+  the Korean (`values-ko`) policy:
+    * `app_name`, contributor display names, brand-y labels
+      ("Quick Share", "bada") — proper nouns.
+    * `credit_section_*` headers — render in English on Japanese
+      devices too (designed wordmarks, not translatable labels).
+    * `credit_teqhnikacross_desc` — the contributor explicitly
+      asked for "We all want to be loved" rendered as-is.
+    * `credit_yeonfeel_desc`, `credit_thanks_compact` — already
+      Korean in the canonical file (used as the default for every
+      non-overriding locale, including Japanese).
+-->
+<resources>
+
+    <!-- Bottom-navigation tab labels for MainActivity. -->
+    <string name="nav_send_receive_title">送受信</string>
+    <string name="nav_settings_title">設定</string>
+
+    <!-- Toolbar overflow menu / Credit screen. "クレジット" is the
+         established loanword for a contributor credit list. -->
+    <string name="menu_credit">クレジット</string>
+    <string name="credit_activity_label">クレジット</string>
+
+    <!-- `credit_section_developer`, `credit_section_polisher`,
+         `credit_section_qa`, `credit_section_thanks` are intentionally
+         NOT translated here (no override), matching the Korean policy:
+         the four credit section headers render in English on Japanese
+         devices too. -->
+
+    <!-- Credit screen, Developer section. -->
+    <string name="credit_kevin_desc">マイルが足りません</string>
+    <!-- Credit screen, QA section. -->
+    <string name="credit_chiyak_qa_desc">コンサートのチケットが買いたいです</string>
+    <string name="credit_parami_desc">毎日感謝の祈りを捧げよう</string>
+
+    <string name="credit_avatar_description">貢献者のアバター</string>
+
+    <!-- File-picker entry point on the Send/Receive tab. -->
+    <string name="main_send_files_button">ファイルを送信</string>
+    <string name="main_send_files_subtitle">この端末のファイル（写真、ドキュメントなど何でも）を選んで、近くの Quick Share 端末に送信します。</string>
+    <string name="main_send_files_pick_failed">この端末でファイル選択画面を開けませんでした。</string>
+    <string name="main_send_files_no_selection">ファイルが選択されていません。</string>
+
+    <!-- Idle state caption above the photo preview cards. -->
+    <string name="main_send_waiting">ファイルを待っています…</string>
+    <string name="main_send_preview_photo_description">最近のギャラリー写真のプレビュー</string>
+
+    <!-- Always-visible pill (#34) — ON / OFF labels, tooltip, and
+         caption. -->
+    <string name="main_always_visible_title">常に表示</string>
+    <string name="main_always_visible_subtitle">近くの送信側からの Bluetooth 信号がなくても、この端末を Wi-Fi 上で見つけられる状態に保ちます。省電力のためオフにすると、送信側がスキャンしている間だけ一時的に表示されます。</string>
+    <string name="main_always_visible_off_title">スキャン時に表示</string>
+    <string name="main_always_visible_caption_on">近くにいる誰でも自分にファイルを共有できます。</string>
+    <string name="main_always_visible_caption_off">近くの端末が Bluetooth でスキャンしている間だけ有効になります。</string>
+
+    <!-- Shake-to-report bug toggle. -->
+    <string name="main_bug_report_title">振ってバグを報告</string>
+    <string name="main_bug_report_subtitle">有効にすると、Bada を開いた状態で端末を振ったときに、最近の診断情報・端末の状態・スクリーンショットを zip にまとめて自分で保存できます。自動的にアップロードされることはありません。</string>
+
+    <!-- Save-location settings (#42). -->
+    <string name="main_save_location_title">受信ファイルの保存先</string>
+    <string name="main_save_location_subtitle">受信したファイルの保存場所を選択します。</string>
+    <string name="main_save_location_default">ダウンロード（既定）</string>
+    <string name="main_save_location_current">現在: %1$s</string>
+    <string name="main_save_location_pick">フォルダを選択…</string>
+    <string name="main_save_location_clear">既定に戻す</string>
+    <string name="main_save_location_pick_failed">そのフォルダを保存できませんでした。別の場所を選択してください。</string>
+
+    <!-- Advertised Quick Share device name (#141). -->
+    <string name="main_advertised_name_title">Quick Share 表示名</string>
+    <string name="main_advertised_name_subtitle">近くの Quick Share 端末がこの端末を見つけたときに表示される名前です。空のままにすると Android の端末名が使われます。名前が長すぎる場合は、他の端末で正しく表示できるよう自動的に短縮されます。</string>
+    <string name="main_advertised_name_hint">端末名</string>
+    <string name="main_advertised_name_current">現在の表示名: %1$s</string>
+    <string name="main_advertised_name_save">名前を保存</string>
+    <string name="main_advertised_name_reset">既定値を使用</string>
+
+    <!-- Folder-send entry point (#38). -->
+    <string name="main_send_folder_button">フォルダを送信</string>
+    <string name="main_send_folder_subtitle">この端末のフォルダを選んで、近くの Quick Share 端末に送信します。サブフォルダとフォルダ構造は受信側でそのまま保持されます。</string>
+    <string name="send_folder_subtitle_walking">フォルダの内容を読み込み中…</string>
+    <string name="send_folder_empty">選択したフォルダにファイルがありません。ファイルを 1 つ以上追加してからもう一度お試しください。</string>
+    <string name="send_folder_walk_failed">フォルダの内容を読み込めませんでした。別のフォルダを選んでもう一度お試しください。</string>
+
+    <!-- Legacy package migration banner (#145). -->
+    <string name="main_legacy_wvmg_banner_title">以前のアプリを削除してください</string>
+    <string name="main_legacy_wvmg_banner_body">この端末にはこのアプリの古いバージョンがまだインストールされています。2 つのインストールが Bluetooth 上で干渉し、Galaxy などの標準 Quick Share 送信側がこの端末に接続できなくなります。古いバージョンを削除するには「削除」をタップしてください。</string>
+    <string name="main_legacy_wvmg_banner_uninstall">古いバージョンを削除</string>
+    <string name="main_legacy_wvmg_banner_unavailable">%1$s の削除画面を開けませんでした。システム設定から手動で削除してください。</string>
+
+    <!-- Battery-optimization banner (#47). -->
+    <string name="main_battery_banner_title">バックグラウンド動作を許可</string>
+    <string name="main_battery_banner_body">この端末では、このアプリをバッテリー最適化の対象外にしないと、バックグラウンドで Quick Share ファイルを受信できないことがあります。「設定を開く」をタップして対象外に追加するか、アプリを開いているときだけ Quick Share を使う場合は「スキップ」を選んでください。</string>
+    <string name="main_battery_banner_open">設定を開く</string>
+    <string name="main_battery_banner_skip">スキップ</string>
+    <string name="main_battery_banner_unavailable">この端末で適切な設定画面が見つかりませんでした。システム設定からバッテリー最適化を手動で管理できます。</string>
+    <string name="dialog_battery_skip_toast">設定から変更できます。</string>
+
+    <!-- Settings tab "Background activity" row. -->
+    <string name="settings_battery_title">バックグラウンド動作</string>
+    <string name="settings_battery_subtitle">画面がオフのときでも Quick Share ファイルを受信し続けられるよう、このアプリをバッテリー最適化の対象外にします。</string>
+    <string name="settings_battery_status_exempt">現在: バッテリー最適化の対象外</string>
+    <string name="settings_battery_status_not_exempt">現在: 対象外ではありません。バックグラウンドで受信が停止することがあります</string>
+    <string name="settings_battery_open">バッテリー設定を開く</string>
+
+    <!-- Permissions onboarding (#26 + #31). -->
+    <string name="onboarding_title">アプリの権限</string>
+    <string name="onboarding_intro">Quick Share では、ローカル Wi-Fi ネットワーク上で近くの端末を見つけ、近くの Quick Share 受信側を起こす短い Bluetooth Low Energy 信号を送受信し、転送状況をお知らせするために、いくつかの Android 権限が必要です。各権限が何に使われるかは以下で説明します。</string>
+    <string name="onboarding_empty_state">この端末では Phase 1 に必要なランタイム権限はありません。準備は完了しています。</string>
+    <string name="onboarding_grant_button">権限を許可</string>
+    <string name="onboarding_open_settings">アプリ設定を開く</string>
+    <string name="onboarding_continue">権限なしで続行</string>
+    <string name="onboarding_continue_partial">一部の権限なしで続行</string>
+    <string name="onboarding_continue_degraded">制限モードで続行</string>
+
+    <!-- Same-Wi-Fi-network onboarding card (#85). -->
+    <string name="onboarding_network_card_title">近くの端末を見つける条件</string>
+    <string name="onboarding_network_card_body">共有 Wi-Fi は今も Quick Share の基本経路で、特に受信時に使われます。近くの標準 Quick Share 端末に送信するとき、両端末が同じ LAN 上にない場合は、Bada は Bluetooth 補助によるブートストラップも使えます。この経路のために Bluetooth はオンのままにしてください。</string>
+    <string name="onboarding_network_card_dismiss">OK</string>
+
+    <!-- NEARBY_WIFI_DEVICES (API 33+). -->
+    <string name="permission_nearby_wifi_title">近くの Wi-Fi 端末</string>
+    <string name="permission_nearby_wifi_rationale">同じ Wi-Fi ネットワーク上の他の Quick Share 端末を見つけて広告するために必要です。Quick Share がこの権限であなたの物理的な位置を特定することはありません。</string>
+
+    <!-- POST_NOTIFICATIONS (API 33+). -->
+    <string name="permission_notifications_title">通知</string>
+    <string name="permission_notifications_rationale">フォアグラウンド転送サービスの表示や、受信ファイルのお知らせに使われます。この権限がなくても転送は動作しますが、通知は届きません。</string>
+
+    <!-- BLUETOOTH_ADVERTISE (API 31+, #31 / #121). -->
+    <string name="permission_bluetooth_advertise_title">Bluetooth 広告</string>
+    <string name="permission_bluetooth_advertise_rationale">2 種類の Bluetooth Low Energy 信号を送るために使われます。送信を開始したときに近くの受信側を起こす信号と、他の端末の Quick Share 選択画面にこの端末を表示させる信号です。この権限がなくても転送は動作しますが、接続が始まるまでは一般的なラベルで表示されることがあります。</string>
+
+    <!-- BLUETOOTH_SCAN (API 31+, #31). -->
+    <string name="permission_bluetooth_scan_title">近くの Bluetooth 端末</string>
+    <string name="permission_bluetooth_scan_rationale">近くの Quick Share 送信側を検知し、必要なときだけ受信側を起こすために使われます。Quick Share がこの権限であなたの物理的な位置を特定することはありません。</string>
+
+    <!-- BLUETOOTH_CONNECT (API 31+). -->
+    <string name="permission_bluetooth_connect_title">Bluetooth 接続</string>
+    <string name="permission_bluetooth_connect_rationale">Bluetooth Low Energy の直接リンクを開き、近くの Quick Share 検索のために Bluetooth アダプターの状態を読み取るために使われます。転送には引き続き Quick Share の暗号化が使われます。</string>
+
+    <!-- ACCESS_FINE_LOCATION (legacy nearby-device discovery). -->
+    <string name="permission_legacy_nearby_location_title">近くの端末の位置情報アクセス</string>
+    <string name="permission_legacy_nearby_location_rationale">Android 11 以前では、Bluetooth Low Energy のスキャン結果は位置情報権限を通じて渡されます。Bada はこの権限を近くの Quick Share 端末を見つけるためだけに使い、あなたの物理的な位置は使いません。</string>
+
+    <!-- Permission status labels. -->
+    <string name="permission_status_granted">許可済み</string>
+    <string name="permission_status_denied">必須 - 未許可</string>
+    <string name="permission_status_optional_denied">任意 - 未許可（制限モード）</string>
+    <string name="permission_status_optional_denied_ble">任意 - 未許可（mDNS のみのモード）</string>
+
+    <!-- Share-intent (#24) sender flow. -->
+    <string name="send_activity_label">Quick Share で送信</string>
+    <string name="send_subtitle_discovering">近くの端末を検索中…</string>
+    <string name="send_subtitle_pick_peer">端末をタップして送信します。</string>
+    <string name="send_subtitle_no_usable_route">近くの端末は見つかりましたが、まだ利用できる転送経路がありません。</string>
+    <string name="send_empty_state">近くに端末がありません。受信側で Quick Share が開いているか確認してください。共有 Wi-Fi が基本経路です。両端末が同じ LAN 上にない場合は、近くのブートストラップのために Bluetooth をオンにしておいてください。</string>
+
+    <!-- Same-Wi-Fi-network hint card (#85). -->
+    <string name="send_network_hint_title">近くの端末を見つける条件</string>
+    <string name="send_network_hint_body">共有 Wi-Fi が基本経路です。一部の受信側は、利用できる転送経路を公開する前に BLE から名前だけ分かることがあります。両端末を同じ Wi-Fi ネットワークに接続するか、利用できるブートストラップ経路のために Bluetooth を使える状態にしておいてください。</string>
+    <string name="send_network_hint_dismiss">OK</string>
+    <!-- Picker-state help link + bottom sheet content. -->
+    <string name="send_help_link">端末が見つかりませんか？</string>
+    <string name="send_help_sheet_title">端末が見つかりませんか？</string>
+    <string name="send_help_sheet_visibility_title">受信側のモードを確認</string>
+    <string name="send_help_sheet_visibility_body">受信側の端末で、切り替えが「受信の準備完了」になっているか確認してください。このモードでは、近くにいる誰でもファイルを共有できます。すでにこのモードなのにここに表示されない場合は、両方の端末で Bada を完全に終了してから開き直してみてください。</string>
+    <string name="send_help_sheet_qr_title">または QR コードで共有</string>
+    <string name="send_help_sheet_qr_body">それでも受信側が表示されない場合は、このカードの右上にある QR コードボタンをタップしてください。受信側にコードをスキャンしてもらうか、リンクを開いてもらうと転送を開始できます。</string>
+    <string name="send_help_sheet_close">OK</string>
+
+    <string name="send_show_qr">QR を表示</string>
+    <string name="send_cancel">キャンセル</string>
+    <string name="send_done">完了</string>
+    <string name="send_unsupported">この共有は送信できませんでした。インテントにファイルやテキストが含まれていません。</string>
+
+    <!-- Payload summary templates. -->
+    <string name="send_payload_text">テキストを共有中</string>
+    <string name="send_payload_single_file">ファイル 1 件</string>
+    <string name="send_payload_single_file_with_size">ファイル 1 件 • %1$s</string>
+    <string name="send_payload_multiple_files">ファイル %1$d 件</string>
+    <string name="send_payload_multiple_files_with_size">ファイル %1$d 件 • %2$s</string>
+
+    <!-- Connection-phase labels. -->
+    <string name="send_phase_connecting">接続中…</string>
+    <string name="send_phase_handshaking">安全にペアリング中…</string>
+    <string name="send_phase_awaiting_acceptance">受信側の承諾を待っています</string>
+    <string name="send_phase_sending">送信中</string>
+    <string name="send_phase_completed">送信が完了しました</string>
+    <string name="send_phase_rejected">受信側が転送を拒否しました</string>
+    <!-- Named-receiver variant of the rejection terminal. -->
+    <string name="send_phase_rejected_by_named">%1$s がファイル転送を拒否しました</string>
+    <string name="send_phase_cancelled">転送がキャンセルされました</string>
+    <string name="send_phase_failed">転送に失敗しました</string>
+
+    <!-- Status-panel messages. -->
+    <string name="send_status_target">送信先: %1$s</string>
+    <string name="send_status_pin_prompt">このコードが受信側の画面と一致するか確認してください。</string>
+    <string name="send_status_failure_reason">理由: %1$s</string>
+    <string name="send_status_progress">%1$s / %2$s</string>
+    <string name="send_status_retrying_route">%1$s で再試行中…</string>
+
+    <!-- Rate + ETA suffixes. -->
+    <string name="send_status_rate">%1$s/秒</string>
+    <string name="send_status_eta">残り %1$s</string>
+    <string name="send_status_duration_few_seconds">1 秒未満</string>
+    <string name="send_status_duration_seconds">%1$d 秒</string>
+    <string name="send_status_duration_about_minutes">約 %1$d 分</string>
+    <string name="send_status_duration_about_hours">約 %1$d 時間</string>
+
+    <!-- Shake-to-report bug-report flow (#162). -->
+    <string name="bug_report_confirm_title">バグを報告しますか？</string>
+    <string name="bug_report_confirm_body">Bada は最近のアプリの診断情報・端末の状態・スクリーンショットを zip にまとめ、保存先を選ぶまで端末内にのみ保管します。</string>
+    <string name="bug_report_confirm_yes">はい</string>
+    <string name="bug_report_confirm_no">いいえ</string>
+    <string name="bug_report_include_bssid_label">現在の Wi-Fi BSSID を含める（識別性が高くなります）</string>
+    <string name="bug_report_collecting">バグ報告を準備中…</string>
+    <string name="bug_report_collect_failed">バグ報告を準備できませんでした: %1$s</string>
+    <string name="bug_report_save_cancelled">バグ報告の保存がキャンセルされました。</string>
+    <string name="bug_report_save_failed">バグ報告を保存できませんでした: %1$s</string>
+    <string name="bug_report_saved_title">バグ報告を保存しました</string>
+    <string name="bug_report_saved_body">バグ報告の zip を保存しました。GitHub を開いて、新しいイシューに手動で添付できます。</string>
+    <string name="bug_report_saved_open_issue">GitHub のイシューを開く</string>
+    <string name="bug_report_saved_dismiss">閉じる</string>
+    <string name="bug_report_issue_chooser">アプリで開く</string>
+    <string name="bug_report_issue_unavailable">GitHub を開けるブラウザや対応アプリがありません。</string>
+
+    <!-- QR-code (#20 + #84) screen. -->
+    <string name="show_qr_title">QR コードとリンク</string>
+    <string name="show_qr_intro">受け取る相手に QR コードのスキャンか、リンクを開くようお願いしてください。QR コードやリンクを持っている人は、あなたの追加の承認なしにファイルを受け取れます。</string>
+    <string name="show_qr_image_description">Quick Share ペアリング URL の QR コード</string>
+    <string name="show_qr_done">完了</string>
+    <string name="show_qr_close">閉じる</string>
+    <string name="show_qr_copy_link">リンクをコピー</string>
+    <string name="show_qr_link_copied">リンクをコピーしました</string>
+
+    <!-- Consent trampoline (#22). -->
+    <string name="consent_activity_label">受信リクエスト</string>
+    <!-- Short header above the 4-digit confirmation PIN. -->
+    <string name="consent_pin_label">PIN</string>
+    <string name="consent_files_label">受信するファイル</string>
+    <string name="consent_button_accept">承諾</string>
+    <string name="consent_button_reject">拒否</string>
+    <string name="consent_unknown_sender">近くの端末が共有しようとしています</string>
+    <!-- Type-specific consent title templates. %1$s is the sender
+         device name. -->
+    <string name="consent_title_with_name">%1$s が共有しようとしています</string>
+    <string name="consent_title_with_name_images">%1$s が画像を共有しようとしています</string>
+    <string name="consent_title_with_name_videos">%1$s が動画を共有しようとしています</string>
+    <string name="consent_title_with_name_files">%1$s がファイルを共有しようとしています</string>
+    <string name="consent_summary_n_items">%1$d 件（%2$s）</string>
+    <string name="consent_summary_no_items">項目なし</string>
+    <string name="consent_summary_folder">フォルダ \"%1$s\"（ファイル %2$d 件、%3$s）</string>
+    <!-- Per-item rows: name on one line, size on the next. -->
+    <string name="consent_file_line">%1$s\n%2$s</string>
+    <string name="consent_text_line_with_title">%1$s\n%2$s</string>
+    <string name="consent_more_items">…他 %1$d 件</string>
+    <string name="consent_dismissed">転送は保留中ではなくなりました</string>
+
+    <!-- Post-Accept consent flow states. -->
+    <string name="consent_state_receiving">受信中…</string>
+    <string name="consent_state_progress">%1$s / %2$s</string>
+    <string name="consent_state_completed">転送が完了しました</string>
+    <string name="consent_state_completed_one">ファイル 1 件を受信しました</string>
+    <string name="consent_state_completed_many">ファイル %1$d 件を受信しました</string>
+    <string name="consent_state_failed">転送に失敗しました</string>
+    <string name="consent_state_cancelled">転送がキャンセルされました</string>
+    <string name="consent_state_view_image">画像を表示</string>
+    <string name="consent_state_close">閉じる</string>
+    <string name="consent_state_view_image_unavailable">この画像を開けるアプリがありません。</string>
+
+</resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -285,4 +285,20 @@
     <string name="consent_state_close">閉じる</string>
     <string name="consent_state_view_image_unavailable">この画像を開けるアプリがありません。</string>
 
+    <!-- Quick Settings tile. `qs_tile_label` ("Bada") is a proper noun
+         and intentionally NOT overridden here. -->
+    <string name="qs_tile_subtitle_on">検出可能</string>
+    <string name="qs_tile_subtitle_off">オフ</string>
+    <string name="qs_tile_content_desc_on">近くの端末から Bada を検出できます</string>
+    <string name="qs_tile_content_desc_off">Bada を検出できません</string>
+
+    <!-- Settings tab "全画面の受信通知" row + first-launch dialog (Android 14+). -->
+    <string name="settings_fsi_title">全画面の受信通知</string>
+    <string name="settings_fsi_subtitle">全画面通知を許可すると、Bada がバックグラウンドにあるときに受信要求が届いても、他のアプリの上やロック画面に PIN がすぐ表示されます。許可しなくても、通知をタップすれば PIN を確認できます。</string>
+    <string name="settings_fsi_status_granted">現在: 全画面通知が許可されています</string>
+    <string name="settings_fsi_status_not_granted">現在: 許可されていません。PIN 要求は通知として届きます</string>
+    <string name="settings_fsi_open">通知設定を開く</string>
+    <string name="fsi_dialog_body">Bada がバックグラウンドにあるときに受信要求が届くと、PIN 要求を画面の上に表示するために全画面通知の権限が必要です。許可しない場合、要求は通常の通知として届き、タップして開けます。設定を開いて許可するか、後で設定タブから対応するにはスキップしてください。</string>
+    <string name="fsi_dialog_skip_toast">設定から変更できます。</string>
+
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -20,9 +20,10 @@
       devices too (designed wordmarks, not translatable labels).
     * `credit_teqhnikacross_desc` — the contributor explicitly
       asked for "We all want to be loved" rendered as-is.
-    * `credit_yeonfeel_desc`, `credit_thanks_compact` — already
-      Korean in the canonical file (used as the default for every
-      non-overriding locale, including Japanese).
+    * `credit_thanks_compact` — already Korean in the canonical file
+      (used as the default for every non-overriding locale, including
+      Japanese). (`credit_yeonfeel_desc` is now fully localized:
+      English canonical, Korean in values-ko, Japanese here.)
 -->
 <resources>
 
@@ -43,6 +44,9 @@
 
     <!-- Credit screen, Developer section. -->
     <string name="credit_kevin_desc">マイルが足りません</string>
+    <!-- YEONFEEL's tagline (Japanese rendering of the Korean source
+         "아무도 알지 못하는 세상을 걷는 법"). -->
+    <string name="credit_yeonfeel_desc">誰も知らない世界の歩き方</string>
     <!-- Credit screen, QA section. -->
     <string name="credit_chiyak_qa_desc">コンサートのチケットが買いたいです</string>
     <string name="credit_parami_desc">毎日感謝の祈りを捧げよう</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -300,4 +300,11 @@
     <string name="consent_state_close">닫기</string>
     <string name="consent_state_view_image_unavailable">이 이미지를 열 수 있는 앱이 없습니다.</string>
 
+    <!-- Quick Settings tile. `qs_tile_label` ("Bada") is a proper noun
+         and intentionally NOT overridden here. -->
+    <string name="qs_tile_subtitle_on">검색 가능</string>
+    <string name="qs_tile_subtitle_off">꺼짐</string>
+    <string name="qs_tile_content_desc_on">근처 기기에서 Bada를 검색할 수 있습니다</string>
+    <string name="qs_tile_content_desc_off">Bada를 검색할 수 없습니다</string>
+
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -129,6 +129,15 @@
     <string name="settings_battery_status_not_exempt">현재: 제외되지 않음. 백그라운드에서 수신이 중단될 수 있습니다</string>
     <string name="settings_battery_open">배터리 설정 열기</string>
 
+    <!-- Settings tab "전체 화면 수신 알림" row + first-launch dialog (Android 14+). -->
+    <string name="settings_fsi_title">전체 화면 수신 알림</string>
+    <string name="settings_fsi_subtitle">전체 화면 알림을 허용하면 Bada가 백그라운드에 있을 때 수신 요청이 와도 다른 앱 위나 잠금 화면에서 PIN이 바로 표시됩니다. 허용하지 않아도 알림을 눌러 PIN을 확인할 수 있습니다.</string>
+    <string name="settings_fsi_status_granted">현재: 전체 화면 알림 허용됨</string>
+    <string name="settings_fsi_status_not_granted">현재: 허용되지 않음. PIN 요청이 알림으로 표시됩니다</string>
+    <string name="settings_fsi_open">알림 설정 열기</string>
+    <string name="fsi_dialog_body">Bada가 백그라운드에 있을 때 수신 요청이 오면, 화면 위로 PIN 요청을 띄우기 위해 전체 화면 알림 권한이 필요합니다. 허용하지 않으면 요청이 일반 알림으로 도착하며, 눌러서 열 수 있습니다. 설정을 열어 허용하거나, 나중에 설정 탭에서 처리하려면 건너뛰세요.</string>
+    <string name="fsi_dialog_skip_toast">설정에서 변경할 수 있습니다.</string>
+
     <!-- Permissions onboarding (#26 + #31). -->
     <string name="onboarding_title">앱 권한</string>
     <string name="onboarding_intro">Quick Share는 로컬 Wi-Fi 네트워크에서 근처 기기를 검색하고, 근처 Quick Share 수신기를 깨우는 짧은 Bluetooth Low Energy 신호를 송수신하며, 전송 상태를 알리기 위해 몇 가지 Android 권한이 필요합니다. 아래에서 각 권한이 어떻게 사용되는지 확인할 수 있습니다.</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -18,9 +18,10 @@
     * `credit_teqhnikacross_desc` — the contributor explicitly
       asked for "We all want to be loved" rendered as-is on Korean
       devices too.
-    * `credit_yeonfeel_desc`, `credit_thanks_compact` — already
-      Korean in the canonical file (used as the default for both
-      English and Korean locales).
+    * `credit_thanks_compact` — already Korean in the canonical file
+      (used as the default for both English and Korean locales).
+      (`credit_yeonfeel_desc` is now fully localized: English canonical,
+      Korean here, Japanese in values-ja.)
 -->
 <resources>
 
@@ -53,6 +54,9 @@
 
     <!-- Credit screen, Developer section. -->
     <string name="credit_kevin_desc">마일리지가 모자라요</string>
+    <!-- YEONFEEL's tagline (Korean source). English / Japanese
+         renderings live in values/ and values-ja respectively. -->
+    <string name="credit_yeonfeel_desc">아무도 알지 못하는 세상을 걷는 법</string>
     <!-- Credit screen, QA section. -->
     <string name="credit_chiyak_qa_desc">콘서트 티켓이 사고 싶어요</string>
     <string name="credit_parami_desc">매일 감사하는 기도를 올리자</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,7 +31,10 @@
     <string name="credit_kevin_name">Kevin Cho</string>
     <string name="credit_kevin_desc">I\'m running low on miles</string>
     <string name="credit_yeonfeel_name">YEONFEEL</string>
-    <string name="credit_yeonfeel_desc">나의 멜로디도 너에게 닿기를</string>
+    <!-- YEONFEEL's tagline is fully localized: this is the English
+         rendering of the Korean source "아무도 알지 못하는 세상을 걷는 법"
+         (the Korean original lives in values-ko, Japanese in values-ja). -->
+    <string name="credit_yeonfeel_desc">How to walk a world no one knows</string>
     <!-- Chiyak shows up in BOTH the QA section (top of three) and
          the bottom-of-screen Special Thanks compact line. The
          duplication is intentional: the QA listing recognizes

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -442,4 +442,19 @@
       survives string formatting unchanged.
     -->
     <string name="transfer_progress_percent">%1$d%%</string>
+
+    <!--
+      Quick Settings tile (BadaQuickShareTileService). Toggles the
+      receiver's "always visible" override from the system Quick Settings
+      panel. `qs_tile_label` is also the tile's manifest android:label
+      (shown in the Quick Settings edit tray) — keep it under ~18 chars
+      and untranslated (proper noun). The subtitle/state strings render
+      under the tile label on API 29+; the content descriptions back
+      TalkBack on every API level.
+    -->
+    <string name="qs_tile_label">Bada</string>
+    <string name="qs_tile_subtitle_on">Discoverable</string>
+    <string name="qs_tile_subtitle_off">Off</string>
+    <string name="qs_tile_content_desc_on">Bada is discoverable to nearby devices</string>
+    <string name="qs_tile_content_desc_off">Bada is not discoverable</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -185,6 +185,22 @@
     <string name="settings_battery_status_not_exempt">Currently: not exempt — receiving may stop in the background</string>
     <string name="settings_battery_open">Open battery settings</string>
 
+    <!-- Settings tab "Full-screen transfer alerts" row + first-launch
+         dialog (Android 14+). On API 34+ USE_FULL_SCREEN_INTENT is a
+         special access that is auto-denied; without it the incoming
+         consent prompt (with the PIN) cannot pop full-screen over other
+         apps / the lock screen while Bada is in the background and
+         degrades to a heads-up notification. The row and dialog route
+         the user to the system page that grants it. The row is hidden
+         entirely below API 34, where the permission is install-time. -->
+    <string name="settings_fsi_title">Full-screen transfer alerts</string>
+    <string name="settings_fsi_subtitle">Allow full-screen notifications so an incoming transfer can show its PIN over other apps and on the lock screen when Bada is in the background. Without it, you still get a notification you can tap to see the PIN.</string>
+    <string name="settings_fsi_status_granted">Currently: full-screen alerts allowed</string>
+    <string name="settings_fsi_status_not_granted">Currently: not allowed — the PIN prompt arrives as a notification instead</string>
+    <string name="settings_fsi_open">Open notification settings</string>
+    <string name="fsi_dialog_body">When a transfer arrives while Bada is in the background, Android needs the full-screen notification permission to pop the PIN prompt over your screen. Without it, the prompt arrives as a regular notification you tap to open. Open settings to allow it, or Skip to handle it later from the Settings tab.</string>
+    <string name="fsi_dialog_skip_toast">You can change this from Settings.</string>
+
     <!-- Permissions onboarding (#26 + #31). -->
     <string name="onboarding_title">App permissions</string>
     <string name="onboarding_intro">Quick Share needs a small set of Android permissions to discover nearby devices over your local Wi-Fi network, to broadcast and listen for short Bluetooth Low Energy pulses that wake nearby Quick Share receivers, and to keep you informed about transfers. Each permission below explains exactly what it is used for.</string>

--- a/service-android/src/main/res/values-ja/strings.xml
+++ b/service-android/src/main/res/values-ja/strings.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Japanese (`ja`) string overrides for :service-android. Mirrors
+  every user-visible string in `values/strings.xml` so receiver and
+  consent notifications render in Japanese on a Japanese-locale
+  device while every other locale falls back to the English
+  originals.
+
+  Format placeholders (%1$s, %1$d, etc.) and escaped quotes are
+  preserved verbatim — translators only adjust the surrounding
+  prose. Pluralisation is still handled in code (no `<plurals>`
+  resources here yet); the segment strings below match what the
+  consent / progress notification builders interpolate.
+-->
+<resources xmlns:tools="http://schemas.android.com/tools">
+
+    <!-- Receiver foreground notification channel + body (#21). -->
+    <string name="receiver_notification_channel_name">Quick Share 受信機</string>
+    <string name="receiver_notification_channel_description">Quick Share の転送を待ち受けている間のステータス通知</string>
+    <string name="receiver_notification_title">Quick Share が有効です</string>
+    <string name="receiver_notification_text">近くのファイルを受信中…</string>
+    <string name="receiver_notification_text_with_ssid">\"%1$s\" で受信中</string>
+    <string name="receiver_notification_text_unknown_ssid">このネットワークで受信中</string>
+
+    <!-- Consent notification (#22). -->
+    <string name="consent_notification_channel_name">受信リクエスト</string>
+    <string name="consent_notification_channel_description">他の端末がファイル送信を求めたときに表示されるヘッドアップ通知</string>
+    <string name="consent_notification_title_with_name">%1$s が共有しようとしています</string>
+    <string name="consent_notification_title_unknown_sender">近くの端末が共有しようとしています</string>
+
+    <string name="consent_notification_summary_n_items" tools:ignore="PluralsCandidate">%1$d 件（%2$s）</string>
+    <string name="consent_notification_summary_no_items">項目なし</string>
+
+    <!-- Mixed-introduction summary (#40). -->
+    <string name="consent_notification_summary_kinds_with_size">%1$s（%2$s）</string>
+    <string name="consent_notification_segment_files" tools:ignore="PluralsCandidate">ファイル %1$d 件</string>
+    <string name="consent_notification_segment_urls" tools:ignore="PluralsCandidate">URL %1$d 件</string>
+    <string name="consent_notification_segment_addresses" tools:ignore="PluralsCandidate">住所 %1$d 件</string>
+    <string name="consent_notification_segment_phone_numbers" tools:ignore="PluralsCandidate">電話番号 %1$d 件</string>
+    <string name="consent_notification_segment_texts" tools:ignore="PluralsCandidate">テキスト %1$d 件</string>
+
+    <!-- Folder-receive summary (#39). -->
+    <string name="consent_notification_summary_folder" tools:ignore="PluralsCandidate">フォルダ \"%1$s\"（ファイル %2$d 件、%3$s）</string>
+
+    <string name="consent_notification_body">%1$s · PIN %2$s</string>
+    <string name="consent_notification_bigtext_pin_line">PIN を確認: %1$s</string>
+
+    <string name="consent_notification_action_accept">承諾</string>
+    <string name="consent_notification_action_reject">拒否</string>
+
+    <!-- Transfer progress notification (#46). -->
+    <string name="transfer_progress_channel_name">転送の進行状況</string>
+    <string name="transfer_progress_channel_description">進行中の Quick Share 転送のための控えめな進行状況通知</string>
+
+    <string name="transfer_progress_title_with_name">%1$s から受信中</string>
+    <string name="transfer_progress_title_unknown_sender">ファイルを受信中</string>
+
+    <string name="transfer_progress_body_size">%1$s / %2$s</string>
+    <string name="transfer_progress_body_rate">%1$s/秒</string>
+    <string name="transfer_progress_body_eta">残り %1$s</string>
+
+    <string name="transfer_progress_duration_few_seconds">1 秒未満</string>
+    <string name="transfer_progress_duration_seconds" tools:ignore="PluralsCandidate">%1$d 秒</string>
+    <string name="transfer_progress_duration_about_minutes" tools:ignore="PluralsCandidate">約 %1$d 分</string>
+    <string name="transfer_progress_duration_about_hours" tools:ignore="PluralsCandidate">約 %1$d 時間</string>
+
+    <string name="transfer_progress_action_cancel">キャンセル</string>
+
+</resources>


### PR DESCRIPTION
Combined PR superseding #182, #183, and #184. They were split per feature, but the Japanese strings for the new tile / consent surfaces can only be added once their base keys exist, so bundling them keeps `values-ja` complete in a single landing. Each feature is a distinct commit below.

## 1. Japanese (ja) localization (was #182)
- New `values-ja` for `:app` and `:service-android` mirroring the Korean override structure (same keys, same intentional non-translations: proper nouns, `credit_section_*` wordmarks).

## 2. Quick Settings tile (was #183)
- `BadaQuickShareTileService` toggles the receiver's always-visible override (`MdnsVisibilityOverrideHolder`) and brings `ReceiverForegroundService` up/down, so the device can be made discoverable from the Quick Settings panel.
- A QS tap is not on the platform FGS-start-from-background exemption list, so the tile catches `ForegroundServiceStartNotAllowedException` and falls back to opening the app (a visible/exempt context). Permission-missing routes into onboarding. API 34 `startActivityAndCollapse(PendingIntent)` handled.

## 3. Background consent full-screen popup (was #184)
- `FullScreenIntentPermission` + a first-launch dialog (chained after the battery prompt) + a Settings-tab row, so on Android 14+ the user can grant `USE_FULL_SCREEN_INTENT`. Without it the incoming-transfer consent prompt (with the PIN) degrades to a heads-up notification instead of popping full-screen while Bada is backgrounded. Hidden below API 34 (install-time grant).

## 4. Japanese strings for the new surfaces
- `values-ja` entries for the `qs_tile_*` and `settings_fsi_*` / `fsi_dialog_*` keys added by features 2 and 3.

## Testing
- `./gradlew staticAnalysis` and `:app:assembleDebug` pass.
- Verified on a vivo device (Android 16, ja-JP locale): tile foreground + background-fallback paths; credit screen renders the localized YEONFEEL tagline in Japanese; app UI renders in Japanese throughout.