### PR TITLE
feat(bugreport): capture BLE L2CAP/GATT bootstrap diagnostics on disk

### DIFF
--- a/app/src/main/kotlin/dev/bluehouse/bada/BadaApplication.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/BadaApplication.kt
@@ -36,6 +36,9 @@ class BadaApplication : Application() {
         super.onCreate()
         ReceiverForegroundService.openAppTarget = MainActivity::class.java
         ReceiverForegroundService.consentTrampolineTarget = ConsentTrampolineActivity::class.java
-        (getExternalFilesDir(null) ?: filesDir)?.let { DiagnosticLog.configureFileSink(it) }
+        // Must match where BugReportCollector reads the log back from
+        // (getExternalFilesDir(null)); a filesDir fallback would write logs
+        // the collector never picks up.
+        getExternalFilesDir(null)?.let { DiagnosticLog.configureFileSink(it) }
     }
 }

--- a/app/src/main/kotlin/dev/bluehouse/bada/BadaApplication.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/BadaApplication.kt
@@ -7,6 +7,7 @@ package dev.bluehouse.bada
 
 import android.app.Application
 import dev.bluehouse.bada.consent.ConsentTrampolineActivity
+import dev.bluehouse.bada.discovery.diagnostics.DiagnosticLog
 import dev.bluehouse.bada.service.receiver.ReceiverForegroundService
 
 /**
@@ -25,11 +26,16 @@ import dev.bluehouse.bada.service.receiver.ReceiverForegroundService
  * `BroadcastReceiver`, `Activity`) of the app, so by the time the
  * receiver service first tries to build a notification PendingIntent
  * the targets are already set.
+ *
+ * It also points [DiagnosticLog]'s on-disk sink at the app's external
+ * files dir so BLE/discovery diagnostics persist into the bug report past
+ * the 15-minute in-memory ring-buffer window (#201).
  */
 class BadaApplication : Application() {
     override fun onCreate() {
         super.onCreate()
         ReceiverForegroundService.openAppTarget = MainActivity::class.java
         ReceiverForegroundService.consentTrampolineTarget = ConsentTrampolineActivity::class.java
+        (getExternalFilesDir(null) ?: filesDir)?.let { DiagnosticLog.configureFileSink(it) }
     }
 }

--- a/app/src/main/kotlin/dev/bluehouse/bada/bugreport/BugReportCollector.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/bugreport/BugReportCollector.kt
@@ -78,7 +78,7 @@ internal class BugReportCollector(
             }
 
             val outboundLogBytes = readOptionalExternalFile("bada-outbound.log", failures, "outbound_log")
