### PR TITLE
fix: bootstrap off-LAN sends over Bluetooth RFCOMM (#214)

### DIFF
--- a/app/src/main/kotlin/dev/bluehouse/bada/send/SendActivity.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/send/SendActivity.kt
@@ -325,7 +325,12 @@ public class SendActivity : AppCompatActivity() {
                     logger = ::logOutboundWireMessage,
                 )
             is NearbyPeerRoute.BluetoothClassic -> {
-                if (!UserFacingMediumFeatures.BLUETOOTH_CLASSIC_USER_FACING_ENABLED) return null
+                if (
+                    !UserFacingMediumFeatures.BLUETOOTH_CLASSIC_BOOTSTRAP_ROUTE_ENABLED &&
+                    !UserFacingMediumFeatures.BLUETOOTH_CLASSIC_USER_FACING_ENABLED
+                ) {
+                    return null
+                }
                 val client = BluetoothClassicBootstrapClient(applicationContext)
                 bluetoothBootstrapClient = client
                 val transport =

--- a/app/src/main/kotlin/dev/bluehouse/bada/send/SendBootstrapPlan.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/send/SendBootstrapPlan.kt
@@ -159,10 +159,12 @@ internal data class SendBootstrapPlan(
                 }
 
                 else -> {
+                    // Emit rejections in the same priority order as the
+                    // when-chain / viableRoutes(): LAN, RFCOMM, L2CAP, GATT.
+                    rejectedCandidates += lanRejection(peer)
                     rejectedCandidates += bluetoothClassicRejection(peer)
                     rejectedCandidates += bleL2capRejection(peer)
                     rejectedCandidates += bleGattRejection(peer)
-                    rejectedCandidates += lanRejection(peer)
                     null
                 }
             }

--- a/app/src/main/kotlin/dev/bluehouse/bada/send/SendBootstrapPlan.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/send/SendBootstrapPlan.kt
@@ -7,7 +7,6 @@ package dev.bluehouse.bada.send
 
 import dev.bluehouse.bada.discovery.NearbyPeer
 import dev.bluehouse.bada.discovery.NearbyPeerRoute
-import dev.bluehouse.bada.discovery.UserFacingMediumFeatures
 
 internal data class SendBootstrapPlan(
     val action: Action,
@@ -83,17 +82,19 @@ internal data class SendBootstrapPlan(
          * bootstrap-route failure, so we stop falling back.
          *
          * The order mirrors [directRoute]'s `when` chain:
-         * Wi-Fi LAN → BLE-L2CAP → BLE-GATT → Bluetooth Classic. An
-         * empty list means no usable route; the caller falls through
-         * to the same "no route" terminal that [Action.Unavailable]
-         * would render.
+         * Wi-Fi LAN → Bluetooth RFCOMM → BLE-L2CAP → BLE-GATT. RFCOMM
+         * leads the off-LAN ladder because stock GMS receivers bootstrap
+         * stock senders over it, while their BLE L2CAP/GATT server paths
+         * are unreliable (#214). An empty list means no usable route; the
+         * caller falls through to the same "no route" terminal that
+         * [Action.Unavailable] would render.
          */
         fun viableRoutes(peer: NearbyPeer): List<NearbyPeerRoute> =
             listOfNotNull(
                 lanRoute(peer),
+                bluetoothRoute(peer),
                 bleL2capRoute(peer),
                 bleGattRoute(peer),
-                bluetoothRoute(peer),
             )
 
         /**
@@ -123,7 +124,7 @@ internal data class SendBootstrapPlan(
             val subtitle =
                 when (route) {
                     is NearbyPeerRoute.Lan -> "Wi-Fi LAN ${route.address.hostAddress}:${route.port}"
-                    is NearbyPeerRoute.BluetoothClassic -> "Unsupported Bluetooth route"
+                    is NearbyPeerRoute.BluetoothClassic -> "Bluetooth RFCOMM ${route.macAddress}"
                     is NearbyPeerRoute.BleL2cap -> "BLE L2CAP ${route.macAddress} psm=${route.psm}"
                     is NearbyPeerRoute.BleGatt -> "BLE GATT ${route.macAddress}"
                 }
@@ -140,29 +141,28 @@ internal data class SendBootstrapPlan(
             rejectedCandidates: MutableList<String>,
         ): NearbyPeerRoute? {
             val lanRoute = lanRoute(peer)
+            val bluetoothRoute = bluetoothRoute(peer)
             val bleL2capRoute = bleL2capRoute(peer)
             val bleGattRoute = bleGattRoute(peer)
-            val bluetoothRoute = bluetoothRoute(peer)
             return when {
                 lanRoute != null -> lanRoute
-                bleL2capRoute != null -> bleL2capRoute
+                bluetoothRoute != null -> bluetoothRoute
+                bleL2capRoute != null -> {
+                    rejectedCandidates += bluetoothClassicRejection(peer)
+                    bleL2capRoute
+                }
+
                 bleGattRoute != null -> {
+                    rejectedCandidates += bluetoothClassicRejection(peer)
                     rejectedCandidates += bleL2capRejection(peer)
                     bleGattRoute
                 }
 
-                bluetoothRoute != null -> {
-                    rejectedCandidates += lanRejection(peer)
-                    rejectedCandidates += bleL2capRejection(peer)
-                    rejectedCandidates += bleGattRejection(peer)
-                    bluetoothRoute
-                }
-
                 else -> {
+                    rejectedCandidates += bluetoothClassicRejection(peer)
                     rejectedCandidates += bleL2capRejection(peer)
                     rejectedCandidates += bleGattRejection(peer)
                     rejectedCandidates += lanRejection(peer)
-                    rejectedCandidates += bluetoothClassicRejection(peer)
                     null
                 }
             }
@@ -275,18 +275,18 @@ internal data class SendBootstrapPlan(
         }
 
         private fun bluetoothRoute(peer: NearbyPeer): NearbyPeerRoute.BluetoothClassic? =
-            if (UserFacingMediumFeatures.BLUETOOTH_CLASSIC_USER_FACING_ENABLED) {
-                peer.bluetoothEndpoint?.let { NearbyPeerRoute.BluetoothClassic(it.macAddress) }
-            } else {
-                null
-            }
+            peer.takeIf { it.endpointInfo != null }?.bluetoothClassicRoute()
 
-        private fun bluetoothClassicRejection(peer: NearbyPeer): String =
-            when {
-                !UserFacingMediumFeatures.BLUETOOTH_CLASSIC_USER_FACING_ENABLED ->
-                    "bluetooth-classic=disabled"
-                peer.bluetoothEndpoint == null -> "bluetooth-classic=missing"
+        private fun bluetoothClassicRejection(peer: NearbyPeer): String {
+            val macKnown =
+                peer.publishedBluetoothMac != null ||
+                    peer.bluetoothEndpoint != null
+            return when {
+                !macKnown -> "bluetooth-classic=no-mac"
+                peer.endpointInfo == null -> "bluetooth-classic=no-endpoint-info"
+                peer.bluetoothClassicRoute() == null -> "bluetooth-classic=disabled"
                 else -> "bluetooth-classic=unusable"
             }
+        }
     }
 }

--- a/app/src/test/kotlin/dev/bluehouse/bada/send/SendBootstrapPlanTest.kt
+++ b/app/src/test/kotlin/dev/bluehouse/bada/send/SendBootstrapPlanTest.kt
@@ -94,6 +94,91 @@ class SendBootstrapPlanTest {
     }
 
     @Test
+    fun `published Bluetooth MAC routes over RFCOMM before BLE off-LAN`() {
+        val peer =
+            peer(
+                publishedBluetoothMac = "08:B3:39:10:C2:6A",
+                bleAddress = "AA:BB:CC:DD:EE:FF",
+                blePsm = 0x1234,
+            )
+
+        val plan = SendBootstrapPlan.resolve(peer = peer)
+
+        assertTrue(plan.isConnectable)
+        assertEquals(
+            NearbyPeerRoute.BluetoothClassic("08:B3:39:10:C2:6A"),
+            (plan.action as SendBootstrapPlan.Action.Direct).route,
+        )
+    }
+
+    @Test
+    fun `same Wi-Fi LAN still wins over a published Bluetooth MAC`() {
+        val peer =
+            peer(
+                lanAddress = "192.168.1.20",
+                lanPort = 7654,
+                publishedBluetoothMac = "08:B3:39:10:C2:6A",
+            )
+
+        val plan = SendBootstrapPlan.resolve(peer = peer)
+
+        assertEquals(
+            NearbyPeerRoute.Lan(InetAddress.getByName("192.168.1.20"), 7654),
+            (plan.action as SendBootstrapPlan.Action.Direct).route,
+        )
+    }
+
+    @Test
+    fun `viable routes order RFCOMM between LAN and the BLE fallbacks`() {
+        val peer =
+            peer(
+                lanAddress = "192.168.1.20",
+                lanPort = 7654,
+                publishedBluetoothMac = "08:B3:39:10:C2:6A",
+                bleAddress = "AA:BB:CC:DD:EE:FF",
+                blePsm = 0x1234,
+            )
+
+        val routes = SendBootstrapPlan.viableRoutes(peer)
+
+        assertEquals(
+            listOf(
+                NearbyPeerRoute.Lan(InetAddress.getByName("192.168.1.20"), 7654),
+                NearbyPeerRoute.BluetoothClassic("08:B3:39:10:C2:6A"),
+                NearbyPeerRoute.BleL2cap("AA:BB:CC:DD:EE:FF", 0x1234),
+                NearbyPeerRoute.BleGatt("AA:BB:CC:DD:EE:FF"),
+            ),
+            routes,
+        )
+    }
+
+    @Test
+    fun `published Bluetooth MAC alone makes an off-LAN peer connectable`() {
+        val peer = peer(publishedBluetoothMac = "08:B3:39:10:C2:6A")
+
+        val plan = SendBootstrapPlan.resolve(peer = peer)
+
+        assertTrue(plan.isConnectable)
+        assertEquals(
+            NearbyPeerRoute.BluetoothClassic("08:B3:39:10:C2:6A"),
+            (plan.action as SendBootstrapPlan.Action.Direct).route,
+        )
+    }
+
+    @Test
+    fun `published Bluetooth MAC requires parsed endpoint info`() {
+        val peer =
+            peer(
+                publishedBluetoothMac = "08:B3:39:10:C2:6A",
+                endpointInfoPresent = false,
+            )
+
+        val plan = SendBootstrapPlan.resolve(peer = peer)
+
+        assertFalse(plan.isConnectable)
+    }
+
+    @Test
     fun `peer with malformed endpoint info stays unavailable`() {
         val peer =
             peer(
@@ -195,6 +280,7 @@ class SendBootstrapPlanTest {
         lanAddress: String? = null,
         lanPort: Int = 7654,
         bluetoothMac: String? = null,
+        publishedBluetoothMac: String? = null,
         bleAddress: String? = null,
         blePsm: Int? = null,
         bleGattConnectable: Boolean = true,
@@ -243,5 +329,6 @@ class SendBootstrapPlanTest {
                         displayNameSource = "fast-advertisement-endpoint-info",
                     )
                 },
+            publishedBluetoothMac = publishedBluetoothMac,
         )
 }

--- a/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/endpoint/BleServiceData.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/endpoint/BleServiceData.kt
@@ -525,12 +525,26 @@ public object BleServiceData {
         if (offset + len + BLUETOOTH_MAC_LEN > bytes.size) return null
         val infoBytes = bytes.copyOfRange(offset, offset + len)
         val info = EndpointInfo.parse(infoBytes) ?: return null
+        offset += len
+        val macBytes = bytes.copyOfRange(offset, offset + BLUETOOTH_MAC_LEN)
         return Parsed(
             version = version,
             pcp = pcp,
             endpointId = endpointId,
             endpointInfo = info,
+            bluetoothMacAddress = formatBluetoothMac(macBytes),
         )
+    }
+
+    /**
+     * Renders the 6-byte Bluetooth Classic MAC that follows the
+     * EndpointInfo in the regular (non-fast) advertisement body as the
+     * canonical colon-separated upper-case string, or `null` when the
+     * advertiser left it zeroed (no BR/EDR listener).
+     */
+    private fun formatBluetoothMac(macBytes: ByteArray): String? {
+        if (macBytes.all { it == 0.toByte() }) return null
+        return macBytes.joinToString(":") { "%02X".format(it.toInt() and UNSIGNED_BYTE_MASK) }
     }
 
     @Suppress("ReturnCount")
@@ -607,6 +621,13 @@ public object BleServiceData {
         public val pcp: Int,
         public val endpointId: ByteArray,
         public val endpointInfo: EndpointInfo,
+        /**
+         * Bluetooth Classic MAC ("AA:BB:CC:DD:EE:FF") carried by the
+         * regular (non-fast) advertisement body; `null` for fast
+         * advertisements and zeroed-out regular ones. Stock senders use
+         * this address for the RFCOMM initial connection.
+         */
+        public val bluetoothMacAddress: String? = null,
     ) {
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
@@ -614,7 +635,8 @@ public object BleServiceData {
             return version == other.version &&
                 pcp == other.pcp &&
                 endpointId.contentEquals(other.endpointId) &&
-                endpointInfo == other.endpointInfo
+                endpointInfo == other.endpointInfo &&
+                bluetoothMacAddress == other.bluetoothMacAddress
         }
 
         override fun hashCode(): Int {
@@ -622,6 +644,7 @@ public object BleServiceData {
             result = 31 * result + pcp
             result = 31 * result + endpointId.contentHashCode()
             result = 31 * result + endpointInfo.hashCode()
+            result = 31 * result + (bluetoothMacAddress?.hashCode() ?: 0)
             return result
         }
     }

--- a/core-protocol/src/test/kotlin/dev/bluehouse/bada/protocol/endpoint/BleServiceDataTest.kt
+++ b/core-protocol/src/test/kotlin/dev/bluehouse/bada/protocol/endpoint/BleServiceDataTest.kt
@@ -120,6 +120,56 @@ class BleServiceDataTest {
         assertThat(parsed.version).isEqualTo(BleServiceData.DEFAULT_VERSION)
         assertThat(parsed.pcp).isEqualTo(BleServiceData.DEFAULT_PCP)
         assertThat(parsed.endpointInfo).isEqualTo(info)
+        assertThat(parsed.bluetoothMacAddress).isEqualTo("70:4E:E0:12:DE:3A")
+    }
+
+    @Test
+    fun `parse extracts the Bluetooth Classic MAC from a captured stock regular advertisement body`() {
+        // 49-byte regular advertisement body captured by HCI snoop from a
+        // Xiaomi 17 Ultra stock receiver (GMS 26.20.31) in
+        // foreground-visible mode during the #214 investigation. Layout:
+        // [0x23 PCP | fc9f5e hash | "17NT" | 0x20 | EndpointInfo(32) |
+        //  BT MAC 08:B3:39:10:C2:6A | 2 trailing bytes]. Stock senders use
+        // this MAC for the RFCOMM initial connection.
+        val payload =
+            hex(
+                "23fc9f5e31374e542022fce18cb548757c1582bdd2cf9c" +
+                    "f9eb910eeab79ceca78427732070686f6e6508b33910c26a0000",
+            )
+
+        val parsed = BleServiceData.parse(payload)
+
+        assertThat(parsed).isNotNull()
+        assertThat(String(parsed!!.endpointId, Charsets.US_ASCII)).isEqualTo("17NT")
+        assertThat(parsed.endpointInfo.deviceName).isEqualTo("규진's phone")
+        assertThat(parsed.bluetoothMacAddress).isEqualTo("08:B3:39:10:C2:6A")
+    }
+
+    @Test
+    fun `parse returns a null MAC when the regular advertisement body zeroes it out`() {
+        val info = hiddenPhoneEndpointInfo()
+        val payload = regularBleBody("LPPM", info)
+        val macOffset =
+            BleServiceData.REGULAR_FIXED_HEADER_LEN + info.serialize().size
+        for (i in 0 until BleServiceData.BLUETOOTH_MAC_LEN) {
+            payload[macOffset + i] = 0x00
+        }
+
+        val parsed = BleServiceData.parse(payload)
+
+        assertThat(parsed).isNotNull()
+        assertThat(parsed!!.bluetoothMacAddress).isNull()
+    }
+
+    @Test
+    fun `parse leaves the MAC null for fast advertisement bodies`() {
+        val info = hiddenPhoneEndpointInfo()
+        val payload = BleServiceData.encodeFramed("DROP", info)
+
+        val parsed = BleServiceData.parse(payload)
+
+        assertThat(parsed).isNotNull()
+        assertThat(parsed!!.bluetoothMacAddress).isNull()
     }
 
     @Test
@@ -374,4 +424,11 @@ class BleServiceDataTest {
             .getInstance("SHA-256")
             .digest(bytes)
             .copyOfRange(0, BleServiceData.DEVICE_TOKEN_LEN)
+
+    private fun hex(value: String): ByteArray {
+        require(value.length % 2 == 0) { "hex string must have even length" }
+        return ByteArray(value.length / 2) { i ->
+            value.substring(i * 2, i * 2 + 2).toInt(16).toByte()
+        }
+    }
 }

--- a/core-protocol/src/test/kotlin/dev/bluehouse/bada/protocol/endpoint/BleServiceDataTest.kt
+++ b/core-protocol/src/test/kotlin/dev/bluehouse/bada/protocol/endpoint/BleServiceDataTest.kt
@@ -349,6 +349,19 @@ class BleServiceDataTest {
     }
 
     @Test
+    fun `parse rejects a regular body whose declared EndpointInfo leaves no room for the MAC`() {
+        // Regular-form header (hash prefix present) with a valid EndpointInfo
+        // length, but the buffer is cut into the trailing 6-byte MAC (the
+        // helper appends 2 bytes after the MAC, so drop those plus one MAC
+        // byte). parseRegularBody must reject rather than read past the buffer
+        // when extracting the Bluetooth MAC (#214).
+        val info = hiddenPhoneEndpointInfo()
+        val full = regularBleBody("LPPM", info)
+        val truncated = full.copyOfRange(0, full.size - 3)
+        assertThat(BleServiceData.parse(truncated)).isNull()
+    }
+
+    @Test
     fun `parse returns null when the embedded EndpointInfo cannot be decoded`() {
         // The 1-byte length prefix says 4 EndpointInfo bytes follow, but
         // EndpointInfo.parse requires at least 17 bytes (1 header + 16

--- a/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/DiscoveredService.kt
+++ b/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/DiscoveredService.kt
@@ -40,6 +40,11 @@ public data class DiscoveredService(
     val addresses: List<InetAddress>,
     val port: Int,
     val endpointInfo: EndpointInfo?,
+    /**
+     * Bluetooth Classic MAC from the TXT `b` record, when the advertiser
+     * published one. Feeds the RFCOMM bootstrap fallback (#214).
+     */
+    val bluetoothMacAddress: String? = null,
 ) {
     /**
      * Convenience helper: returns the first non-loopback InetAddress, falling
@@ -61,7 +66,8 @@ public data class DiscoveredService(
             (endpointId?.contentEquals(other.endpointId) ?: (other.endpointId == null)) &&
             addresses == other.addresses &&
             port == other.port &&
-            endpointInfo == other.endpointInfo
+            endpointInfo == other.endpointInfo &&
+            bluetoothMacAddress == other.bluetoothMacAddress
     }
 
     override fun hashCode(): Int {
@@ -70,6 +76,7 @@ public data class DiscoveredService(
         result = 31 * result + addresses.hashCode()
         result = 31 * result + port
         result = 31 * result + (endpointInfo?.hashCode() ?: 0)
+        result = 31 * result + (bluetoothMacAddress?.hashCode() ?: 0)
         return result
     }
 }

--- a/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/Discovery.kt
+++ b/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/Discovery.kt
@@ -372,8 +372,39 @@ public class Discovery internal constructor(
             addresses = addresses,
             port = event.port,
             endpointInfo = endpointInfo,
+            bluetoothMacAddress =
+                decodeTxtBluetoothMac(event.attributes[QuickShareMdns.TXT_KEY_BLUETOOTH_MAC]),
         )
     }
+
+    /**
+     * Decodes the TXT `b` value into a canonical colon-separated MAC.
+     * Stock GMS records carry base64 of the ASCII MAC string; tolerate a
+     * raw MAC string too. Returns `null` for anything else.
+     */
+    private fun decodeTxtBluetoothMac(raw: ByteArray?): String? {
+        val text = raw?.let { String(it, Charsets.US_ASCII) }?.trim()
+        val candidate =
+            when {
+                text == null -> null
+                BLUETOOTH_MAC_REGEX.matches(text) -> text
+                else ->
+                    decodeBase64Lenient(text)
+                        ?.let { String(it, Charsets.US_ASCII).trim() }
+                        ?.takeIf { BLUETOOTH_MAC_REGEX.matches(it) }
+            }
+        return candidate?.uppercase(java.util.Locale.ROOT)
+    }
+
+    private fun decodeBase64Lenient(text: String): ByteArray? =
+        Base64Url.decode(text)
+            ?: try {
+                java.util.Base64
+                    .getDecoder()
+                    .decode(text)
+            } catch (_: IllegalArgumentException) {
+                null
+            }
 
     private fun isLocalInterfaceRecord(addresses: List<InetAddress>): Boolean {
         val localAddresses = localAddressProvider()
@@ -489,6 +520,9 @@ public class Discovery internal constructor(
 
         /** logcat tag — shared with the rest of the discovery module. */
         internal const val TAG: String = "BadaDiscovery"
+
+        /** Canonical colon-separated Bluetooth MAC, case-insensitive. */
+        private val BLUETOOTH_MAC_REGEX = Regex("^[0-9A-Fa-f]{2}(:[0-9A-Fa-f]{2}){5}$")
 
         /**
          * Test-only factory that wires up [Discovery] with caller-supplied

--- a/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/NearbyPeer.kt
+++ b/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/NearbyPeer.kt
@@ -32,6 +32,14 @@ public data class NearbyPeer(
     val lanEndpoint: LanEndpoint? = null,
     val bluetoothEndpoint: BluetoothEndpoint? = null,
     val bleAdvertisement: BleAdvertisement? = null,
+    /**
+     * Bluetooth Classic MAC the peer itself published — via the regular
+     * (non-fast) 0xFEF3 advertisement body or the mDNS TXT `b` record.
+     * Distinct from [bluetoothEndpoint], which is produced by Bluetooth
+     * Classic *discovery*. When present, the peer accepts the RFCOMM
+     * bootstrap route (#214).
+     */
+    val publishedBluetoothMac: String? = null,
 ) {
     /**
      * Discovery / candidate mediums currently known for this peer.
@@ -49,6 +57,12 @@ public data class NearbyPeer(
                 ) {
                     add(Medium.BLUETOOTH)
                 }
+                if (
+                    publishedBluetoothMac != null &&
+                    UserFacingMediumFeatures.BLUETOOTH_CLASSIC_BOOTSTRAP_ROUTE_ENABLED
+                ) {
+                    add(Medium.BLUETOOTH)
+                }
                 if (bleAdvertisement != null) {
                     add(Medium.BLE)
                     if (bleAdvertisement.l2capPsm != null) add(Medium.BLE_L2CAP)
@@ -63,13 +77,16 @@ public data class NearbyPeer(
      * Select the initial-control route.
      *
      * LAN remains first priority to preserve the direct same-Wi-Fi path when
-     * a peer is already reachable by mDNS + TCP. BLE L2CAP is the preferred
-     * off-LAN bootstrap path when the receiver advertises a PSM. A visible
-     * BLE receiver without a PSM is only a GATT bootstrap candidate after the
-     * GATT advertisement-slot probe verifies the service; header-only and raw
-     * scan-result-only BLE observations remain discovery metadata until
-     * another route confirms a transport.
+     * a peer is already reachable by mDNS + TCP. Off-LAN, Bluetooth Classic
+     * RFCOMM is preferred when the peer published its BR/EDR MAC — stock
+     * GMS receivers bootstrap stock senders over RFCOMM, while their BLE
+     * GATT/L2CAP server paths are unreliable (#214). BLE L2CAP follows when
+     * the receiver advertises a PSM, then GATT once the advertisement-slot
+     * probe verifies the service; header-only and raw scan-result-only BLE
+     * observations remain discovery metadata until another route confirms a
+     * transport.
      */
+    @Suppress("ReturnCount")
     public fun preferredRoute(): NearbyPeerRoute? {
         if (endpointInfo == null) {
             return null
@@ -82,6 +99,7 @@ public data class NearbyPeer(
                 port = lan.port,
             )
         }
+        bluetoothClassicRoute()?.let { return it }
         val ble = bleAdvertisement
         val bleAddress = ble?.advertiserAddress
         val l2capPsm = ble?.l2capPsm
@@ -91,10 +109,23 @@ public data class NearbyPeer(
         if (bleAddress != null && ble.gattConnectable) {
             return NearbyPeerRoute.BleGatt(macAddress = bleAddress)
         }
+        return null
+    }
+
+    /**
+     * RFCOMM connect-route candidate. The BLE-derived MAC (regular
+     * advertisement body) rides the bootstrap-route gate; a MAC found by
+     * Bluetooth Classic *discovery* stays behind the user-facing gate.
+     */
+    public fun bluetoothClassicRoute(): NearbyPeerRoute.BluetoothClassic? {
+        if (UserFacingMediumFeatures.BLUETOOTH_CLASSIC_BOOTSTRAP_ROUTE_ENABLED) {
+            publishedBluetoothMac?.let {
+                return NearbyPeerRoute.BluetoothClassic(it)
+            }
+        }
         if (UserFacingMediumFeatures.BLUETOOTH_CLASSIC_USER_FACING_ENABLED) {
-            val bluetooth = bluetoothEndpoint
-            if (bluetooth != null) {
-                return NearbyPeerRoute.BluetoothClassic(bluetooth.macAddress)
+            bluetoothEndpoint?.let {
+                return NearbyPeerRoute.BluetoothClassic(it.macAddress)
             }
         }
         return null

--- a/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/NearbyPeerDiscovery.kt
+++ b/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/NearbyPeerDiscovery.kt
@@ -142,7 +142,13 @@ private class PeerAggregator {
         lanInstanceIndex[service.instanceName] = state.stableId
         state.lanAddresses = service.addresses
         state.lanPort = service.port
-        service.bluetoothMacAddress?.let { state.publishedBluetoothMac = it }
+        // mDNS TXT 'b' is the authoritative MAC source: it is the device's
+        // own published record over a reliable channel. Let it win over a
+        // BLE-advertised MAC regardless of which collector observed first.
+        service.bluetoothMacAddress?.let {
+            state.publishedBluetoothMac = it
+            state.publishedBluetoothMacFromLan = true
+        }
 
         return changeEvents(before, state.toPeerOrNull())
     }
@@ -184,7 +190,12 @@ private class PeerAggregator {
         state.bleRssi = observation.rssi
         state.bleL2capPsm = observation.l2capPsm
         state.bleGattConnectable = state.bleGattConnectable || observation.gattConnectable
-        observation.bluetoothMacAddress?.let { state.publishedBluetoothMac = it }
+        // Only adopt a BLE-advertised MAC when mDNS has not already supplied
+        // the authoritative one (see onLanResolved); avoids a last-writer-wins
+        // race between the parallel LAN and BLE collectors.
+        observation.bluetoothMacAddress?.let {
+            if (!state.publishedBluetoothMacFromLan) state.publishedBluetoothMac = it
+        }
         observation.displayName?.toDisplayNameOrNull()?.let { displayName ->
             state.bleDisplayName = displayName
             state.bleDisplayNameSource = observation.displayNameSource?.logLabel
@@ -323,6 +334,7 @@ private data class MutablePeer(
     var bleDisplayName: String? = null,
     var bleDisplayNameSource: String? = null,
     var publishedBluetoothMac: String? = null,
+    var publishedBluetoothMacFromLan: Boolean = false,
 ) {
     fun toPeerOrNull(): NearbyPeer? {
         val lan =

--- a/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/NearbyPeerDiscovery.kt
+++ b/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/NearbyPeerDiscovery.kt
@@ -142,6 +142,7 @@ private class PeerAggregator {
         lanInstanceIndex[service.instanceName] = state.stableId
         state.lanAddresses = service.addresses
         state.lanPort = service.port
+        service.bluetoothMacAddress?.let { state.publishedBluetoothMac = it }
 
         return changeEvents(before, state.toPeerOrNull())
     }
@@ -183,6 +184,7 @@ private class PeerAggregator {
         state.bleRssi = observation.rssi
         state.bleL2capPsm = observation.l2capPsm
         state.bleGattConnectable = state.bleGattConnectable || observation.gattConnectable
+        observation.bluetoothMacAddress?.let { state.publishedBluetoothMac = it }
         observation.displayName?.toDisplayNameOrNull()?.let { displayName ->
             state.bleDisplayName = displayName
             state.bleDisplayNameSource = observation.displayNameSource?.logLabel
@@ -288,6 +290,7 @@ private class PeerAggregator {
             val ble = peer.bleAdvertisement
             when {
                 ble == null -> add("ble-missing")
+                peer.bluetoothClassicRoute() != null -> Unit
                 ble.advertiserAddress == null -> add("ble-no-address")
                 ble.l2capPsm != null -> Unit
                 ble.gattConnectable -> add("ble-gatt-pending-endpoint-info")
@@ -319,6 +322,7 @@ private data class MutablePeer(
     var bleGattConnectable: Boolean = false,
     var bleDisplayName: String? = null,
     var bleDisplayNameSource: String? = null,
+    var publishedBluetoothMac: String? = null,
 ) {
     fun toPeerOrNull(): NearbyPeer? {
         val lan =
@@ -357,6 +361,7 @@ private data class MutablePeer(
             lanEndpoint = lan,
             bluetoothEndpoint = bluetooth,
             bleAdvertisement = ble,
+            publishedBluetoothMac = publishedBluetoothMac,
         )
     }
 }

--- a/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/QuickShareMdns.kt
+++ b/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/QuickShareMdns.kt
@@ -89,6 +89,14 @@ public object QuickShareMdns {
     public const val TXT_KEY_WIFI_FREQUENCY: String = "f"
 
     /**
+     * TXT-record key carrying the advertiser's Bluetooth Classic MAC as
+     * base64 of the ASCII "AA:BB:CC:DD:EE:FF" string (shape observed on
+     * stock GMS 26.20.31 records). Senders use it for the RFCOMM
+     * bootstrap fallback when the TCP route fails (#214).
+     */
+    public const val TXT_KEY_BLUETOOTH_MAC: String = "b"
+
+    /**
      * Alphabet used when generating the random 4-byte endpoint ID portion of
      * the service-instance name. Restricting to alphanumeric ASCII keeps the
      * raw bytes safely round-trippable through every URL-safe-base64

--- a/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/UserFacingMediumFeatures.kt
+++ b/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/UserFacingMediumFeatures.kt
@@ -11,9 +11,21 @@ package dev.bluehouse.bada.discovery
  */
 public object UserFacingMediumFeatures {
     /**
-     * Bluetooth Classic RFCOMM remains implemented for future re-enable
-     * work, but normal discovery, picker routing, and bootstrap flows must
-     * not expose it to users.
+     * Bluetooth Classic RFCOMM *discovery* (inquiry / device-name scanning
+     * via [BluetoothClassicPeerScanner]) remains implemented but hidden:
+     * normal discovery and picker surfaces must not expose peers found
+     * through it.
      */
     public const val BLUETOOTH_CLASSIC_USER_FACING_ENABLED: Boolean = false
+
+    /**
+     * Bluetooth Classic RFCOMM as a *connect route* for the sender
+     * bootstrap (#214). Stock GMS receivers bootstrap off-LAN over RFCOMM
+     * (verified by HCI snoop of stock-to-stock transfers); their BLE
+     * GATT/L2CAP server paths are unreliable because stock senders never
+     * exercise them. The peer's BR/EDR MAC arrives via already-supported
+     * discovery surfaces (regular 0xFEF3 advertisement body, mDNS TXT),
+     * so enabling the route does not surface any new discovery medium.
+     */
+    public const val BLUETOOTH_CLASSIC_BOOTSTRAP_ROUTE_ENABLED: Boolean = true
 }

--- a/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/ble/BleFastAdvertisementScanner.kt
+++ b/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/ble/BleFastAdvertisementScanner.kt
@@ -197,6 +197,12 @@ public class BleFastAdvertisementScanner(
         val gattConnectable: Boolean,
         val displayName: String? = null,
         val displayNameSource: DisplayNameSource? = null,
+        /**
+         * Bluetooth Classic MAC carried by the regular (non-fast) 0xFEF3
+         * advertisement body. Stock receivers in foreground-visible mode
+         * publish it so senders can bootstrap over RFCOMM (#214).
+         */
+        val bluetoothMacAddress: String? = null,
     )
 
     public enum class DisplayNameSource(
@@ -493,6 +499,7 @@ public class BleFastAdvertisementScanner(
                         displayName != null -> fallbackDisplayNameSource
                         else -> null
                     },
+                bluetoothMacAddress = parsed.bluetoothMacAddress,
             )
         }
 
@@ -545,6 +552,7 @@ public class BleFastAdvertisementScanner(
                 rssi = rssi,
                 l2capPsm = l2capPsm,
                 gattConnectable = gattConnectable && advertiserAddress != null && l2capPsm != null,
+                bluetoothMacAddress = parsed.bluetoothMacAddress,
                 displayName = displayName,
                 displayNameSource =
                     when {

--- a/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/bootstrap/BleL2capInitialControlClient.kt
+++ b/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/bootstrap/BleL2capInitialControlClient.kt
@@ -219,15 +219,29 @@ private class BleL2capClientTransport(
         }
     }
 
+    @Suppress("ReturnCount")
     private fun openDataConnection(): Boolean {
-        channel.outputStream.write(COMMAND_REQUEST_DATA_CONNECTION)
-        channel.outputStream.flush()
-        val response = channel.inputStream.read()
-        if (response == COMMAND_RESPONSE_DATA_CONNECTION_READY) {
+        // Shipped GMS (observed on 26.20.31) frames every L2CAP packet with a
+        // 4-byte big-endian length prefix and times out the incoming socket
+        // after 1000 ms if the first readInt() never completes. The raw
+        // single-byte command from OSS google/nearby mainline starves that
+        // read and the server closes the channel.
+        synchronized(writeLock) {
+            channel.outputStream.writeLengthPrefixedPacket(
+                byteArrayOf(COMMAND_REQUEST_DATA_CONNECTION.toByte()),
+            )
+        }
+        val responseLength = channel.inputStream.readExactly(L2CAP_PACKET_LENGTH_BYTES).decodeLength()
+        if (responseLength <= 0 || responseLength > MAX_DATA_CONNECTION_RESPONSE_BYTES) {
+            DiagnosticLog.w(TAG, "unexpected BLE L2CAP data-connection response length=$responseLength")
+            return false
+        }
+        val response = channel.inputStream.readExactly(responseLength)
+        if (response[0].toInt() == COMMAND_RESPONSE_DATA_CONNECTION_READY) {
             DiagnosticLog.i(TAG, "BLE L2CAP data connection ready")
             return true
         }
-        DiagnosticLog.w(TAG, "unexpected BLE L2CAP data-connection response=$response")
+        DiagnosticLog.w(TAG, "unexpected BLE L2CAP data-connection response=${response[0]}")
         return false
     }
 
@@ -362,6 +376,7 @@ private class BleL2capClientTransport(
         private const val COMMAND_RESPONSE_DATA_CONNECTION_READY: Int = 23
         private const val SERVICE_ID_HASH_LEN: Int = 3
         private const val L2CAP_PACKET_LENGTH_BYTES: Int = 4
+        private const val MAX_DATA_CONNECTION_RESPONSE_BYTES: Int = 64
         private val CONTROL_PACKET_PREFIX: ByteArray = ByteArray(SERVICE_ID_HASH_LEN)
     }
 }

--- a/discovery-android/src/test/kotlin/dev/bluehouse/bada/discovery/DiscoveredServiceMappingTest.kt
+++ b/discovery-android/src/test/kotlin/dev/bluehouse/bada/discovery/DiscoveredServiceMappingTest.kt
@@ -49,6 +49,64 @@ class DiscoveredServiceMappingTest {
     }
 
     @Test
+    fun `TXT b record decodes the published Bluetooth Classic MAC`() {
+        // Literal value captured from a stock GMS 26.20.31 record:
+        // base64("B8:A2:5D:EF:63:73").
+        val event =
+            NsdBrowserEvent.Resolved(
+                instanceName = "IzAxMjP8n14AAA",
+                addresses = listOf(InetAddress.getByName("192.168.1.42")),
+                port = 54_321,
+                attributes =
+                    mapOf(
+                        QuickShareMdns.TXT_KEY_BLUETOOTH_MAC to
+                            "Qjg6QTI6NUQ6RUY6NjM6NzM".toByteArray(Charsets.US_ASCII),
+                    ),
+            )
+
+        val result = newDiscovery().toDiscoveredService(event)
+        assertThat(result).isNotNull()
+        assertThat(result!!.bluetoothMacAddress).isEqualTo("B8:A2:5D:EF:63:73")
+    }
+
+    @Test
+    fun `TXT b record tolerates a raw MAC string and normalizes case`() {
+        val event =
+            NsdBrowserEvent.Resolved(
+                instanceName = "IzAxMjP8n14AAA",
+                addresses = listOf(InetAddress.getByName("192.168.1.42")),
+                port = 54_321,
+                attributes =
+                    mapOf(
+                        QuickShareMdns.TXT_KEY_BLUETOOTH_MAC to
+                            "08:b3:39:10:c2:6a".toByteArray(Charsets.US_ASCII),
+                    ),
+            )
+
+        val result = newDiscovery().toDiscoveredService(event)
+        assertThat(result).isNotNull()
+        assertThat(result!!.bluetoothMacAddress).isEqualTo("08:B3:39:10:C2:6A")
+    }
+
+    @Test
+    fun `garbage TXT b record yields a null MAC without crashing`() {
+        val event =
+            NsdBrowserEvent.Resolved(
+                instanceName = "IzAxMjP8n14AAA",
+                addresses = listOf(InetAddress.getByName("192.168.1.42")),
+                port = 54_321,
+                attributes =
+                    mapOf(
+                        QuickShareMdns.TXT_KEY_BLUETOOTH_MAC to byteArrayOf(0xFF.toByte(), 0x00),
+                    ),
+            )
+
+        val result = newDiscovery().toDiscoveredService(event)
+        assertThat(result).isNotNull()
+        assertThat(result!!.bluetoothMacAddress).isNull()
+    }
+
+    @Test
     fun `missing TXT key yields null endpointInfo but still surfaces the peer`() {
         val event =
             NsdBrowserEvent.Resolved(

--- a/discovery-android/src/test/kotlin/dev/bluehouse/bada/discovery/NearbyPeerDiscoveryTest.kt
+++ b/discovery-android/src/test/kotlin/dev/bluehouse/bada/discovery/NearbyPeerDiscoveryTest.kt
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test
 import java.net.InetAddress
 
 @OptIn(ExperimentalCoroutinesApi::class)
+@Suppress("LargeClass") // Accumulating aggregation-scenario cases; one class keeps fixtures shared.
 class NearbyPeerDiscoveryTest {
     @Test
     fun `Bluetooth metadata stays hidden until LAN route arrives`() =
@@ -277,6 +278,124 @@ class NearbyPeerDiscoveryTest {
             assertThat(resolved.peer.isConnectable).isTrue()
             assertThat(resolved.peer.candidateMediums)
                 .containsExactly(Medium.BLE, Medium.BLUETOOTH)
+            assertThat(resolved.peer.preferredRoute()).isEqualTo(
+                NearbyPeerRoute.BluetoothClassic(macAddress = "08:B3:39:10:C2:6A"),
+            )
+
+            collector.cancel()
+        }
+
+    @Test
+    fun `mDNS TXT Bluetooth MAC aggregates and yields an RFCOMM route when no LAN address resolves`() =
+        runTest {
+            val lanEvents = MutableSharedFlow<DiscoveryEvent>()
+            val bleEvents = MutableSharedFlow<BleFastAdvertisementScanner.Observation>()
+            val bluetoothEvents = MutableSharedFlow<BluetoothClassicPeerScanner.Observation>()
+            val discovery =
+                NearbyPeerDiscovery.forTesting(
+                    lanEvents = lanEvents,
+                    bleEvents = bleEvents,
+                    bluetoothEvents = bluetoothEvents,
+                )
+            val seen = mutableListOf<NearbyPeerEvent>()
+            val collector =
+                backgroundScope.launch {
+                    discovery.browse().collect { seen += it }
+                }
+            runCurrent()
+
+            // Resolved mDNS record carrying the TXT 'b' MAC but no usable IP
+            // (addresses empty): the LAN route is unavailable, so the
+            // aggregated publishedBluetoothMac must surface an RFCOMM route.
+            lanEvents.emit(
+                DiscoveryEvent.Resolved(
+                    DiscoveredService(
+                        instanceName = "instance-17nt",
+                        endpointId = "17NT".toByteArray(Charsets.US_ASCII),
+                        addresses = emptyList(),
+                        port = 53601,
+                        endpointInfo = endpointInfo(name = "규진's phone"),
+                        bluetoothMacAddress = "08:B3:39:10:C2:6A",
+                    ),
+                ),
+            )
+            runCurrent()
+
+            val resolved = seen.last() as NearbyPeerEvent.Resolved
+            assertThat(resolved.peer.publishedBluetoothMac).isEqualTo("08:B3:39:10:C2:6A")
+            assertThat(resolved.peer.isConnectable).isTrue()
+            assertThat(resolved.peer.preferredRoute()).isEqualTo(
+                NearbyPeerRoute.BluetoothClassic(macAddress = "08:B3:39:10:C2:6A"),
+            )
+
+            collector.cancel()
+        }
+
+    @Test
+    fun `mDNS Bluetooth MAC wins over a different BLE-advertised MAC regardless of arrival order`() =
+        runTest {
+            val lanEvents = MutableSharedFlow<DiscoveryEvent>()
+            val bleEvents = MutableSharedFlow<BleFastAdvertisementScanner.Observation>()
+            val bluetoothEvents = MutableSharedFlow<BluetoothClassicPeerScanner.Observation>()
+            val discovery =
+                NearbyPeerDiscovery.forTesting(
+                    lanEvents = lanEvents,
+                    bleEvents = bleEvents,
+                    bluetoothEvents = bluetoothEvents,
+                )
+            val seen = mutableListOf<NearbyPeerEvent>()
+            val collector =
+                backgroundScope.launch {
+                    discovery.browse().collect { seen += it }
+                }
+            runCurrent()
+
+            // BLE advertises one MAC first; the authoritative mDNS TXT 'b'
+            // record then supplies a different one. mDNS must win — the BLE
+            // value must not clobber it, and the merge must be deterministic
+            // across the two parallel collectors.
+            bleEvents.emit(
+                BleFastAdvertisementScanner.Observation(
+                    endpointId = "17NT",
+                    endpointInfo = endpointInfo(name = "규진's phone"),
+                    advertiserAddress = "77:88:99:AA:BB:CC",
+                    rssi = -47,
+                    l2capPsm = null,
+                    gattConnectable = false,
+                    bluetoothMacAddress = "AA:AA:AA:AA:AA:AA",
+                ),
+            )
+            lanEvents.emit(
+                DiscoveryEvent.Resolved(
+                    DiscoveredService(
+                        instanceName = "instance-17nt",
+                        endpointId = "17NT".toByteArray(Charsets.US_ASCII),
+                        addresses = emptyList(),
+                        port = 53601,
+                        endpointInfo = endpointInfo(name = "규진's phone"),
+                        bluetoothMacAddress = "08:B3:39:10:C2:6A",
+                    ),
+                ),
+            )
+            runCurrent()
+
+            // A later BLE observation with yet another MAC must still not
+            // override the authoritative mDNS-sourced value.
+            bleEvents.emit(
+                BleFastAdvertisementScanner.Observation(
+                    endpointId = "17NT",
+                    endpointInfo = endpointInfo(name = "규진's phone"),
+                    advertiserAddress = "77:88:99:AA:BB:CC",
+                    rssi = -50,
+                    l2capPsm = null,
+                    gattConnectable = false,
+                    bluetoothMacAddress = "BB:BB:BB:BB:BB:BB",
+                ),
+            )
+            runCurrent()
+
+            val resolved = seen.last() as NearbyPeerEvent.Resolved
+            assertThat(resolved.peer.publishedBluetoothMac).isEqualTo("08:B3:39:10:C2:6A")
             assertThat(resolved.peer.preferredRoute()).isEqualTo(
                 NearbyPeerRoute.BluetoothClassic(macAddress = "08:B3:39:10:C2:6A"),
             )

--- a/discovery-android/src/test/kotlin/dev/bluehouse/bada/discovery/NearbyPeerDiscoveryTest.kt
+++ b/discovery-android/src/test/kotlin/dev/bluehouse/bada/discovery/NearbyPeerDiscoveryTest.kt
@@ -236,6 +236,55 @@ class NearbyPeerDiscoveryTest {
         }
 
     @Test
+    fun `regular advertisement Bluetooth MAC makes the peer connectable over RFCOMM`() =
+        runTest {
+            val lanEvents = MutableSharedFlow<DiscoveryEvent>()
+            val bleEvents = MutableSharedFlow<BleFastAdvertisementScanner.Observation>()
+            val bluetoothEvents = MutableSharedFlow<BluetoothClassicPeerScanner.Observation>()
+            val discovery =
+                NearbyPeerDiscovery.forTesting(
+                    lanEvents = lanEvents,
+                    bleEvents = bleEvents,
+                    bluetoothEvents = bluetoothEvents,
+                )
+            val seen = mutableListOf<NearbyPeerEvent>()
+            val collector =
+                backgroundScope.launch {
+                    discovery.browse().collect { seen += it }
+                }
+            runCurrent()
+
+            // A foreground-visible stock receiver: regular 0xFEF3
+            // advertisement carries the BR/EDR MAC but no PSM, and the
+            // GATT slot probe has not verified anything. RFCOMM must be
+            // the route (#214) — this peer was previously hidden as
+            // "ble-no-verified-bootstrap".
+            bleEvents.emit(
+                BleFastAdvertisementScanner.Observation(
+                    endpointId = "17NT",
+                    endpointInfo = endpointInfo(name = "규진's phone"),
+                    advertiserAddress = "77:88:99:AA:BB:CC",
+                    rssi = -47,
+                    l2capPsm = null,
+                    gattConnectable = false,
+                    bluetoothMacAddress = "08:B3:39:10:C2:6A",
+                ),
+            )
+            runCurrent()
+
+            val resolved = seen.single() as NearbyPeerEvent.Resolved
+            assertThat(resolved.peer.publishedBluetoothMac).isEqualTo("08:B3:39:10:C2:6A")
+            assertThat(resolved.peer.isConnectable).isTrue()
+            assertThat(resolved.peer.candidateMediums)
+                .containsExactly(Medium.BLE, Medium.BLUETOOTH)
+            assertThat(resolved.peer.preferredRoute()).isEqualTo(
+                NearbyPeerRoute.BluetoothClassic(macAddress = "08:B3:39:10:C2:6A"),
+            )
+
+            collector.cancel()
+        }
+
+    @Test
     fun `same Wi-Fi LAN is preferred after peer also advertises BLE bootstrap`() =
         runTest {
             val lanEvents = MutableSharedFlow<DiscoveryEvent>()


### PR DESCRIPTION
Closes #214. Fixes the off-LAN pre-UKEY2 failure tracked in #189 / #213.

## Problem

Off-LAN sends to stock GMS receivers failed before UKEY2. The receiver terminated the BLE GATT link (`status=19`, `GATT_CONN_TERMINATE_PEER_USER`) ~1.2 s after Bada wrote its `ConnectionRequest`, and BLE L2CAP never reached the multiplex stage — surfacing to the user as a raw `Pipe closed`.

## Root cause (verified by HCI snoop)

A Bluetooth HCI snoop of a **stock-to-stock** off-LAN transfer (Samsung → Xiaomi 17 Ultra, GMS 26.20.31) showed that stock Quick Share bootstraps off-LAN over **Bluetooth Classic RFCOMM**, not BLE:

- SDP lookup for `UUID.nameUUIDFromBytes("NearbySharing")` = `a82efa21-ae5c-3dde-9bbc-f16da7b16c5a`, then on the RFCOMM socket an immediate length-prefixed `ConnectionRequest` + UKEY2 ClientInit, then an in-band Wi-Fi Direct bandwidth upgrade.
- Stock senders never drive the receiver's BLE GATT/L2CAP server paths, so those GMS server paths are unreliable (receiver-side GATT threw `No handler registered for characteristic 00000100-…`; L2CAP uses 4-byte length-prefixed framing, not OSS mainline's raw byte).

## Fix

Enable RFCOMM as the off-LAN sender bootstrap route. The peer's BR/EDR MAC already arrives through supported discovery surfaces, so **no new discovery medium is exposed** — the Bluetooth Classic *discovery* scanner stays gated off (per #154).

- Parse the 6-byte MAC after EndpointInfo in the regular 0xFEF3 advertisement body (`BleServiceData.parseRegularBody`) and decode the mDNS TXT `b` record (`QuickShareMdns.TXT_KEY_BLUETOOTH_MAC`), surfacing both as `NearbyPeer.publishedBluetoothMac`.
- Add `BLUETOOTH_CLASSIC_BOOTSTRAP_ROUTE_ENABLED`, distinct from the user-facing discovery gate. Route ladder becomes `WIFI_LAN → BLUETOOTH(RFCOMM) → BLE_L2CAP → BLE_GATT`.
- Frame the BLE L2CAP data-connection handshake with the 4-byte length prefix shipped GMS expects, so the fallback path gets past the data-connection stage.

## Verification

Real-device debug loop, off-LAN (both Wi-Fi radios on, no shared AP), Bada sender → stock GMS Xiaomi receiver:

- Picker selects `Bluetooth RFCOMM 08:B3:39:10:C2:6A`.
- UKEY2 completes, PIN matches (7664), introduction received, consent accepted.
- Receiver: `IncomingPayloadTransferEnd bytesReceived=309347 status=1`; file written to `Downloads/Quick Share/`.

Note: the Wi-Fi *radio* must be on (even off-LAN) for the receiver to bring up the Wi-Fi Direct payload-upgrade medium; with it off, stock shows "Can't transfer files" — stock behavior, not a Bada regression.

## Tests

JVM regression coverage added/extended:
- `BleServiceDataTest` — MAC extraction from a captured 49-byte regular advertisement body; null for fast/zeroed bodies.
- `DiscoveredServiceMappingTest` — TXT `b` base64 / raw-MAC decoding and garbage tolerance.
- `NearbyPeerDiscoveryTest` — regular-advertisement MAC makes an off-LAN peer RFCOMM-connectable.
- `SendBootstrapPlanTest` — RFCOMM ordering between LAN and the BLE fallbacks.

`:core-protocol`, `:discovery-android`, `:app` unit tests and `staticAnalysis` all pass.

## Follow-ups (separate issues)

- Send UKEY2 ClientInit immediately after `ConnectionRequest` and demultiplex `UPGRADE_PATH_AVAILABLE` concurrently on BLE bootstraps.
- Reverse-engineer shipped GMS's L2CAP data-phase framing.