### PR TITLE
fix: shorten pre-UKEY2 BLE offer wait so ClientInit is sent before receiver drop (#216)

### DIFF
--- a/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnectionDriver.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnectionDriver.kt
@@ -288,7 +288,10 @@ internal class OutboundConnectionDriver(
         if (!shouldProbePreUkey2Upgrade()) {
             return PreUkey2Negotiation.Ready(PreSecureTransport(transport, initialTransport.medium))
         }
-        logger("medium-upgrade: probing for pre-UKEY2 BLE upgrade offer")
+        logger(
+            "medium-upgrade: probing ${PRE_UKEY2_UPGRADE_OFFER_WAIT_TIMEOUT_MILLIS}ms " +
+                "for pre-UKEY2 BLE upgrade offer before sending ClientInit",
+        )
         return when (
             val probe =
                 PreUkey2BandwidthUpgrade.receiveOfferProbe(
@@ -1637,7 +1640,18 @@ internal class OutboundConnectionDriver(
             v1.bandwidthUpgradeNegotiation.eventType == expected
 
     private companion object {
-        private const val PRE_UKEY2_UPGRADE_OFFER_WAIT_TIMEOUT_MILLIS: Long = 1_500L
+        // How long to wait for a pre-UKEY2 BLE bandwidth-upgrade offer
+        // before giving up and sending ClientInit on the current medium.
+        // This bounds ONLY the no-offer path: the probe returns the instant
+        // an offer is buffered, so a receiver that does send one is detected
+        // just as fast regardless of this value. Stock GMS receivers never
+        // send a pre-UKEY2 offer (issue #216) — they sit silent waiting for
+        // ClientInit and drop the BLE GATT link ~1.05–1.24s after our
+        // ConnectionRequest. The old 1500ms wait pushed ClientInit past that
+        // window, so the receiver tore us down before UKEY2 began. 400ms is
+        // comfortably under the earliest observed drop (≥650ms margin) while
+        // still leaving ample headroom to catch a real proactive offer.
+        private const val PRE_UKEY2_UPGRADE_OFFER_WAIT_TIMEOUT_MILLIS: Long = 400L
         private const val BLE_WIFI_DIRECT_UPGRADE_TIMEOUT_MILLIS: Long = 3_000L
         private const val BLE_WIFI_DIRECT_POLL_DELAY_MILLIS: Long = 25L
 

--- a/core-protocol/src/test/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnectionTest.kt
+++ b/core-protocol/src/test/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnectionTest.kt
@@ -744,6 +744,56 @@ class OutboundConnectionTest {
         }
 
     @Test
+    fun `preconnected BLE bootstrap sends ClientInit when no pre-UKEY2 offer arrives`() =
+        runBlocking {
+            withTimeout(WALLCLOCK_TIMEOUT_MS) {
+                val (client, server) = connectedSocketPair()
+                val directUpgradePair = LoopbackUpgradePair(Medium.WIFI_DIRECT)
+                val logs = mutableListOf<String>()
+                val outbound =
+                    OutboundConnection(
+                        transport = client.asConnectedTransport(Medium.BLE),
+                        secureRandom = SecureRandom("outbound-ble-no-offer-clientinit".toByteArray()),
+                        mediumRegistry =
+                            MediumRegistry(
+                                providers =
+                                    listOf(
+                                        MediumRegistry.DefaultWifiLan.providerFor(Medium.WIFI_LAN)!!,
+                                        directUpgradePair.clientProvider,
+                                        SupportedProvider(Medium.BLE),
+                                    ),
+                                ladder = MediumLadder(listOf(Medium.WIFI_DIRECT, Medium.WIFI_LAN, Medium.BLE)),
+                            ),
+                        initialHandshakeTimeoutMillis = SHORT_INITIAL_HANDSHAKE_TIMEOUT_MS,
+                        logger = logs::add,
+                    )
+                val oldWire = FramedConnection(server.asConnectedTransport(Medium.BLE))
+
+                try {
+                    coroutineScope {
+                        val outboundJob = async { outbound.run(emptyList()) }
+                        // Peer reads ConnectionRequest and, like a stock GMS
+                        // receiver, sends NO pre-UKEY2 upgrade offer.
+                        assertThat(OfflineFrame.parseFrom(oldWire.receiveFrame()).isConnectionRequest()).isTrue()
+                        // Issue #216: rather than stalling until the receiver
+                        // drops the link, the sender must give up waiting for an
+                        // offer and send ClientInit on the BLE medium.
+                        val next = Ukey2Message.parseFrom(oldWire.receiveFrame())
+                        assertThat(next.messageType).isEqualTo(Ukey2Message.Type.CLIENT_INIT)
+
+                        oldWire.close()
+                        assertThat(outboundJob.await()).isInstanceOf(OutboundResult.Failed::class.java)
+                    }
+
+                    assertThat(logs).contains("medium-upgrade: no pre-UKEY2 upgrade offer; continuing on BLE")
+                } finally {
+                    runCatching { oldWire.close() }
+                    directUpgradePair.close()
+                }
+            }
+        }
+
+    @Test
     fun `preconnected BLE bootstrap times out when pre-UKEY2 peer stays silent`() =
         runBlocking {
             withTimeout(WALLCLOCK_TIMEOUT_MS) {


### PR DESCRIPTION
Closes #216.

## Problem

On a BLE bootstrap that supports a Wi-Fi Direct upgrade (`shouldProbePreUkey2Upgrade()`), the sender waited up to **1500 ms** for a pre-UKEY2 `UPGRADE_PATH_AVAILABLE` offer before sending UKEY2 ClientInit. Stock GMS receivers never send that offer — they sit silent waiting for ClientInit and drop the BLE GATT link **~1.05–1.24 s** after our `ConnectionRequest` (the #189/#213 failure). The 1500 ms wait pushed ClientInit past that window, so the receiver tore us down before UKEY2 began.

## Fix

Reduce the no-offer wait to **400 ms**. This bounds *only* the no-offer path: `receiveOfferProbe` returns the instant an offer is buffered, so a receiver that does send one is detected just as fast regardless of this value, and the existing pre-UKEY2 upgrade path is **unchanged**. 400 ms is comfortably under the earliest observed drop (≥650 ms margin) while leaving ample headroom to catch a real proactive offer.

## Why not the issue's "eager ClientInit + concurrent demux"?

I prototyped that design and **rejected it**: sending ClientInit before classifying the first inbound frame leaves a stray ClientInit on the BLE channel. On the upgrade path that channel is then torn down via `finishPriorChannel`, which exchanges clean `LAST_WRITE_TO_PRIOR_CHANNEL` / `SAFE_TO_CLOSE_PRIOR_CHANNEL` frames — the stray ClientInit corrupts that exchange (demonstrated by the `consumes pre-UKEY2 Wi-Fi Direct offer` integration test failing). The breakage is on the pre-UKEY2 upgrade path, which **cannot be device-verified** because no observed receiver sends a pre-UKEY2 offer. Shortening the wait achieves the same goal (no fatal stall) without touching the upgrade path.

## Tests

- New: `preconnected BLE bootstrap sends ClientInit when no pre-UKEY2 offer arrives` — asserts ClientInit reaches the wire on the no-offer BLE path.
- Unaffected: the existing `consumes pre-UKEY2 Wi-Fi Direct offer` (offer path) and `times out when pre-UKEY2 peer stays silent` tests still pass.
- Full `:core-protocol` / `:app` / `:discovery-android` unit tests, `staticAnalysis`, and `:app:assembleDebug` pass.

## Verification note

End-to-end BLE-path device validation against the repro Xiaomi 17 Ultra is confounded by that receiver's GMS GATT/L2CAP server bugs (tracked in #217), which #216 does not address. This is the narrower BLE-path improvement; #215 (RFCOMM bootstrap) remains the primary off-LAN fix for stock GMS receivers. The behavior change here is fully covered by JVM loopback tests.