### PR TITLE
fix: consent/cancel notification actions on Android 14+ and assorted copy/i18n cleanup

### DIFF
--- a/app/src/main/res/layout/activity_send.xml
+++ b/app/src/main/res/layout/activity_send.xml
@@ -361,6 +361,7 @@
                                     android:layout_width="match_parent"
                                     android:layout_height="wrap_content"
                                     android:layout_marginTop="24dp"
+                                    android:paddingHorizontal="16dp"
                                     android:text="@string/send_empty_state"
                                     android:textAppearance="@style/TextAppearance.AppCompat.Body1"
                                     android:visibility="gone" />
@@ -376,6 +377,8 @@
                                     android:id="@+id/send_network_hint"
                                     android:layout_width="match_parent"
                                     android:layout_height="wrap_content"
+                                    android:layout_marginStart="16dp"
+                                    android:layout_marginEnd="16dp"
                                     android:layout_marginTop="16dp"
                                     android:background="?android:attr/colorBackgroundFloating"
                                     android:orientation="vertical"

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -50,7 +50,7 @@
     <string name="credit_yeonfeel_desc">だれもが識らない世界の歩き方</string>
     <!-- Credit screen, QA section. -->
     <string name="credit_chiyak_qa_desc">コンサートのチケットが買いたいです</string>
-    <string name="credit_parami_desc">毎日感謝の祈りを捧げよう</string>
+    <string name="credit_parami_desc">Justice will be served.</string>
 
     <string name="credit_avatar_description">貢献者のアバター</string>
     <!-- Special Thanks compact line. "Chiyak" is a proper noun; only the
@@ -84,8 +84,8 @@
     <string name="main_save_location_subtitle">受信したファイルの保存場所を選択します。</string>
     <string name="main_save_location_default">ダウンロード（既定）</string>
     <string name="main_save_location_current">現在: %1$s</string>
