### PR TITLE
feat: check for updates against GitHub releases

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -115,6 +115,10 @@ android {
 
     buildFeatures {
         viewBinding = true
+        // BuildConfig is opt-in on AGP 8+; UpdateRepository reads
+        // BuildConfig.VERSION_NAME to compare the installed app against
+        // the latest GitHub release tag, so it needs to be generated.
+        buildConfig = true
     }
 }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -265,6 +265,18 @@
             android:parentActivityName=".MainActivity" />
 
         <!--
+          "Check for updates" screen reachable from MainActivity's
+          overflow menu. Runs a one-shot GitHub releases/latest query
+          via UpdateRepository / UpdateChecker and opens the matching
+          release page when the user taps "Update".
+        -->
+        <activity
+            android:name=".update.CheckForUpdatesActivity"
+            android:exported="false"
+            android:label="@string/update_activity_label"
+            android:parentActivityName=".MainActivity" />
+
+        <!--
           Sender share-intent target (#24).
 
           ACTION_SEND (single attachment) and ACTION_SEND_MULTIPLE

--- a/app/src/main/kotlin/dev/bluehouse/bada/MainActivity.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/MainActivity.kt
@@ -10,6 +10,8 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.provider.Settings
+import android.text.SpannableString
+import android.text.Spanned
 import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
@@ -21,6 +23,9 @@ import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import dev.bluehouse.bada.battery.BatteryOptimizationOemHelper
@@ -35,6 +40,11 @@ import dev.bluehouse.bada.ui.CreditActivity
 import dev.bluehouse.bada.ui.ElasticBottomNavigationView
 import dev.bluehouse.bada.ui.SendReceiveFragment
 import dev.bluehouse.bada.ui.SettingsFragment
+import dev.bluehouse.bada.update.CenteredImageSpan
+import dev.bluehouse.bada.update.CheckForUpdatesActivity
+import dev.bluehouse.bada.update.UpdateRepository
+import dev.bluehouse.bada.update.UpdateState
+import kotlinx.coroutines.launch
 
 /**
  * Top-level launcher activity. Splits the UI into:
@@ -104,6 +114,14 @@ class MainActivity : AppCompatActivity() {
      */
     private lateinit var bugReportFlowSupport: BugReportFlowSupport
 
+    /**
+     * Toolbar reference kept on the instance so the [UpdateRepository]
+     * state observer can swap [MaterialToolbar.overflowIcon] between
+     * the no-dot and red-dot kebab variants when a new GitHub release
+     * is detected (or cleared after an in-app upgrade).
+     */
+    private var mainToolbar: MaterialToolbar? = null
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
@@ -130,6 +148,20 @@ class MainActivity : AppCompatActivity() {
         // every minSdk we target.
         toolbar.overflowIcon = ContextCompat.getDrawable(this, R.drawable.ic_overflow_kebab_24)
         setSupportActionBar(toolbar)
+        mainToolbar = toolbar
+
+        // Update-check pipeline (issue #211). Seed the state from the
+        // cached "latest known release" so the red dot is correct from
+        // the very first frame even when the device is offline; then
+        // kick a one-shot background refresh against GitHub so the dot
+        // also reflects any release published since the last cold start.
+        UpdateRepository.seedFromCache(this)
+        lifecycleScope.launch { UpdateRepository.refresh(this@MainActivity) }
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                UpdateRepository.state.collect { applyUpdateBadge(it) }
+            }
+        }
 
         val bottomNav = findViewById<BottomNavigationView>(R.id.main_bottom_nav)
         bottomNav.setOnItemSelectedListener { item ->
@@ -246,14 +278,76 @@ class MainActivity : AppCompatActivity() {
         return true
     }
 
+    override fun onPrepareOptionsMenu(menu: Menu): Boolean {
+        // Append a vertically-centred red dot to the "Check for
+        // updates" menu item when UpdateRepository surfaces
+        // UpdateAvailable, so the in-popup indicator matches the red
+        // dot painted on the kebab.
+        val item = menu.findItem(R.id.menu_check_updates)
+        if (item != null) {
+            val rawTitle = getString(R.string.menu_check_updates)
+            item.title =
+                if (UpdateRepository.hasPendingUpdate()) {
+                    rawTitle.withTrailingBadgeOrPlain()
+                } else {
+                    rawTitle
+                }
+        }
+        return super.onPrepareOptionsMenu(menu)
+    }
+
+    /**
+     * Returns this title with a trailing vertically-centred badge dot
+     * spanned in, or the plain title if the badge drawable cannot be
+     * resolved. Extracted from [onPrepareOptionsMenu] to keep the
+     * menu hook flat for detekt's NestedBlockDepth.
+     */
+    private fun String.withTrailingBadgeOrPlain(): CharSequence {
+        val badge =
+            ContextCompat
+                .getDrawable(this@MainActivity, R.drawable.update_badge_dot)
+                ?.apply { setBounds(0, 0, intrinsicWidth, intrinsicHeight) }
+                ?: return this
+        return SpannableString("$this  ").apply {
+            setSpan(
+                CenteredImageSpan(badge),
+                length - 1,
+                length,
+                Spanned.SPAN_EXCLUSIVE_EXCLUSIVE,
+            )
+        }
+    }
+
     override fun onOptionsItemSelected(item: MenuItem): Boolean =
         when (item.itemId) {
+            R.id.menu_check_updates -> {
+                startActivity(Intent(this, CheckForUpdatesActivity::class.java))
+                true
+            }
             R.id.menu_credit -> {
                 startActivity(Intent(this, CreditActivity::class.java))
                 true
             }
             else -> super.onOptionsItemSelected(item)
         }
+
+    /**
+     * Re-render the toolbar's overflow indicator for the current
+     * [UpdateState]. Swapping the kebab drawable updates the at-a-glance
+     * red dot; `invalidateOptionsMenu()` triggers a re-prepare so the
+     * matching dot next to the menu item text follows the same
+     * transition without the user having to close and re-open the popup.
+     */
+    private fun applyUpdateBadge(state: UpdateState) {
+        val drawableRes =
+            if (state is UpdateState.UpdateAvailable) {
+                R.drawable.ic_overflow_kebab_with_dot_24
+            } else {
+                R.drawable.ic_overflow_kebab_24
+            }
+        mainToolbar?.overflowIcon = ContextCompat.getDrawable(this, drawableRes)
+        invalidateOptionsMenu()
+    }
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)

