### PR TITLE
feat(tile): long-press opens app + larger Quick Settings tile glyph (#207)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -243,6 +243,16 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <!--
+              Long-press on Bada's Quick Settings tile (issue #207). The
+              platform fires ACTION_QS_TILE_PREFERENCES; without a matching
+              activity it falls back to the system App Info page. Routing
+              it to MainActivity opens the in-app surface the user actually
+              expects when they long-press the tile.
+            -->
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE_PREFERENCES" />
+            </intent-filter>
         </activity>
 
         <activity

--- a/app/src/main/res/drawable/ic_qs_bada_visible.xml
+++ b/app/src/main/res/drawable/ic_qs_bada_visible.xml
@@ -16,7 +16,20 @@
     android:viewportWidth="24"
     android:viewportHeight="24"
     android:tint="#FFFFFFFF">
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:pathData="M12,11c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2zM18,13c0,-3.31 -2.69,-6 -6,-6s-6,2.69 -6,6c0,2.22 1.21,4.15 3,5.19l1,-1.74c-1.19,-0.7 -2,-1.97 -2,-3.45 0,-2.21 1.79,-4 4,-4s4,1.79 4,4c0,1.48 -0.81,2.75 -2,3.45l1,1.74c1.79,-1.04 3,-2.97 3,-5.19zM12,3C6.48,3 2,7.48 2,13c0,3.7 2.01,6.92 4.99,8.65l1,-1.73C5.61,18.53 4,15.96 4,13c0,-4.42 3.58,-8 8,-8s8,3.58 8,8c0,2.96 -1.61,5.53 -4,6.92l1,1.73c2.98,-1.73 4.99,-4.95 4.99,-8.65C22,7.48 17.52,3 12,3z" />
+    <!--
+      Scale the glyph 1.2× from the viewport centre so it reads larger
+      inside the QS tile chrome (issue #207). 24dp viewport is unchanged;
+      scaled paths still fit because the outer ring tops out near y=3 / 21
+      (±9 from centre), and 9 × 1.2 = 10.8 leaves headroom in the 24-unit
+      box.
+    -->
+    <group
+        android:pivotX="12"
+        android:pivotY="12"
+        android:scaleX="1.2"
+        android:scaleY="1.2">
+        <path
+            android:fillColor="#FFFFFFFF"
+            android:pathData="M12,11c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2zM18,13c0,-3.31 -2.69,-6 -6,-6s-6,2.69 -6,6c0,2.22 1.21,4.15 3,5.19l1,-1.74c-1.19,-0.7 -2,-1.97 -2,-3.45 0,-2.21 1.79,-4 4,-4s4,1.79 4,4c0,1.48 -0.81,2.75 -2,3.45l1,1.74c1.79,-1.04 3,-2.97 3,-5.19zM12,3C6.48,3 2,7.48 2,13c0,3.7 2.01,6.92 4.99,8.65l1,-1.73C5.61,18.53 4,15.96 4,13c0,-4.42 3.58,-8 8,-8s8,3.58 8,8c0,2.96 -1.61,5.53 -4,6.92l1,1.73c2.98,-1.73 4.99,-4.95 4.99,-8.65C22,7.48 17.52,3 12,3z" />
+    </group>
 </vector>


### PR DESCRIPTION
Closes #207.

## Summary

Two small Quick Settings tile improvements requested in the issue, and for design polish:

1. **Long-press routes to the in-app surface.** Previously, long-pressing the Bada QS tile fell back to the system *App Info* page because no activity claimed `ACTION_QS_TILE_PREFERENCES`. Add an intent-filter for that action on `MainActivity` so long-press opens the app the user actually wants.
2. **Scale the tile glyph 1.2× from the viewport centre** so the icon reads larger inside the QS tile chrome. The 24×24 viewport is unchanged; the existing broadcast-mark path is wrapped in a `<group>` with `scaleX/scaleY=1.2, pivotX/Y=12`. Scaled paths still fit (outer ring tops out at ±9 from centre, 9×1.2 = 10.8).

## Verification

Verified on a real device (vivo PD2547 / Android 16):

- Short tap on the tile: still toggles always-visible (`MdnsVisibilityOverrideHolder`) and starts / stops the receiver — unchanged behaviour.
- Long-press on the tile: now opens `MainActivity` instead of the system App Info page.
- `adb shell cmd package resolve-activity --brief -a android.service.quicksettings.action.QS_TILE_PREFERENCES dev.bluehouse.bada` resolves to `dev.bluehouse.bada/.MainActivity`.
- Tile glyph is noticeably larger inside the QS chrome.

## Tests / Gate

- `./gradlew staticAnalysis` ✓
- `./gradlew :app:assembleDebug` ✓