-    <string name="main_save_location_pick">フォルダを選択…</string>
-    <string name="main_save_location_clear">既定に戻す</string>
+    <string name="main_save_location_pick">フォルダを選択</string>
+    <string name="main_save_location_clear">リセット</string>
     <string name="main_save_location_pick_failed">そのフォルダを保存できませんでした。別の場所を選択してください。</string>
 
     <!-- Advertised Quick Share device name (#141). -->
@@ -94,7 +94,7 @@
     <string name="main_advertised_name_hint">端末名</string>
     <string name="main_advertised_name_current">現在の表示名: %1$s</string>
     <string name="main_advertised_name_save">名前を保存</string>
-    <string name="main_advertised_name_reset">既定値を使用</string>
+    <string name="main_advertised_name_reset">リセット</string>
 
     <!-- Folder-send entry point (#38). -->
     <string name="main_send_folder_button">フォルダを送信</string>
@@ -174,7 +174,7 @@
     <string name="send_subtitle_discovering">近くの端末を検索中…</string>
     <string name="send_subtitle_pick_peer">端末をタップして送信します。</string>
     <string name="send_subtitle_no_usable_route">近くの端末は見つかりましたが、まだ利用できる転送経路がありません。</string>
-    <string name="send_empty_state">近くに端末がありません。受信側で Quick Share が開いているか確認してください。共有 Wi-Fi が基本経路です。両端末が同じ LAN 上にない場合は、近くのブートストラップのために Bluetooth をオンにしておいてください。</string>
+    <string name="send_empty_state">近くに端末がありません。受信側で Quick Share が開いているか確認してください。</string>
 
     <!-- Same-Wi-Fi-network hint card (#85). -->
     <string name="send_network_hint_title">近くの端末を見つける条件</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -60,7 +60,7 @@
     <string name="credit_yeonfeel_desc">아무도 알지 못하는 세상을 걷는 법</string>
     <!-- Credit screen, QA section. -->
     <string name="credit_chiyak_qa_desc">콘서트 티켓이 사고 싶어요</string>
-    <string name="credit_parami_desc">매일 감사하는 기도를 올리자</string>
+    <string name="credit_parami_desc">Justice will be served.</string>
 
     <string name="credit_avatar_description">기여자 프로필 사진</string>
     <!-- Special Thanks compact line. "Chiyak" is a proper noun; only the
@@ -97,8 +97,8 @@
     <string name="main_save_location_subtitle">받은 파일을 어디에 저장할지 선택합니다.</string>
     <string name="main_save_location_default">다운로드 (기본값)</string>
     <string name="main_save_location_current">현재: %1$s</string>
-    <string name="main_save_location_pick">폴더 선택…</string>
-    <string name="main_save_location_clear">다운로드로 초기화</string>
+    <string name="main_save_location_pick">폴더 선택</string>
+    <string name="main_save_location_clear">초기화</string>
     <string name="main_save_location_pick_failed">해당 폴더를 저장할 수 없습니다. 다른 위치를 선택해 주세요.</string>
 
     <!-- Advertised Quick Share device name (#141). -->
@@ -107,7 +107,7 @@
     <string name="main_advertised_name_hint">기기 이름</string>
     <string name="main_advertised_name_current">현재 표시 중: %1$s</string>
     <string name="main_advertised_name_save">이름 저장</string>
-    <string name="main_advertised_name_reset">시스템 기본값 사용</string>
+    <string name="main_advertised_name_reset">초기화</string>
 
     <!-- Folder-send entry point (#38). -->
     <string name="main_send_folder_button">폴더 보내기</string>
@@ -196,7 +196,7 @@
     <string name="send_subtitle_discovering">근처 기기 찾는 중…</string>
     <string name="send_subtitle_pick_peer">기기를 눌러 보내세요.</string>
     <string name="send_subtitle_no_usable_route">근처 기기가 발견되었지만 아직 지원되는 전송 경로가 없습니다.</string>
-    <string name="send_empty_state">근처에 기기가 없습니다. 받는 기기에서 Quick Share가 열려 있는지 확인하세요. 공유 Wi-Fi가 기본 경로이며, LAN 외부에 있다면 근처 부트스트랩을 위해 Bluetooth를 켜두세요.</string>
+    <string name="send_empty_state">근처에 기기가 없습니다. 받는 기기에서 Quick Share가 열려 있는지 확인하세요.</string>
 
     <!-- Same-Wi-Fi-network hint card (#85). -->
     <string name="send_network_hint_title">근처 검색 요건</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,0 +1,286 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  简体中文 (zh-rCN) 字符串覆盖。Android 资源系统会为主区域设置为简体中文
+  (zh-CN、zh-rCN) 的设备选用此文件；其他区域设置将回退到 values/strings.xml
+  中的英文版本。
+
+  翻译说明：
+    * app_name、贡献者姓名、品牌标签（"Quick Share"、"bada"）等专有名词不翻译。
+    * credit_teqhnikacross_desc —— 贡献者要求该句在所有语言中保持英文原文。
+    * credit_parami_desc —— 跨区域保持英文原文。
+    * qs_tile_label、transfer_progress_percent 不覆盖（参见 ko 注释）。
+    * 格式占位符（%1$s、%1$d、%%、\n 等）和转义字符原样保留。
+-->
+<resources xmlns:tools="http://schemas.android.com/tools">
+
+    <!-- 主界面底部导航标签 -->
+    <string name="nav_send_receive_title">发送 / 接收</string>
+    <string name="nav_settings_title">设置</string>
+
+    <!-- 工具栏溢出菜单 / 致谢界面 -->
+    <string name="menu_credit">致谢</string>
+    <string name="credit_activity_label">致谢</string>
+
+    <!-- 致谢界面，开发者板块 -->
+    <string name="credit_kevin_desc">里程快不够用了</string>
+    <!-- YEONFEEL 的标语（简体中文版）。英文版在 values/，韩文版在 values-ko/，日文版在 values-ja/ -->
+    <string name="credit_yeonfeel_desc">走在无人知晓的世界里</string>
+    <!-- 致谢界面，QA 板块 -->
+    <string name="credit_chiyak_qa_desc">好想买演唱会门票</string>
+    <string name="credit_parami_desc">Justice will be served.</string>
+
+    <string name="credit_avatar_description">贡献者头像</string>
+    <!-- 底部特别感谢紧凑行。"Chiyak" 为专有名词，仅括号内的说明文字翻译 -->
+    <string name="credit_thanks_compact">Chiyak（提供开发者令牌）</string>
+
+    <!-- 发送/接收标签页的文件选择入口 -->
+    <string name="main_send_files_button">发送文件</string>
+    <string name="main_send_files_subtitle">从本设备选择一个或多个文件（照片、文档，任何类型均可），发送到附近的 Quick Share 设备。</string>
+    <string name="main_send_files_pick_failed">无法在此设备上打开文件选择器。</string>
+    <string name="main_send_files_no_selection">未选择任何文件。</string>
+
+    <!-- 发送/接收标签页照片预览卡片上方的空闲状态说明 -->
+    <string name="main_send_waiting">等待接收文件…</string>
+    <string name="main_send_preview_photo_description">最近相册照片预览</string>
+
+    <!-- 始终可见开关（#34）—— 开/关标签、提示和说明文字 -->
+    <string name="main_always_visible_title">始终保持可见</string>
+    <string name="main_always_visible_subtitle">即使附近没有发送方的 Bluetooth 脉冲信号，也在 Wi-Fi 上保持本设备可被发现。关闭可节省电量；仅在发送方扫描时短暂可见。</string>
+    <string name="main_always_visible_off_title">扫描时可见</string>
+    <string name="main_always_visible_caption_on">附近任何人都可以向我共享文件。</string>
+    <string name="main_always_visible_caption_off">仅在附近设备通过蓝牙扫描时激活。</string>
+
+    <!-- 摇晃举报 Bug 开关 -->
+    <string name="main_bug_report_title">摇晃手机以举报 Bug</string>
+    <string name="main_bug_report_subtitle">启用后，在 Bada 打开时摇晃手机，即可将最近的诊断信息、设备状态和截图打包成 zip 文件并自行保存。不会自动上传任何内容。</string>
+
+    <!-- 保存位置设置（#42） -->
+    <string name="main_save_location_title">接收文件保存位置</string>
+    <string name="main_save_location_subtitle">选择传入文件的保存位置。</string>
+    <string name="main_save_location_default">下载（默认）</string>
+    <string name="main_save_location_current">当前：%1$s</string>
+    <string name="main_save_location_pick">选择文件夹</string>
+    <string name="main_save_location_clear">重置</string>
+    <string name="main_save_location_pick_failed">无法保存该文件夹，请选择其他位置。</string>
+
+    <!-- Quick Share 设备广播名称（#141） -->
+    <string name="main_advertised_name_title">Quick Share 广播名称</string>
+    <string name="main_advertised_name_subtitle">附近的 Quick Share 设备发现本设备时显示的名称。留空则使用 Android 设备名称回退链。名称过长时将自动截短，以确保其他设备能正确读取。</string>
+    <string name="main_advertised_name_hint">设备名称</string>
+    <string name="main_advertised_name_current">当前广播名称：%1$s</string>
+    <string name="main_advertised_name_save">保存名称</string>
+    <string name="main_advertised_name_reset">重置</string>
+
+    <!-- 文件夹发送入口（#38） -->
+    <string name="main_send_folder_button">发送文件夹</string>
+    <string name="main_send_folder_subtitle">选择本设备上的文件夹发送到附近的 Quick Share 设备。子目录和目录结构在接收方保持不变。</string>
+    <string name="send_folder_subtitle_walking">正在读取文件夹内容…</string>
+    <string name="send_folder_empty">所选文件夹为空，请添加至少一个文件后重试。</string>
+    <string name="send_folder_walk_failed">无法读取文件夹内容，请选择其他文件夹后重试。</string>
+
+    <!-- 旧版应用迁移横幅（#145） -->
+    <string name="main_legacy_wvmg_banner_title">请卸载旧版应用</string>
+    <string name="main_legacy_wvmg_banner_body">此设备上仍安装着本应用的旧版本。两个版本在蓝牙上存在冲突，导致 Galaxy 等原生 Quick Share 发送方无法连接到本设备。请点击"卸载"以移除旧版本。</string>
+    <string name="main_legacy_wvmg_banner_uninstall">卸载旧版本</string>
+    <string name="main_legacy_wvmg_banner_unavailable">无法打开 %1$s 的卸载对话框，请在系统设置中手动卸载。</string>
+
+    <!-- 电池优化横幅（#47） -->
+    <string name="main_battery_banner_title">允许后台活动</string>
+    <string name="main_battery_banner_body">若本应用未免除电池优化，此手机可能无法在后台接收 Quick Share 文件。点击"打开设置"添加免除项，若仅在应用前台运行时使用 Quick Share，可点击"跳过"。</string>
+    <string name="main_battery_banner_open">打开设置</string>
+    <string name="main_battery_banner_skip">跳过</string>
+    <string name="main_battery_banner_unavailable">在此设备上未找到合适的设置页面，您可以在系统设置中手动管理电池优化。</string>
+    <string name="dialog_battery_skip_toast">您可以在设置中更改此选项。</string>
+
+    <!-- 设置标签页"后台活动"行 -->
+    <string name="settings_battery_title">后台活动</string>
+    <string name="settings_battery_subtitle">将本应用从电池优化中排除，以便在屏幕关闭时也能持续接收 Quick Share 文件。</string>
+    <string name="settings_battery_status_exempt">当前：已免除电池优化</string>
+    <string name="settings_battery_status_not_exempt">当前：未免除 —— 后台接收可能中断</string>
+    <string name="settings_battery_open">打开电池设置</string>
+
+    <!-- 设置标签页"全屏传输提醒"行 + 首次启动对话框（Android 14+） -->
+    <string name="settings_fsi_title">全屏传输提醒</string>
+    <string name="settings_fsi_subtitle">允许全屏通知，以便在 Bada 处于后台时，传入的传输请求可在其他应用上方或锁屏界面直接显示 PIN。不允许时仍可通过点击通知查看 PIN。</string>
+    <string name="settings_fsi_status_granted">当前：已允许全屏提醒</string>
+    <string name="settings_fsi_status_not_granted">当前：未允许 —— PIN 提示将以通知形式出现</string>
+    <string name="settings_fsi_open">打开通知设置</string>
+    <string name="fsi_dialog_body">当 Bada 处于后台时收到传输请求，Android 需要全屏通知权限才能在屏幕上弹出 PIN 提示。不允许时，提示将以普通通知的形式到达，点击即可打开。打开设置以允许，或点击"跳过"留待以后在设置标签页中处理。</string>
+    <string name="fsi_dialog_skip_toast">您可以在设置中更改此选项。</string>
+
+    <!-- 权限引导界面（#26 + #31） -->
+    <string name="onboarding_title">应用权限</string>
+    <string name="onboarding_intro">Quick Share 需要少量 Android 权限，以便通过本地 Wi-Fi 网络发现附近设备、收发用于唤醒附近 Quick Share 接收方的短暂蓝牙低功耗（BLE）脉冲信号，以及向您通知传输状态。以下每项权限均说明了其具体用途。</string>
+    <string name="onboarding_empty_state">此设备在 Phase 1 无需任何运行时权限，您已准备就绪。</string>
+    <string name="onboarding_grant_button">授予权限</string>
+    <string name="onboarding_open_settings">打开应用设置</string>
+    <string name="onboarding_continue">不授权继续</string>
+    <string name="onboarding_continue_partial">不授全部权限继续</string>
+    <string name="onboarding_continue_degraded">以降级模式继续</string>
+
+    <!-- 同一 Wi-Fi 网络引导卡片（#85） -->
+    <string name="onboarding_network_card_title">附近发现要求</string>
+    <string name="onboarding_network_card_body">共享 Wi-Fi 仍是 Quick Share 的基础路径，尤其是接收时。向附近原生 Quick Share 设备发送时，若设备不在同一局域网，Bada 也可使用蓝牙辅助引导，请保持蓝牙开启以使用该路径。</string>
+    <string name="onboarding_network_card_dismiss">好的</string>
+
+    <!-- NEARBY_WIFI_DEVICES（API 33+） -->
+    <string name="permission_nearby_wifi_title">附近 Wi-Fi 设备</string>
+    <string name="permission_nearby_wifi_rationale">用于在同一 Wi-Fi 网络上发现其他 Quick Share 设备并向其广播。Quick Share 不会用此权限确定您的物理位置。</string>
+
+    <!-- POST_NOTIFICATIONS（API 33+） -->
+    <string name="permission_notifications_title">通知</string>
+    <string name="permission_notifications_rationale">用于显示前台传输服务指示器并提醒您有传入文件。没有此权限，传输仍可正常进行，但您不会收到通知。</string>
+
+    <!-- BLUETOOTH_ADVERTISE（API 31+，#31 / #121） -->
+    <string name="permission_bluetooth_advertise_title">蓝牙广播</string>
+    <string name="permission_bluetooth_advertise_rationale">用于发送两种蓝牙低功耗（BLE）脉冲：一种在您开始发送时唤醒附近的接收方，另一种让本设备在其他手机的 Quick Share 选择器中可见。没有此权限，传输仍可正常进行，但在连接建立前设备可能以通用标签显示。</string>
+
+    <!-- BLUETOOTH_SCAN（API 31+，#31） -->
+    <string name="permission_bluetooth_scan_title">附近蓝牙设备</string>
+    <string name="permission_bluetooth_scan_rationale">用于侦听附近的 Quick Share 发送方，以便仅在需要时唤醒接收方。Quick Share 不会用此权限确定您的物理位置。</string>
+
+    <!-- BLUETOOTH_CONNECT（API 31+） -->
+    <string name="permission_bluetooth_connect_title">蓝牙连接</string>
+    <string name="permission_bluetooth_connect_rationale">用于建立蓝牙低功耗（BLE）直连并读取蓝牙适配器状态以支持附近 Quick Share 发现。传输仍使用 Quick Share 加密。</string>
+
+    <!-- ACCESS_FINE_LOCATION（旧版附近设备发现） -->
+    <string name="permission_legacy_nearby_location_title">附近设备位置权限</string>
+    <string name="permission_legacy_nearby_location_rationale">Android 11 及更低版本通过位置权限传递蓝牙低功耗（BLE）扫描结果。Bada 仅用此权限发现附近的 Quick Share 设备，不使用您的物理位置。</string>
+
+    <!-- 权限状态标签 -->
+    <string name="permission_status_granted">已授权</string>
+    <string name="permission_status_denied">必要权限 - 未授权</string>
+    <string name="permission_status_optional_denied">可选权限 - 未授权（降级模式）</string>
+    <string name="permission_status_optional_denied_ble">可选权限 - 未授权（仅 mDNS 模式）</string>
+
+    <!-- 分享意图（#24）发送流程 -->
+    <string name="send_activity_label">通过 Quick Share 发送</string>
+    <string name="send_subtitle_discovering">正在搜索附近设备…</string>
+    <string name="send_subtitle_pick_peer">点击设备以发送。</string>
+    <string name="send_subtitle_no_usable_route">已发现附近设备，但暂无可用的传输路径。</string>
+    <string name="send_empty_state">附近暂无设备。请确保接收方已打开 Quick Share。</string>
+
+    <!-- 同一 Wi-Fi 网络提示卡片（#85） -->
+    <string name="send_network_hint_title">附近发现要求</string>
+    <string name="send_network_hint_body">共享 Wi-Fi 仍是基础路径。部分接收方在通过 BLE 曝光前可能没有可用的传输路径，请将两台设备连接到同一 Wi-Fi 网络，或保持蓝牙开启以支持引导路径。</string>
+    <string name="send_network_hint_dismiss">知道了</string>
+    <!-- 选择器状态的帮助链接 + 底部弹出内容 -->
+    <string name="send_help_link">找不到设备？</string>
+    <string name="send_help_sheet_title">找不到设备？</string>
+    <string name="send_help_sheet_visibility_title">检查接收方状态</string>
+    <string name="send_help_sheet_visibility_body">在接收设备上，确认开关显示为"准备好接收"。在该模式下，附近任何人都可以向其共享文件。若已处于该模式但仍未出现，请尝试在两台设备上完全关闭 Bada 后重新打开。</string>
+    <string name="send_help_sheet_qr_title">通过二维码共享</string>
+    <string name="send_help_sheet_qr_body">若接收方仍未出现，请点击此卡右上角的二维码按钮。让接收方扫描二维码或打开链接即可开始传输。</string>
+    <string name="send_help_sheet_compat_title">检查设备兼容性</string>
+    <string name="send_help_sheet_compat_body">bada 目前是一个实验性项目。部分设备可能可被发现但无法接收文件，另一些设备可能根本无法被发现。我们计划在后续更新中扩大设备支持范围。</string>
+    <string name="send_help_sheet_close">知道了</string>
+
+    <string name="send_show_qr">显示二维码</string>
+    <string name="send_cancel">取消</string>
+    <string name="send_done">完成</string>
+    <string name="send_unsupported">此共享内容无法发送，Intent 中未包含文件或文本内容。</string>
+
+    <!-- 载荷摘要模板 -->
+    <string name="send_payload_text">正在共享文字</string>
+    <string name="send_payload_single_file">1 个文件</string>
+    <string name="send_payload_multiple_files">%1$d 个文件</string>
+
+    <!-- 连接阶段标签（与 OutboundConnectionState 对应） -->
+    <string name="send_phase_connecting">连接中…</string>
+    <string name="send_phase_handshaking">安全配对中…</string>
+    <string name="send_phase_awaiting_acceptance">等待接收方确认</string>
+    <string name="send_phase_sending">发送中</string>
+    <string name="send_phase_completed">发送成功</string>
+    <string name="send_phase_rejected">接收方拒绝了传输</string>
+    <!-- 具名接收方的拒绝终态。%1$s 为接收方显示名称 -->
+    <string name="send_phase_rejected_by_named">%1$s 拒绝了文件传输</string>
+    <string name="send_phase_cancelled">传输已取消</string>
+    <string name="send_phase_failed">传输失败</string>
+
+    <!-- 状态面板消息（模板） -->
+    <string name="send_status_target">目标：%1$s</string>
+    <string name="send_status_pin_prompt">请确认此验证码与接收方屏幕上的一致。</string>
+    <string name="send_status_failure_reason">原因：%1$s</string>
+    <string name="send_status_progress">%1$s / %2$s</string>
+    <!-- 传输路径回退重试时显示。%1$s 为正在尝试的路径短标签 -->
+    <string name="send_status_retrying_route">正在通过 %1$s 重试…</string>
+
+    <!-- 发送过程中进度行追加的速率和剩余时间后缀 -->
+    <string name="send_status_rate">%1$s/秒</string>
+    <string name="send_status_eta">剩余 %1$s</string>
+    <string name="send_status_duration_few_seconds">不到一秒</string>
+    <string name="send_status_duration_seconds" tools:ignore="PluralsCandidate">%1$d 秒</string>
+    <string name="send_status_duration_about_minutes" tools:ignore="PluralsCandidate">约 %1$d 分钟</string>
+    <string name="send_status_duration_about_hours" tools:ignore="PluralsCandidate">约 %1$d 小时</string>
+
+    <!-- 摇晃举报 Bug 流程（#162） -->
+    <string name="bug_report_confirm_title">要举报 Bug 吗？</string>
+    <string name="bug_report_confirm_body">Bada 将收集最近的应用诊断信息、设备状态和截图并打包成 zip 文件，保存在本设备上，直到您选择保存位置为止。</string>
+    <string name="bug_report_confirm_yes">是</string>
+    <string name="bug_report_confirm_no">否</string>
+    <string name="bug_report_include_bssid_label">包含当前 Wi-Fi BSSID（含更多标识信息）</string>
+    <string name="bug_report_collecting">正在准备 Bug 报告…</string>
+    <string name="bug_report_collect_failed">无法准备 Bug 报告：%1$s</string>
+    <string name="bug_report_save_cancelled">Bug 报告保存已取消。</string>
+    <string name="bug_report_save_failed">无法保存 Bug 报告：%1$s</string>
+    <string name="bug_report_saved_title">Bug 报告已保存</string>
+    <string name="bug_report_saved_body">Bug 报告 zip 文件已保存。您可以立即打开 GitHub 并手动将其附加到新 Issue 中。</string>
+    <string name="bug_report_saved_open_issue">打开 GitHub Issue</string>
+    <string name="bug_report_saved_dismiss">关闭</string>
+    <string name="bug_report_issue_chooser">打开方式</string>
+    <string name="bug_report_issue_unavailable">没有可用的浏览器或兼容应用来打开 GitHub。</string>
+
+    <!-- 二维码界面（#20 + #84） -->
+    <string name="show_qr_title">二维码与链接</string>
+    <!-- 二维码面板上的说明文字 -->
+    <string name="show_qr_intro">请让接收方扫描二维码或打开链接。持有二维码或链接的任何人均可接收文件。</string>
+    <string name="show_qr_image_description">Quick Share 配对 URL 的二维码</string>
+    <string name="show_qr_done">完成</string>
+    <!-- 二维码面板底部操作行 -->
+    <string name="show_qr_close">关闭</string>
+    <string name="show_qr_copy_link">复制链接</string>
+    <!-- 点击"复制链接"后显示的 Toast -->
+    <string name="show_qr_link_copied">链接已复制</string>
+
+    <!-- 同意跳板界面（#22） -->
+    <string name="consent_activity_label">传入传输请求</string>
+    <!-- 4 位确认 PIN 上方的简短标题 -->
+    <string name="consent_pin_label">PIN</string>
+    <string name="consent_files_label">待接收文件</string>
+    <string name="consent_button_accept">接受</string>
+    <string name="consent_button_reject">拒绝</string>
+    <string name="consent_unknown_sender">附近有设备请求共享</string>
+    <!-- 基于载荷 MIME 类型的具名同意标题模板。%1$s 为发送方设备名称 -->
+    <string name="consent_title_with_name">%1$s 想要共享</string>
+    <string name="consent_title_with_name_images">%1$s 想要共享图片</string>
+    <string name="consent_title_with_name_videos">%1$s 想要共享视频</string>
+    <string name="consent_title_with_name_files">%1$s 想要共享文件</string>
+    <string name="consent_summary_n_items">%1$d 个项目（%2$s）</string>
+    <string name="consent_summary_no_items">无项目</string>
+    <!-- 文件夹接收摘要（#39）。每个文件均共享相同根目录 parent_folder 时显示 -->
+    <string name="consent_summary_folder">文件夹 \"%1$s\"（%2$d 个文件，%3$s）</string>
+    <!-- 同意对话框文件列表中的逐项行。文件名在第一行，人类可读大小在第二行 -->
+    <string name="consent_file_line">%1$s\n%2$s</string>
+    <string name="consent_text_line_with_title">%1$s\n%2$s</string>
+    <string name="consent_more_items">…以及另外 %1$d 个</string>
+    <string name="consent_dismissed">传输请求已不再待处理</string>
+
+    <!-- 接受后的同意流程状态（接收中 → 完成/失败） -->
+    <string name="consent_state_receiving">接收中…</string>
+    <string name="consent_state_progress">%1$s / %2$s</string>
+    <string name="consent_state_completed">传输完成</string>
+    <string name="consent_state_completed_one">已接收 1 个文件</string>
+    <string name="consent_state_completed_many">已接收 %1$d 个文件</string>
+    <string name="consent_state_failed">传输失败</string>
+    <string name="consent_state_cancelled">传输已取消</string>
+    <string name="consent_state_view_image">查看图片</string>
+    <string name="consent_state_close">关闭</string>
+    <string name="consent_state_view_image_unavailable">没有应用可以打开此图片。</string>
+
+    <!-- 快捷设置磁贴。qs_tile_label（"Bada"）为专有名词，此处不覆盖 -->
+    <string name="qs_tile_subtitle_on">可被发现</string>
+    <string name="qs_tile_subtitle_off">已关闭</string>
+    <string name="qs_tile_content_desc_on">Bada 可被附近设备发现</string>
+    <string name="qs_tile_content_desc_off">Bada 不可被发现</string>
+
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,11 +49,9 @@
          locale. -->
     <string name="credit_teqhnikacross_desc">We all want to be loved</string>
     <string name="credit_parami_name">Parami</string>
-    <!-- Parami's tagline is a self-exhortation in Korean ("매일 감사하는
-         기도를 올리자" — "let's give thanks in prayer every day"); the
-         English form mirrors that "let's …" self-encouraging tone rather
-         than translating the religious/prayer connotation literally. -->
-    <string name="credit_parami_desc">Let\'s give thanks in prayer every day</string>
+    <!-- Parami's tagline. Kept as the same English motto across all
+         locales. -->
+    <string name="credit_parami_desc">Justice will be served.</string>
     <!-- Combined "Name (note)" line for the bottom-centered Special
          Thanks section. Pre-baked into a single string so the layout
          can render it as one small caption rather than the per-row
@@ -118,8 +116,8 @@
     <string name="main_save_location_subtitle">Choose where incoming files are saved.</string>
     <string name="main_save_location_default">Downloads (default)</string>
     <string name="main_save_location_current">Current: %1$s</string>
-    <string name="main_save_location_pick">Choose folder…</string>
-    <string name="main_save_location_clear">Use default</string>
+    <string name="main_save_location_pick">Choose folder</string>
+    <string name="main_save_location_clear">Reset</string>
     <string name="main_save_location_pick_failed">Could not save that folder. Please pick a different location.</string>
 
     <!-- Advertised Quick Share device name (#141). The receiver uses
@@ -131,7 +129,7 @@
     <string name="main_advertised_name_hint">Device name</string>
     <string name="main_advertised_name_current">Currently advertised: %1$s</string>
     <string name="main_advertised_name_save">Save name</string>
-    <string name="main_advertised_name_reset">Use default</string>
+    <string name="main_advertised_name_reset">Reset</string>
 
     <!-- Folder-send entry point (#38). Android's share sheet only routes
          individual files; to ship a directory tree (preserving the
@@ -269,7 +267,7 @@
     <string name="send_subtitle_discovering">Looking for nearby devices…</string>
     <string name="send_subtitle_pick_peer">Tap a device to send.</string>
     <string name="send_subtitle_no_usable_route">Nearby device found, but no supported transfer route is available yet.</string>
-    <string name="send_empty_state">No devices nearby yet. Make sure the receiver has Quick Share open. Shared Wi-Fi is still the baseline path; if the devices are off-LAN, keep Bluetooth on for nearby bootstrap.</string>
+    <string name="send_empty_state">No devices nearby yet. Make sure the receiver has Quick Share open.</string>
 
     <!-- Same-Wi-Fi-network hint card (#85). Surfaced after a few seconds
          of empty peer list so the user understands why nothing has

--- a/service-android/src/main/kotlin/dev/bluehouse/bada/service/receiver/consent/ConsentNotification.kt
+++ b/service-android/src/main/kotlin/dev/bluehouse/bada/service/receiver/consent/ConsentNotification.kt
@@ -271,12 +271,18 @@ public object ConsentNotification {
         connectionId: Long,
     ): Intent =
         Intent(action).apply {
-            // Explicit component scoping locks the broadcast to our
-            // process. Without this, an `ACTION_ACCEPT` intent could
-            // theoretically be observed by an exported receiver in a
-            // sibling package (none exist today; future-proofing).
+            // Dispatch via setPackage + action only. ConsentBroadcastReceiver
+            // is registered dynamically by ReceiverForegroundService with
+            // RECEIVER_NOT_EXPORTED — there is no manifest entry, so an
+            // explicit setClass(receiver::class) component reference does
+            // not resolve at the BroadcastQueue and the broadcast is
+            // silently dropped (observed on Vivo Funtouch 16 during the
+            // #151 hardware loop, and on OnePlus 15 / Android 16 / ColorOS
+            // 16 where the strict broadcast routing also drops it).
+            // setPackage(packageName) is enough to keep delivery inside
+            // our process; the dynamic receiver's IntentFilter is the
+            // only listener for ACCEPT / REJECT in the package.
             setPackage(context.packageName)
-            setClass(context, ConsentBroadcastReceiver::class.java)
             putExtra(ConsentIntents.EXTRA_CONNECTION_ID, connectionId)
         }
 

--- a/service-android/src/main/kotlin/dev/bluehouse/bada/service/receiver/progress/TransferProgressNotification.kt
+++ b/service-android/src/main/kotlin/dev/bluehouse/bada/service/receiver/progress/TransferProgressNotification.kt
@@ -233,10 +233,13 @@ public object TransferProgressNotification {
         connectionId: Long,
     ): Intent =
         Intent(ConsentIntents.ACTION_CANCEL_TRANSFER).apply {
-            // Explicit component scoping so the broadcast cannot be
-            // observed by an exported receiver in a sibling package.
+            // setPackage-only routing. ConsentBroadcastReceiver is
+            // registered dynamically (RECEIVER_NOT_EXPORTED) — explicit
+            // setClass(receiver::class) does not resolve at the
+            // BroadcastQueue and silently drops the broadcast on stricter
+            // Android 14+ devices (Vivo Funtouch 16 / OnePlus 15 Android
+            // 16 ColorOS). setPackage keeps delivery inside our process.
             setPackage(context.packageName)
-            setClass(context, ConsentBroadcastReceiver::class.java)
             putExtra(ConsentIntents.EXTRA_CONNECTION_ID, connectionId)
         }
 


### PR DESCRIPTION
Bundled two different commit into one PR.
Resolves problem of #195 and #190 .

## 1. `fix(receiver): use setPackage-only routing for consent/cancel notification broadcasts`

The **Accept / Reject** buttons on the consent notification and the **Cancel** button on the in-progress transfer notification silently do nothing on stricter Android 14+ devices — reported on OnePlus 15 / Android 16 / ColorOS 16.0.7.207, and previously observed on Vivo Funtouch 16 (issue #151 and #195).

**Root cause.** Both notification builders construct their PendingIntent target with `Intent#setClass(context, ConsentBroadcastReceiver::class.java)`, scoping the broadcast to a specific receiver class. But `ConsentBroadcastReceiver` is registered **dynamically** at runtime by `ReceiverForegroundService` (with `RECEIVER_NOT_EXPORTED`) — there is **no manifest `<receiver>` entry**. Explicit-component lookup only resolves manifest-registered receivers; dynamic receivers are addressed via `IntentFilter` action match. The system finds no manifest target for the class name and silently drops the broadcast.

The same pitfall was previously found and fixed for `ConsentTrampolineActivity.sendBroadcast`. The notification PendingIntents kept the buggy form.

**Fix.** Drop the `setClass(...)` call in both notification builders. Keep `setPackage(packageName)` for in-process scoping; the dynamic receiver's `IntentFilter` matches `ACCEPT` / `REJECT` / `ACTION_CANCEL_TRANSFER`, and those actions are listened to only by `ConsentBroadcastReceiver` within the package, so action matching is unambiguous.

Files: `service-android/.../consent/ConsentNotification.kt`, `service-android/.../progress/TransferProgressNotification.kt`.

## 2. `chore(i18n): copy cleanup, empty-state padding, and zh-CN translations`

- **Settings buttons** (en/ko/ja): drop the trailing "…" on `main_save_location_pick`; rename `main_save_location_clear` and `main_advertised_name_reset` to a short "Reset" / "초기화" / "リセット" so the two buttons stop wrapping to a second line and breaking the settings card layout.
- **Empty-state copy** (en/ko/ja): trim the "Shared Wi-Fi is still the baseline path…" clause from `send_empty_state`.
- **Empty-state portrait padding regression**: the landscape send-picker refactor pulled the peer-list frame to full card width via negative side margins, which also stretched the empty-state TextView and the network-hint card to the card edges in portrait. Restore the 16dp horizontal inset so they align with the title again.
- **Simplified Chinese (zh-CN)**: add `values-zh-rCN/strings.xml` with 187 translated keys, mirroring the Korean / Japanese coverage. Brand names and tech acronyms kept in their canonical form; format placeholders and escapes preserved verbatim. (issue #190)

## Verification

- `./gradlew staticAnalysis` ✓
- `./gradlew :core-protocol:test :service-android:testDebugUnitTest` ✓
- `./gradlew :app:assembleDebug` ✓