--- a/app/src/main/kotlin/dev/bluehouse/bada/update/CenteredImageSpan.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/update/CenteredImageSpan.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.update
+
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.drawable.Drawable
+import android.text.style.ImageSpan
+
+/**
+ * `ImageSpan` variant that paints the drawable at the **vertical centre
+ * of the line** instead of pinned to the typographic baseline.
+ *
+ * `ImageSpan.ALIGN_CENTER` is the platform's centred-alignment mode,
+ * but it was only added in API 29 — Bada's `minSdk` is 24, so we need
+ * a hand-rolled draw that runs on every supported version. The dot
+ * appended to the "Check for updates" overflow item title uses this
+ * span so it sits visually centred against the large CJK glyphs of
+ * the Korean / Japanese / Chinese menu labels, not anchored to the
+ * baseline like the U+25CF / U+2022 text bullets would be.
+ */
+internal class CenteredImageSpan(
+    drawable: Drawable,
+) : ImageSpan(drawable, ALIGN_BASELINE) {
+    override fun draw(
+        canvas: Canvas,
+        text: CharSequence,
+        start: Int,
+        end: Int,
+        x: Float,
+        top: Int,
+        y: Int,
+        bottom: Int,
+        paint: Paint,
+    ) {
+        val drawableHeight = drawable.bounds.height()
+        val transY = top + ((bottom - top) - drawableHeight) / 2
+        canvas.save()
+        canvas.translate(x, transY.toFloat())
+        drawable.draw(canvas)
+        canvas.restore()
+    }
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/update/CheckForUpdatesActivity.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/update/CheckForUpdatesActivity.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.update
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.view.View
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.google.android.material.appbar.MaterialToolbar
+import com.google.android.material.button.MaterialButton
+import dev.bluehouse.bada.R
+import kotlinx.coroutines.launch
+
+/**
+ * "Check for updates" screen reached from MainActivity's overflow menu.
+ *
+ * Owns nothing of its own: the in-flight check, the cached snapshot and
+ * the version comparison live in [UpdateRepository], and this activity
+ * just renders [UpdateRepository.state] onto three views (title,
+ * subtitle, button) and forwards the button tap.
+ *
+ * The first visit triggers a fresh [UpdateRepository.refresh] so the
+ * user sees a current answer even if the background check started by
+ * MainActivity is still in flight.
+ */
+internal class CheckForUpdatesActivity : AppCompatActivity() {
+    private lateinit var statusTitle: TextView
+    private lateinit var statusSubtitle: TextView
+    private lateinit var primaryButton: MaterialButton
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_check_for_updates)
+
+        val toolbar = findViewById<MaterialToolbar>(R.id.update_toolbar)
+        setSupportActionBar(toolbar)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        toolbar.setNavigationOnClickListener { finish() }
+
+        statusTitle = findViewById(R.id.update_status_title)
+        statusSubtitle = findViewById(R.id.update_status_subtitle)
+        primaryButton = findViewById(R.id.update_primary_button)
+
+        primaryButton.setOnClickListener { onPrimaryClicked() }
+
+        UpdateRepository.seedFromCache(this)
+
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                UpdateRepository.state.collect(::renderState)
+            }
+        }
+
+        // Kick a fresh check on every entry so the user never sees a
+        // stale "up to date" answer if a release landed since the last
+        // background check.
+        lifecycleScope.launch { UpdateRepository.refresh(this@CheckForUpdatesActivity) }
+    }
+
+    private fun renderState(state: UpdateState) {
+        when (state) {
+            is UpdateState.Idle,
+            is UpdateState.Checking,
+            -> {
+                statusTitle.setText(R.string.update_status_checking)
+                statusSubtitle.visibility = View.GONE
+                primaryButton.setText(R.string.update_button_check_again)
+                primaryButton.isEnabled = false
+            }
+            is UpdateState.UpToDate -> {
+                statusTitle.setText(R.string.update_status_up_to_date)
+                statusSubtitle.text =
+                    getString(R.string.update_subtitle_current_version, state.installedVersion)
+                statusSubtitle.visibility = View.VISIBLE
+                primaryButton.setText(R.string.update_button_check_again)
+                primaryButton.isEnabled = true
+            }
+            is UpdateState.UpdateAvailable -> {
+                statusTitle.setText(R.string.update_status_available)
+                statusSubtitle.text =
+                    getString(R.string.update_subtitle_latest_version, state.latestVersion)
+                statusSubtitle.visibility = View.VISIBLE
+                primaryButton.setText(R.string.update_button_update)
+                primaryButton.isEnabled = true
+            }
+            is UpdateState.Error -> {
+                statusTitle.setText(R.string.update_status_error)
+                statusSubtitle.text = state.message
+                statusSubtitle.visibility = View.VISIBLE
+                primaryButton.setText(R.string.update_button_check_again)
+                primaryButton.isEnabled = true
+            }
+        }
+    }
+
+    private fun onPrimaryClicked() {
+        when (val state = UpdateRepository.state.value) {
+            is UpdateState.UpdateAvailable -> openReleasePage(state.releaseUrl)
+            else -> lifecycleScope.launch { UpdateRepository.refresh(this@CheckForUpdatesActivity) }
+        }
+    }
+
+    private fun openReleasePage(url: String) {
+        val intent =
+            Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+        // resolveActivity guards the rare case where no browser is
+        // installed; without it the explicit intent throws ActivityNotFound.
+        if (intent.resolveActivity(packageManager) != null) {
+            startActivity(intent)
+        }
+    }
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateChecker.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateChecker.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.update
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+import java.net.HttpURLConnection
+import java.net.URL
+
+/**
+ * Single-shot caller for `GET /repos/{owner}/{repo}/releases/latest`
+ * on the GitHub REST API. No auth token: the unauthenticated quota is
+ * 60 req/h per source IP, which is more than enough for one check at
+ * each app start.
+ *
+ * Returned [Result.success] always carries a populated [LatestRelease]
+ * — failures (network, HTTP non-2xx, JSON shape mismatch, draft /
+ * prerelease) are surfaced as [Result.failure] so the caller decides
+ * whether to log, retry, or surface to the user.
+ *
+ * Built on `java.net.HttpURLConnection` so we do not pull in an extra
+ * HTTP dependency: per CLAUDE.md the project keeps third-party deps
+ * deliberately narrow.
+ */
+internal object UpdateChecker {
+    /**
+     * GitHub upstream repository. The release tag scheme follows the
+     * app's `versionName` (`YYYYMMDD.NN`), optionally prefixed with
+     * `v` — see CLAUDE.md "Release process".
+     */
+    private const val RELEASES_LATEST_URL =
+        "https://api.github.com/repos/kyujin-cho/Bada/releases/latest"
+    private const val USER_AGENT = "Bada-Android-UpdateChecker"
+    private const val CONNECT_TIMEOUT_MS = 10_000
+    private const val READ_TIMEOUT_MS = 10_000
+
+    suspend fun fetchLatestRelease(): Result<LatestRelease> =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                val connection = openConnection()
+                try {
+                    val responseCode = connection.responseCode
+                    if (responseCode !in 200..299) {
+                        error("GitHub releases query failed: HTTP $responseCode")
+                    }
+                    val body = connection.inputStream.bufferedReader().use { it.readText() }
+                    val json = JSONObject(body)
+                    if (json.optBoolean("draft", false)) {
+                        error("Latest release is a draft; skipping")
+                    }
+                    if (json.optBoolean("prerelease", false)) {
+                        error("Latest release is a prerelease; skipping")
+                    }
+                    val tag =
+                        json.optString("tag_name").takeIf { it.isNotBlank() }
+                            ?: error("`tag_name` missing from GitHub response")
+                    val htmlUrl =
+                        json.optString("html_url").takeIf { it.isNotBlank() }
+                            ?: error("`html_url` missing from GitHub response")
+                    LatestRelease(version = stripVPrefix(tag), releaseUrl = htmlUrl)
+                } finally {
+                    connection.disconnect()
+                }
+            }
+        }
+
+    private fun openConnection(): HttpURLConnection {
+        val connection = URL(RELEASES_LATEST_URL).openConnection() as HttpURLConnection
+        connection.requestMethod = "GET"
+        connection.connectTimeout = CONNECT_TIMEOUT_MS
+        connection.readTimeout = READ_TIMEOUT_MS
+        connection.setRequestProperty("Accept", "application/vnd.github+json")
+        connection.setRequestProperty("X-GitHub-Api-Version", "2022-11-28")
+        connection.setRequestProperty("User-Agent", USER_AGENT)
+        return connection
+    }
+
+    private fun stripVPrefix(tag: String): String =
+        if (tag.startsWith("v") || tag.startsWith("V")) tag.substring(1) else tag
+}
+
+/**
+ * Minimal `releases/latest` projection: just the version string the
+ * UI needs to render, and the URL the user is sent to when they tap
+ * "Update".
+ */
+internal data class LatestRelease(
+    val version: String,
+    val releaseUrl: String,
+)

