### PR TITLE
feat: add keep-screen-on transfer setting

### DIFF
--- a/app/src/main/kotlin/dev/bluehouse/bada/consent/ConsentTrampolineActivity.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/consent/ConsentTrampolineActivity.kt
@@ -25,6 +25,7 @@ import android.util.Log
 import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
+import android.view.WindowManager
 import android.view.animation.DecelerateInterpolator
 import android.widget.Button
 import android.widget.FrameLayout
@@ -50,6 +51,7 @@ import dev.bluehouse.bada.service.receiver.consent.ConsentIntents
 import dev.bluehouse.bada.service.receiver.consent.ConsentModalRegistry
 import dev.bluehouse.bada.service.receiver.consent.ConsentNotificationContent
 import dev.bluehouse.bada.service.receiver.consent.ConsentRegistry
+import dev.bluehouse.bada.transfer.KeepScreenOnPreferences
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -266,6 +268,7 @@ class ConsentTrampolineActivity : AppCompatActivity() {
     }
 
     override fun onDestroy() {
+        setTransferKeepScreenOn(active = false)
         // If the user dismissed the activity without an explicit
         // decision (e.g. swipe-back, screen lock), DO NOT auto-reject —
         // the issue's acceptance criteria explicitly call out that
@@ -538,22 +541,46 @@ class ConsentTrampolineActivity : AppCompatActivity() {
             lifecycleScope.launch {
                 connection.state.collect { state ->
                     when (state) {
-                        is InboundConnectionState.Receiving ->
+                        is InboundConnectionState.Receiving -> {
+                            setTransferKeepScreenOn(active = true)
                             renderProgress(
                                 bytesReceived = state.progress.bytesTransferred,
                                 totalBytes = state.progress.totalSize,
                             )
-                        is InboundConnectionState.Completed -> showCompletedPanel(state.items)
-                        is InboundConnectionState.Cancelled ->
+                        }
+                        is InboundConnectionState.Completed -> {
+                            setTransferKeepScreenOn(active = false)
+                            showCompletedPanel(state.items)
+                        }
+                        is InboundConnectionState.Cancelled -> {
+                            setTransferKeepScreenOn(active = false)
                             showFailedPanel(getString(R.string.consent_state_cancelled), reason = null)
-                        is InboundConnectionState.Failed ->
+                        }
+                        is InboundConnectionState.Failed -> {
+                            setTransferKeepScreenOn(active = false)
                             showFailedPanel(getString(R.string.consent_state_failed), reason = state.reason)
-                        is InboundConnectionState.Rejected ->
+                        }
+                        is InboundConnectionState.Rejected -> {
+                            setTransferKeepScreenOn(active = false)
                             showFailedPanel(getString(R.string.consent_state_failed), reason = null)
+                        }
                         else -> Unit
                     }
                 }
             }
+    }
+
+    private fun setTransferKeepScreenOn(active: Boolean) {
+        val keepScreenOn =
+            active &&
+                KeepScreenOnPreferences
+                    .from(this)
+                    .isKeepScreenOnDuringTransfersEnabled()
+        if (keepScreenOn) {
+            window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        } else {
+            window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
     }
 
     private fun renderProgress(

--- a/app/src/main/kotlin/dev/bluehouse/bada/send/SendActivity.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/send/SendActivity.kt
@@ -28,6 +28,7 @@ import android.transition.TransitionManager
 import android.util.Log
 import android.view.View
 import android.view.ViewGroup
+import android.view.WindowManager
 import android.view.animation.AccelerateInterpolator
 import android.view.animation.OvershootInterpolator
 import android.widget.Toast
@@ -64,6 +65,7 @@ import dev.bluehouse.bada.protocol.qr.QrTlvMatcher
 import dev.bluehouse.bada.protocol.qr.QrUrl
 import dev.bluehouse.bada.service.receiver.AdvertisedDeviceNames
 import dev.bluehouse.bada.service.receiver.OutboundSessionActiveHolder
+import dev.bluehouse.bada.transfer.KeepScreenOnPreferences
 import dev.bluehouse.bada.ui.BackdropBlurView
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -283,6 +285,7 @@ public class SendActivity : AppCompatActivity() {
     }
 
     override fun onDestroy() {
+        setTransferKeepScreenOn(active = false)
         super.onDestroy()
         // Cancel any pending fade-out for the rejection banner so its
         // Runnable does not fire against a recycled binding.
@@ -755,6 +758,7 @@ public class SendActivity : AppCompatActivity() {
         state: OutboundConnectionState,
         peer: NearbyPeer,
     ) {
+        setTransferKeepScreenOn(active = state is OutboundConnectionState.Sending)
         // Animate any bounds change in the status panel triggered by
         // this state — chiefly the PIN appearing on
         // AwaitingRemoteAcceptance / Sending and disappearing on
@@ -853,6 +857,19 @@ public class SendActivity : AppCompatActivity() {
         }
     }
 
+    private fun setTransferKeepScreenOn(active: Boolean) {
+        val keepScreenOn =
+            active &&
+                KeepScreenOnPreferences
+                    .from(this)
+                    .isKeepScreenOnDuringTransfersEnabled()
+        if (keepScreenOn) {
+            window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        } else {
+            window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
+    }
+
     // -----------------------------------------------------------------
     // Terminal / unsupported / QR
     // -----------------------------------------------------------------
@@ -875,6 +892,7 @@ public class SendActivity : AppCompatActivity() {
         message: String,
         isSuccess: Boolean = false,
     ) {
+        setTransferKeepScreenOn(active = false)
         peerPickerController.stopBleAdvertise()
         beginCardBoundsTransition(BOUNDS_DURATION_MS)
         binding.sendStatusPanel.visibility = View.VISIBLE
@@ -1340,6 +1358,7 @@ public class SendActivity : AppCompatActivity() {
         // flow back through the StateFlow collector and finish the UI.
         val connection = activeConnection
         if (connection != null && binding.sendStatusPanel.isVisible) {
+            setTransferKeepScreenOn(active = false)
             connection.cancel()
             return
         }

--- a/app/src/main/kotlin/dev/bluehouse/bada/transfer/KeepScreenOnPreferences.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/transfer/KeepScreenOnPreferences.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.transfer
+
+import android.content.Context
+import android.content.SharedPreferences
+
+/**
+ * User-facing display preference for long-running transfers.
+ *
+ * Kept as a narrow SharedPreferences wrapper to match the rest of the
+ * Settings tab's lightweight boolean stores.
+ */
+internal class KeepScreenOnPreferences(
+    private val prefs: SharedPreferences,
+) {
+    fun isKeepScreenOnDuringTransfersEnabled(): Boolean = prefs.getBoolean(KEY_KEEP_SCREEN_ON_DURING_TRANSFERS, true)
+
+    fun setKeepScreenOnDuringTransfersEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_KEEP_SCREEN_ON_DURING_TRANSFERS, enabled).apply()
+    }
+
+    internal companion object {
+        private const val PREFS_NAME = "bada.transfer_display"
+        private const val KEY_KEEP_SCREEN_ON_DURING_TRANSFERS = "keep_screen_on_during_transfers"
+
+        fun from(context: Context): KeepScreenOnPreferences =
+            KeepScreenOnPreferences(
+                context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE),
+            )
+    }
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/ui/SettingsFragment.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/ui/SettingsFragment.kt
@@ -26,6 +26,7 @@ import dev.bluehouse.bada.service.downloads.SaveLocationDisplayName
 import dev.bluehouse.bada.service.downloads.SaveLocationPreferences
 import dev.bluehouse.bada.service.receiver.AdvertisedDeviceNames
 import dev.bluehouse.bada.service.receiver.ReceiverForegroundService
+import dev.bluehouse.bada.transfer.KeepScreenOnPreferences
 
 /**
  * Settings tab content for the bottom-navigation shell in
@@ -128,6 +129,13 @@ internal class SettingsFragment : Fragment(R.layout.fragment_settings) {
         bugReportSwitch.setOnCheckedChangeListener { _, checked ->
             bugReportPreferences.setShakeToReportEnabled(checked)
         }
+
+        val keepScreenOnSwitch = view.findViewById<SwitchCompat>(R.id.main_keep_screen_on_switch)
+        val keepScreenOnPreferences = KeepScreenOnPreferences.from(requireContext())
+        keepScreenOnSwitch.isChecked = keepScreenOnPreferences.isKeepScreenOnDuringTransfersEnabled()
+        keepScreenOnSwitch.setOnCheckedChangeListener { _, checked ->
+            keepScreenOnPreferences.setKeepScreenOnDuringTransfersEnabled(checked)
+        }
     }
 
     override fun onStart() {
@@ -142,6 +150,7 @@ internal class SettingsFragment : Fragment(R.layout.fragment_settings) {
         refreshBatteryStatus()
         refreshFullScreenIntentSection()
         refreshBugReportSwitch()
+        refreshKeepScreenOnSwitch()
     }
 
     override fun onResume() {
@@ -174,6 +183,23 @@ internal class SettingsFragment : Fragment(R.layout.fragment_settings) {
         val v = view ?: return
         val switch = v.findViewById<SwitchCompat>(R.id.main_bug_report_switch) ?: return
         val enabled = BugReportPreferences.from(requireContext()).isShakeToReportEnabled()
+        if (switch.isChecked != enabled) {
+            switch.isChecked = enabled
+        }
+    }
+
+    /**
+     * Re-sync the transfer display switch in case another Settings
+     * surface or restored app state mutates the preference while this
+     * fragment is alive.
+     */
+    private fun refreshKeepScreenOnSwitch() {
+        val v = view ?: return
+        val switch = v.findViewById<SwitchCompat>(R.id.main_keep_screen_on_switch) ?: return
+        val enabled =
+            KeepScreenOnPreferences
+                .from(requireContext())
+                .isKeepScreenOnDuringTransfersEnabled()
         if (switch.isChecked != enabled) {
             switch.isChecked = enabled
         }

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -31,7 +31,8 @@
     1. Save-location settings (#42).
     2. Advertised Quick Share name (#141).
     3. Background activity (#47 follow-up).
-    4. Shake-to-report bug toggle (#166).
+    4. Keep screen on during transfers (#219).
+    5. Shake-to-report bug toggle (#166).
 -->
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
@@ -331,7 +332,50 @@
 
         </LinearLayout>
 
-        <!-- ============ Card 4: Shake-to-report bug ============ -->
+        <!-- ============ Card 4: Keep screen on during transfers ============ -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:background="@drawable/settings_card_background"
+            android:orientation="vertical"
+            android:padding="20dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/main_keep_screen_on_title"
+                    android:textAppearance="@style/TextAppearance.AppCompat.Subhead"
+                    android:textColor="?android:attr/textColorPrimary"
+                    android:textStyle="bold" />
+
+                <androidx.appcompat.widget.SwitchCompat
+                    android:id="@+id/main_keep_screen_on_switch"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="12dp" />
+
+            </LinearLayout>
+
+            <TextView
+                android:id="@+id/main_keep_screen_on_subtitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:text="@string/main_keep_screen_on_subtitle"
+                android:textAppearance="@style/TextAppearance.AppCompat.Small"
+                android:textColor="?android:attr/textColorSecondary" />
+
+        </LinearLayout>
+
+        <!-- ============ Card 5: Shake-to-report bug ============ -->
         <!--
           Switch row: title and Switch share a horizontal row so
           the toggle's affordance reads against its label. Subtitle

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -90,6 +90,8 @@
     <!-- Shake-to-report bug toggle. -->
     <string name="main_bug_report_title">振ってバグを報告</string>
     <string name="main_bug_report_subtitle">有効にすると、Bada を開いた状態で端末を振ったときに、最近の診断情報・端末の状態・スクリーンショットを zip にまとめて自分で保存できます。自動的にアップロードされることはありません。</string>
+    <string name="main_keep_screen_on_title">転送中は画面をオンのままにする</string>
+    <string name="main_keep_screen_on_subtitle">ファイルの送受信中に画面が消えないようにして、長い転送の進行状況と安定性を保ちます。</string>
 
     <!-- Save-location settings (#42). -->
     <string name="main_save_location_title">受信ファイルの保存先</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -103,6 +103,8 @@
     <!-- Shake-to-report bug toggle. -->
     <string name="main_bug_report_title">흔들어서 버그 보고</string>
     <string name="main_bug_report_subtitle">활성화 시 Bada가 열려 있을 때 휴대폰을 흔들면 최근 진단 정보, 기기 상태, 스크린샷을 압축 파일로 묶어 직접 저장할 수 있습니다. 자동으로 업로드되지 않습니다.</string>
+    <string name="main_keep_screen_on_title">전송 중 화면 켜두기</string>
+    <string name="main_keep_screen_on_subtitle">파일을 보내거나 받는 동안 화면이 꺼지지 않게 유지해 긴 전송을 계속 확인하고 안정적으로 진행할 수 있게 합니다.</string>
 
     <!-- Save-location settings (#42). -->
     <string name="main_save_location_title">받은 파일 저장 위치</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -53,6 +53,8 @@
     <!-- 摇晃举报 Bug 开关 -->
     <string name="main_bug_report_title">摇晃手机以举报 Bug</string>
     <string name="main_bug_report_subtitle">启用后，在 Bada 打开时摇晃手机，即可将最近的诊断信息、设备状态和截图打包成 zip 文件并自行保存。不会自动上传任何内容。</string>
+    <string name="main_keep_screen_on_title">传输时保持屏幕开启</string>
+    <string name="main_keep_screen_on_subtitle">发送或接收文件时保持屏幕唤醒，便于查看长时间传输并提升连接可靠性。</string>
 
     <!-- 保存位置设置（#42） -->
     <string name="main_save_location_title">接收文件保存位置</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -73,6 +73,8 @@
     <!-- Shake-to-report bug toggle. -->
     <string name="main_bug_report_title">搖動手機回報錯誤</string>
     <string name="main_bug_report_subtitle">啟用後，在 Bada 開啟時搖動手機，即可將近期診斷紀錄、裝置狀態與螢幕截圖打包成 ZIP 檔，自行儲存。不會自動上傳任何內容。</string>
+    <string name="main_keep_screen_on_title">傳輸時保持螢幕開啟</string>
+    <string name="main_keep_screen_on_subtitle">傳送或接收檔案時保持螢幕喚醒，方便查看長時間傳輸並提升連線可靠性。</string>
 
     <!-- Save-location settings (#42). -->
     <string name="main_save_location_title">接收檔案儲存位置</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -123,6 +123,8 @@
     <string name="main_always_visible_caption_off">Active only while a nearby device is scanning over Bluetooth.</string>
     <string name="main_bug_report_title">Shake to report a bug</string>
     <string name="main_bug_report_subtitle">When enabled, shaking the phone while Bada is open offers to package recent diagnostics, device state, and a screenshot into a zip that you save yourself. Nothing is uploaded automatically.</string>
+    <string name="main_keep_screen_on_title">Keep screen on during transfers</string>
+    <string name="main_keep_screen_on_subtitle">Keep the display awake while sending or receiving files so long transfers stay visible and reliable.</string>
 
     <!-- Save location settings (#42). The "current location" line shows
          either the picked folder's display name or "Downloads" as the


### PR DESCRIPTION
## Summary
- Add a persisted Settings toggle for keeping the screen awake during transfers, enabled by default.
- Apply `FLAG_KEEP_SCREEN_ON` while sender and receiver transfer states are active.
- Clear the flag on terminal states, local cancellation, and activity destruction.

## Verification
- `./gradlew staticAnalysis :app:testDebugUnitTest :app:assembleDebug`
- `./gradlew check` currently fails on pre-existing `discovery-android` lint errors in `Discovery.kt` for `java.util.Base64` API 26 usage with minSdk 24.

Closes #219