### PR TITLE
fix: re-resolve LAN address and retry on connect failure (#203)

### DIFF
--- a/app/src/main/kotlin/dev/bluehouse/bada/send/LanReresolvePolicy.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/send/LanReresolvePolicy.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.send
+
+import dev.bluehouse.bada.discovery.NearbyPeerRoute
+
+/**
+ * Pure decision helpers for the LAN re-resolve-on-connect-failure retry
+ * (issue #203).
+ *
+ * The picker bakes a peer's LAN address into its route at pick time and
+ * stops discovery the moment a peer is selected, so a cached IP can go
+ * stale (Wi-Fi roam, DHCP lease renewal, AP hop) with no way to refresh
+ * it — the outbound socket then fails with `ECONNREFUSED` to the old
+ * address and the share dies. When a LAN bootstrap fails before a
+ * SecureChannel exists, the sender re-resolves the peer's current LAN
+ * address and retries once with the fresh route before falling through
+ * to other transports.
+ *
+ * The trigger / address-diff logic lives here as a side-effect-free
+ * object so it can be unit-tested on the JVM without an Activity,
+ * discovery, or a live socket.
+ */
+internal object LanReresolvePolicy {
+    /**
+     * How long to wait for a fresh LAN resolve before giving up the
+     * retry. Shorter than [dev.bluehouse.bada.discovery.AndroidNsdBrowser]'s
+     * 5 s resolve timeout so a stuck re-resolve cannot stall the picker
+     * UI longer than a single connect attempt would.
+     */
+    const val DEFAULT_TIMEOUT_MILLIS: Long = 3_500L
+
+    /**
+     * `true` when [route] is a LAN route whose failure ([failureReason])
+     * is a pre-SecureChannel bootstrap failure — the only class of
+     * failure a stale-address re-resolve can plausibly fix. Failures
+     * after the secure channel is up (peer rejection, UKEY2 mismatch,
+     * payload I/O) deliberately fall through: re-resolving the address
+     * would not help and would hide the real reason.
+     */
+    fun shouldReresolveLan(
+        route: NearbyPeerRoute,
+        failureReason: String,
+    ): Boolean =
+        route is NearbyPeerRoute.Lan &&
+            SendBootstrapRetryPolicy.isRetryableBootstrapFailure(failureReason)
+
+    /**
+     * Whether the freshly-resolved LAN route points at a different
+     * address tuple than the one that just failed. Used for diagnostics
+     * only — the retry fires on any fresh LAN resolve (a same-address
+     * resolve also recovers the case where the receiver came up a beat
+     * late), but distinguishing the two in the log is what confirms the
+     * stale-IP hypothesis on a real device.
+     */
+    fun addressChanged(
+        previous: NearbyPeerRoute.Lan,
+        fresh: NearbyPeerRoute.Lan,
+    ): Boolean = previous.address != fresh.address || previous.port != fresh.port
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/send/SendActivity.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/send/SendActivity.kt
@@ -574,7 +574,11 @@ public class SendActivity : AppCompatActivity() {
                             SendBootstrapPlan.forRoute(peer, route)
                         }
                     val isLastAttempt = index == routes.lastIndex
-                    pendingFallback = !isLastAttempt
+                    // Suppress the per-attempt terminal while another
+                    // attempt may still follow — either a lower-priority
+                    // fallback route, or (for a LAN route) an in-place
+                    // re-resolve retry against a refreshed address.
+                    pendingFallback = !isLastAttempt || route is NearbyPeerRoute.Lan
                     if (index > 0) {
                         // Re-paint the status panel for the fallback
                         // attempt so the user sees the transport switch
@@ -586,7 +590,7 @@ public class SendActivity : AppCompatActivity() {
                             "retry: attempting fallback route=$route after primary failed",
                         )
                     }
-                    val outcome = attemptOutbound(peer, attemptPlan)
+                    val outcome = attemptRouteOutcome(peer, route, attemptPlan)
                     pendingFallback = false
                     val shouldFallback =
                         !isLastAttempt &&
@@ -614,6 +618,72 @@ public class SendActivity : AppCompatActivity() {
                     return@launch
                 }
             }
+    }
+
+    /**
+     * Run one route's connect attempt and, for a LAN route, fold in the
+     * re-resolve retry (#203). Keeps [proceedWithPeer]'s fallback loop
+     * focused on route ordering: a non-failing attempt is returned as-is,
+     * and a failing one is handed to [retryLanAfterReresolve], which only
+     * acts on a stale-address LAN failure and otherwise returns the
+     * original outcome unchanged.
+     */
+    private suspend fun attemptRouteOutcome(
+        peer: NearbyPeer,
+        route: NearbyPeerRoute,
+        attemptPlan: SendBootstrapPlan,
+    ): OutboundResult {
+        val firstOutcome = attemptOutbound(peer, attemptPlan)
+        if (firstOutcome !is OutboundResult.Failed) return firstOutcome
+        return retryLanAfterReresolve(peer, route, firstOutcome) ?: firstOutcome
+    }
+
+    /**
+     * LAN re-resolve-on-connect-failure retry (issue #203).
+     *
+     * When a LAN bootstrap fails before a SecureChannel exists, the
+     * cached address may be stale — the peer roamed Wi-Fi or its DHCP
+     * lease renewed while we held a frozen route snapshot from pick time
+     * and discovery was suspended. Re-resolve the peer's current LAN
+     * address and, if a fresh LAN route surfaces, retry the connection
+     * once with it.
+     *
+     * Returns the retry's [OutboundResult], or `null` when no re-resolve
+     * was warranted (non-LAN route, or a post-secure failure that a new
+     * address cannot fix) or no fresh LAN address surfaced in time — in
+     * which case the caller keeps the original failure and proceeds to
+     * the next viable route.
+     */
+    @Suppress("ReturnCount") // Two early bail-outs (no re-resolve warranted /
+    // no fresh address) plus the retry result read clearer as guards.
+    private suspend fun retryLanAfterReresolve(
+        peer: NearbyPeer,
+        failedRoute: NearbyPeerRoute,
+        failure: OutboundResult.Failed,
+    ): OutboundResult? {
+        if (!LanReresolvePolicy.shouldReresolveLan(failedRoute, failure.reason)) return null
+        val previousLan = failedRoute as NearbyPeerRoute.Lan
+        val freshLan =
+            peerPickerController.reresolveLan(peer, LanReresolvePolicy.DEFAULT_TIMEOUT_MILLIS)
+        if (freshLan == null) {
+            logOutboundDiagnostic(
+                "reresolve: no fresh LAN address for peer=${peer.stableId}; keeping original failure",
+            )
+            return null
+        }
+        logOutboundDiagnostic(
+            "reresolve: retrying LAN peer=${peer.stableId} " +
+                "old=${previousLan.address.hostAddress}:${previousLan.port} " +
+                "new=${freshLan.address.hostAddress}:${freshLan.port} " +
+                "changed=${LanReresolvePolicy.addressChanged(previousLan, freshLan)}",
+        )
+        binding.sendStatusPhase.setText(R.string.send_phase_connecting)
+        binding.sendStatusMessage.text =
+            getString(
+                R.string.send_status_retrying_route,
+                SendBootstrapPlan.forRoute(peer, freshLan).subtitle,
+            )
+        return attemptOutbound(peer, SendBootstrapPlan.forRoute(peer, freshLan))
     }
 
     /**

--- a/app/src/main/kotlin/dev/bluehouse/bada/send/SendPeerPickerController.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/send/SendPeerPickerController.kt
@@ -23,7 +23,9 @@ import dev.bluehouse.bada.service.receiver.ReceiverAdvertisementStateHolder
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import dev.bluehouse.bada.discovery.diagnostics.DiagnosticLog as Log
 
 @Suppress("LongParameterList") // Every collaborator (UI, lifecycle, callbacks, sender id) is needed.
@@ -130,6 +132,69 @@ internal class SendPeerPickerController(
     fun onHintDismissed() {
         emptyPeerHintTimer.markDismissed()
         binding.sendNetworkHint.visibility = View.GONE
+    }
+
+    /**
+     * Re-resolve [peer]'s current LAN address by running a short,
+     * transient discovery session, and return the fresh LAN route — or
+     * `null` if no matching LAN-capable peer surfaces within [timeoutMs].
+     *
+     * Used by the sender's LAN re-resolve-on-connect-failure retry
+     * (issue #203): the picker stops discovery the moment a peer is
+     * picked ([suspendPicker]), so the route's baked-in address can go
+     * stale (Wi-Fi roam / DHCP renew) with no live discovery to refresh
+     * it. This spins up a fresh [NearbyPeerDiscovery] browse, waits for
+     * the same peer to re-resolve, and tears the browse down again as
+     * soon as it matches (or the timeout elapses).
+     *
+     * Matching is by `endpointId` when both sides have one — it is
+     * stable across an IP change within a single advertising session —
+     * and falls back to `stableId` otherwise. The fresh LAN route is
+     * built through [SendBootstrapPlan.viableRoutes] so it honours the
+     * same connectability gates (parseable endpoint info, dialable
+     * primary address) the picker applies.
+     */
+    suspend fun reresolveLan(
+        peer: NearbyPeer,
+        timeoutMs: Long,
+    ): NearbyPeerRoute.Lan? {
+        logDiagnostic(
+            "reresolve: browsing for peer=${peer.stableId} " +
+                "endpointId=${peer.endpointId ?: "<none>"} timeoutMs=$timeoutMs",
+        )
+        val discovery = NearbyPeerDiscovery(context.applicationContext)
+        val match =
+            withTimeoutOrNull(timeoutMs) {
+                discovery.browse().firstOrNull { event ->
+                    event is NearbyPeerEvent.Resolved &&
+                        matchesReresolveTarget(event.peer, peer) &&
+                        freshLanRoute(event.peer) != null
+                } as? NearbyPeerEvent.Resolved
+            }
+        val route = match?.peer?.let(::freshLanRoute)
+        logDiagnostic(
+            "reresolve: result peer=${peer.stableId} found=${route != null}" +
+                (route?.let { " addr=${it.address.hostAddress}:${it.port}" } ?: ""),
+        )
+        return route
+    }
+
+    private fun freshLanRoute(peer: NearbyPeer): NearbyPeerRoute.Lan? =
+        SendBootstrapPlan
+            .viableRoutes(peer)
+            .filterIsInstance<NearbyPeerRoute.Lan>()
+            .firstOrNull()
+
+    private fun matchesReresolveTarget(
+        candidate: NearbyPeer,
+        target: NearbyPeer,
+    ): Boolean {
+        val targetEndpoint = target.endpointId
+        return if (targetEndpoint != null && candidate.endpointId != null) {
+            candidate.endpointId == targetEndpoint
+        } else {
+            candidate.stableId == target.stableId
+        }
     }
 
     fun peerLabel(peer: NearbyPeer): String = peer.displayName()

