### PR TITLE
fix(receiver): consent/cancel notification actions silently dropped on Android 14+

### DIFF
--- a/service-android/src/main/kotlin/dev/bluehouse/bada/service/receiver/consent/ConsentNotification.kt
+++ b/service-android/src/main/kotlin/dev/bluehouse/bada/service/receiver/consent/ConsentNotification.kt
@@ -271,12 +271,18 @@ public object ConsentNotification {
         connectionId: Long,
     ): Intent =
         Intent(action).apply {
-            // Explicit component scoping locks the broadcast to our
-            // process. Without this, an `ACTION_ACCEPT` intent could
-            // theoretically be observed by an exported receiver in a
-            // sibling package (none exist today; future-proofing).
+            // Dispatch via setPackage + action only. ConsentBroadcastReceiver
+            // is registered dynamically by ReceiverForegroundService with
+            // RECEIVER_NOT_EXPORTED — there is no manifest entry, so an
+            // explicit setClass(receiver::class) component reference does
+            // not resolve at the BroadcastQueue and the broadcast is
+            // silently dropped (observed on Vivo Funtouch 16 during the
+            // #151 hardware loop, and on OnePlus 15 / Android 16 / ColorOS
+            // 16 where the strict broadcast routing also drops it).
+            // setPackage(packageName) is enough to keep delivery inside
+            // our process; the dynamic receiver's IntentFilter is the
+            // only listener for ACCEPT / REJECT in the package.
             setPackage(context.packageName)
-            setClass(context, ConsentBroadcastReceiver::class.java)
             putExtra(ConsentIntents.EXTRA_CONNECTION_ID, connectionId)
         }
 

--- a/service-android/src/main/kotlin/dev/bluehouse/bada/service/receiver/progress/TransferProgressNotification.kt
+++ b/service-android/src/main/kotlin/dev/bluehouse/bada/service/receiver/progress/TransferProgressNotification.kt
@@ -233,10 +233,13 @@ public object TransferProgressNotification {
         connectionId: Long,
     ): Intent =
         Intent(ConsentIntents.ACTION_CANCEL_TRANSFER).apply {
-            // Explicit component scoping so the broadcast cannot be
-            // observed by an exported receiver in a sibling package.
+            // setPackage-only routing. ConsentBroadcastReceiver is
+            // registered dynamically (RECEIVER_NOT_EXPORTED) — explicit
+            // setClass(receiver::class) does not resolve at the
+            // BroadcastQueue and silently drops the broadcast on stricter
+            // Android 14+ devices (Vivo Funtouch 16 / OnePlus 15 Android
+            // 16 ColorOS). setPackage keeps delivery inside our process.
             setPackage(context.packageName)
-            setClass(context, ConsentBroadcastReceiver::class.java)
             putExtra(ConsentIntents.EXTRA_CONNECTION_ID, connectionId)
         }
 


### PR DESCRIPTION
## Summary

The **Accept / Reject** buttons on the consent notification (and the **Cancel** button on the in-progress transfer notification) silently do nothing on stricter Android 14+ devices.

Reported by a user on OnePlus 15 / Android 16 / ColorOS 16.0.7.207 — also reproducible on Vivo Funtouch 16 per the historical comment in [`ConsentTrampolineActivity`](https://github.com/kyujin-cho/Bada/blob/main/app/src/main/kotlin/dev/bluehouse/bada/consent/ConsentTrampolineActivity.kt) (issue #151).

## Root cause

Both notification builders constructed the PendingIntent target with:

\`\`\`kotlin
Intent(action).apply {
    setPackage(context.packageName)
    setClass(context, ConsentBroadcastReceiver::class.java)   // ← the bug
    ...
}
\`\`\`

But `ConsentBroadcastReceiver` is registered **dynamically** at runtime by `ReceiverForegroundService` (with `RECEIVER_NOT_EXPORTED`) — there is **no manifest `<receiver>` entry**. Explicit-component lookup against the BroadcastQueue only resolves manifest-registered receivers; dynamic receivers are addressed via `IntentFilter` action match. On stricter Android 14+ routing the system finds no manifest target for the class name and silently drops the broadcast.

The same pitfall was previously found and fixed for `ConsentTrampolineActivity.sendBroadcast` (Vivo Funtouch 16). The notification PendingIntents kept the buggy form.

## Fix

Drop the `setClass(...)` call in both notification builders. Keep `setPackage(packageName)` for in-process scoping; the dynamic receiver's `IntentFilter` matches `ACCEPT` / `REJECT` / `ACTION_CANCEL_TRANSFER` actions, and those actions are listened to only by `ConsentBroadcastReceiver` within our package, so action matching is unambiguous.

Files changed:
- `service-android/.../consent/ConsentNotification.kt` (consent Accept/Reject PendingIntent)
- `service-android/.../progress/TransferProgressNotification.kt` (transfer Cancel PendingIntent)

## Tests

- `./gradlew :service-android:ktlintCheck :service-android:detekt` ✓
- `./gradlew :service-android:assembleDebug :app:assembleDebug` ✓
- `./gradlew :service-android:testDebugUnitTest` ✓

## Verification by reporter

After applying this build, tapping Accept / Reject on the consent notification (and Cancel on the in-progress notification) should reliably forward the user's decision to `InboundConnection.submitUserConsent` / cancel registry on Android 14+ devices.