-            val diagnosticsLogBytes = readRotatedExternalFile("bada-diagnostics.log", failures, "diagnostics_log")
+            val diagnosticsLogBytes = collectDiagnosticsLog(includeWifiBssid, failures)
             val ringbufferText =
                 DiagnosticLog.dumpRecent(
                     maxAgeMillis = DiagnosticLog.DEFAULT_MAX_AGE_MILLIS,
@@ -127,7 +127,8 @@ internal class BugReportCollector(
                     ),
                     BugReportArchiveEntry(
                         "logs/diagnostics.log",
-                        diagnosticsLogBytes ?: "not_available\n".encodeToByteArray(),
+                        diagnosticsLogBytes
+                            ?: "${failures["diagnostics_log"] ?: "not_available"}\n".encodeToByteArray(),
                     ),
                     BugReportArchiveEntry(
                         "logs/ringbuffer.txt",
@@ -168,7 +169,7 @@ internal class BugReportCollector(
         - permissions.txt: granted/denied runtime permissions
         - discovery.txt: receiver/discovery runtime state
         - logs/outbound.log: on-disk outbound diagnostic log when available
-        - logs/diagnostics.log: persisted BLE/discovery diagnostics (rotated), incl. L2CAP/GATT bootstrap detail
+        - logs/diagnostics.log: persisted BLE/discovery diagnostics (rotated), incl. L2CAP/GATT bootstrap detail; only when more-identifying details consent is given
         - logs/ringbuffer.txt: recent in-memory diagnostics from the last 15 minutes
         - screenshot.png: screenshot of the current Bada activity, or a placeholder when redacted
         
@@ -405,6 +406,24 @@ internal class BugReportCollector(
             failures[failureKey] = "not_available: could not read $fileName (${t.message})"
             null
         }
+    }
+
+    /**
+     * `bada-diagnostics.log` carries BLE/discovery detail that includes
+     * nearby-device identifiers (peer BLE MACs, advertisement payloads), so it
+     * ships only when the user opts in via the same more-identifying-details
+     * consent that gates the Wi-Fi BSSID (#201).
+     */
+    private fun collectDiagnosticsLog(
+        includeWifiBssid: Boolean,
+        failures: MutableMap<String, String>,
+    ): ByteArray? {
+        if (!includeWifiBssid) {
+            failures["diagnostics_log"] =
+                "redacted: contains nearby-device identifiers; not collected without consent"
+            return null
+        }
+        return readRotatedExternalFile("bada-diagnostics.log", failures, "diagnostics_log")
     }
 
     /**

--- a/app/src/main/kotlin/dev/bluehouse/bada/bugreport/BugReportCollector.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/bugreport/BugReportCollector.kt
@@ -78,6 +78,7 @@ internal class BugReportCollector(
             }
 
             val outboundLogBytes = readOptionalExternalFile("bada-outbound.log", failures, "outbound_log")
+            val diagnosticsLogBytes = readRotatedExternalFile("bada-diagnostics.log", failures, "diagnostics_log")
             val ringbufferText =
                 DiagnosticLog.dumpRecent(
                     maxAgeMillis = DiagnosticLog.DEFAULT_MAX_AGE_MILLIS,
@@ -125,6 +126,10 @@ internal class BugReportCollector(
                         outboundLogBytes ?: "not_available\n".encodeToByteArray(),
                     ),
                     BugReportArchiveEntry(
+                        "logs/diagnostics.log",
+                        diagnosticsLogBytes ?: "not_available\n".encodeToByteArray(),
+                    ),
+                    BugReportArchiveEntry(
                         "logs/ringbuffer.txt",
                         ringbufferText.ifBlank { "not_available\n" }.encodeToByteArray(),
                     ),
@@ -163,6 +168,7 @@ internal class BugReportCollector(
         - permissions.txt: granted/denied runtime permissions
         - discovery.txt: receiver/discovery runtime state
         - logs/outbound.log: on-disk outbound diagnostic log when available
+        - logs/diagnostics.log: persisted BLE/discovery diagnostics (rotated), incl. L2CAP/GATT bootstrap detail
         - logs/ringbuffer.txt: recent in-memory diagnostics from the last 15 minutes
         - screenshot.png: screenshot of the current Bada activity, or a placeholder when redacted
         
@@ -396,6 +402,39 @@ internal class BugReportCollector(
             return null
         }
         return runCatching { file.readBytes() }.getOrElse { t ->
+            failures[failureKey] = "not_available: could not read $fileName (${t.message})"
+            null
+        }
+    }
+
+    /**
+     * Reads a size-rotated log written by [DiagnosticLog]'s file sink:
+     * the single `<name>.1` backup (older lines) followed by `<name>`
+     * (newer lines), concatenated in chronological order. Returns `null`
+     * and records a failure when neither file exists.
+     */
+    private fun readRotatedExternalFile(
+        fileName: String,
+        failures: MutableMap<String, String>,
+        failureKey: String,
+    ): ByteArray? {
+        val dir = context.getExternalFilesDir(null)
+        val ordered =
+            if (dir == null) {
+                emptyList()
+            } else {
+                listOf(File(dir, "$fileName.1"), File(dir, fileName)).filter { it.exists() }
+            }
+        if (ordered.isEmpty()) {
+            failures[failureKey] = "not_available: $fileName does not exist"
+            return null
+        }
+        return runCatching {
+            ByteArrayOutputStream().use { out ->
+                ordered.forEach { out.write(it.readBytes()) }
+                out.toByteArray()
+            }
+        }.getOrElse { t ->
             failures[failureKey] = "not_available: could not read $fileName (${t.message})"
             null
         }

--- a/app/src/main/kotlin/dev/bluehouse/bada/bugreport/BugReportCollector.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/bugreport/BugReportCollector.kt
@@ -423,6 +423,9 @@ internal class BugReportCollector(
                 "redacted: contains nearby-device identifiers; not collected without consent"
             return null
         }
+        // The sink writes asynchronously off the BLE/GATT threads, so drain any
+        // queued lines to disk before reading the file back.
+        DiagnosticLog.flushFileSink()
         return readRotatedExternalFile("bada-diagnostics.log", failures, "diagnostics_log")
     }
 

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -233,7 +233,7 @@
     <string name="bug_report_confirm_body">Bada は最近のアプリの診断情報・端末の状態・スクリーンショットを zip にまとめ、保存先を選ぶまで端末内にのみ保管します。</string>
     <string name="bug_report_confirm_yes">はい</string>
     <string name="bug_report_confirm_no">いいえ</string>
-    <string name="bug_report_include_bssid_label">現在の Wi-Fi BSSID を含める（識別性が高くなります）</string>
+    <string name="bug_report_include_bssid_label">識別性の高い詳細情報を含める（Wi-Fi BSSID と周辺デバイスの診断情報）</string>
     <string name="bug_report_collecting">バグ報告を準備中…</string>
     <string name="bug_report_collect_failed">バグ報告を準備できませんでした: %1$s</string>
     <string name="bug_report_save_cancelled">バグ報告の保存がキャンセルされました。</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -257,7 +257,7 @@
     <string name="bug_report_confirm_body">Bada가 최근 앱 진단 정보, 기기 상태, 스크린샷을 압축 파일로 모은 뒤 사용자가 저장 위치를 선택할 때까지 기기에만 보관합니다.</string>
     <string name="bug_report_confirm_yes">예</string>
     <string name="bug_report_confirm_no">아니요</string>
-    <string name="bug_report_include_bssid_label">현재 Wi-Fi BSSID 포함 (식별 정보가 더 많아짐)</string>
+    <string name="bug_report_include_bssid_label">식별 가능성이 높은 정보 포함 (Wi-Fi BSSID 및 주변 기기 진단 정보)</string>
     <string name="bug_report_collecting">버그 보고서 준비 중…</string>
     <string name="bug_report_collect_failed">버그 보고서를 준비할 수 없습니다: %1$s</string>
     <string name="bug_report_save_cancelled">버그 보고서 저장이 취소되었습니다.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -218,7 +218,7 @@
     <string name="bug_report_confirm_body">Bada 将收集最近的应用诊断信息、设备状态和截图并打包成 zip 文件，保存在本设备上，直到您选择保存位置为止。</string>
     <string name="bug_report_confirm_yes">是</string>
     <string name="bug_report_confirm_no">否</string>
-    <string name="bug_report_include_bssid_label">包含当前 Wi-Fi BSSID（含更多标识信息）</string>
+    <string name="bug_report_include_bssid_label">包含更具标识性的详细信息（Wi-Fi BSSID 和附近设备诊断信息）</string>
     <string name="bug_report_collecting">正在准备 Bug 报告…</string>
     <string name="bug_report_collect_failed">无法准备 Bug 报告：%1$s</string>
     <string name="bug_report_save_cancelled">Bug 报告保存已取消。</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -238,7 +238,7 @@
     <string name="bug_report_confirm_body">Bada 將收集近期的應用程式診斷紀錄、裝置狀態及螢幕截圖，打包成 ZIP 檔留存在裝置上，直到選擇儲存位置為止。</string>
     <string name="bug_report_confirm_yes">是</string>
     <string name="bug_report_confirm_no">否</string>
-    <string name="bug_report_include_bssid_label">包含目前 Wi-Fi BSSID（較容易識別身分）</string>
+    <string name="bug_report_include_bssid_label">包含較容易識別身分的詳細資訊（Wi-Fi BSSID 與鄰近裝置診斷資訊）</string>
     <string name="bug_report_collecting">正在準備錯誤報告…</string>
     <string name="bug_report_collect_failed">無法準備錯誤報告：%1$s</string>
     <string name="bug_report_save_cancelled">錯誤報告儲存已取消。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -358,7 +358,7 @@
     <string name="bug_report_confirm_body">Bada will collect recent app diagnostics, device state, and a screenshot into a zip that stays on this device until you choose where to save it.</string>
     <string name="bug_report_confirm_yes">Yes</string>
     <string name="bug_report_confirm_no">No</string>
-    <string name="bug_report_include_bssid_label">Include the current Wi-Fi BSSID (more identifying)</string>
+    <string name="bug_report_include_bssid_label">Include more-identifying details (Wi-Fi BSSID and nearby-device diagnostics)</string>
     <string name="bug_report_collecting">Preparing bug report…</string>
     <string name="bug_report_collect_failed">Could not prepare the bug report: %1$s</string>
     <string name="bug_report_save_cancelled">Bug report save cancelled.</string>

--- a/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/bootstrap/BleGattInitialControlClient.kt
+++ b/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/bootstrap/BleGattInitialControlClient.kt
@@ -29,10 +29,10 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
-import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.core.content.ContextCompat
 import com.google.location.nearby.mediums.proto.BleFramesProto
+import dev.bluehouse.bada.discovery.diagnostics.DiagnosticLog
 import dev.bluehouse.bada.protocol.endpoint.NearbyServiceId
 import dev.bluehouse.bada.protocol.medium.Medium
 import dev.bluehouse.bada.protocol.medium.NearbyBleSocketFrames
@@ -75,7 +75,7 @@ public class BleGattInitialControlClient internal constructor(
     public suspend fun connect(macAddress: String): ConnectedTransport? =
         withContext(dispatcher) {
             if (!isAvailable()) {
-                Log.w(TAG, "BLE GATT initial connect unavailable")
+                DiagnosticLog.w(TAG, "BLE GATT initial connect unavailable")
                 return@withContext null
             }
             val adapter =
@@ -87,7 +87,7 @@ public class BleGattInitialControlClient internal constructor(
                 try {
                     adapter.getRemoteDevice(macAddress)
                 } catch (badAddress: IllegalArgumentException) {
-                    Log.w(TAG, "invalid BLE GATT address=$macAddress", badAddress)
+                    DiagnosticLog.w(TAG, "invalid BLE GATT address=$macAddress", badAddress)
                     return@withContext null
                 }
             val transport =
@@ -103,11 +103,11 @@ public class BleGattInitialControlClient internal constructor(
             }
             val ready = transport.awaitReady(CONNECTION_READY_TIMEOUT_MILLIS)
             if (!ready) {
-                Log.w(TAG, "BLE GATT initial connect timed out waiting for socket ready")
+                DiagnosticLog.w(TAG, "BLE GATT initial connect timed out waiting for socket ready")
                 transport.close()
                 return@withContext null
             }
-            Log.w(TAG, "BLE GATT initial connect ready mac=$macAddress")
+            DiagnosticLog.w(TAG, "BLE GATT initial connect ready mac=$macAddress")
             transport
         }
 
@@ -224,8 +224,8 @@ private class BleGattClientTransport(
             runCatching {
                 val refresh = BluetoothGatt::class.java.getMethod("refresh")
                 val ok = refresh.invoke(opened) as? Boolean
-                Log.w(TAG, "BluetoothGatt.refresh() invoked result=$ok")
-            }.onFailure { Log.w(TAG, "refresh() reflection failed", it) }
+                DiagnosticLog.w(TAG, "BluetoothGatt.refresh() invoked result=$ok")
+            }.onFailure { DiagnosticLog.w(TAG, "refresh() reflection failed", it) }
         }
         return opened != null
     }
@@ -237,7 +237,7 @@ private class BleGattClientTransport(
         status: Int,
         newState: Int,
     ) {
-        Log.w(TAG, "gatt state device=${device.safeAddress()} status=$status newState=$newState")
+        DiagnosticLog.w(TAG, "gatt state device=${device.safeAddress()} status=$status newState=$newState")
         if (status != BluetoothGatt.GATT_SUCCESS || newState != BluetoothProfile.STATE_CONNECTED) {
             close()
             return
@@ -255,10 +255,10 @@ private class BleGattClientTransport(
         // exchange and only drop priority once they switch to the
         // upgraded medium.
         runCatching { gatt.requestConnectionPriority(BluetoothGatt.CONNECTION_PRIORITY_HIGH) }
-            .onFailure { Log.w(TAG, "requestConnectionPriority(HIGH) threw", it) }
+            .onFailure { DiagnosticLog.w(TAG, "requestConnectionPriority(HIGH) threw", it) }
         mainHandler.postDelayed({
             if (closed) return@postDelayed
-            Log.w(TAG, "post-connect grace expired; requesting MTU device=${device.safeAddress()}")
+            DiagnosticLog.w(TAG, "post-connect grace expired; requesting MTU device=${device.safeAddress()}")
             val requested = gatt.requestMtu(REQUESTED_MTU)
             if (!requested) discoverServicesOnce(gatt)
         }, POST_CONNECT_DELAY_MILLIS)
@@ -269,7 +269,7 @@ private class BleGattClientTransport(
         mtu: Int,
         status: Int,
     ) {
-        Log.w(TAG, "mtu changed mtu=$mtu status=$status device=${device.safeAddress()}")
+        DiagnosticLog.w(TAG, "mtu changed mtu=$mtu status=$status device=${device.safeAddress()}")
         if (status == BluetoothGatt.GATT_SUCCESS) {
             mtuPayloadSize = (mtu - GATT_ATT_HEADER_BYTES).coerceAtLeast(WeaveFrames.DEFAULT_ATT_PAYLOAD_SIZE)
         }
@@ -281,7 +281,7 @@ private class BleGattClientTransport(
         status: Int,
     ) {
         if (status != BluetoothGatt.GATT_SUCCESS) {
-            Log.w(TAG, "service discovery failed status=$status")
+            DiagnosticLog.w(TAG, "service discovery failed status=$status")
             close()
             return
         }
@@ -295,10 +295,10 @@ private class BleGattClientTransport(
                 s.characteristics.joinToString(",") { c ->
                     "${c.uuid}(props=${c.properties})"
                 }
-            Log.w(TAG, "gatt service ${s.uuid} chars=[$charDump]")
+            DiagnosticLog.w(TAG, "gatt service ${s.uuid} chars=[$charDump]")
         }
         if (!bindWeaveAndSlotsAcrossServices(gatt)) {
-            Log.w(TAG, "BLE GATT bootstrap missing Weave write/notify characteristics")
+            DiagnosticLog.w(TAG, "BLE GATT bootstrap missing Weave write/notify characteristics")
             close()
             return
         }
@@ -309,7 +309,7 @@ private class BleGattClientTransport(
         // parity and for receivers that expect it before the Weave
         // request.
         if (slotCharacteristics.isEmpty()) {
-            Log.w(TAG, "no advertisement slot characteristics found; subscribing immediately")
+            DiagnosticLog.w(TAG, "no advertisement slot characteristics found; subscribing immediately")
             subscribeAndConnect(gatt)
             return
         }
@@ -320,20 +320,20 @@ private class BleGattClientTransport(
     private fun readNextSlot(gatt: BluetoothGatt) {
         val slot = slotCharacteristics.getOrNull(slotReadIndex)
         if (slot == null) {
-            Log.w(TAG, "all advertisement slots read; waiting before CCCD subscribe")
+            DiagnosticLog.w(TAG, "all advertisement slots read; waiting before CCCD subscribe")
             // Hold another grace window before CCCD. Some receivers may
             // take additional time after slot reads to wire their GATT
             // handler.
             mainHandler.postDelayed({
                 if (closed) return@postDelayed
-                Log.w(TAG, "post-slot grace expired; subscribing CCCD")
+                DiagnosticLog.w(TAG, "post-slot grace expired; subscribing CCCD")
                 subscribeAndConnect(gatt)
             }, POST_SLOT_DELAY_MILLIS)
             return
         }
-        Log.w(TAG, "reading advertisement slot[$slotReadIndex] uuid=${slot.uuid}")
+        DiagnosticLog.w(TAG, "reading advertisement slot[$slotReadIndex] uuid=${slot.uuid}")
         if (!gatt.readCharacteristic(slot)) {
-            Log.w(TAG, "readCharacteristic returned false for slot[$slotReadIndex]; skipping rest")
+            DiagnosticLog.w(TAG, "readCharacteristic returned false for slot[$slotReadIndex]; skipping rest")
             subscribeAndConnect(gatt)
         }
     }
@@ -341,19 +341,19 @@ private class BleGattClientTransport(
     private fun subscribeAndConnect(gatt: BluetoothGatt) {
         val outgoing = fromPeripheral ?: return close()
         if (!gatt.setCharacteristicNotification(outgoing, true)) {
-            Log.w(TAG, "setCharacteristicNotification returned false")
+            DiagnosticLog.w(TAG, "setCharacteristicNotification returned false")
             close()
             return
         }
         val descriptor = outgoing.getDescriptor(CLIENT_CHARACTERISTIC_CONFIG_UUID)
         if (descriptor == null) {
-            Log.w(TAG, "notification descriptor missing")
+            DiagnosticLog.w(TAG, "notification descriptor missing")
             close()
             return
         }
         descriptor.value = cccdValueFor(outgoing)
         if (!gatt.writeDescriptor(descriptor)) {
-            Log.w(TAG, "write notification descriptor returned false")
+            DiagnosticLog.w(TAG, "write notification descriptor returned false")
             close()
         }
     }
@@ -382,7 +382,7 @@ private class BleGattClientTransport(
         value: ByteArray,
         status: Int,
     ) {
-        Log.w(
+        DiagnosticLog.w(
             TAG,
             "slot read uuid=${characteristic.uuid} status=$status " +
                 "len=${value.size} preview=${value.previewHex()} full=${value.toHex()}",
@@ -397,7 +397,7 @@ private class BleGattClientTransport(
         status: Int,
     ) {
         if (descriptor.uuid != CLIENT_CHARACTERISTIC_CONFIG_UUID || status != BluetoothGatt.GATT_SUCCESS) {
-            Log.w(TAG, "descriptor write failed uuid=${descriptor.uuid} status=$status")
+            DiagnosticLog.w(TAG, "descriptor write failed uuid=${descriptor.uuid} status=$status")
             close()
             return
         }
@@ -412,11 +412,11 @@ private class BleGattClientTransport(
         synchronized(this) {
             writeInFlight = false
             if (status != BluetoothGatt.GATT_SUCCESS) {
-                Log.w(TAG, "characteristic write failed status=$status")
+                DiagnosticLog.w(TAG, "characteristic write failed status=$status")
                 close()
                 return
             }
-            Log.w(TAG, "characteristic write complete device=${device.safeAddress()}")
+            DiagnosticLog.w(TAG, "characteristic write complete device=${device.safeAddress()}")
             drainWritesLocked()
         }
     }
@@ -456,7 +456,7 @@ private class BleGattClientTransport(
         if (serviceDiscoveryStarted) return
         serviceDiscoveryStarted = true
         if (!gatt.discoverServices()) {
-            Log.w(TAG, "discoverServices returned false")
+            DiagnosticLog.w(TAG, "discoverServices returned false")
             close()
         }
     }
@@ -478,7 +478,7 @@ private class BleGattClientTransport(
             .filter { it.uuid == BleGattInitialControlServer.SERVICE_UUID }
             .forEach { service -> bindServiceShape(service, slots) }
         slotCharacteristics = slots
-        Log.w(TAG, "bound Weave chars=${toPeripheral != null}/${fromPeripheral != null} slots=${slots.size}")
+        DiagnosticLog.w(TAG, "bound Weave chars=${toPeripheral != null}/${fromPeripheral != null} slots=${slots.size}")
         return toPeripheral != null && fromPeripheral != null
     }
 
@@ -534,7 +534,7 @@ private class BleGattClientTransport(
         mainHandler.postDelayed({
             synchronized(this) {
                 if (closed || weaveConnected) return@synchronized
-                Log.w(
+                DiagnosticLog.w(
                     TAG,
                     "no Weave CONNECTION_CONFIRM after attempt=$attempt; " +
                         "resending CONNECTION_REQUEST device=${device.safeAddress()}",
@@ -556,19 +556,19 @@ private class BleGattClientTransport(
     @Synchronized
     private fun handleNotification(packetBytes: ByteArray) {
         if (closed) return
-        Log.w(TAG, "notification len=${packetBytes.size} header=${packetBytes.firstByteHex()}")
+        DiagnosticLog.w(TAG, "notification len=${packetBytes.size} header=${packetBytes.firstByteHex()}")
         when (val packet = WeaveFrames.parse(packetBytes)) {
             is WeavePacket.ConnectionConfirm -> handleConnectionConfirm(packet)
             is WeavePacket.Data -> handleDataPacket(packet)
             is WeavePacket.ConnectionClose -> close()
             is WeavePacket.ConnectionRequest -> Unit
-            null -> Log.w(TAG, "invalid Weave packet ${packetBytes.toHex()}")
+            null -> DiagnosticLog.w(TAG, "invalid Weave packet ${packetBytes.toHex()}")
         }
     }
 
     private fun handleConnectionConfirm(packet: WeavePacket.ConnectionConfirm) {
         if (packet.version != WeaveFrames.VERSION) {
-            Log.w(TAG, "unsupported Weave version=${packet.version}")
+            DiagnosticLog.w(TAG, "unsupported Weave version=${packet.version}")
             close()
             return
         }
@@ -578,7 +578,10 @@ private class BleGattClientTransport(
                 ?.coerceAtMost(WeaveFrames.MAX_PACKET_SIZE)
                 ?: WeaveFrames.MIN_PACKET_SIZE
         weaveConnected = true
-        Log.w(TAG, "Weave connected raw Nearby stream packetSize=$negotiatedPacketSize device=${device.safeAddress()}")
+        DiagnosticLog.w(
+            TAG,
+            "Weave connected raw Nearby stream packetSize=$negotiatedPacketSize device=${device.safeAddress()}",
+        )
         sendWeaveMessage(NearbyBleSocketFrames.encodeIntroductionPacket())
         // Samsung's GMS raw Nearby handler expects the first app payload
         // immediately after the socket-introduction packet. Waiting after
@@ -599,7 +602,7 @@ private class BleGattClientTransport(
 
     private fun handleSocketMessage(message: ByteArray) {
         if (message.size < SERVICE_ID_HASH_LEN) {
-            Log.w(TAG, "discarded undersized BLE GATT socket message")
+            DiagnosticLog.w(TAG, "discarded undersized BLE GATT socket message")
             close()
             return
         }
@@ -612,7 +615,7 @@ private class BleGattClientTransport(
                 feedIncoming(payload)
             }
             else -> {
-                Log.w(TAG, "discarded BLE GATT socket message for unexpected service hash")
+                DiagnosticLog.w(TAG, "discarded BLE GATT socket message for unexpected service hash")
                 close()
             }
         }
@@ -621,15 +624,15 @@ private class BleGattClientTransport(
     private fun handleControlPacket(packet: ByteArray) {
         val control = NearbyBleSocketFrames.parseControlPacket(packet)
         if (control == null) {
-            Log.w(TAG, "BLE GATT unknown control packet raw=${packet.toHex()}")
+            DiagnosticLog.w(TAG, "BLE GATT unknown control packet raw=${packet.toHex()}")
             return
         }
         when (control.type) {
             BleFramesProto.SocketControlFrame.ControlFrameType.PACKET_ACKNOWLEDGEMENT -> {
-                Log.w(TAG, "BLE GATT packet ack size=${control.packetAcknowledgement.receivedSize}")
+                DiagnosticLog.w(TAG, "BLE GATT packet ack size=${control.packetAcknowledgement.receivedSize}")
             }
             BleFramesProto.SocketControlFrame.ControlFrameType.DISCONNECTION -> close()
-            else -> Log.w(TAG, "BLE GATT control frame type=${control.type}")
+            else -> DiagnosticLog.w(TAG, "BLE GATT control frame type=${control.type}")
         }
     }
 
@@ -639,23 +642,23 @@ private class BleGattClientTransport(
             inputWriter.write(bytes)
             inputWriter.flush()
         } catch (io: IOException) {
-            Log.w(TAG, "BLE GATT virtual input closed while feeding data", io)
+            DiagnosticLog.w(TAG, "BLE GATT virtual input closed while feeding data", io)
             close()
         }
     }
 
     private fun sendSocketServiceBytes(bytes: ByteArray) {
         if (bytes.isEmpty()) return
-        // Log.w (not Log.i) here is the Funtouch OS / vivo workaround from PR #144:
-        // Funtouch filters Log.i for non-system apps, leaving us blind to the
-        // outbound write path during BLE GATT bootstrap diagnostics. Log.w
-        // also lands in `getExternalFilesDir(null)/bada-outbound.log` via
-        // OutboundConnection's logger so on-device logs survive a logcat
-        // flush. The function split (sendSocketServiceBytes vs.
-        // sendSocketServiceMessage) is from PR #146, where new callers send
-        // already-prefixed socket payloads and want the inner helper without
-        // the extra logging.
-        Log.w(TAG, "BLE GATT service write bytes=${bytes.size} preview=${bytes.previewHex()}")
+        // DiagnosticLog.w (not .i) here is the Funtouch OS / vivo workaround
+        // from PR #144: Funtouch filters Log.i for non-system apps, leaving us
+        // blind to the outbound write path during BLE GATT bootstrap
+        // diagnostics. DiagnosticLog mirrors to Log.w *and* persists to
+        // `getExternalFilesDir(null)/bada-diagnostics.log` (#201) so on-device
+        // logs survive a logcat flush and reach the bug report. The function
+        // split (sendSocketServiceBytes vs. sendSocketServiceMessage) is from
+        // PR #146, where new callers send already-prefixed socket payloads and
+        // want the inner helper without the extra logging.
+        DiagnosticLog.w(TAG, "BLE GATT service write bytes=${bytes.size} preview=${bytes.previewHex()}")
         sendSocketServiceMessage(bytes)
     }
 
@@ -686,11 +689,11 @@ private class BleGattClientTransport(
 
     private fun enqueueWriteLocked(packet: ByteArray) {
         if (closed) return
-        // Log.w (not Log.i): same Funtouch OS / vivo workaround as
+        // DiagnosticLog.w (not .i): same Funtouch OS / vivo workaround as
         // sendSocketServiceBytes above — Log.i is filtered by Funtouch
         // for non-system apps, leaving us blind to the per-packet
         // enqueue path during BLE GATT bootstrap diagnostics.
-        Log.w(
+        DiagnosticLog.w(
             TAG,
             "enqueue write len=${packet.size} header=${packet.firstByteHex()} device=${device.safeAddress()}",
         )
@@ -705,14 +708,14 @@ private class BleGattClientTransport(
         val outgoing = toPeripheral ?: return close()
         outgoing.writeType = writeTypeFor(outgoing)
         outgoing.value = packet
-        Log.i(
+        DiagnosticLog.i(
             TAG,
             "write characteristic len=${packet.size} header=${packet.firstByteHex()} " +
                 "type=${outgoing.writeType} properties=${outgoing.properties} device=${device.safeAddress()}",
         )
         writeInFlight = openGatt.writeCharacteristic(outgoing)
         if (!writeInFlight) {
-            Log.w(TAG, "writeCharacteristic returned false")
+            DiagnosticLog.w(TAG, "writeCharacteristic returned false")
             close()
         }
     }

--- a/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/bootstrap/BleL2capInitialControlClient.kt
+++ b/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/bootstrap/BleL2capInitialControlClient.kt
@@ -10,11 +10,11 @@ package dev.bluehouse.bada.discovery.bootstrap
 
 import android.content.Context
 import android.os.Build
-import android.util.Log
 import androidx.annotation.ChecksSdkIntAtLeast
 import androidx.annotation.RequiresApi
 import com.google.location.nearby.mediums.proto.BleFramesProto
 import com.google.location.nearby.mediums.proto.MultiplexFramesProto
+import dev.bluehouse.bada.discovery.diagnostics.DiagnosticLog
 import dev.bluehouse.bada.discovery.medium.BluetoothL2capIo
 import dev.bluehouse.bada.discovery.medium.DefaultBluetoothL2capIo
 import dev.bluehouse.bada.discovery.medium.L2capChannel
@@ -60,7 +60,7 @@ public class BleL2capInitialControlClient internal constructor(
     ): ConnectedTransport? =
         withContext(dispatcher) {
             if (!isAvailable() || psm !in PSM_RANGE) {
-                Log.i(TAG, "BLE L2CAP initial connect unavailable psm=$psm")
+                DiagnosticLog.i(TAG, "BLE L2CAP initial connect unavailable psm=$psm")
                 return@withContext null
             }
             val channel = connectOnQ(macAddress, psm) ?: return@withContext null
@@ -74,11 +74,11 @@ public class BleL2capInitialControlClient internal constructor(
             transport.start()
             val ready = transport.awaitReady(CONNECTION_READY_TIMEOUT_MILLIS)
             if (!ready) {
-                Log.w(TAG, "BLE L2CAP initial connect timed out waiting for multiplex accept")
+                DiagnosticLog.w(TAG, "BLE L2CAP initial connect timed out waiting for multiplex accept")
                 transport.close()
                 return@withContext null
             }
-            Log.i(TAG, "BLE L2CAP initial connect ready mac=$macAddress psm=$psm")
+            DiagnosticLog.i(TAG, "BLE L2CAP initial connect ready mac=$macAddress psm=$psm")
             transport
         }
 
@@ -202,7 +202,7 @@ private class BleL2capClientTransport(
                 val packetLengthPrefix = channel.inputStream.readExactly(L2CAP_PACKET_LENGTH_BYTES)
                 val packetLength = packetLengthPrefix.decodeLength()
                 if (packetLength <= 0 || packetLength >= FramedConnection.SANE_FRAME_LENGTH) {
-                    Log.w(TAG, "invalid BLE L2CAP packet length=$packetLength")
+                    DiagnosticLog.w(TAG, "invalid BLE L2CAP packet length=$packetLength")
                     close()
                     return
                 }
@@ -211,10 +211,10 @@ private class BleL2capClientTransport(
         } catch (_: EOFException) {
             close()
         } catch (io: IOException) {
-            if (!closed) Log.w(TAG, "BLE L2CAP client pump failed", io)
+            if (!closed) DiagnosticLog.w(TAG, "BLE L2CAP client pump failed", io)
             close()
         } catch (t: Throwable) {
-            if (!closed) Log.w(TAG, "BLE L2CAP client pump crashed", t)
+            if (!closed) DiagnosticLog.w(TAG, "BLE L2CAP client pump crashed", t)
             close()
         }
     }
@@ -224,10 +224,10 @@ private class BleL2capClientTransport(
         channel.outputStream.flush()
         val response = channel.inputStream.read()
         if (response == COMMAND_RESPONSE_DATA_CONNECTION_READY) {
-            Log.i(TAG, "BLE L2CAP data connection ready")
+            DiagnosticLog.i(TAG, "BLE L2CAP data connection ready")
             return true
         }
-        Log.w(TAG, "unexpected BLE L2CAP data-connection response=$response")
+        DiagnosticLog.w(TAG, "unexpected BLE L2CAP data-connection response=$response")
         return false
     }
 
@@ -244,7 +244,7 @@ private class BleL2capClientTransport(
 
     private fun handleIncomingPacket(packet: ByteArray) {
         if (packet.size < SERVICE_ID_HASH_LEN) {
-            Log.w(TAG, "discarded undersized BLE L2CAP packet=${packet.toHex()}")
+            DiagnosticLog.w(TAG, "discarded undersized BLE L2CAP packet=${packet.toHex()}")
             close()
             return
         }
@@ -257,7 +257,7 @@ private class BleL2capClientTransport(
                 receiveMultiplexBytes(payload)
             }
             else -> {
-                Log.w(TAG, "discarded BLE L2CAP packet for unexpected service hash packet=${packet.toHex()}")
+                DiagnosticLog.w(TAG, "discarded BLE L2CAP packet for unexpected service hash packet=${packet.toHex()}")
                 close()
             }
         }
@@ -266,13 +266,13 @@ private class BleL2capClientTransport(
     private fun handleControlPacket(packet: ByteArray) {
         val control = NearbyBleSocketFrames.parseControlPacket(packet)
         if (control == null) {
-            Log.w(TAG, "BLE L2CAP unknown control packet raw=${packet.toHex()}")
+            DiagnosticLog.w(TAG, "BLE L2CAP unknown control packet raw=${packet.toHex()}")
             return
         }
         when (control.type) {
             BleFramesProto.SocketControlFrame.ControlFrameType.PACKET_ACKNOWLEDGEMENT -> Unit
             BleFramesProto.SocketControlFrame.ControlFrameType.DISCONNECTION -> close()
-            else -> Log.i(TAG, "BLE L2CAP control frame type=${control.type}")
+            else -> DiagnosticLog.i(TAG, "BLE L2CAP control frame type=${control.type}")
         }
     }
 
@@ -306,7 +306,7 @@ private class BleL2capClientTransport(
     private fun handleMultiplexFrame(frameBytes: ByteArray) {
         val frame =
             NearbyMultiplexFrames.parseFrame(frameBytes) ?: run {
-                Log.w(TAG, "discarded invalid multiplex frame=${frameBytes.toHex()}")
+                DiagnosticLog.w(TAG, "discarded invalid multiplex frame=${frameBytes.toHex()}")
                 return
             }
         when (frame.frameType) {
@@ -337,7 +337,7 @@ private class BleL2capClientTransport(
             inputWriter.write(bytes)
             inputWriter.flush()
         } catch (io: IOException) {
-            Log.w(TAG, "BLE L2CAP virtual input closed while feeding data", io)
+            DiagnosticLog.w(TAG, "BLE L2CAP virtual input closed while feeding data", io)
             close()
         }
     }

--- a/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/diagnostics/DiagnosticLog.kt
+++ b/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/diagnostics/DiagnosticLog.kt
@@ -6,10 +6,17 @@
 package dev.bluehouse.bada.discovery.diagnostics
 
 import android.util.Log
+import java.io.BufferedWriter
 import java.io.File
+import java.io.FileOutputStream
+import java.io.OutputStreamWriter
 import java.io.PrintWriter
 import java.io.StringWriter
 import java.util.ArrayDeque
+import java.util.concurrent.BlockingQueue
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
 
 /**
  * Shared Android logging facade that also mirrors recent lines into an in-memory
@@ -43,9 +50,20 @@ public object DiagnosticLog {
         directory: File,
         maxBytes: Long = DEFAULT_FILE_MAX_BYTES,
     ) {
+        val previous = fileSink
         fileSink =
             runCatching { DiagnosticFileSink(File(directory, FILE_NAME), maxBytes) }
                 .getOrNull()
+        previous?.shutdown()
+    }
+
+    /**
+     * Block up to [timeoutMillis] until queued diagnostics are written and
+     * flushed to disk. The bug-report collector calls this before reading the
+     * file back so the lines that prompted the report are not still buffered.
+     */
+    public fun flushFileSink(timeoutMillis: Long = DEFAULT_FLUSH_TIMEOUT_MILLIS) {
+        fileSink?.flush(timeoutMillis)
     }
 
     public fun i(
@@ -102,12 +120,6 @@ public object DiagnosticLog {
                 cutoffMillis = nowMillis - maxAgeMillis,
             ).joinToString(separator = "\n") { line -> formatLine(line) }
 
-    /**
-     * Absolute path of the on-disk diagnostics file, or `null` if no sink is
-     * configured. The bug-report collector reads this back into the archive.
-     */
-    public fun fileSinkPath(): String? = fileSink?.path
-
     private fun emit(
         level: Char,
         tag: String,
@@ -137,6 +149,7 @@ public object DiagnosticLog {
 
     internal fun clearForTesting() {
         recentLogBuffer.clear()
+        fileSink?.shutdown()
         fileSink = null
     }
 
@@ -155,42 +168,127 @@ public object DiagnosticLog {
     public const val DEFAULT_FILE_MAX_BYTES: Long = 512 * 1024L
 
     internal const val FILE_NAME: String = "bada-diagnostics.log"
+
+    /** Default barrier for [flushFileSink] at bug-report time. */
+    public const val DEFAULT_FLUSH_TIMEOUT_MILLIS: Long = 2_000L
 }
 
 /**
- * Append-only text sink with a single-backup size rotation. When [file] grows
- * past [maxBytes] it is renamed to `<file>.1` (replacing any previous backup)
- * and a fresh [file] is started. Reading both `<file>.1` then `<file>` yields
- * the lines in chronological order.
+ * Append-only text sink with a single-backup size rotation. When the current
+ * file grows past [maxBytes] it is renamed to `<file>.1` (replacing any
+ * previous backup) and a fresh file is started; reading `<file>.1` then
+ * `<file>` yields the lines in chronological order.
  *
- * Pure `java.io` so it stays JVM-testable; all writes are serialized on the
- * instance lock because diagnostics arrive from arbitrary BLE/GATT threads.
+ * Diagnostics arrive from arbitrary BLE/GATT binder threads, where blocking on
+ * disk I/O could stall callback processing during the very bootstrap path we
+ * are trying to diagnose (#201). So [append] only hands the line to an
+ * unbounded queue drained by a single daemon writer thread that holds one
+ * long-lived [BufferedWriter] — no `open`/`write`/`close` per line, and no disk
+ * work on the caller. The writer flushes after each drained batch (so a burst
+ * lands on disk promptly once it quiesces); [flush] adds an explicit barrier
+ * for read-back at report time.
  */
 internal class DiagnosticFileSink(
     private val file: File,
     private val maxBytes: Long,
 ) {
-    val path: String = file.absolutePath
     private val backup: File = File(file.parentFile, "${file.name}.1")
+    private val queue: BlockingQueue<Item> = LinkedBlockingQueue()
 
     init {
         file.parentFile?.mkdirs()
+        Thread(::runLoop, "bada-diag-sink").apply {
+            isDaemon = true
+            start()
+        }
     }
 
-    @Synchronized
     fun append(line: String) {
-        runCatching {
-            // length() is 0 for a missing file, so this only trips once the
-            // current file actually exists and is over the cap.
-            if (file.length() >= maxBytes) {
-                if (backup.exists()) backup.delete()
-                // If the rename fails (filesystem-dependent), fall back to
-                // truncating so the cap stays a real bound instead of letting
-                // the file grow without limit.
-                if (!file.renameTo(backup)) file.writeText("")
+        queue.offer(Item.Line(line))
+    }
+
+    fun flush(timeoutMillis: Long) {
+        val latch = CountDownLatch(1)
+        queue.offer(Item.Flush(latch))
+        runCatching { latch.await(timeoutMillis, TimeUnit.MILLISECONDS) }
+    }
+
+    fun shutdown() {
+        queue.offer(Item.Stop)
+    }
+
+    @Suppress("NestedBlockDepth")
+    private fun runLoop() {
+        var out: BufferedWriter? = null
+        // Append mode preserves earlier-session logs; seed the byte counter
+        // from disk so the size cap accounts for them.
+        var written: Long = if (file.exists()) file.length() else 0L
+        try {
+            while (true) {
+                val batch = ArrayList<Item>()
+                batch.add(queue.take())
+                queue.drainTo(batch)
+                for (item in batch) {
+                    when (item) {
+                        is Item.Line -> {
+                            val text = item.line + "\n"
+                            if (written >= maxBytes) {
+                                out?.close()
+                                out = null
+                                rotate()
+                                written = 0L
+                            }
+                            val writer = out ?: openWriter().also { out = it }
+                            writer.write(text)
+                            written += text.toByteArray(Charsets.UTF_8).size
+                        }
+
+                        is Item.Flush -> {
+                            runCatching { out?.flush() }
+                            item.latch.countDown()
+                        }
+
+                        Item.Stop -> {
+                            runCatching {
+                                out?.flush()
+                                out?.close()
+                            }
+                            return
+                        }
+                    }
+                }
+                runCatching { out?.flush() }
             }
-            file.appendText("$line\n")
+        } catch (_: InterruptedException) {
+            runCatching {
+                out?.flush()
+                out?.close()
+            }
         }
+    }
+
+    private fun openWriter(): BufferedWriter =
+        BufferedWriter(OutputStreamWriter(FileOutputStream(file, true), Charsets.UTF_8))
+
+    private fun rotate() {
+        runCatching {
+            if (backup.exists()) backup.delete()
+            // If the rename fails (filesystem-dependent), truncate instead so
+            // the cap stays a real bound rather than letting the file grow.
+            if (!file.renameTo(backup)) file.writeText("")
+        }
+    }
+
+    private sealed interface Item {
+        data class Line(
+            val line: String,
+        ) : Item
+
+        data class Flush(
+            val latch: CountDownLatch,
+        ) : Item
+
+        data object Stop : Item
     }
 }
 

--- a/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/diagnostics/DiagnosticLog.kt
+++ b/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/diagnostics/DiagnosticLog.kt
@@ -180,9 +180,14 @@ internal class DiagnosticFileSink(
     @Synchronized
     fun append(line: String) {
         runCatching {
-            if (file.length() >= maxBytes && file.exists()) {
+            // length() is 0 for a missing file, so this only trips once the
+            // current file actually exists and is over the cap.
+            if (file.length() >= maxBytes) {
                 if (backup.exists()) backup.delete()
-                file.renameTo(backup)
+                // If the rename fails (filesystem-dependent), fall back to
+                // truncating so the cap stays a real bound instead of letting
+                // the file grow without limit.
+                if (!file.renameTo(backup)) file.writeText("")
             }
             file.appendText("$line\n")
         }

--- a/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/diagnostics/DiagnosticLog.kt
+++ b/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/diagnostics/DiagnosticLog.kt
@@ -6,6 +6,7 @@
 package dev.bluehouse.bada.discovery.diagnostics
 
 import android.util.Log
+import java.io.File
 import java.io.PrintWriter
 import java.io.StringWriter
 import java.util.ArrayDeque
@@ -18,20 +19,40 @@ import java.util.ArrayDeque
  * bug-report collector cannot rely on reading the system buffer at report time.
  * Instead, the app writes its own high-signal diagnostics into
  * [recentLogBuffer] as they are emitted.
+ *
+ * The ring buffer is bounded by both count (2048 lines) and age (15 minutes),
+ * which is fine for an immediate shake-to-report but loses BLE bootstrap
+ * context once a user retries a few times before reporting. When an on-disk
+ * sink is configured via [configureFileSink], every emitted line is also
+ * appended to a size-rotating file the bug-report collector can read back,
+ * so the diagnostics survive past the ring-buffer window (#201).
  */
 public object DiagnosticLog {
     private val recentLogBuffer: RecentLogRingBuffer = RecentLogRingBuffer()
+
+    @Volatile
+    private var fileSink: DiagnosticFileSink? = null
+
+    /**
+     * Point the on-disk sink at [directory] (typically
+     * `getExternalFilesDir(null)`), creating `bada-diagnostics.log`. Safe to
+     * call more than once; the last call wins. Failures are swallowed — the
+     * in-memory buffer and logcat mirror keep working regardless.
+     */
+    public fun configureFileSink(
+        directory: File,
+        maxBytes: Long = DEFAULT_FILE_MAX_BYTES,
+    ) {
+        fileSink =
+            runCatching { DiagnosticFileSink(File(directory, FILE_NAME), maxBytes) }
+                .getOrNull()
+    }
 
     public fun i(
         tag: String,
         message: String,
     ): Int {
-        recentLogBuffer.record(
-            timestampMillis = System.currentTimeMillis(),
-            level = 'I',
-            tag = tag,
-            message = message,
-        )
+        emit(level = 'I', tag = tag, message = message)
         return Log.i(tag, message)
     }
 
@@ -39,12 +60,7 @@ public object DiagnosticLog {
         tag: String,
         message: String,
     ): Int {
-        recentLogBuffer.record(
-            timestampMillis = System.currentTimeMillis(),
-            level = 'W',
-            tag = tag,
-            message = message,
-        )
+        emit(level = 'W', tag = tag, message = message)
         return Log.w(tag, message)
     }
 
@@ -53,12 +69,7 @@ public object DiagnosticLog {
         message: String,
         throwable: Throwable,
     ): Int {
-        recentLogBuffer.record(
-            timestampMillis = System.currentTimeMillis(),
-            level = 'W',
-            tag = tag,
-            message = messageWithThrowable(message, throwable),
-        )
+        emit(level = 'W', tag = tag, message = messageWithThrowable(message, throwable))
         return Log.w(tag, message, throwable)
     }
 
@@ -66,12 +77,7 @@ public object DiagnosticLog {
         tag: String,
         message: String,
     ): Int {
-        recentLogBuffer.record(
-            timestampMillis = System.currentTimeMillis(),
-            level = 'E',
-            tag = tag,
-            message = message,
-        )
+        emit(level = 'E', tag = tag, message = message)
         return Log.e(tag, message)
     }
 
@@ -80,12 +86,7 @@ public object DiagnosticLog {
         message: String,
         throwable: Throwable,
     ): Int {
-        recentLogBuffer.record(
-            timestampMillis = System.currentTimeMillis(),
-            level = 'E',
-            tag = tag,
-            message = messageWithThrowable(message, throwable),
-        )
+        emit(level = 'E', tag = tag, message = messageWithThrowable(message, throwable))
         return Log.e(tag, message, throwable)
     }
 
@@ -99,12 +100,44 @@ public object DiagnosticLog {
         recentLogBuffer
             .snapshotSince(
                 cutoffMillis = nowMillis - maxAgeMillis,
-            ).joinToString(separator = "\n") { line ->
-                "${line.timestampMillis} ${line.level}/${line.tag}: ${line.message}"
-            }
+            ).joinToString(separator = "\n") { line -> formatLine(line) }
+
+    /**
+     * Absolute path of the on-disk diagnostics file, or `null` if no sink is
+     * configured. The bug-report collector reads this back into the archive.
+     */
+    public fun fileSinkPath(): String? = fileSink?.path
+
+    private fun emit(
+        level: Char,
+        tag: String,
+        message: String,
+    ) {
+        val timestampMillis = System.currentTimeMillis()
+        recentLogBuffer.record(
+            timestampMillis = timestampMillis,
+            level = level,
+            tag = tag,
+            message = message,
+        )
+        fileSink?.append(
+            formatLine(
+                BufferedLogLine(
+                    timestampMillis = timestampMillis,
+                    level = level,
+                    tag = tag,
+                    message = message,
+                ),
+            ),
+        )
+    }
+
+    private fun formatLine(line: BufferedLogLine): String =
+        "${line.timestampMillis} ${line.level}/${line.tag}: ${line.message}"
 
     internal fun clearForTesting() {
         recentLogBuffer.clear()
+        fileSink = null
     }
 
     private fun messageWithThrowable(
@@ -117,6 +150,43 @@ public object DiagnosticLog {
     }
 
     public const val DEFAULT_MAX_AGE_MILLIS: Long = 15 * 60 * 1000L
+
+    /** Per-file cap before the current log rotates to a single `.1` backup. */
+    public const val DEFAULT_FILE_MAX_BYTES: Long = 512 * 1024L
+
+    internal const val FILE_NAME: String = "bada-diagnostics.log"
+}
+
+/**
+ * Append-only text sink with a single-backup size rotation. When [file] grows
+ * past [maxBytes] it is renamed to `<file>.1` (replacing any previous backup)
+ * and a fresh [file] is started. Reading both `<file>.1` then `<file>` yields
+ * the lines in chronological order.
+ *
+ * Pure `java.io` so it stays JVM-testable; all writes are serialized on the
+ * instance lock because diagnostics arrive from arbitrary BLE/GATT threads.
+ */
+internal class DiagnosticFileSink(
+    private val file: File,
+    private val maxBytes: Long,
+) {
+    val path: String = file.absolutePath
+    private val backup: File = File(file.parentFile, "${file.name}.1")
+
+    init {
+        file.parentFile?.mkdirs()
+    }
+
+    @Synchronized
+    fun append(line: String) {
+        runCatching {
+            if (file.length() >= maxBytes && file.exists()) {
+                if (backup.exists()) backup.delete()
+                file.renameTo(backup)
+            }
+            file.appendText("$line\n")
+        }
+    }
 }
 
 /**

--- a/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/medium/BluetoothL2capIo.kt
+++ b/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/medium/BluetoothL2capIo.kt
@@ -24,6 +24,7 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.annotation.RequiresPermission
 import androidx.core.content.ContextCompat
+import dev.bluehouse.bada.discovery.diagnostics.DiagnosticLog
 import java.io.Closeable
 import java.io.InputStream
 import java.io.OutputStream
@@ -255,6 +256,9 @@ public class DefaultBluetoothL2capIo(
             // and the platform call. Both map to "skip the upgrade".
             @Suppress("TooGenericExceptionCaught") t: Throwable,
         ) {
+            // The reason is otherwise invisible to the bug report (#201);
+            // record the exception class + message before demoting.
+            DiagnosticLog.w(TAG, "L2CAP listen failed: ${t.describe()}")
             null
         }
     }
@@ -279,6 +283,10 @@ public class DefaultBluetoothL2capIo(
             // null so the framework can demote the medium cleanly.
             @Suppress("TooGenericExceptionCaught") t: Throwable,
         ) {
+            // This catch is exactly where #189/#191/#192 lose the reason
+            // the BLE L2CAP bootstrap fails. Record the concrete cause so
+            // the bug report shows it instead of a bare "Pipe closed".
+            DiagnosticLog.w(TAG, "L2CAP connect failed psm=$psm: ${t.describe()}")
             null
         }
     }
@@ -325,6 +333,8 @@ public class DefaultBluetoothL2capIo(
     }
 
     private companion object {
+        private const val TAG: String = "BadaBleL2cap"
+
         /** Parse `"AA:BB:CC:DD:EE:FF"` into 6 bytes, or `null`. */
         fun parseMacAddress(value: String): ByteArray? {
             val parts = value.split(':')
@@ -338,5 +348,8 @@ public class DefaultBluetoothL2capIo(
             }
             return out
         }
+
+        /** Class name + message, e.g. `IOException: connect failed`. */
+        fun Throwable.describe(): String = "${javaClass.simpleName}: ${message ?: "no message"}"
     }
 }

--- a/discovery-android/src/test/kotlin/dev/bluehouse/bada/discovery/diagnostics/DiagnosticFileSinkTest.kt
+++ b/discovery-android/src/test/kotlin/dev/bluehouse/bada/discovery/diagnostics/DiagnosticFileSinkTest.kt
@@ -12,10 +12,18 @@ import org.junit.jupiter.api.io.TempDir
 import java.io.File
 
 class DiagnosticFileSinkTest {
+    private val sinks = mutableListOf<DiagnosticFileSink>()
+
+    private fun sink(
+        file: File,
+        maxBytes: Long,
+    ): DiagnosticFileSink = DiagnosticFileSink(file, maxBytes).also { sinks += it }
+
     @AfterEach
     fun tearDown() {
-        // The sink is configured on the DiagnosticLog singleton; reset it so
-        // one test's file path never leaks into another's.
+        sinks.forEach { it.shutdown() }
+        // The sink is also configured on the DiagnosticLog singleton in one
+        // test; reset it so no writer thread or path leaks across tests.
         DiagnosticLog.clearForTesting()
     }
 
@@ -23,10 +31,11 @@ class DiagnosticFileSinkTest {
     fun `append writes lines to the configured file`(
         @TempDir dir: File,
     ) {
-        val sink = DiagnosticFileSink(File(dir, "diag.log"), maxBytes = 1_024)
+        val sink = sink(File(dir, "diag.log"), maxBytes = 1_024)
 
         sink.append("first")
         sink.append("second")
+        sink.flush(FLUSH_TIMEOUT_MILLIS)
 
         assertThat(File(dir, "diag.log").readText()).isEqualTo("first\nsecond\n")
     }
@@ -39,16 +48,18 @@ class DiagnosticFileSinkTest {
         val backup = File(dir, "diag.log.1")
         // Cap smaller than any single line, so every append after the first
         // finds the file already over the cap and rotates it.
-        val sink = DiagnosticFileSink(file, maxBytes = 4)
+        val sink = sink(file, maxBytes = 4)
 
         sink.append("aaaaaaaa") // file empty -> no rotation, file now over cap
         sink.append("bbbbbbbb") // file over cap -> rotate to .1, fresh file gets this
+        sink.flush(FLUSH_TIMEOUT_MILLIS)
 
         assertThat(backup.readText()).isEqualTo("aaaaaaaa\n")
         assertThat(file.readText()).isEqualTo("bbbbbbbb\n")
 
         // A second rotation must replace (not append to) the existing backup.
         sink.append("cccccccc")
+        sink.flush(FLUSH_TIMEOUT_MILLIS)
 
         assertThat(backup.readText()).isEqualTo("bbbbbbbb\n")
         assertThat(file.readText()).isEqualTo("cccccccc\n")
@@ -61,8 +72,13 @@ class DiagnosticFileSinkTest {
         DiagnosticLog.configureFileSink(dir, maxBytes = 64 * 1_024)
 
         DiagnosticLog.w("BadaBleL2cap", "L2CAP connect failed psm=135: IOException: connect failed")
+        DiagnosticLog.flushFileSink(FLUSH_TIMEOUT_MILLIS)
 
         val written = File(dir, DiagnosticLog.FILE_NAME).readText()
         assertThat(written).contains("W/BadaBleL2cap: L2CAP connect failed psm=135: IOException: connect failed")
+    }
+
+    private companion object {
+        const val FLUSH_TIMEOUT_MILLIS: Long = 2_000L
     }
 }

--- a/discovery-android/src/test/kotlin/dev/bluehouse/bada/discovery/diagnostics/DiagnosticFileSinkTest.kt
+++ b/discovery-android/src/test/kotlin/dev/bluehouse/bada/discovery/diagnostics/DiagnosticFileSinkTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.discovery.diagnostics
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class DiagnosticFileSinkTest {
+    @AfterEach
+    fun tearDown() {
+        // The sink is configured on the DiagnosticLog singleton; reset it so
+        // one test's file path never leaks into another's.
+        DiagnosticLog.clearForTesting()
+    }
+
+    @Test
+    fun `append writes lines to the configured file`(
+        @TempDir dir: File,
+    ) {
+        val sink = DiagnosticFileSink(File(dir, "diag.log"), maxBytes = 1_024)
+
+        sink.append("first")
+        sink.append("second")
+
+        assertThat(File(dir, "diag.log").readText()).isEqualTo("first\nsecond\n")
+    }
+
+    @Test
+    fun `oversized file rotates to a single backup and starts fresh`(
+        @TempDir dir: File,
+    ) {
+        val file = File(dir, "diag.log")
+        val backup = File(dir, "diag.log.1")
+        // Cap smaller than any single line, so every append after the first
+        // finds the file already over the cap and rotates it.
+        val sink = DiagnosticFileSink(file, maxBytes = 4)
+
+        sink.append("aaaaaaaa") // file empty -> no rotation, file now over cap
+        sink.append("bbbbbbbb") // file over cap -> rotate to .1, fresh file gets this
+
+        assertThat(backup.readText()).isEqualTo("aaaaaaaa\n")
+        assertThat(file.readText()).isEqualTo("bbbbbbbb\n")
+
+        // A second rotation must replace (not append to) the existing backup.
+        sink.append("cccccccc")
+
+        assertThat(backup.readText()).isEqualTo("bbbbbbbb\n")
+        assertThat(file.readText()).isEqualTo("cccccccc\n")
+    }
+
+    @Test
+    fun `configureFileSink routes emitted log lines to disk`(
+        @TempDir dir: File,
+    ) {
+        DiagnosticLog.configureFileSink(dir, maxBytes = 64 * 1_024)
+
+        DiagnosticLog.w("BadaBleL2cap", "L2CAP connect failed psm=135: IOException: connect failed")
+
+        val written = File(dir, DiagnosticLog.FILE_NAME).readText()
+        assertThat(written).contains("W/BadaBleL2cap: L2CAP connect failed psm=135: IOException: connect failed")
+    }
+}


### PR DESCRIPTION
## Summary

Tier 1 of #201. The bug-report archive could not explain the off-LAN BLE sender-bootstrap failures (#189, #191, #192). Those reports all end at a bare `Pipe closed`, with no way to tell *why* L2CAP failed or what GATT status preceded the close.

Two root causes:
- `DefaultBluetoothL2capIo.connect()` / `.listen()` swallowed every exception (IOException / SecurityException / IllegalArgumentException) into `null`, so the actual L2CAP failure reason was never logged anywhere.
- Both BLE bootstrap clients (`BleL2capInitialControlClient`, `BleGattInitialControlClient`) logged rich detail — GATT status codes, MTU, slot reads, Weave state — but via raw `android.util.Log`, which is mirrored to **neither** the `DiagnosticLog` ring buffer **nor** disk, so none of it reached the bug report.

## Changes

- Route both BLE bootstrap clients' diagnostics through `DiagnosticLog` instead of raw `Log`, so GATT status codes, MTU, slot reads, Weave state, and connect/timeout reasons land in the ring buffer. Level mapping is 1:1 (`Log.w`→`DiagnosticLog.w`, `Log.i`→`DiagnosticLog.i`), preserving the Funtouch `Log.w` workaround.
- Record the concrete L2CAP connect/listen failure (`ExceptionClass: message`) in `DefaultBluetoothL2capIo` before demoting to `null`. PSM is logged; MAC is not (privacy).
- Add a size-rotating on-disk sink to `DiagnosticLog` (`bada-diagnostics.log`, single `.1` backup, 512 KB cap), configured at app startup in `BadaApplication`, so BLE diagnostics survive past the 15-minute ring-buffer window.
- Collect the rotated log into the archive as `logs/diagnostics.log` (reads `.1` then current, chronological) and document it in the README artifact.

## Effect

A future #189/#191/#192 repro produces an archive whose `logs/diagnostics.log` shows the concrete L2CAP failure cause and the GATT status sequence leading to `Pipe closed`, instead of a bare error.

## Testing

- `DiagnosticFileSinkTest`: append, single-backup rotation/replacement, end-to-end routing through `DiagnosticLog`.
- `./gradlew staticAnalysis :discovery-android:testDebugUnitTest :app:testDebugUnitTest :core-protocol:test :app:assembleDebug` — all pass.

## Pre-merge note

This touches BLE initial-control, so per the repo's pre-merge rule it needs the real-device debug-loop regression (one GMS + one non-GMS device, both directions) before merge. That is a manual on-device step not run in this PR. The changes are diagnostic-only (logging + bug-report collection) and do not alter the bootstrap control flow.

Refs #201. Diagnostics for #189, #191, #192.