--- a/app/src/test/kotlin/dev/bluehouse/bada/send/LanReresolvePolicyTest.kt
+++ b/app/src/test/kotlin/dev/bluehouse/bada/send/LanReresolvePolicyTest.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.send
+
+import dev.bluehouse.bada.discovery.NearbyPeerRoute
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.net.InetAddress
+
+class LanReresolvePolicyTest {
+    private fun lan(
+        address: String,
+        port: Int,
+    ): NearbyPeerRoute.Lan = NearbyPeerRoute.Lan(InetAddress.getByName(address), port)
+
+    @Test
+    fun `re-resolves a LAN route on a pre-secure initial-connect failure`() {
+        assertTrue(
+            LanReresolvePolicy.shouldReresolveLan(
+                route = lan("192.168.1.20", 7654),
+                failureReason = "Initial connect failed: ECONNREFUSED",
+            ),
+        )
+    }
+
+    @Test
+    fun `re-resolves a LAN route on an initial-handshake timeout`() {
+        assertTrue(
+            LanReresolvePolicy.shouldReresolveLan(
+                route = lan("192.168.1.20", 7654),
+                failureReason = "Initial handshake timed out after 5000ms",
+            ),
+        )
+    }
+
+    @Test
+    fun `does not re-resolve a LAN route on a post-secure failure`() {
+        // Anything that is not a pre-SecureChannel bootstrap failure must
+        // surface as-is — re-resolving the address cannot fix a peer
+        // rejection, UKEY2 mismatch, or payload-streaming error.
+        assertFalse(
+            LanReresolvePolicy.shouldReresolveLan(
+                route = lan("192.168.1.20", 7654),
+                failureReason = "Receiver rejected the transfer",
+            ),
+        )
+    }
+
+    @Test
+    fun `does not re-resolve a non-LAN route even on a retryable failure`() {
+        assertFalse(
+            LanReresolvePolicy.shouldReresolveLan(
+                route = NearbyPeerRoute.BleL2cap("AA:BB:CC:DD:EE:FF", 0x1234),
+                failureReason = "Initial connect failed: ECONNREFUSED",
+            ),
+        )
+    }
+
+    @Test
+    fun `addressChanged is true when the IP differs`() {
+        assertTrue(
+            LanReresolvePolicy.addressChanged(
+                previous = lan("192.168.1.20", 7654),
+                fresh = lan("192.168.1.30", 7654),
+            ),
+        )
+    }
+
+    @Test
+    fun `addressChanged is true when the port differs`() {
+        assertTrue(
+            LanReresolvePolicy.addressChanged(
+                previous = lan("192.168.1.20", 7654),
+                fresh = lan("192.168.1.20", 8888),
+            ),
+        )
+    }
+
+    @Test
+    fun `addressChanged is false when the tuple is identical`() {
+        assertFalse(
+            LanReresolvePolicy.addressChanged(
+                previous = lan("192.168.1.20", 7654),
+                fresh = lan("192.168.1.20", 7654),
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the highest-value, framework-independent part of #203: a discovered peer whose IP changes **while Bada keeps running** (Wi-Fi roam, DHCP lease renewal, AP hop) could not be reached. The picker bakes the LAN address into the route at pick time and **cancels discovery the moment a peer is selected** (`SendPeerPickerController.suspendPicker`), so the outbound socket kept dialing the stale IP and failed with `ECONNREFUSED` — with no recovery path.

Reported symptom:

```
Initial connect failed: failed to connect to /xxx.xx.x.xx (port xxxx) from … ECONNREFUSED
```

## Approach

When a LAN bootstrap fails **before a SecureChannel exists**, re-resolve the peer's current LAN address via a short transient discovery session and retry once with the fresh route before falling through to other transports. This slots into the existing route-fallback loop in `SendActivity.proceedWithPeer`.

- The re-resolve is matched by **`endpointId`** (stable across an IP change within one advertising session), falling back to `stableId`.
- It fires on **any fresh LAN resolve**, not only a changed IP — this also recovers the "receiver came up a beat late" case. The diagnostic log records `changed=true/false` so a real-device repro can confirm the stale-IP hypothesis.
- Only **pre-secure** failures (`Initial connect failed:` / `Initial handshake timed out`) trigger it; post-secure failures (peer rejection, UKEY2 mismatch, payload I/O) surface unchanged — re-resolving the address cannot fix those and would hide the real reason.
- Bounded to **one** re-resolve+retry per LAN route; if it still fails retryably the existing loop falls through to BLE/other routes as before.

## Changes

- **`LanReresolvePolicy`** (new, pure object) — the trigger (`shouldReresolveLan`) and address-diff (`addressChanged`) decisions, side-effect-free and JVM-unit-tested.
- **`SendPeerPickerController.reresolveLan`** — runs a transient `NearbyPeerDiscovery.browse()`, waits (`withTimeoutOrNull`, 3.5 s) for the matching peer to re-resolve with a dialable LAN route, then tears the browse down. The fresh route is built through `SendBootstrapPlan.viableRoutes` so it honours the same connectability gates the picker uses.
- **`SendActivity`** — `attemptRouteOutcome` folds the retry into the fallback loop; `retryLanAfterReresolve` performs the re-resolve + single retry and logs old/new address + `changed`. `pendingFallback` is held while a LAN re-resolve may still follow so the UI doesn't flash a premature "failed" terminal.

## Testing

- `LanReresolvePolicyTest` — 7 cases: LAN + `ECONNREFUSED` / handshake-timeout → re-resolve; post-secure failure and non-LAN route → no re-resolve; `addressChanged` on IP/port/identical tuples.
- `./gradlew :app:testDebugUnitTest :app:ktlintCheck :app:detekt :app:assembleDebug` — all green.

## ⚠️ Required pre-merge gate (not yet run)

Per `CLAUDE.md`, this changes discovery / Wi-Fi connect behavior, so it **must** pass the real-device debug loop (one vanilla-GMS device + one non-GMS device, 5 consecutive successful transfers both directions) before merge. I could not run that here. Scenario to add: discover a peer, change its IP (Wi-Fi roam / DHCP renew) **without restarting Bada**, then send — confirm the connect uses the new IP (check `logs/diagnostics.log` for the `reresolve:` lines added in #202's on-disk sink).

Closes #203 (re-resolve-on-failure portion). The other robustness items from #203 (dial all resolved addresses, `registerServiceInfoCallback` on API 34+, TTL eviction) remain tracked there.
