### PR TITLE
feat: QR code / link sharing to stock Quick Share (#28, sender side)

### DIFF
--- a/app/src/main/kotlin/dev/bluehouse/bada/send/SendActivity.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/send/SendActivity.kt
@@ -52,7 +52,11 @@ import dev.bluehouse.bada.protocol.connection.OutboundConnectionState
 import dev.bluehouse.bada.protocol.connection.OutboundResult
 import dev.bluehouse.bada.protocol.endpoint.DeviceType
 import dev.bluehouse.bada.protocol.endpoint.EndpointInfo
+import dev.bluehouse.bada.protocol.qr.DerivedQrKeys
+import dev.bluehouse.bada.protocol.qr.GeneratedQrKeyData
 import dev.bluehouse.bada.protocol.qr.QrKeyData
+import dev.bluehouse.bada.protocol.qr.QrKeyDerivation
+import dev.bluehouse.bada.protocol.qr.QrTlvMatcher
 import dev.bluehouse.bada.protocol.qr.QrUrl
 import dev.bluehouse.bada.service.receiver.AdvertisedDeviceNames
 import dev.bluehouse.bada.service.receiver.OutboundSessionActiveHolder
@@ -60,6 +64,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.security.PrivateKey
 import java.security.SecureRandom
 import kotlin.math.min
 
@@ -124,6 +129,24 @@ public class SendActivity : AppCompatActivity() {
      * through the picker→terminal→picker bounce.
      */
     private var pendingFallback: Boolean = false
+
+    /**
+     * QR-code/link share session (#28, direction B). While the QR panel
+     * is showing, [qrSession] holds the freshly generated keypair whose
+     * public X coordinate is published in the QR/link, and [qrDerivedKeys]
+     * the HKDF advertising token + name-encryption key derived from it.
+     * The discovery callback matches each resolved peer's EndpointInfo
+     * against [qrDerivedKeys] via [dev.bluehouse.bada.protocol.qr.QrTlvMatcher];
+     * on a match it auto-connects to that peer. [qrSigningKey] is the
+     * private half threaded into the outbound connection so it can sign
+     * the UKEY2 authString for `qr_code_handshake_data`. [qrMatchConnectStarted]
+     * latches the auto-connect to fire at most once per QR session.
+     */
+    private var qrSession: GeneratedQrKeyData? = null
+    private var qrDerivedKeys: DerivedQrKeys? = null
+    private var qrSigningKey: PrivateKey? = null
+    private var qrMatchConnectStarted: Boolean = false
+
     private lateinit var senderEndpointId: String
     private lateinit var senderEndpointInfo: EndpointInfo
     private lateinit var senderEndpointInfoBytes: ByteArray
@@ -173,6 +196,7 @@ public class SendActivity : AppCompatActivity() {
                 lifecycle = lifecycle,
                 scope = lifecycleScope,
                 onPeerSelected = ::onPeerSelected,
+                onPeersResolved = ::onQrPeersResolved,
                 logDiagnostic = ::logOutboundDiagnostic,
                 senderEndpointId = senderEndpointId,
             )
@@ -263,6 +287,7 @@ public class SendActivity : AppCompatActivity() {
                     endpointId = senderEndpointId,
                     endpointInfo = endpointInfo,
                     useNearbyMultiplexInitialTransport = useNearbyMultiplexInitialTransport,
+                    qrSigningKey = qrSigningKey,
                     mediumRegistry = mediumRegistry,
                     logger = ::logOutboundWireMessage,
                 )
@@ -280,6 +305,7 @@ public class SendActivity : AppCompatActivity() {
                     transport = transport,
                     endpointId = senderEndpointId,
                     endpointInfo = endpointInfo,
+                    qrSigningKey = qrSigningKey,
                     mediumRegistry = mediumRegistry,
                     logger = ::logOutboundWireMessage,
                 )
@@ -297,6 +323,7 @@ public class SendActivity : AppCompatActivity() {
                     transport = transport,
                     endpointId = senderEndpointId,
                     endpointInfo = endpointInfo,
+                    qrSigningKey = qrSigningKey,
                     mediumRegistry = mediumRegistry,
                     logger = ::logOutboundWireMessage,
                 )
@@ -314,6 +341,7 @@ public class SendActivity : AppCompatActivity() {
                     transport = transport,
                     endpointId = senderEndpointId,
                     endpointInfo = endpointInfo,
+                    qrSigningKey = qrSigningKey,
                     mediumRegistry = mediumRegistry,
                     logger = ::logOutboundWireMessage,
                 )
@@ -351,6 +379,48 @@ public class SendActivity : AppCompatActivity() {
     // -----------------------------------------------------------------
     // Outbound connection
     // -----------------------------------------------------------------
+
+    /**
+     * Discovery callback for the QR-code/link share path (#28, direction
+     * B). While a QR session is active, test each resolved peer's
+     * EndpointInfo against the QR-derived keys: the device that opened our
+     * QR/link is now advertising a type=1 TLV carrying the advertising
+     * token (visible mode) or the AES-GCM-encrypted device name (hidden
+     * mode). On the first match, latch [qrMatchConnectStarted], stash the
+     * QR private key for `qr_code_handshake_data`, dismiss the QR panel,
+     * and auto-connect to that peer.
+     */
+    private fun onQrPeersResolved(resolved: List<NearbyPeer>) {
+        val keys = qrDerivedKeys
+        if (keys == null || qrMatchConnectStarted) return
+        val match =
+            resolved.firstNotNullOfOrNull { peer ->
+                peer.endpointInfo?.let { info ->
+                    val result = QrTlvMatcher.matches(info, keys)
+                    if (result is QrTlvMatcher.QrMatchResult.NoMatch) null else peer to result
+                }
+            } ?: return
+        val (peer, result) = match
+        qrMatchConnectStarted = true
+        qrSigningKey = qrSession?.keyPair?.private
+        logOutboundDiagnostic(
+            "qr: matched peer=${peer.stableId} result=${result::class.simpleName}",
+        )
+        dismissQrPanelForConnect()
+        onPeerSelected(peer)
+    }
+
+    /**
+     * Instantly tear down the QR panel (no exit animation) so the
+     * connection status panel can take over when a QR match auto-connects.
+     */
+    private fun dismissQrPanelForConnect() {
+        binding.sendQrPanel.animate().cancel()
+        binding.sendQrScroll.visibility = View.GONE
+        binding.sendPickerContent.alpha = 1f
+        binding.sendPickerContent.visibility = View.VISIBLE
+        binding.sendShowQrButton.visibility = View.GONE
+    }
 
     private fun onPeerSelected(peer: NearbyPeer) {
         val plan = SendBootstrapPlan.resolve(peer = peer)
@@ -1174,6 +1244,12 @@ public class SendActivity : AppCompatActivity() {
         if (binding.sendQrScroll.isVisible) return
 
         val generated = QrKeyData.generate()
+        // Persist the keypair for this QR session: the discovery callback
+        // matches resolved peers against the derived keys and the matched
+        // connection signs the UKEY2 authString with the private half.
+        qrSession = generated
+        qrDerivedKeys = QrKeyDerivation.deriveKeys(generated.qrKeyData)
+        qrMatchConnectStarted = false
         val url = QrUrl.build(generated.qrKeyData)
         binding.sendQrUrl.text = url
 
@@ -1251,6 +1327,10 @@ public class SendActivity : AppCompatActivity() {
      * single continuous shrink.
      */
     private fun onQrDoneClicked() {
+        // User dismissed the QR panel without a match — end the QR session
+        // so the discovery callback stops auto-matching resolved peers.
+        qrDerivedKeys = null
+        qrSession = null
         val panel = binding.sendQrPanel
         panel
             .animate()

--- a/app/src/main/kotlin/dev/bluehouse/bada/send/SendActivity.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/send/SendActivity.kt
@@ -21,6 +21,7 @@ import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.os.SystemClock
 import android.transition.ChangeBounds
 import android.transition.Transition
 import android.transition.TransitionManager
@@ -146,6 +147,14 @@ public class SendActivity : AppCompatActivity() {
     private var qrDerivedKeys: DerivedQrKeys? = null
     private var qrSigningKey: PrivateKey? = null
     private var qrMatchConnectStarted: Boolean = false
+
+    /**
+     * `SystemClock.elapsedRealtime()` of the first QR match seen with only
+     * a BLE route (no Wi-Fi LAN yet), or 0 if none. Used by [chooseQrMatch]
+     * to wait briefly for the QR endpoint's Wi-Fi LAN route to surface
+     * before falling back to a BLE connection.
+     */
+    private var qrFirstBleOnlyMatchAtMs: Long = 0L
 
     private lateinit var senderEndpointId: String
     private lateinit var senderEndpointInfo: EndpointInfo
@@ -393,21 +402,42 @@ public class SendActivity : AppCompatActivity() {
     private fun onQrPeersResolved(resolved: List<NearbyPeer>) {
         val keys = qrDerivedKeys
         if (keys == null || qrMatchConnectStarted) return
-        val match =
-            resolved.firstNotNullOfOrNull { peer ->
+        val matches =
+            resolved.mapNotNull { peer ->
                 peer.endpointInfo?.let { info ->
                     val result = QrTlvMatcher.matches(info, keys)
                     if (result is QrTlvMatcher.QrMatchResult.NoMatch) null else peer to result
                 }
-            } ?: return
-        val (peer, result) = match
+            }
+        val chosen = chooseQrMatch(matches) ?: return
         qrMatchConnectStarted = true
         qrSigningKey = qrSession?.keyPair?.private
+        val (peer, result) = chosen
         logOutboundDiagnostic(
-            "qr: matched peer=${peer.stableId} result=${result::class.simpleName}",
+            "qr: connecting matched peer=${peer.stableId} result=${result::class.simpleName} " +
+                "route=${if (peer.lanEndpoint != null) "wifi-lan" else "ble"}",
         )
         dismissQrPanelForConnect()
         onPeerSelected(peer)
+    }
+
+    /**
+     * Pick which QR-matched peer to connect to. Stock Quick Share's QR
+     * receiver first advertises the QR token over BLE only, then upgrades
+     * the same endpoint to also carry a Wi-Fi LAN route. Wi-Fi LAN is far
+     * more reliable than the BLE bootstrap, so prefer a LAN-capable match;
+     * if only BLE-only matches exist, wait up to [QR_LAN_WAIT_GRACE_MS] for
+     * the LAN route to surface before falling back to BLE.
+     */
+    @Suppress("ReturnCount")
+    private fun chooseQrMatch(
+        matches: List<Pair<NearbyPeer, QrTlvMatcher.QrMatchResult>>,
+    ): Pair<NearbyPeer, QrTlvMatcher.QrMatchResult>? {
+        if (matches.isEmpty()) return null
+        matches.firstOrNull { it.first.lanEndpoint != null }?.let { return it }
+        val now = SystemClock.elapsedRealtime()
+        if (qrFirstBleOnlyMatchAtMs == 0L) qrFirstBleOnlyMatchAtMs = now
+        return if (now - qrFirstBleOnlyMatchAtMs >= QR_LAN_WAIT_GRACE_MS) matches.first() else null
     }
 
     /**
@@ -1250,6 +1280,7 @@ public class SendActivity : AppCompatActivity() {
         qrSession = generated
         qrDerivedKeys = QrKeyDerivation.deriveKeys(generated.qrKeyData)
         qrMatchConnectStarted = false
+        qrFirstBleOnlyMatchAtMs = 0L
         val url = QrUrl.build(generated.qrKeyData)
         binding.sendQrUrl.text = url
 
@@ -1523,6 +1554,14 @@ public class SendActivity : AppCompatActivity() {
 
         private const val OUTBOUND_TAG: String = "BadaOutbound"
         private const val PERCENT_SCALE = 100
+
+        /**
+         * How long to wait for a QR-matched peer's Wi-Fi LAN route to
+         * surface before falling back to a BLE connection (#28). Stock
+         * Quick Share advertises the QR token over BLE first and upgrades
+         * the same endpoint to Wi-Fi LAN a beat later.
+         */
+        private const val QR_LAN_WAIT_GRACE_MS: Long = 5000L
 
         // In-card QR panel animation tunables. Entry uses an
         // overshoot easing so the panel briefly scales past 1.0 before

--- a/app/src/main/kotlin/dev/bluehouse/bada/send/SendPeerPickerController.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/send/SendPeerPickerController.kt
@@ -26,12 +26,20 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import dev.bluehouse.bada.discovery.diagnostics.DiagnosticLog as Log
 
+@Suppress("LongParameterList") // Every collaborator (UI, lifecycle, callbacks, sender id) is needed.
 internal class SendPeerPickerController(
     private val context: Context,
     private val binding: ActivitySendBinding,
     private val lifecycle: Lifecycle,
     private val scope: CoroutineScope,
     private val onPeerSelected: (NearbyPeer) -> Unit,
+    /**
+     * Invoked after every discovery update with the current resolved-peer
+     * snapshot. The QR-code/link share path (#28) uses it to match peers
+     * against the active QR session and auto-connect; the normal picker
+     * flow ignores it. Default no-op so non-QR callers need not supply it.
+     */
+    private val onPeersResolved: (List<NearbyPeer>) -> Unit = {},
     private val logDiagnostic: (String) -> Unit,
     /**
      * Sender's 4-byte endpoint slug. Threaded into the BLE FastInitiation
@@ -221,6 +229,7 @@ internal class SendPeerPickerController(
             }
         }
         renderPeerList()
+        onPeersResolved(peers.toList())
     }
 
     private fun upsertResolvedPeer(incoming: NearbyPeer) {

--- a/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnection.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnection.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.withContext
 import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.net.Socket
+import java.security.PrivateKey
 import java.security.SecureRandom
 
 /**
@@ -128,10 +129,13 @@ import java.security.SecureRandom
  *   [dev.bluehouse.bada.protocol.endpoint.EndpointInfo] bytes
  *   describing the sender. Default: empty (sender does not advertise a
  *   name; the receiver shows a generic "Someone wants to share").
- * @param qrCodeHandshakeData Optional QR-handshake bytes
- *   ([dev.bluehouse.bada.protocol.qr]) used when the user
- *   reached the sender via a scanned QR code. When non-null, attached
- *   to the outgoing `PairedKeyEncryptionFrame.qr_code_handshake_data`.
+ * @param qrSigningKey Optional EC P-256 private key matching the public
+ *   key published in a QR code/link this sender showed
+ *   ([dev.bluehouse.bada.protocol.qr]). When non-null, the driver signs
+ *   the UKEY2 `authString` with it (see [QrHandshakeSigner]) and attaches
+ *   the IEEE-P1363 signature to the outgoing
+ *   `PairedKeyEncryptionFrame.qr_code_handshake_data`, proving to the
+ *   QR-bonded receiver that this sender owns the QR keypair.
  * @param connectTimeoutMillis TCP connect timeout. Default 5 seconds —
  *   matches NearDrop's default and is generous enough for Wi-Fi LAN
  *   without making "host is down" cases linger.
@@ -172,7 +176,7 @@ public class OutboundConnection private constructor(
     private val transport: ConnectedTransport?,
     private val endpointId: String = generateEndpointId(),
     private val endpointInfo: ByteArray = ByteArray(0),
-    private val qrCodeHandshakeData: ByteArray? = null,
+    private val qrSigningKey: PrivateKey? = null,
     private val connectTimeoutMillis: Int = DEFAULT_CONNECT_TIMEOUT_MILLIS,
     private val initialHandshakeTimeoutMillis: Long = DEFAULT_INITIAL_HANDSHAKE_TIMEOUT_MILLIS,
     private val useNearbyMultiplexInitialTransport: Boolean = false,
@@ -194,7 +198,7 @@ public class OutboundConnection private constructor(
         port: Int,
         endpointId: String = generateEndpointId(),
         endpointInfo: ByteArray = ByteArray(0),
-        qrCodeHandshakeData: ByteArray? = null,
+        qrSigningKey: PrivateKey? = null,
         connectTimeoutMillis: Int = DEFAULT_CONNECT_TIMEOUT_MILLIS,
         initialHandshakeTimeoutMillis: Long = DEFAULT_INITIAL_HANDSHAKE_TIMEOUT_MILLIS,
         useNearbyMultiplexInitialTransport: Boolean = false,
@@ -208,7 +212,7 @@ public class OutboundConnection private constructor(
         transport = null,
         endpointId = endpointId,
         endpointInfo = endpointInfo,
-        qrCodeHandshakeData = qrCodeHandshakeData,
+        qrSigningKey = qrSigningKey,
         connectTimeoutMillis = connectTimeoutMillis,
         initialHandshakeTimeoutMillis = initialHandshakeTimeoutMillis,
         useNearbyMultiplexInitialTransport = useNearbyMultiplexInitialTransport,
@@ -222,7 +226,7 @@ public class OutboundConnection private constructor(
         transport: ConnectedTransport,
         endpointId: String = generateEndpointId(),
         endpointInfo: ByteArray = ByteArray(0),
-        qrCodeHandshakeData: ByteArray? = null,
+        qrSigningKey: PrivateKey? = null,
         connectTimeoutMillis: Int = DEFAULT_CONNECT_TIMEOUT_MILLIS,
         initialHandshakeTimeoutMillis: Long = DEFAULT_INITIAL_HANDSHAKE_TIMEOUT_MILLIS,
         remoteAcceptanceTimeoutMillis: Long = DEFAULT_REMOTE_ACCEPTANCE_TIMEOUT_MILLIS,
@@ -235,7 +239,7 @@ public class OutboundConnection private constructor(
         transport = transport,
         endpointId = endpointId,
         endpointInfo = endpointInfo,
-        qrCodeHandshakeData = qrCodeHandshakeData,
+        qrSigningKey = qrSigningKey,
         connectTimeoutMillis = connectTimeoutMillis,
         initialHandshakeTimeoutMillis = initialHandshakeTimeoutMillis,
         useNearbyMultiplexInitialTransport = false,
@@ -384,7 +388,7 @@ public class OutboundConnection private constructor(
                 mutableState = mutableState,
                 endpointId = endpointId,
                 endpointInfo = endpointInfo,
-                qrCodeHandshakeData = qrCodeHandshakeData,
+                qrSigningKey = qrSigningKey,
                 files = files,
                 mediumRegistry = mediumRegistry,
                 onHandshakeComplete = ::markHandshakeComplete,

--- a/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnectionDriver.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnectionDriver.kt
@@ -18,6 +18,7 @@ import dev.bluehouse.bada.protocol.medium.MediumRegistry
 import dev.bluehouse.bada.protocol.payload.PayloadAssembler
 import dev.bluehouse.bada.protocol.payload.PayloadEvent
 import dev.bluehouse.bada.protocol.payload.PayloadTransferEncoder
+import dev.bluehouse.bada.protocol.qr.QrHandshakeSigner
 import dev.bluehouse.bada.protocol.sharing.OutboundSharingFsm
 import dev.bluehouse.bada.protocol.sharing.OutboundSharingState
 import dev.bluehouse.bada.protocol.sharing.PairedKeyEncryptionFrame
@@ -45,6 +46,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.selects.onTimeout
 import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.withTimeoutOrNull
+import java.security.PrivateKey
 import java.security.SecureRandom
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -76,7 +78,7 @@ internal class OutboundConnectionDriver(
     private val mutableState: MutableStateFlow<OutboundConnectionState>,
     private val endpointId: String,
     private val endpointInfo: ByteArray,
-    private val qrCodeHandshakeData: ByteArray?,
+    private val qrSigningKey: PrivateKey?,
     private val files: List<FileSource>,
     private val mediumRegistry: MediumRegistry = MediumRegistry.DefaultWifiLan,
     private val onHandshakeComplete: () -> Unit = {},
@@ -102,6 +104,15 @@ internal class OutboundConnectionDriver(
     private var framedConnection: FramedConnection? = null
     private var secureChannel: SecureChannel? = null
     private var fsm: OutboundSharingFsm? = null
+
+    /**
+     * `qr_code_handshake_data` for the outgoing PairedKeyEncryption frame:
+     * an IEEE-P1363 ECDSA signature of the UKEY2 `authString` made with
+     * [qrSigningKey]. Computed once the session keys are derived (the
+     * authString is not known until then) and consumed by
+     * [rewriteForQrIfNeeded]. Stays null when this is not a QR-bonded send.
+     */
+    private var qrCodeHandshakeData: ByteArray? = null
 
     /** 4-digit confirmation PIN derived from UKEY2 `authString`. */
     private var pin: String = ""
@@ -177,6 +188,15 @@ internal class OutboundConnectionDriver(
             )
         pin = PinDerivation.deriveFourDigitPin(sessionKeys.authString)
         logger("step 5: D2D keys derived, PIN=$pin")
+
+        // QR-bonded send: sign the UKEY2 authString with the QR keypair's
+        // private key now that the authString exists. The signature rides
+        // the PairedKeyEncryption frame via rewriteForQrIfNeeded, proving
+        // to the QR receiver that this sender owns the published QR key.
+        qrSigningKey?.let { key ->
+            qrCodeHandshakeData = QrHandshakeSigner.sign(key, sessionKeys.authString)
+            logger("step 5: signed UKEY2 authString for QR handshake (${qrCodeHandshakeData?.size} bytes)")
+        }
 
         // Step 6: SecureChannel takes over.
         val channel =

--- a/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/qr/QrHandshakeSigner.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/qr/QrHandshakeSigner.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.protocol.qr
+
+import java.security.PrivateKey
+import java.security.Signature
+
+/**
+ * Builds the `qr_code_handshake_data` value the QR-originating (file-
+ * sending) device must place in its `PairedKeyEncryptionFrame`.
+ *
+ * Per PROTOCOL.md "QR codes": the sending device proves it owns the
+ * keypair published in the QR code by sending an **ECDSA signature of
+ * the UKEY2 auth key** (the same `authString` the connection PIN is
+ * derived from), made with the **private key matching the QR public
+ * key**. The signature is emitted in **IEEE P1363** form — the raw
+ * fixed-width `R || S` concatenation (64 bytes for P-256), not the ASN.1
+ * DER `SEQUENCE { INTEGER r, INTEGER s }` that `java.security.Signature`
+ * produces by default — so we sign with `SHA256withECDSA` and convert
+ * DER → P1363 ourselves (the `*inP1363Format` JCA aliases are not
+ * available across every API level we ship to).
+ */
+public object QrHandshakeSigner {
+    /** P-256 coordinate width in bytes; the P1363 signature is twice this. */
+    private const val COORD_LEN: Int = 32
+
+    private const val SIGNATURE_ALGORITHM: String = "SHA256withECDSA"
+
+    private const val DER_SEQUENCE_TAG: Int = 0x30
+    private const val DER_INTEGER_TAG: Int = 0x02
+    private const val BYTE_MASK: Int = 0xFF
+
+    /**
+     * Signs [ukey2AuthKey] with [privateKey] (an EC P-256 key) and returns
+     * the 64-byte IEEE P1363 `R || S` signature for use as
+     * `qr_code_handshake_data`.
+     */
+    public fun sign(
+        privateKey: PrivateKey,
+        ukey2AuthKey: ByteArray,
+    ): ByteArray {
+        val signature = Signature.getInstance(SIGNATURE_ALGORITHM)
+        signature.initSign(privateKey)
+        signature.update(ukey2AuthKey)
+        return derToP1363(signature.sign())
+    }
+
+    /**
+     * Converts an ASN.1 DER ECDSA signature (`SEQUENCE { INTEGER r,
+     * INTEGER s }`) into the fixed-width `R || S` P1363 form, each
+     * integer left-padded / leading-zero-stripped to [COORD_LEN] bytes.
+     *
+     * A P-256 DER signature is always short enough that every length
+     * field uses the single-byte short form, so we parse it directly
+     * without a general-purpose ASN.1 length decoder.
+     */
+    private fun derToP1363(der: ByteArray): ByteArray {
+        var offset = 0
+        require(der[offset++].toInt() and BYTE_MASK == DER_SEQUENCE_TAG) { "not a DER SEQUENCE" }
+        offset++ // sequence length (short form for a P-256 signature)
+        require(der[offset++].toInt() and BYTE_MASK == DER_INTEGER_TAG) { "missing INTEGER r" }
+        val rLen = der[offset++].toInt() and BYTE_MASK
+        val r = der.copyOfRange(offset, offset + rLen)
+        offset += rLen
+        require(der[offset++].toInt() and BYTE_MASK == DER_INTEGER_TAG) { "missing INTEGER s" }
+        val sLen = der[offset++].toInt() and BYTE_MASK
+        val s = der.copyOfRange(offset, offset + sLen)
+        return toFixedWidth(r) + toFixedWidth(s)
+    }
+
+    /**
+     * Renders a DER INTEGER (signed big-endian, possibly carrying a
+     * leading sign byte or fewer than [COORD_LEN] significant bytes) as
+     * an unsigned big-endian value exactly [COORD_LEN] bytes wide.
+     */
+    private fun toFixedWidth(value: ByteArray): ByteArray {
+        var start = 0
+        while (start < value.size - 1 && value[start].toInt() == 0) {
+            start++
+        }
+        val trimmed = value.copyOfRange(start, value.size)
+        require(trimmed.size <= COORD_LEN) { "integer wider than P-256 coordinate" }
+        val out = ByteArray(COORD_LEN)
+        trimmed.copyInto(out, destinationOffset = COORD_LEN - trimmed.size)
+        return out
+    }
+}


### PR DESCRIPTION
Implements the Bada **sender** side of QR-code / link sharing so a file shown as a QR/link is actually delivered to a peer that opens it — verified end-to-end against stock Quick Share on a Galaxy Z Fold7.

## Background
The QR panel already generated a valid `https://quickshare.google/qrcode#key=...` URL, but nothing acted on it: the receive/match/connect path was deferred (#28). Opening the link on a Galaxy launches Google Quick Share, which derives an advertising token from the QR key and advertises it (hidden-mode TLV). This PR wires Bada to find that peer, prove QR ownership, and send.

## Changes
- **`QrHandshakeSigner` (core-protocol)** — signs the UKEY2 `authString` with the QR keypair's EC P-256 private key and returns the IEEE-P1363 (64-byte `R‖S`) signature used for `qr_code_handshake_data` (per PROTOCOL.md).
- **`OutboundConnection` / `OutboundConnectionDriver`** — take a `qrSigningKey: PrivateKey?` instead of static handshake bytes; the driver signs the authString at PairedKeyEncryption time and attaches the signature.
- **`SendActivity`** — persists the QR keypair for the panel session, derives the advertising/name keys, and on each discovery update matches resolved peers' EndpointInfo via `QrTlvMatcher`. On a match it auto-connects, threading the QR private key.
- **Wi-Fi LAN preference** — stock Quick Share advertises the QR token over BLE first, then upgrades the same endpoint to Wi-Fi LAN. Bada prefers a LAN-capable match (far more reliable than the BLE bootstrap), waiting a short grace period for the LAN route to surface before falling back to BLE.
- **`SendPeerPickerController`** — new `onPeersResolved` callback feeding the QR matcher.

## Verified on-device (vivo V2547A → Galaxy Z Fold7, both Android 16)
- Opening the Bada link launches Google Quick Share (`SamsungQrCodeActivity`).
- Bada derives the same keys and matches the Galaxy's hidden-mode token (`HiddenMatch`, recovering the device name).
- Connects over Wi-Fi LAN → UKEY2 → paired-key (the `qr_code_handshake_data` signature is accepted) → Introduction → file streamed → safe-disconnect acknowledged.
- The file lands in the Galaxy's Quick Share received folder.

## Testing
- `./gradlew staticAnalysis` and `:core-protocol:test` pass.

## Notes / follow-ups
- Receiver-side QR (Bada scanning someone else's QR) is still out of scope — this is the sender path only.
- A first attempt occasionally times out before the receiver accepts (transient); a retry succeeds. Hardening the BLE-only fallback and surfacing the recovered device name in the UI are good follow-ups.