--- a/app/src/main/kotlin/dev/bluehouse/bada/update/UpdatePreferences.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/update/UpdatePreferences.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.update
+
+import android.content.Context
+import android.content.SharedPreferences
+
+/**
+ * Persists the last successful "latest release" snapshot from GitHub
+ * so the red-dot indicator on the toolbar overflow can stay accurate
+ * across cold starts even when the device is offline.
+ *
+ * Only a single tuple is stored: the most recent version + the URL
+ * for the release page. Comparison against `BuildConfig.VERSION_NAME`
+ * happens at read time so an app upgrade automatically clears the
+ * "update available" badge without needing an explicit clear.
+ */
+internal class UpdatePreferences(
+    private val prefs: SharedPreferences,
+) {
+    fun latestKnownVersion(): String? = prefs.getString(KEY_LATEST_VERSION, null)
+
+    fun latestKnownReleaseUrl(): String? = prefs.getString(KEY_LATEST_URL, null)
+
+    fun saveLatestRelease(
+        version: String,
+        releaseUrl: String,
+    ) {
+        prefs
+            .edit()
+            .putString(KEY_LATEST_VERSION, version)
+            .putString(KEY_LATEST_URL, releaseUrl)
+            .apply()
+    }
+
+    internal companion object {
+        private const val PREFS_NAME = "bada.update"
+        private const val KEY_LATEST_VERSION = "latest_release_version"
+        private const val KEY_LATEST_URL = "latest_release_url"
+
+        fun from(context: Context): UpdatePreferences =
+            UpdatePreferences(
+                context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE),
+            )
+    }
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateRepository.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateRepository.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.update
+
+import android.content.Context
+import dev.bluehouse.bada.BuildConfig
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Single source of truth for the "is there a newer release?" check.
+ *
+ * Process-singleton (object) so the toolbar overflow's red-dot
+ * indicator on every MainActivity instance reads the same state
+ * and a refresh from the foreground triggers the dot to clear on
+ * every observing surface at once. Survives configuration changes
+ * because it lives on the process, not on the activity.
+ *
+ * State derivation order on cold start:
+ *   1. Seed [state] from [UpdatePreferences] so the dot is correct
+ *      from the very first frame even without a network call.
+ *   2. Kick a background [refresh] which updates [state] to
+ *      [UpdateState.UpToDate] / [UpdateState.UpdateAvailable] /
+ *      [UpdateState.Error] once the GitHub call lands.
+ *
+ * Version comparison: `versionName` is `YYYYMMDD.NN` everywhere in
+ * the project, so a plain lexicographic comparison is monotonic with
+ * release order — no Semver parsing required.
+ */
+internal object UpdateRepository {
+    private val _state: MutableStateFlow<UpdateState> = MutableStateFlow(UpdateState.Idle)
+    val state: StateFlow<UpdateState> = _state.asStateFlow()
+
+    private val refreshMutex = Mutex()
+
+    /**
+     * Initialise [state] from the cached snapshot — call once early
+     * (e.g. from `MainActivity.onCreate`) so the toolbar's red dot is
+     * rendered correctly before the network check completes. Safe to
+     * call repeatedly: the second call is a no-op when [state] has
+     * already advanced past [UpdateState.Idle].
+     */
+    fun seedFromCache(context: Context) {
+        if (_state.value != UpdateState.Idle) return
+        val prefs = UpdatePreferences.from(context)
+        val cachedVersion = prefs.latestKnownVersion()
+        val cachedUrl = prefs.latestKnownReleaseUrl()
+        if (cachedVersion != null && cachedUrl != null) {
+            _state.value =
+                if (isNewer(cachedVersion, BuildConfig.VERSION_NAME)) {
+                    UpdateState.UpdateAvailable(cachedVersion, cachedUrl)
+                } else {
+                    UpdateState.UpToDate(BuildConfig.VERSION_NAME)
+                }
+        }
+    }
+
+    /**
+     * Fire a one-shot GitHub `releases/latest` query and update [state]
+     * with the result. Concurrent callers are coalesced through
+     * [refreshMutex] so the network call only happens once at a time.
+     */
+    suspend fun refresh(context: Context) {
+        refreshMutex.withLock {
+            _state.value = UpdateState.Checking
+            val result = UpdateChecker.fetchLatestRelease()
+            _state.value =
+                result.fold(
+                    onSuccess = { release ->
+                        UpdatePreferences
+                            .from(context)
+                            .saveLatestRelease(release.version, release.releaseUrl)
+                        if (isNewer(release.version, BuildConfig.VERSION_NAME)) {
+                            UpdateState.UpdateAvailable(release.version, release.releaseUrl)
+                        } else {
+                            UpdateState.UpToDate(BuildConfig.VERSION_NAME)
+                        }
+                    },
+                    onFailure = { throwable ->
+                        UpdateState.Error(throwable.message ?: throwable.javaClass.simpleName)
+                    },
+                )
+        }
+    }
+
+    /**
+     * True iff the [_state] currently surfaces an
+     * [UpdateState.UpdateAvailable] — used by the toolbar overflow
+     * indicator to decide whether to paint a red dot.
+     */
+    fun hasPendingUpdate(): Boolean = _state.value is UpdateState.UpdateAvailable
+
+    /**
+     * Strict-greater string comparison. Works for the project's fixed
+     * `YYYYMMDD.NN` versionName scheme because every field is
+     * zero-padded to a fixed width.
+     */
+    private fun isNewer(
+        candidate: String,
+        installed: String,
+    ): Boolean = candidate > installed
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateState.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateState.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.update
+
+/**
+ * Lifecycle of a single "is there a newer release on GitHub?" check.
+ *
+ * Modelled as a sealed hierarchy so the UI can render every leaf
+ * without re-querying any other source. [latestKnownVersion] /
+ * [latestReleaseUrl] are remembered across cold starts via
+ * [UpdatePreferences] so the red-dot indicator on the toolbar can
+ * stay accurate even when the device is offline at the moment the
+ * app starts.
+ */
+internal sealed interface UpdateState {
+    /** No check has been performed yet in this process. */
+    data object Idle : UpdateState
+
+    /** A network call is in flight. */
+    data object Checking : UpdateState
+
+    /** Latest GitHub release is identical to (or older than) the installed version. */
+    data class UpToDate(
+        val installedVersion: String,
+    ) : UpdateState
+
+    /** Latest GitHub release is strictly newer than the installed version. */
+    data class UpdateAvailable(
+        val latestVersion: String,
+        val releaseUrl: String,
+    ) : UpdateState
+
+    /** The check failed (network, JSON, HTTP non-2xx, ...). */
+    data class Error(
+        val message: String,
+    ) : UpdateState
+}

--- a/app/src/main/res/drawable/ic_overflow_kebab_with_dot_24.xml
+++ b/app/src/main/res/drawable/ic_overflow_kebab_with_dot_24.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Variant of `ic_overflow_kebab_24` with a solid red dot in the top-right
+  corner. Swapped onto the MaterialToolbar's `overflowIcon` when
+  `UpdateRepository` reports an `UpdateState.UpdateAvailable`. Same 24dp
+  viewport / pure-white rings as the no-dot variant so the active /
+  inactive toolbar tinting still applies to the kebab; the dot keeps its
+  red fill regardless of tinting state.
+
+  Geometry: kebab pair at the exact same geometry as ic_overflow_kebab_24
+  — no scaling, full original size — so the overflow button never
+  shrinks when the dot is on. The red dot is a 3-radius circle centred
+  at (21, 3), tucked into the top-right corner so it touches the
+  viewport edge (no wasted right whitespace) while still leaving a
+  ~3-unit gap from the kebab's right extent at x=15.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:pathData="M12,7 m-3.0,0 a3.0,3.0 0 1,0 6.0,0 a3.0,3.0 0 1,0 -6.0,0 M12,17 m-3.0,0 a3.0,3.0 0 1,0 6.0,0 a3.0,3.0 0 1,0 -6.0,0"
+        android:strokeColor="@color/toolbar_overflow_tint"
+        android:strokeWidth="2.0" />
+    <path
+        android:fillColor="@color/update_badge_red"
+        android:pathData="M21,3 m-3.0,0 a3.0,3.0 0 1,0 6.0,0 a3.0,3.0 0 1,0 -6.0,0" />
+</vector>

--- a/app/src/main/res/drawable/update_badge_dot.xml
+++ b/app/src/main/res/drawable/update_badge_dot.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Small filled red circle painted next to the "Check for updates"
+  overflow item title when UpdateRepository surfaces UpdateAvailable.
+  Drawn through a CenteredImageSpan so the dot lines up with the
+  vertical centre of the menu text (the U+25CF BLACK CIRCLE glyph the
+  span replaces was naturally pulled down to the typographic baseline
+  by the CJK font metrics, leaving the dot looking low against the
+  large Korean glyphs).
+
+  Sized to ≈ 8dp diameter so the rendered size matches the radius-3
+  red badge painted on the kebab in `ic_overflow_kebab_with_dot_24`.
+-->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <size
+        android:width="8dp"
+        android:height="8dp" />
+    <solid android:color="@color/update_badge_red" />
+</shape>

--- a/app/src/main/res/layout/activity_check_for_updates.xml
+++ b/app/src/main/res/layout/activity_check_for_updates.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  "Check for updates" screen. Same shell as CreditActivity (vivo-style
+  toolbar above a colorBackground page) so it reads as part of the same
+  family of overflow-menu destinations.
+
+  Inside the page, a single white panel hosts every UI state — the
+  status title, an optional secondary line carrying the latest version,
+  and one CTA button:
+
+    * `Checking…`              → title shows the in-flight string;
+                                  subtitle hidden; button shown as
+                                  "Check again" but disabled.
+    * `You're on the latest`   → title shows the up-to-date string;
+                                  subtitle shows the installed version;
+                                  button is "Check again".
+    * `New update available`   → title shows the announcement; subtitle
+                                  shows the latest version; button is
+                                  "Update" and opens the GitHub release
+                                  page so the user can download the APK.
+    * `Couldn't check…`        → title shows the error string; subtitle
+                                  shows the underlying message; button
+                                  is "Check again".
+
+  CheckForUpdatesActivity drives the state transitions; this layout is
+  state-agnostic and just exposes the four ids it touches.
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?android:attr/colorBackground"
+    android:fitsSystemWindows="true"
+    android:orientation="vertical">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/update_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/app_toolbar_height"
+        android:background="?android:attr/colorBackground"
+        android:paddingTop="@dimen/app_toolbar_padding_top"
+        app:navigationIcon="?attr/homeAsUpIndicator"
+        app:title="@string/update_activity_label"
+        app:titleCentered="false"
+        app:titleTextAppearance="@style/TextAppearance.Bada.ToolbarTitle"
+        app:titleTextColor="?android:attr/textColorPrimary" />
+
+    <!--
+      Body sits on the same colorBackground as the toolbar (no card)
+      so the page reads as a single calm surface; the status block is
+      vertically and horizontally centred inside the available area.
+      A ScrollView wraps it so the block stays reachable on the rare
+      tall content case (e.g. a long error message wrapping multiple
+      lines on a short landscape window).
+    -->
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:fillViewport="true">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:gravity="center"
+            android:orientation="vertical"
+            android:paddingHorizontal="32dp"
+            android:paddingVertical="24dp">
+
+            <TextView
+                android:id="@+id/update_status_title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:textColor="?android:attr/textColorPrimary"
+                android:textSize="18sp"
+                android:textStyle="bold"
+                tools:text="New update available" />
+
+            <TextView
+                android:id="@+id/update_status_subtitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:gravity="center"
+                android:textAppearance="@style/TextAppearance.AppCompat.Caption"
+                android:textColor="?android:attr/textColorSecondary"
+                tools:text="20260606.01" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/update_primary_button"
+                style="@style/Widget.Bada.Button"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:text="@string/update_button_update"
+                tools:text="Update" />
+
+        </LinearLayout>
+
+    </ScrollView>
+
+</LinearLayout>

--- a/app/src/main/res/menu/main_overflow_menu.xml
+++ b/app/src/main/res/menu/main_overflow_menu.xml
@@ -1,17 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  Overflow menu shown by MainActivity's Toolbar. Currently a single
-  destination — the Credit screen. Items use
-  `app:showAsAction="never"` so they never spill out of the overflow
-  popup as a top-level icon, matching the kebab-only pattern users
-  expect from the vivo / OriginOS native apps.
+  Overflow menu shown by MainActivity's Toolbar. Two destinations —
+  the "Check for updates" screen (red dot when an update is available;
+  see UpdateRepository / MainActivity.onPrepareOptionsMenu) and the
+  Credit screen. Items use `app:showAsAction="never"` so they never
+  spill out of the overflow popup as a top-level icon, matching the
+  kebab-only pattern users expect from the vivo / OriginOS native apps.
+
+  Two groups so the popup renders a faint divider between the
+  diagnostic and acknowledgements destinations rather than stacking
+  them as a single-cell list.
 -->
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <item
-        android:id="@+id/menu_credit"
-        android:title="@string/menu_credit"
-        app:showAsAction="never" />
+    <group android:id="@+id/menu_group_updates">
+        <item
+            android:id="@+id/menu_check_updates"
+            android:title="@string/menu_check_updates"
+            app:showAsAction="never" />
+    </group>
+
+    <group android:id="@+id/menu_group_credit">
+        <item
+            android:id="@+id/menu_credit"
+            android:title="@string/menu_credit"
+            app:showAsAction="never" />
+    </group>
 
 </menu>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -37,6 +37,18 @@
     <string name="menu_credit">クレジット</string>
     <string name="credit_activity_label">クレジット</string>
 
+    <!-- "アップデートを確認" オーバーフロー項目 + 画面。 -->
+    <string name="menu_check_updates">アップデートを確認</string>
+    <string name="update_activity_label">アップデートを確認</string>
+    <string name="update_status_checking">アップデートを確認しています…</string>
+    <string name="update_status_up_to_date">最新バージョンです</string>
+    <string name="update_status_available">新しいアップデートがあります</string>
+    <string name="update_status_error">アップデートを確認できませんでした</string>
+    <string name="update_subtitle_current_version">現在: %1$s</string>
+    <string name="update_subtitle_latest_version">%1$s</string>
+    <string name="update_button_check_again">再確認</string>
+    <string name="update_button_update">アップデート</string>
+
     <!-- `credit_section_developer`, `credit_section_polisher`,
          `credit_section_qa`, `credit_section_thanks` are intentionally
          NOT translated here (no override), matching the Korean policy:

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -38,6 +38,18 @@
     <string name="menu_credit">크레딧</string>
     <string name="credit_activity_label">크레딧</string>
 
+    <!-- "업데이트 확인" 오버플로우 항목 + 화면. -->
+    <string name="menu_check_updates">업데이트 확인</string>
+    <string name="update_activity_label">업데이트 확인</string>
+    <string name="update_status_checking">업데이트를 확인하는 중…</string>
+    <string name="update_status_up_to_date">최신 버전입니다</string>
+    <string name="update_status_available">새 업데이트가 있습니다</string>
+    <string name="update_status_error">업데이트를 확인할 수 없습니다</string>
+    <string name="update_subtitle_current_version">현재: %1$s</string>
+    <string name="update_subtitle_latest_version">%1$s</string>
+    <string name="update_button_check_again">다시 확인</string>
+    <string name="update_button_update">업데이트</string>
+
     <!-- `credit_section_developer`, `credit_section_polisher`,
          `credit_section_qa`, `credit_section_thanks` are intentionally
          NOT translated here (no override). Per product direction the

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -302,4 +302,16 @@
     <string name="qs_tile_content_desc_on">附近裝置目前可以搜尋到 Bada</string>
     <string name="qs_tile_content_desc_off">附近裝置目前無法搜尋到 Bada</string>
 
+    <!-- "檢查更新" overflow item + screen. -->
+    <string name="menu_check_updates">檢查更新</string>
+    <string name="update_activity_label">檢查更新</string>
+    <string name="update_status_checking">正在檢查更新…</string>
+    <string name="update_status_up_to_date">已是最新版本</string>
+    <string name="update_status_available">有新版本可用</string>
+    <string name="update_status_error">無法檢查更新</string>
+    <string name="update_subtitle_current_version">目前: %1$s</string>
+    <string name="update_subtitle_latest_version">%1$s</string>
+    <string name="update_button_check_again">再次檢查</string>
+    <string name="update_button_update">更新</string>
+
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -136,4 +136,10 @@
       the edge needs more visual weight to delineate.
     -->
     <color name="credit_avatar_stroke">#1F000000</color>
+
+    <!-- "New release available" badge red. Painted on top of the
+         toolbar kebab (ic_overflow_kebab_with_dot_24) and as the
+         bullet appended to the "Check for updates" overflow item
+         when UpdateRepository surfaces UpdateAvailable. -->
+    <color name="update_badge_red">#FFE53935</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,6 +14,21 @@
          there. -->
     <string name="menu_credit">Credit</string>
     <string name="credit_activity_label">Credit</string>
+
+    <!-- "Check for updates" overflow entry + screen. Reached from the
+         toolbar overflow on MainActivity; runs a one-shot GitHub
+         releases/latest check and lets the user open the release page
+         to download the APK. -->
+    <string name="menu_check_updates">Check for updates</string>
+    <string name="update_activity_label">Check for updates</string>
+    <string name="update_status_checking">Checking for updates…</string>
+    <string name="update_status_up_to_date">You\'re on the latest version</string>
+    <string name="update_status_available">New update available</string>
+    <string name="update_status_error">Couldn\'t check for updates</string>
+    <string name="update_subtitle_current_version">Current: %1$s</string>
+    <string name="update_subtitle_latest_version">%1$s</string>
+    <string name="update_button_check_again">Check again</string>
+    <string name="update_button_update">Update</string>
     <string name="credit_placeholder_text">credit</string>
 
     <!--


### PR DESCRIPTION
## Summary

Adds an in-app "Check for updates" feature that queries the GitHub
Releases REST endpoint for the latest published Bada release and
surfaces it to the user without going through the Play Store.

## Why

There is no Play Store distribution channel for Bada, so users
have no way of knowing when a new APK is published. This PR closes
that gap: the launcher toolbar paints a red dot on the kebab the
moment a release newer than `BuildConfig.VERSION_NAME` shows up, and
a dedicated screen renders the new version + a one-tap jump to the
release page where the APK lives.

## What's new

**Update screen** (`update.CheckForUpdatesActivity`)

Reachable from the toolbar overflow menu next to **Credit**. Renders
four states off a single `StateFlow<UpdateState>` exposed by
`UpdateRepository`:

| State           | Title                         | Subtitle               | Primary button |
|-----------------|-------------------------------|------------------------|----------------|
| `Checking`      | "Checking for updates…"       | —                      | (disabled)     |
| `UpToDate`      | "You're on the latest version"| current version        | Check again    |
| `UpdateAvailable`| "New update available"       | latest version (small) | Update         |
| `Error`         | "Couldn't check for updates"  | error message          | Check again    |

The `Update` action opens the release URL via `ACTION_VIEW`.

**Cold-start refresh + dot indicator**

`MainActivity.onCreate` calls `UpdateRepository.seedFromCache()` (so
the dot is correct on the very first frame, even offline) and kicks
a one-shot `refresh()` that hits GitHub. The toolbar `overflowIcon`
swaps between `ic_overflow_kebab_24` and
`ic_overflow_kebab_with_dot_24`, and `onPrepareOptionsMenu` appends a
vertically-centred red dot to the menu item title via
`CenteredImageSpan` so the in-popup indicator matches the kebab dot.
Both follow the same StateFlow.

**Persistence**

`UpdatePreferences` caches the last-known release tag + URL in
SharedPreferences (project convention, not DataStore). Race between
`seedFromCache` and a concurrent `refresh` is guarded by a `Mutex`
inside the repository.

## Files

- `app/src/main/kotlin/dev/bluehouse/bada/update/`
  - `UpdateState.kt`, `UpdateRepository.kt`, `UpdateChecker.kt`,
    `UpdatePreferences.kt`, `CheckForUpdatesActivity.kt`,
    `CenteredImageSpan.kt`
- `res/drawable/ic_overflow_kebab_with_dot_24.xml`,
  `res/drawable/update_badge_dot.xml`
- `res/layout/activity_check_for_updates.xml`
- `MainActivity` wiring + overflow menu entry
- New translatable strings added to `values/`, `values-ko/`,
  `values-ja/`, and `values-zh-rTW/` per the add-to-every-locale
  policy

## Dependencies

None new. Uses `HttpURLConnection` + `org.json.JSONObject` (both
already in the Android SDK). `BuildConfig.VERSION_NAME` is used for
the installed-version side of the comparison; `buildConfig = true`
was added to `buildFeatures` to keep AGP 8 happy.

## Test gate

- `./gradlew staticAnalysis` — passes
- `./gradlew :app:testDebugUnitTest :app:assembleDebug` — passes
- Manual sanity checked on a vivo (non-GMS) device: cold-start
  badge dot, popup dot, screen state transitions, release URL jump.