### PR TITLE
feat: add transfer expert view

### DIFF
--- a/app/src/main/kotlin/dev/bluehouse/bada/consent/ConsentTrampolineActivity.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/consent/ConsentTrampolineActivity.kt
@@ -45,6 +45,8 @@ import dev.bluehouse.bada.protocol.connection.InboundConnection
 import dev.bluehouse.bada.protocol.connection.InboundConnectionState
 import dev.bluehouse.bada.protocol.connection.ReceivedItem
 import dev.bluehouse.bada.protocol.connection.TransferItem
+import dev.bluehouse.bada.protocol.connection.TransferProgress
+import dev.bluehouse.bada.protocol.medium.Medium
 import dev.bluehouse.bada.service.receiver.consent.ConsentBroadcastReceiver
 import dev.bluehouse.bada.service.receiver.consent.ConsentDiagnostic
 import dev.bluehouse.bada.service.receiver.consent.ConsentIntents
@@ -52,8 +54,11 @@ import dev.bluehouse.bada.service.receiver.consent.ConsentModalRegistry
 import dev.bluehouse.bada.service.receiver.consent.ConsentNotificationContent
 import dev.bluehouse.bada.service.receiver.consent.ConsentRegistry
 import dev.bluehouse.bada.transfer.KeepScreenOnPreferences
+import dev.bluehouse.bada.transfer.TransferExpertDetailsFormatter
+import dev.bluehouse.bada.transfer.TransferExpertViewPreferences
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
@@ -525,7 +530,16 @@ class ConsentTrampolineActivity : AppCompatActivity() {
         // Seed the running counter with the announced totals so the
         // user sees "0 B / 100 MB" immediately rather than empty
         // space until the first Receiving event lands.
-        renderProgress(bytesReceived = 0, totalBytes = totalAnnouncedBytes)
+        renderProgress(
+            progress =
+                TransferProgress.of(
+                    bytesTransferred = 0,
+                    totalSize = totalAnnouncedBytes,
+                    bytesPerSecond = 0,
+                ),
+            activeMedium = observedConnection?.activeMedium?.value ?: Medium.WIFI_LAN,
+            wifiFrequencyMhz = observedConnection?.activeWifiFrequencyMhz?.value,
+        )
     }
 
     /**
@@ -539,36 +553,51 @@ class ConsentTrampolineActivity : AppCompatActivity() {
         stateJob?.cancel()
         stateJob =
             lifecycleScope.launch {
-                connection.state.collect { state ->
-                    when (state) {
-                        is InboundConnectionState.Receiving -> {
-                            setTransferKeepScreenOn(active = true)
-                            renderProgress(
-                                bytesReceived = state.progress.bytesTransferred,
-                                totalBytes = state.progress.totalSize,
-                            )
+                connection.state
+                    .combine(connection.activeMedium) { state, medium -> state to medium }
+                    .combine(connection.activeWifiFrequencyMhz) { (state, medium), frequencyMhz ->
+                        ReceiveRenderSnapshot(
+                            state = state,
+                            activeMedium = medium,
+                            wifiFrequencyMhz = frequencyMhz,
+                        )
+                    }.collect { snapshot ->
+                        when (val state = snapshot.state) {
+                            is InboundConnectionState.Receiving -> {
+                                setTransferKeepScreenOn(active = true)
+                                renderProgress(
+                                    progress = state.progress,
+                                    activeMedium = snapshot.activeMedium,
+                                    wifiFrequencyMhz = snapshot.wifiFrequencyMhz,
+                                )
+                            }
+                            is InboundConnectionState.Completed -> {
+                                setTransferKeepScreenOn(active = false)
+                                showCompletedPanel(state.items)
+                            }
+                            is InboundConnectionState.Cancelled -> {
+                                setTransferKeepScreenOn(active = false)
+                                showFailedPanel(getString(R.string.consent_state_cancelled), reason = null)
+                            }
+                            is InboundConnectionState.Failed -> {
+                                setTransferKeepScreenOn(active = false)
+                                showFailedPanel(getString(R.string.consent_state_failed), reason = state.reason)
+                            }
+                            is InboundConnectionState.Rejected -> {
+                                setTransferKeepScreenOn(active = false)
+                                showFailedPanel(getString(R.string.consent_state_failed), reason = null)
+                            }
+                            else -> Unit
                         }
-                        is InboundConnectionState.Completed -> {
-                            setTransferKeepScreenOn(active = false)
-                            showCompletedPanel(state.items)
-                        }
-                        is InboundConnectionState.Cancelled -> {
-                            setTransferKeepScreenOn(active = false)
-                            showFailedPanel(getString(R.string.consent_state_cancelled), reason = null)
-                        }
-                        is InboundConnectionState.Failed -> {
-                            setTransferKeepScreenOn(active = false)
-                            showFailedPanel(getString(R.string.consent_state_failed), reason = state.reason)
-                        }
-                        is InboundConnectionState.Rejected -> {
-                            setTransferKeepScreenOn(active = false)
-                            showFailedPanel(getString(R.string.consent_state_failed), reason = null)
-                        }
-                        else -> Unit
                     }
-                }
             }
     }
+
+    private data class ReceiveRenderSnapshot(
+        val state: InboundConnectionState,
+        val activeMedium: Medium,
+        val wifiFrequencyMhz: Int?,
+    )
 
     private fun setTransferKeepScreenOn(active: Boolean) {
         val keepScreenOn =
@@ -584,21 +613,21 @@ class ConsentTrampolineActivity : AppCompatActivity() {
     }
 
     private fun renderProgress(
-        bytesReceived: Long,
-        totalBytes: Long,
+        progress: TransferProgress,
+        activeMedium: Medium,
+        wifiFrequencyMhz: Int?,
     ) {
         val progressBar = findViewById<CircularProgressIndicator>(R.id.consent_receiving_progress) ?: return
         val percentText = findViewById<TextView>(R.id.consent_receiving_progress_pct)
         val pct =
-            if (totalBytes > 0) {
-                ((bytesReceived.toDouble() / totalBytes.toDouble()) * PERCENT_SCALE).toInt().coerceIn(
-                    0,
-                    PERCENT_SCALE,
-                )
+            if (progress.totalSize > 0) {
+                ((progress.bytesTransferred.toDouble() / progress.totalSize.toDouble()) * PERCENT_SCALE)
+                    .toInt()
+                    .coerceIn(0, PERCENT_SCALE)
             } else {
                 0
             }
-        if (totalBytes > 0) {
+        if (progress.totalSize > 0) {
             // Once we know the total, switch from the spinning
             // indeterminate state to a deterministic ratio so the user
             // can see the bar fill up frame by frame.
@@ -609,9 +638,30 @@ class ConsentTrampolineActivity : AppCompatActivity() {
         findViewById<TextView>(R.id.consent_receiving_progress_text)?.text =
             getString(
                 R.string.consent_state_progress,
-                Formatter.formatShortFileSize(this, bytesReceived),
-                Formatter.formatShortFileSize(this, totalBytes),
+                Formatter.formatShortFileSize(this, progress.bytesTransferred),
+                Formatter.formatShortFileSize(this, progress.totalSize),
             )
+        renderExpertDetails(progress, activeMedium, wifiFrequencyMhz)
+    }
+
+    private fun renderExpertDetails(
+        progress: TransferProgress,
+        activeMedium: Medium,
+        wifiFrequencyMhz: Int?,
+    ) {
+        val details = findViewById<TextView>(R.id.consent_expert_details) ?: return
+        if (!TransferExpertViewPreferences.from(this).isExpertViewEnabled()) {
+            details.visibility = View.GONE
+            return
+        }
+        details.text =
+            TransferExpertDetailsFormatter.format(
+                context = this,
+                progress = progress,
+                activeMedium = activeMedium,
+                wifiFrequencyMhz = wifiFrequencyMhz,
+            )
+        details.visibility = View.VISIBLE
     }
 
     /**
@@ -637,6 +687,7 @@ class ConsentTrampolineActivity : AppCompatActivity() {
      * behavior for that path.
      */
     private fun showCompletedPanel(items: List<ReceivedItem>) {
+        findViewById<TextView>(R.id.consent_expert_details)?.visibility = View.GONE
         val fileItems = items.filterIsInstance<ReceivedItem.File>()
         val targetNames = fileItems.map { it.header.fileName }.toSet()
         lifecycleScope.launch {
@@ -918,6 +969,7 @@ class ConsentTrampolineActivity : AppCompatActivity() {
         reason: String?,
     ) {
         beginPanelTransition()
+        findViewById<TextView>(R.id.consent_expert_details)?.visibility = View.GONE
         findViewById<View>(R.id.consent_receiving_panel).visibility = View.GONE
         findViewById<View>(R.id.consent_completed_panel).visibility = View.GONE
         findViewById<View>(R.id.consent_failed_panel).visibility = View.VISIBLE

--- a/app/src/main/kotlin/dev/bluehouse/bada/send/SendActivity.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/send/SendActivity.kt
@@ -55,8 +55,10 @@ import dev.bluehouse.bada.protocol.connection.FileSource
 import dev.bluehouse.bada.protocol.connection.OutboundConnection
 import dev.bluehouse.bada.protocol.connection.OutboundConnectionState
 import dev.bluehouse.bada.protocol.connection.OutboundResult
+import dev.bluehouse.bada.protocol.connection.TransferProgress
 import dev.bluehouse.bada.protocol.endpoint.DeviceType
 import dev.bluehouse.bada.protocol.endpoint.EndpointInfo
+import dev.bluehouse.bada.protocol.medium.Medium
 import dev.bluehouse.bada.protocol.qr.DerivedQrKeys
 import dev.bluehouse.bada.protocol.qr.GeneratedQrKeyData
 import dev.bluehouse.bada.protocol.qr.QrKeyData
@@ -66,9 +68,12 @@ import dev.bluehouse.bada.protocol.qr.QrUrl
 import dev.bluehouse.bada.service.receiver.AdvertisedDeviceNames
 import dev.bluehouse.bada.service.receiver.OutboundSessionActiveHolder
 import dev.bluehouse.bada.transfer.KeepScreenOnPreferences
+import dev.bluehouse.bada.transfer.TransferExpertDetailsFormatter
+import dev.bluehouse.bada.transfer.TransferExpertViewPreferences
 import dev.bluehouse.bada.ui.BackdropBlurView
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.security.PrivateKey
@@ -728,9 +733,22 @@ public class SendActivity : AppCompatActivity() {
                 activeConnection = connection
                 val collector =
                     lifecycleScope.launch {
-                        connection.state.collect { state ->
-                            renderConnectionState(state, peer)
-                        }
+                        connection.state
+                            .combine(connection.activeMedium) { state, medium -> state to medium }
+                            .combine(connection.activeWifiFrequencyMhz) { (state, medium), frequencyMhz ->
+                                SendRenderSnapshot(
+                                    state = state,
+                                    activeMedium = medium,
+                                    wifiFrequencyMhz = frequencyMhz,
+                                )
+                            }.collect { snapshot ->
+                                renderConnectionState(
+                                    state = snapshot.state,
+                                    peer = peer,
+                                    activeMedium = snapshot.activeMedium,
+                                    wifiFrequencyMhz = snapshot.wifiFrequencyMhz,
+                                )
+                            }
                     }
                 try {
                     connection.run(files)
@@ -754,11 +772,22 @@ public class SendActivity : AppCompatActivity() {
         ) : PreparedConnection
     }
 
+    private data class SendRenderSnapshot(
+        val state: OutboundConnectionState,
+        val activeMedium: Medium,
+        val wifiFrequencyMhz: Int?,
+    )
+
     private fun renderConnectionState(
         state: OutboundConnectionState,
         peer: NearbyPeer,
+        activeMedium: Medium,
+        wifiFrequencyMhz: Int?,
     ) {
         setTransferKeepScreenOn(active = state is OutboundConnectionState.Sending)
+        if (state !is OutboundConnectionState.Sending) {
+            binding.sendExpertDetails?.visibility = View.GONE
+        }
         // Animate any bounds change in the status panel triggered by
         // this state — chiefly the PIN appearing on
         // AwaitingRemoteAcceptance / Sending and disappearing on
@@ -809,7 +838,8 @@ public class SendActivity : AppCompatActivity() {
                 // just phase + target + circle.
                 binding.sendPin.visibility = View.GONE
                 binding.sendStatusMessage.visibility = View.GONE
-                renderCircularProgress(state.progress.bytesTransferred, state.progress.totalSize)
+                renderCircularProgress(state.progress)
+                renderExpertDetails(state.progress, activeMedium, wifiFrequencyMhz)
             }
             OutboundConnectionState.Completed ->
                 renderTerminal(
@@ -896,6 +926,7 @@ public class SendActivity : AppCompatActivity() {
         peerPickerController.stopBleAdvertise()
         beginCardBoundsTransition(BOUNDS_DURATION_MS)
         binding.sendStatusPanel.visibility = View.VISIBLE
+        binding.sendExpertDetails?.visibility = View.GONE
         binding.sendStatusPhase.text = phaseText
         binding.sendDoneButton.visibility = View.VISIBLE
         binding.sendCancelButton.visibility = View.GONE
@@ -964,6 +995,7 @@ public class SendActivity : AppCompatActivity() {
         binding.sendStatusPanel.visibility = View.GONE
         binding.sendPin.visibility = View.GONE
         binding.sendStatusCircleWrapper.visibility = View.GONE
+        binding.sendExpertDetails?.visibility = View.GONE
         binding.sendPinStateBackground.visibility = View.GONE
         binding.sendTerminalPreviewCard.visibility = View.GONE
         binding.sendCardBlur.visibility = View.GONE
@@ -1091,17 +1123,13 @@ public class SendActivity : AppCompatActivity() {
      * `setProgressCompat` is also the API that handles the indeterminate
      * → determinate transition cleanly.
      */
-    private fun renderCircularProgress(
-        bytesTransferred: Long,
-        totalSize: Long,
-    ) {
+    private fun renderCircularProgress(progress: TransferProgress) {
         binding.sendStatusCircleWrapper.visibility = View.VISIBLE
         val pct =
-            if (totalSize > 0L) {
-                ((bytesTransferred.toDouble() / totalSize.toDouble()) * PERCENT_SCALE).toInt().coerceIn(
-                    0,
-                    PERCENT_SCALE,
-                )
+            if (progress.totalSize > 0L) {
+                ((progress.bytesTransferred.toDouble() / progress.totalSize.toDouble()) * PERCENT_SCALE)
+                    .toInt()
+                    .coerceIn(0, PERCENT_SCALE)
             } else {
                 0
             }
@@ -1110,6 +1138,26 @@ public class SendActivity : AppCompatActivity() {
         }
         binding.sendStatusCircle.setProgressCompat(pct, true)
         binding.sendStatusCirclePct.text = getString(R.string.transfer_progress_percent, pct)
+    }
+
+    private fun renderExpertDetails(
+        progress: TransferProgress,
+        activeMedium: Medium,
+        wifiFrequencyMhz: Int?,
+    ) {
+        if (!TransferExpertViewPreferences.from(this).isExpertViewEnabled()) {
+            binding.sendExpertDetails?.visibility = View.GONE
+            return
+        }
+        val expertDetails = binding.sendExpertDetails ?: return
+        expertDetails.text =
+            TransferExpertDetailsFormatter.format(
+                context = this,
+                progress = progress,
+                activeMedium = activeMedium,
+                wifiFrequencyMhz = wifiFrequencyMhz,
+            )
+        expertDetails.visibility = View.VISIBLE
     }
 
     /**

--- a/app/src/main/kotlin/dev/bluehouse/bada/transfer/TransferExpertDetailsFormatter.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/transfer/TransferExpertDetailsFormatter.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.transfer
+
+import android.content.Context
+import android.text.format.Formatter
+import dev.bluehouse.bada.R
+import dev.bluehouse.bada.protocol.connection.TransferProgress
+import dev.bluehouse.bada.protocol.medium.Medium
+
+internal object TransferExpertDetailsFormatter {
+    fun format(
+        context: Context,
+        progress: TransferProgress,
+        activeMedium: Medium,
+        wifiFrequencyMhz: Int?,
+    ): String {
+        val speed =
+            if (progress.bytesPerSecond > 0L) {
+                context.getString(
+                    R.string.transfer_expert_speed_value,
+                    Formatter.formatShortFileSize(context, progress.bytesPerSecond),
+                )
+            } else {
+                context.getString(R.string.transfer_expert_calculating)
+            }
+        val eta =
+            progress.etaSeconds?.let { formatDuration(context, it) }
+                ?: context.getString(R.string.transfer_expert_calculating)
+        val rows =
+            mutableListOf(
+                context.getString(R.string.transfer_expert_speed, speed),
+                context.getString(R.string.transfer_expert_eta, eta),
+                context.getString(R.string.transfer_expert_medium, activeMedium.label(context)),
+            )
+        if (activeMedium == Medium.WIFI_DIRECT) {
+            rows +=
+                context.getString(
+                    R.string.transfer_expert_wifi_band,
+                    wifiBandLabel(context, wifiFrequencyMhz),
+                )
+        }
+        return rows.joinToString(separator = "\n")
+    }
+
+    @Suppress("MagicNumber")
+    private fun wifiBandLabel(
+        context: Context,
+        frequencyMhz: Int?,
+    ): String =
+        when (frequencyMhz) {
+            null -> context.getString(R.string.transfer_expert_unknown)
+            in 2_400..2_500 -> context.getString(R.string.transfer_expert_wifi_band_24)
+            in 4_900..5_900 -> context.getString(R.string.transfer_expert_wifi_band_5)
+            else -> context.getString(R.string.transfer_expert_unknown)
+        }
+
+    @Suppress("MagicNumber")
+    private fun formatDuration(
+        context: Context,
+        etaSeconds: Long,
+    ): String =
+        when {
+            etaSeconds < 1L -> context.getString(R.string.send_status_duration_few_seconds)
+            etaSeconds <= SECONDS_THRESHOLD ->
+                context.getString(R.string.send_status_duration_seconds, etaSeconds)
+            etaSeconds < HOUR_IN_SECONDS -> {
+                val minutes = (etaSeconds + 30L) / 60L
+                context.getString(R.string.send_status_duration_about_minutes, minutes)
+            }
+            else -> {
+                val hours = (etaSeconds + 1800L) / HOUR_IN_SECONDS
+                context.getString(R.string.send_status_duration_about_hours, hours)
+            }
+        }
+
+    private fun Medium.label(context: Context): String =
+        when (this) {
+            Medium.BLUETOOTH -> context.getString(R.string.transfer_expert_medium_bluetooth)
+            Medium.WIFI_HOTSPOT -> context.getString(R.string.transfer_expert_medium_wifi_hotspot)
+            Medium.BLE -> context.getString(R.string.transfer_expert_medium_ble)
+            Medium.WIFI_LAN -> context.getString(R.string.transfer_expert_medium_wifi_lan)
+            Medium.WIFI_AWARE -> context.getString(R.string.transfer_expert_medium_wifi_aware)
+            Medium.WIFI_DIRECT -> context.getString(R.string.transfer_expert_medium_wifi_direct)
+            Medium.WEB_RTC -> context.getString(R.string.transfer_expert_medium_web_rtc)
+            Medium.BLE_L2CAP -> context.getString(R.string.transfer_expert_medium_ble_l2cap)
+        }
+
+    private const val SECONDS_THRESHOLD: Long = 90L
+    private const val HOUR_IN_SECONDS: Long = 3_600L
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/transfer/TransferExpertViewPreferences.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/transfer/TransferExpertViewPreferences.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.transfer
+
+import android.content.Context
+import android.content.SharedPreferences
+
+/**
+ * Settings-tab toggle for the optional transfer diagnostics row.
+ */
+internal class TransferExpertViewPreferences(
+    private val prefs: SharedPreferences,
+) {
+    fun isExpertViewEnabled(): Boolean = prefs.getBoolean(KEY_EXPERT_VIEW_ENABLED, false)
+
+    fun setExpertViewEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_EXPERT_VIEW_ENABLED, enabled).apply()
+    }
+
+    internal companion object {
+        private const val PREFS_NAME = "bada.transfer_expert_view"
+        private const val KEY_EXPERT_VIEW_ENABLED = "transfer_expert_view_enabled"
+
+        fun from(context: Context): TransferExpertViewPreferences =
+            TransferExpertViewPreferences(
+                context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE),
+            )
+    }
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/ui/SettingsFragment.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/ui/SettingsFragment.kt
@@ -27,6 +27,7 @@ import dev.bluehouse.bada.service.downloads.SaveLocationPreferences
 import dev.bluehouse.bada.service.receiver.AdvertisedDeviceNames
 import dev.bluehouse.bada.service.receiver.ReceiverForegroundService
 import dev.bluehouse.bada.transfer.KeepScreenOnPreferences
+import dev.bluehouse.bada.transfer.TransferExpertViewPreferences
 
 /**
  * Settings tab content for the bottom-navigation shell in
@@ -136,6 +137,13 @@ internal class SettingsFragment : Fragment(R.layout.fragment_settings) {
         keepScreenOnSwitch.setOnCheckedChangeListener { _, checked ->
             keepScreenOnPreferences.setKeepScreenOnDuringTransfersEnabled(checked)
         }
+
+        val expertViewSwitch = view.findViewById<SwitchCompat>(R.id.main_transfer_expert_switch)
+        val expertViewPreferences = TransferExpertViewPreferences.from(requireContext())
+        expertViewSwitch.isChecked = expertViewPreferences.isExpertViewEnabled()
+        expertViewSwitch.setOnCheckedChangeListener { _, checked ->
+            expertViewPreferences.setExpertViewEnabled(checked)
+        }
     }
 
     override fun onStart() {
@@ -150,7 +158,7 @@ internal class SettingsFragment : Fragment(R.layout.fragment_settings) {
         refreshBatteryStatus()
         refreshFullScreenIntentSection()
         refreshBugReportSwitch()
-        refreshKeepScreenOnSwitch()
+        refreshTransferSwitches()
     }
 
     override fun onResume() {
@@ -189,19 +197,27 @@ internal class SettingsFragment : Fragment(R.layout.fragment_settings) {
     }
 
     /**
-     * Re-sync the transfer display switch in case another Settings
-     * surface or restored app state mutates the preference while this
+     * Re-sync transfer display switches in case another Settings
+     * surface or restored app state mutates preferences while this
      * fragment is alive.
      */
-    private fun refreshKeepScreenOnSwitch() {
+    private fun refreshTransferSwitches() {
         val v = view ?: return
-        val switch = v.findViewById<SwitchCompat>(R.id.main_keep_screen_on_switch) ?: return
-        val enabled =
-            KeepScreenOnPreferences
-                .from(requireContext())
-                .isKeepScreenOnDuringTransfersEnabled()
-        if (switch.isChecked != enabled) {
-            switch.isChecked = enabled
+        v
+            .findViewById<SwitchCompat>(R.id.main_keep_screen_on_switch)
+            ?.refreshChecked(
+                KeepScreenOnPreferences
+                    .from(requireContext())
+                    .isKeepScreenOnDuringTransfersEnabled(),
+            )
+        v
+            .findViewById<SwitchCompat>(R.id.main_transfer_expert_switch)
+            ?.refreshChecked(TransferExpertViewPreferences.from(requireContext()).isExpertViewEnabled())
+    }
+
+    private fun SwitchCompat.refreshChecked(enabled: Boolean) {
+        if (isChecked != enabled) {
+            isChecked = enabled
         }
     }
 

--- a/app/src/main/res/layout/activity_consent_trampoline.xml
+++ b/app/src/main/res/layout/activity_consent_trampoline.xml
@@ -256,6 +256,19 @@
                 android:textAppearance="@style/TextAppearance.AppCompat.Body1"
                 tools:text="12 MB / 100 MB" />
 
+            <TextView
+                android:id="@+id/consent_expert_details"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:gravity="center"
+                android:lineSpacingExtra="2dp"
+                android:textAlignment="center"
+                android:textAppearance="@style/TextAppearance.AppCompat.Caption"
+                android:textColor="?android:attr/textColorSecondary"
+                android:visibility="gone"
+                tools:text="Speed: 12.4 MB/s&#10;ETA: 30 seconds&#10;Medium: Wi-Fi LAN" />
+
         </LinearLayout>
 
         <!-- Completed state. -->

--- a/app/src/main/res/layout/activity_send.xml
+++ b/app/src/main/res/layout/activity_send.xml
@@ -493,6 +493,19 @@
 
                             </FrameLayout>
 
+                            <TextView
+                                android:id="@+id/send_expert_details"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:layout_marginTop="12dp"
+                                android:gravity="center"
+                                android:lineSpacingExtra="2dp"
+                                android:textAlignment="center"
+                                android:textAppearance="@style/TextAppearance.AppCompat.Caption"
+                                android:textColor="?android:attr/textColorSecondary"
+                                android:visibility="gone"
+                                tools:text="Speed: 12.4 MB/s&#10;ETA: 30 seconds&#10;Medium: Wi-Fi LAN" />
+
                             <!--
                               Square preview of the sent image (success
                               terminal only). Wrapped in a polaroid-style

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -32,7 +32,8 @@
     2. Advertised Quick Share name (#141).
     3. Background activity (#47 follow-up).
     4. Keep screen on during transfers (#219).
-    5. Shake-to-report bug toggle (#166).
+    5. Expert transfer details (#220).
+    6. Shake-to-report bug toggle (#166).
 -->
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
@@ -375,7 +376,50 @@
 
         </LinearLayout>
 
-        <!-- ============ Card 5: Shake-to-report bug ============ -->
+        <!-- ============ Card 5: Expert transfer details ============ -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:background="@drawable/settings_card_background"
+            android:orientation="vertical"
+            android:padding="20dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/main_transfer_expert_title"
+                    android:textAppearance="@style/TextAppearance.AppCompat.Subhead"
+                    android:textColor="?android:attr/textColorPrimary"
+                    android:textStyle="bold" />
+
+                <androidx.appcompat.widget.SwitchCompat
+                    android:id="@+id/main_transfer_expert_switch"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="12dp" />
+
+            </LinearLayout>
+
+            <TextView
+                android:id="@+id/main_transfer_expert_subtitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:text="@string/main_transfer_expert_subtitle"
+                android:textAppearance="@style/TextAppearance.AppCompat.Small"
+                android:textColor="?android:attr/textColorSecondary" />
+
+        </LinearLayout>
+
+        <!-- ============ Card 6: Shake-to-report bug ============ -->
         <!--
           Switch row: title and Switch share a horizontal row so
           the toggle's affordance reads against its label. Subtitle

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -92,6 +92,26 @@
     <string name="main_bug_report_subtitle">有効にすると、Bada を開いた状態で端末を振ったときに、最近の診断情報・端末の状態・スクリーンショットを zip にまとめて自分で保存できます。自動的にアップロードされることはありません。</string>
     <string name="main_keep_screen_on_title">転送中は画面をオンのままにする</string>
     <string name="main_keep_screen_on_subtitle">ファイルの送受信中に画面が消えないようにして、長い転送の進行状況と安定性を保ちます。</string>
+    <string name="main_transfer_expert_title">転送の詳細情報</string>
+    <string name="main_transfer_expert_subtitle">転送画面に現在の速度、残り時間、使用中の転送方式、Wi-Fi Direct の帯域を表示します。</string>
+
+    <string name="transfer_expert_speed">速度: %1$s</string>
+    <string name="transfer_expert_speed_value">%1$s/秒</string>
+    <string name="transfer_expert_eta">残り時間: %1$s</string>
+    <string name="transfer_expert_medium">転送方式: %1$s</string>
+    <string name="transfer_expert_wifi_band">Wi-Fi 帯域: %1$s</string>
+    <string name="transfer_expert_calculating">計算中…</string>
+    <string name="transfer_expert_unknown">不明</string>
+    <string name="transfer_expert_wifi_band_24">2.4 GHz</string>
+    <string name="transfer_expert_wifi_band_5">5 GHz</string>
+    <string name="transfer_expert_medium_bluetooth">Bluetooth</string>
+    <string name="transfer_expert_medium_wifi_hotspot">Wi-Fi ホットスポット</string>
+    <string name="transfer_expert_medium_ble">Bluetooth LE</string>
+    <string name="transfer_expert_medium_wifi_lan">Wi-Fi LAN</string>
+    <string name="transfer_expert_medium_wifi_aware">Wi-Fi Aware</string>
+    <string name="transfer_expert_medium_wifi_direct">Wi-Fi Direct</string>
+    <string name="transfer_expert_medium_web_rtc">WebRTC</string>
+    <string name="transfer_expert_medium_ble_l2cap">Bluetooth LE L2CAP</string>
 
     <!-- Save-location settings (#42). -->
     <string name="main_save_location_title">受信ファイルの保存先</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -105,6 +105,26 @@
     <string name="main_bug_report_subtitle">활성화 시 Bada가 열려 있을 때 휴대폰을 흔들면 최근 진단 정보, 기기 상태, 스크린샷을 압축 파일로 묶어 직접 저장할 수 있습니다. 자동으로 업로드되지 않습니다.</string>
     <string name="main_keep_screen_on_title">전송 중 화면 켜두기</string>
     <string name="main_keep_screen_on_subtitle">파일을 보내거나 받는 동안 화면이 꺼지지 않게 유지해 긴 전송을 계속 확인하고 안정적으로 진행할 수 있게 합니다.</string>
+    <string name="main_transfer_expert_title">전송 상세 정보</string>
+    <string name="main_transfer_expert_subtitle">전송 화면에 실시간 속도, 남은 시간, 사용 중인 전송 방식, Wi-Fi Direct 대역을 표시합니다.</string>
+
+    <string name="transfer_expert_speed">속도: %1$s</string>
+    <string name="transfer_expert_speed_value">%1$s/초</string>
+    <string name="transfer_expert_eta">남은 시간: %1$s</string>
+    <string name="transfer_expert_medium">전송 방식: %1$s</string>
+    <string name="transfer_expert_wifi_band">Wi-Fi 대역: %1$s</string>
+    <string name="transfer_expert_calculating">계산 중…</string>
+    <string name="transfer_expert_unknown">알 수 없음</string>
+    <string name="transfer_expert_wifi_band_24">2.4 GHz</string>
+    <string name="transfer_expert_wifi_band_5">5 GHz</string>
+    <string name="transfer_expert_medium_bluetooth">Bluetooth</string>
+    <string name="transfer_expert_medium_wifi_hotspot">Wi-Fi 핫스팟</string>
+    <string name="transfer_expert_medium_ble">Bluetooth LE</string>
+    <string name="transfer_expert_medium_wifi_lan">Wi-Fi LAN</string>
+    <string name="transfer_expert_medium_wifi_aware">Wi-Fi Aware</string>
+    <string name="transfer_expert_medium_wifi_direct">Wi-Fi Direct</string>
+    <string name="transfer_expert_medium_web_rtc">WebRTC</string>
+    <string name="transfer_expert_medium_ble_l2cap">Bluetooth LE L2CAP</string>
 
     <!-- Save-location settings (#42). -->
     <string name="main_save_location_title">받은 파일 저장 위치</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -55,6 +55,26 @@
     <string name="main_bug_report_subtitle">启用后，在 Bada 打开时摇晃手机，即可将最近的诊断信息、设备状态和截图打包成 zip 文件并自行保存。不会自动上传任何内容。</string>
     <string name="main_keep_screen_on_title">传输时保持屏幕开启</string>
     <string name="main_keep_screen_on_subtitle">发送或接收文件时保持屏幕唤醒，便于查看长时间传输并提升连接可靠性。</string>
+    <string name="main_transfer_expert_title">传输详细信息</string>
+    <string name="main_transfer_expert_subtitle">在传输页面显示实时速度、预计剩余时间、当前传输方式和 Wi-Fi Direct 频段。</string>
+
+    <string name="transfer_expert_speed">速度：%1$s</string>
+    <string name="transfer_expert_speed_value">%1$s/秒</string>
+    <string name="transfer_expert_eta">剩余时间：%1$s</string>
+    <string name="transfer_expert_medium">传输方式：%1$s</string>
+    <string name="transfer_expert_wifi_band">Wi-Fi 频段：%1$s</string>
+    <string name="transfer_expert_calculating">计算中…</string>
+    <string name="transfer_expert_unknown">未知</string>
+    <string name="transfer_expert_wifi_band_24">2.4 GHz</string>
+    <string name="transfer_expert_wifi_band_5">5 GHz</string>
+    <string name="transfer_expert_medium_bluetooth">Bluetooth</string>
+    <string name="transfer_expert_medium_wifi_hotspot">Wi-Fi 热点</string>
+    <string name="transfer_expert_medium_ble">Bluetooth LE</string>
+    <string name="transfer_expert_medium_wifi_lan">Wi-Fi LAN</string>
+    <string name="transfer_expert_medium_wifi_aware">Wi-Fi Aware</string>
+    <string name="transfer_expert_medium_wifi_direct">Wi-Fi Direct</string>
+    <string name="transfer_expert_medium_web_rtc">WebRTC</string>
+    <string name="transfer_expert_medium_ble_l2cap">Bluetooth LE L2CAP</string>
 
     <!-- 保存位置设置（#42） -->
     <string name="main_save_location_title">接收文件保存位置</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -75,6 +75,26 @@
     <string name="main_bug_report_subtitle">啟用後，在 Bada 開啟時搖動手機，即可將近期診斷紀錄、裝置狀態與螢幕截圖打包成 ZIP 檔，自行儲存。不會自動上傳任何內容。</string>
     <string name="main_keep_screen_on_title">傳輸時保持螢幕開啟</string>
     <string name="main_keep_screen_on_subtitle">傳送或接收檔案時保持螢幕喚醒，方便查看長時間傳輸並提升連線可靠性。</string>
+    <string name="main_transfer_expert_title">傳輸詳細資訊</string>
+    <string name="main_transfer_expert_subtitle">在傳輸畫面顯示即時速度、預估剩餘時間、目前傳輸方式與 Wi-Fi Direct 頻段。</string>
+
+    <string name="transfer_expert_speed">速度：%1$s</string>
+    <string name="transfer_expert_speed_value">%1$s/秒</string>
+    <string name="transfer_expert_eta">剩餘時間：%1$s</string>
+    <string name="transfer_expert_medium">傳輸方式：%1$s</string>
+    <string name="transfer_expert_wifi_band">Wi-Fi 頻段：%1$s</string>
+    <string name="transfer_expert_calculating">計算中…</string>
+    <string name="transfer_expert_unknown">未知</string>
+    <string name="transfer_expert_wifi_band_24">2.4 GHz</string>
+    <string name="transfer_expert_wifi_band_5">5 GHz</string>
+    <string name="transfer_expert_medium_bluetooth">Bluetooth</string>
+    <string name="transfer_expert_medium_wifi_hotspot">Wi-Fi 熱點</string>
+    <string name="transfer_expert_medium_ble">Bluetooth LE</string>
+    <string name="transfer_expert_medium_wifi_lan">Wi-Fi LAN</string>
+    <string name="transfer_expert_medium_wifi_aware">Wi-Fi Aware</string>
+    <string name="transfer_expert_medium_wifi_direct">Wi-Fi Direct</string>
+    <string name="transfer_expert_medium_web_rtc">WebRTC</string>
+    <string name="transfer_expert_medium_ble_l2cap">Bluetooth LE L2CAP</string>
 
     <!-- Save-location settings (#42). -->
     <string name="main_save_location_title">接收檔案儲存位置</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -125,6 +125,26 @@
     <string name="main_bug_report_subtitle">When enabled, shaking the phone while Bada is open offers to package recent diagnostics, device state, and a screenshot into a zip that you save yourself. Nothing is uploaded automatically.</string>
     <string name="main_keep_screen_on_title">Keep screen on during transfers</string>
     <string name="main_keep_screen_on_subtitle">Keep the display awake while sending or receiving files so long transfers stay visible and reliable.</string>
+    <string name="main_transfer_expert_title">Expert transfer details</string>
+    <string name="main_transfer_expert_subtitle">Show live speed, ETA, active medium, and Wi-Fi Direct band on transfer screens.</string>
+
+    <string name="transfer_expert_speed">Speed: %1$s</string>
+    <string name="transfer_expert_speed_value">%1$s/s</string>
+    <string name="transfer_expert_eta">ETA: %1$s</string>
+    <string name="transfer_expert_medium">Medium: %1$s</string>
+    <string name="transfer_expert_wifi_band">Wi-Fi band: %1$s</string>
+    <string name="transfer_expert_calculating">calculating…</string>
+    <string name="transfer_expert_unknown">unknown</string>
+    <string name="transfer_expert_wifi_band_24">2.4 GHz</string>
+    <string name="transfer_expert_wifi_band_5">5 GHz</string>
+    <string name="transfer_expert_medium_bluetooth">Bluetooth</string>
+    <string name="transfer_expert_medium_wifi_hotspot">Wi-Fi hotspot</string>
+    <string name="transfer_expert_medium_ble">Bluetooth LE</string>
+    <string name="transfer_expert_medium_wifi_lan">Wi-Fi LAN</string>
+    <string name="transfer_expert_medium_wifi_aware">Wi-Fi Aware</string>
+    <string name="transfer_expert_medium_wifi_direct">Wi-Fi Direct</string>
+    <string name="transfer_expert_medium_web_rtc">WebRTC</string>
+    <string name="transfer_expert_medium_ble_l2cap">Bluetooth LE L2CAP</string>
 
     <!-- Save location settings (#42). The "current location" line shows
          either the picked folder's display name or "Downloads" as the

--- a/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/BandwidthUpgradeOrchestrator.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/BandwidthUpgradeOrchestrator.kt
@@ -131,7 +131,12 @@ internal object BandwidthUpgradeOrchestrator {
             )
         closePriorChannelAfterUpgrade(oldChannel, consumedPeerSafe, logger)
         logger("medium-upgrade: server completed ${credentials.medium}")
-        return ActiveTransportChannel(newChannel, credentials.medium, bufferedFrames)
+        return ActiveTransportChannel(
+            channel = newChannel,
+            medium = credentials.medium,
+            bufferedFrames = bufferedFrames,
+            wifiFrequencyMhz = credentials.wifiDirectFrequencyMhzOrNull(),
+        )
     }
 
     @Suppress("ReturnCount")
@@ -220,7 +225,12 @@ internal object BandwidthUpgradeOrchestrator {
             applicationFrames = bufferedFrames,
         )
         logger("medium-upgrade: client completed ${credentials.medium}")
-        return ActiveTransportChannel(newChannel, credentials.medium, bufferedFrames)
+        return ActiveTransportChannel(
+            channel = newChannel,
+            medium = credentials.medium,
+            bufferedFrames = bufferedFrames,
+            wifiFrequencyMhz = credentials.wifiDirectFrequencyMhzOrNull(),
+        )
     }
 
     private suspend fun exchangeClientPriorChannelClose(
@@ -639,6 +649,7 @@ internal data class ActiveTransportChannel(
     val channel: SecureChannel,
     val medium: Medium,
     val bufferedFrames: List<OfflineFrame> = emptyList(),
+    val wifiFrequencyMhz: Int? = null,
 )
 
 internal sealed interface UpgradeOfferProbe {

--- a/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/InboundConnection.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/InboundConnection.kt
@@ -144,6 +144,9 @@ public class InboundConnection(
     private val mutableActiveMedium: MutableStateFlow<Medium> =
         MutableStateFlow(transport.medium)
 
+    private val mutableActiveWifiFrequencyMhz: MutableStateFlow<Int?> =
+        MutableStateFlow(null)
+
     /**
      * Observable lifecycle state.
      *
@@ -162,6 +165,13 @@ public class InboundConnection(
      * different medium.
      */
     public val activeMedium: StateFlow<Medium> = mutableActiveMedium.asStateFlow()
+
+    /**
+     * Active Wi-Fi channel frequency in MHz when the current medium can
+     * report one. Today this is populated for Wi-Fi Direct upgrades and
+     * remains `null` for Wi-Fi LAN, Bluetooth, BLE, and unknown channels.
+     */
+    public val activeWifiFrequencyMhz: StateFlow<Int?> = mutableActiveWifiFrequencyMhz.asStateFlow()
 
     /**
      * External-event channel. The receive loop drains this between
@@ -250,6 +260,7 @@ public class InboundConnection(
                 externalEvents = externalEvents,
                 mutableState = mutableState,
                 mutableActiveMedium = mutableActiveMedium,
+                mutableActiveWifiFrequencyMhz = mutableActiveWifiFrequencyMhz,
                 factory = factory,
                 mediumRegistry = mediumRegistry,
                 onHandshakeComplete = ::markHandshakeComplete,

--- a/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/InboundConnectionDriver.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/InboundConnectionDriver.kt
@@ -69,6 +69,7 @@ internal class InboundConnectionDriver(
     private val externalEvents: Channel<ExternalEvent>,
     private val mutableState: MutableStateFlow<InboundConnectionState>,
     private val mutableActiveMedium: MutableStateFlow<Medium>,
+    private val mutableActiveWifiFrequencyMhz: MutableStateFlow<Int?>,
     private val factory: FileDestinationFactory,
     private val mediumRegistry: MediumRegistry = MediumRegistry.DefaultWifiLan,
     private val onHandshakeComplete: () -> Unit = {},
@@ -160,7 +161,7 @@ internal class InboundConnectionDriver(
      */
     suspend fun runLifecycle(): InboundResult {
         mutableState.value = InboundConnectionState.Handshaking
-        mutableActiveMedium.value = transport.medium
+        publishActiveTransport(transport.medium, wifiFrequencyMhz = null)
         val framedTransport = FramedConnection(transport).also { framedConnection = it }
 
         // Step 1: read the unencrypted ConnectionRequest from the peer.
@@ -265,7 +266,7 @@ internal class InboundConnectionDriver(
                     logger = logger,
                 )
         val activeChannel = activeTransport.channel.also { secureChannel = it }
-        mutableActiveMedium.value = activeTransport.medium
+        publishActiveTransport(activeTransport.medium, activeTransport.wifiFrequencyMhz)
         val initialWireFrames =
             buildList {
                 if (requestedUpgradeMediums == null) {
@@ -294,6 +295,14 @@ internal class InboundConnectionDriver(
         onHandshakeComplete()
 
         return runReceiveLoop(activeChannel, negotiationFsm, initialWireFrames)
+    }
+
+    private fun publishActiveTransport(
+        medium: Medium,
+        wifiFrequencyMhz: Int?,
+    ) {
+        mutableActiveMedium.value = medium
+        mutableActiveWifiFrequencyMhz.value = wifiFrequencyMhz.takeIf { medium == Medium.WIFI_DIRECT }
     }
 
     private suspend fun pollBufferedInitialWireFrame(channel: SecureChannel): OfflineFrame? {

--- a/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnection.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnection.kt
@@ -5,6 +5,7 @@
  */
 package dev.bluehouse.bada.protocol.connection
 
+import dev.bluehouse.bada.protocol.medium.Medium
 import dev.bluehouse.bada.protocol.medium.MediumRegistry
 import dev.bluehouse.bada.protocol.medium.NearbyMultiplexClientTransport
 import dev.bluehouse.bada.protocol.payload.PayloadProtocolException
@@ -252,6 +253,12 @@ public class OutboundConnection private constructor(
     private val mutableState: MutableStateFlow<OutboundConnectionState> =
         MutableStateFlow(OutboundConnectionState.Idle)
 
+    private val mutableActiveMedium: MutableStateFlow<Medium> =
+        MutableStateFlow(transport?.medium ?: Medium.WIFI_LAN)
+
+    private val mutableActiveWifiFrequencyMhz: MutableStateFlow<Int?> =
+        MutableStateFlow(null)
+
     /**
      * Observable lifecycle state.
      *
@@ -261,6 +268,21 @@ public class OutboundConnection private constructor(
      * are the last value the flow ever publishes.
      */
     public val state: StateFlow<OutboundConnectionState> = mutableState.asStateFlow()
+
+    /**
+     * Medium the live control/payload channel currently runs over.
+     *
+     * Starts at the initial transport and flips if a successful
+     * bandwidth upgrade swaps onto a different medium.
+     */
+    public val activeMedium: StateFlow<Medium> = mutableActiveMedium.asStateFlow()
+
+    /**
+     * Active Wi-Fi channel frequency in MHz when the current medium can
+     * report one. Today this is populated for Wi-Fi Direct upgrades and
+     * remains `null` for Wi-Fi LAN, Bluetooth, BLE, and unknown channels.
+     */
+    public val activeWifiFrequencyMhz: StateFlow<Int?> = mutableActiveWifiFrequencyMhz.asStateFlow()
 
     /**
      * External-event channel. The dispatch loop drains this between
@@ -386,6 +408,8 @@ public class OutboundConnection private constructor(
                 secureRandom = secureRandom,
                 externalEvents = externalEvents,
                 mutableState = mutableState,
+                mutableActiveMedium = mutableActiveMedium,
+                mutableActiveWifiFrequencyMhz = mutableActiveWifiFrequencyMhz,
                 endpointId = endpointId,
                 endpointInfo = endpointInfo,
                 qrSigningKey = qrSigningKey,

--- a/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnectionDriver.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnectionDriver.kt
@@ -76,6 +76,8 @@ internal class OutboundConnectionDriver(
     private val secureRandom: SecureRandom,
     private val externalEvents: Channel<OutboundExternalEvent>,
     private val mutableState: MutableStateFlow<OutboundConnectionState>,
+    private val mutableActiveMedium: MutableStateFlow<Medium>,
+    private val mutableActiveWifiFrequencyMhz: MutableStateFlow<Int?>,
     private val endpointId: String,
     private val endpointInfo: ByteArray,
     private val qrSigningKey: PrivateKey?,
@@ -145,6 +147,7 @@ internal class OutboundConnectionDriver(
                 }
             }
         logger("step 1: pre-secure active medium=${preSecureTransport.medium}")
+        publishActiveTransport(preSecureTransport.medium, preSecureTransport.wifiFrequencyMhz)
 
         val (handshake, peerResponse) =
             runInitialHandshakeWithTimeout(preSecureTransport.connection)
@@ -217,6 +220,7 @@ internal class OutboundConnectionDriver(
                     return OutboundResult.Failed(negotiation.reason)
                 }
             }
+        publishActiveTransport(negotiated.medium, negotiated.wifiFrequencyMhz)
 
         // Step 8: build the OutboundSharingFsm with our IntroductionFrame.
         val introduction = buildIntroductionFrame(files)
@@ -251,6 +255,8 @@ internal class OutboundConnectionDriver(
                 channel = negotiated.channel,
                 fsm = negotiationFsm,
                 initialWireFrames = negotiated.initialWireFrames,
+                initialMedium = negotiated.medium,
+                initialWifiFrequencyMhz = negotiated.wifiFrequencyMhz,
             )
         } else {
             runReceiveLoop(negotiated.channel, negotiationFsm, negotiated.initialWireFrames)
@@ -320,7 +326,13 @@ internal class OutboundConnectionDriver(
                 ) {
                     is PreUkey2UpgradeResult.Ready -> {
                         framedConnection = upgraded.transport
-                        PreUkey2Negotiation.Ready(PreSecureTransport(upgraded.transport, upgraded.medium))
+                        PreUkey2Negotiation.Ready(
+                            PreSecureTransport(
+                                connection = upgraded.transport,
+                                medium = upgraded.medium,
+                                wifiFrequencyMhz = upgraded.wifiFrequencyMhz,
+                            ),
+                        )
                     }
                     is PreUkey2UpgradeResult.Failed -> PreUkey2Negotiation.Failed(upgraded.reason)
                 }
@@ -393,6 +405,7 @@ internal class OutboundConnectionDriver(
             activeTransport.channel,
             activeTransport.medium,
             initialWireFrames,
+            activeTransport.wifiFrequencyMhz,
         )
     }
 
@@ -403,6 +416,18 @@ internal class OutboundConnectionDriver(
     private fun requiresWifiDirectUpgradeForBle(currentMedium: Medium): Boolean =
         currentMedium.isBleBased() &&
             Medium.WIFI_DIRECT in mediumRegistry.supportedMediumsForCurrentTransport(currentMedium)
+
+    private fun publishActiveTransport(activeTransport: ActiveTransportChannel) {
+        publishActiveTransport(activeTransport.medium, activeTransport.wifiFrequencyMhz)
+    }
+
+    private fun publishActiveTransport(
+        medium: Medium,
+        wifiFrequencyMhz: Int?,
+    ) {
+        mutableActiveMedium.value = medium
+        mutableActiveWifiFrequencyMhz.value = wifiFrequencyMhz.takeIf { medium == Medium.WIFI_DIRECT }
+    }
 
     /**
      * Tear down all owned resources. Safe to call multiple times; each
@@ -661,9 +686,12 @@ internal class OutboundConnectionDriver(
         channel: SecureChannel,
         fsm: OutboundSharingFsm,
         initialWireFrames: List<OfflineFrame> = emptyList(),
+        initialMedium: Medium,
+        initialWifiFrequencyMhz: Int?,
     ): OutboundResult {
         var activeChannel = channel
-        var activeMedium = initialTransport.medium
+        var activeMedium = initialMedium
+        var activeWifiFrequencyMhz = initialWifiFrequencyMhz
         val bufferedFrames =
             ArrayDeque<OfflineFrame>().apply {
                 addAll(initialWireFrames)
@@ -712,6 +740,8 @@ internal class OutboundConnectionDriver(
                     }
                     activeChannel = upgraded.channel
                     activeMedium = upgraded.medium
+                    activeWifiFrequencyMhz = upgraded.wifiFrequencyMhz
+                    publishActiveTransport(upgraded)
                     bufferedFrames.addAll(upgraded.bufferedFrames)
                     continue
                 }
@@ -729,6 +759,7 @@ internal class OutboundConnectionDriver(
                             ensureBleWifiDirectBeforePayloads(
                                 channel = activeChannel,
                                 currentMedium = activeMedium,
+                                currentWifiFrequencyMhz = activeWifiFrequencyMhz,
                             )
                         if (upgraded is PayloadChannelSelection.Failed) {
                             return failBleWifiDirect(upgraded.reason, activeChannel)
@@ -736,6 +767,8 @@ internal class OutboundConnectionDriver(
                         val ready = upgraded as PayloadChannelSelection.Ready
                         activeChannel = ready.channel
                         activeMedium = ready.medium
+                        activeWifiFrequencyMhz = ready.wifiFrequencyMhz
+                        publishActiveTransport(activeMedium, activeWifiFrequencyMhz)
                         val result =
                             coroutineScope {
                                 val keepAliveJob = launch { runKeepAliveTicker(activeChannel) }
@@ -858,9 +891,10 @@ internal class OutboundConnectionDriver(
     private suspend fun ensureBleWifiDirectBeforePayloads(
         channel: SecureChannel,
         currentMedium: Medium,
+        currentWifiFrequencyMhz: Int?,
     ): PayloadChannelSelection {
         if (currentMedium == Medium.WIFI_DIRECT) {
-            return PayloadChannelSelection.Ready(channel, currentMedium)
+            return PayloadChannelSelection.Ready(channel, currentMedium, currentWifiFrequencyMhz)
         }
         channel.sendOfflineFrame(
             BandwidthUpgradeFrames.upgradePathRequest(setOf(Medium.WIFI_DIRECT)),
@@ -888,7 +922,11 @@ internal class OutboundConnectionDriver(
                         offer = probe.frame,
                     )
                 if (upgraded.medium == Medium.WIFI_DIRECT) {
-                    PayloadChannelSelection.Ready(upgraded.channel, upgraded.medium)
+                    PayloadChannelSelection.Ready(
+                        channel = upgraded.channel,
+                        medium = upgraded.medium,
+                        wifiFrequencyMhz = upgraded.wifiFrequencyMhz,
+                    )
                 } else {
                     PayloadChannelSelection.Failed(
                         "Wi-Fi Direct upgrade failed before payload streaming; stayed on ${upgraded.medium}",
@@ -1675,6 +1713,7 @@ internal class OutboundConnectionDriver(
             val channel: SecureChannel,
             val medium: Medium,
             val initialWireFrames: List<OfflineFrame>,
+            val wifiFrequencyMhz: Int? = null,
         ) : BandwidthNegotiation
 
         data class Failed(
@@ -1685,6 +1724,7 @@ internal class OutboundConnectionDriver(
     private data class PreSecureTransport(
         val connection: FramedConnection,
         val medium: Medium,
+        val wifiFrequencyMhz: Int? = null,
     )
 
     private sealed interface PreUkey2Negotiation {
@@ -1711,6 +1751,7 @@ internal class OutboundConnectionDriver(
         data class Ready(
             val channel: SecureChannel,
             val medium: Medium,
+            val wifiFrequencyMhz: Int? = null,
         ) : PayloadChannelSelection
 
         data class Failed(

--- a/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/PreUkey2BandwidthUpgrade.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/PreUkey2BandwidthUpgrade.kt
@@ -127,7 +127,11 @@ internal object PreUkey2BandwidthUpgrade {
         }
         finishPriorChannel(oldTransport, logger)
         logger("medium-upgrade: pre-UKEY2 client completed ${credentials.medium}")
-        return PreUkey2UpgradeResult.Ready(newFramedConnection, credentials.medium)
+        return PreUkey2UpgradeResult.Ready(
+            transport = newFramedConnection,
+            medium = credentials.medium,
+            wifiFrequencyMhz = credentials.wifiDirectFrequencyMhzOrNull(),
+        )
     }
 
     private suspend fun finishPriorChannel(
@@ -257,6 +261,7 @@ internal sealed interface PreUkey2UpgradeResult {
     data class Ready(
         val transport: FramedConnection,
         val medium: Medium,
+        val wifiFrequencyMhz: Int? = null,
     ) : PreUkey2UpgradeResult
 
     data class Failed(

--- a/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/UpgradePathCredentialMetadata.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/UpgradePathCredentialMetadata.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.protocol.connection
+
+import dev.bluehouse.bada.protocol.medium.UpgradePathCredentials
+
+internal fun UpgradePathCredentials.wifiDirectFrequencyMhzOrNull(): Int? =
+    (this as? UpgradePathCredentials.WifiDirect)
+        ?.frequency
+        ?.takeIf { it != UpgradePathCredentials.WifiDirect.FREQUENCY_NOT_SET && it > 0 }

--- a/core-protocol/src/test/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnectionTest.kt
+++ b/core-protocol/src/test/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnectionTest.kt
@@ -185,7 +185,24 @@ class OutboundConnectionTest {
     private class LoopbackUpgradePair(
         private val medium: Medium = Medium.BLUETOOTH,
     ) {
-        private val credentials = UpgradePathCredentials.Generic(medium)
+        val wifiFrequencyMhz: Int? =
+            if (medium == Medium.WIFI_DIRECT) {
+                WIFI_DIRECT_TEST_FREQUENCY_MHZ
+            } else {
+                null
+            }
+        private val credentials: UpgradePathCredentials =
+            if (medium == Medium.WIFI_DIRECT) {
+                UpgradePathCredentials.WifiDirect(
+                    ipAddress = byteArrayOf(127, 0, 0, 1),
+                    port = 1,
+                    ssid = "DIRECT-bada-test",
+                    passphrase = "12345678",
+                    frequency = WIFI_DIRECT_TEST_FREQUENCY_MHZ,
+                )
+            } else {
+                UpgradePathCredentials.Generic(medium)
+            }
         private val clientSocket: Socket
         private val serverSocket: Socket
 
@@ -598,7 +615,7 @@ class OutboundConnectionTest {
 
                         assertThat(outboundResult).isEqualTo(OutboundResult.Completed)
                         assertThat(inboundResult).isInstanceOf(InboundResult.Completed::class.java)
-                        assertThat(inbound.activeMedium.value).isEqualTo(Medium.WIFI_DIRECT)
+                        assertWifiDirectMetadata(outbound, inbound, directUpgradePair.wifiFrequencyMhz)
                     }
 
                     assertThat(factory.output[payloadId]?.toByteArray()).isEqualTo(fileBytes)
@@ -1425,7 +1442,20 @@ class OutboundConnectionTest {
             else -> false
         }
 
+    private fun assertWifiDirectMetadata(
+        outbound: OutboundConnection,
+        inbound: InboundConnection,
+        frequencyMhz: Int?,
+    ) {
+        assertThat(inbound.activeMedium.value).isEqualTo(Medium.WIFI_DIRECT)
+        assertThat(outbound.activeMedium.value).isEqualTo(Medium.WIFI_DIRECT)
+        assertThat(inbound.activeWifiFrequencyMhz.value).isEqualTo(frequencyMhz)
+        assertThat(outbound.activeWifiFrequencyMhz.value).isEqualTo(frequencyMhz)
+    }
+
     private companion object {
+        private const val WIFI_DIRECT_TEST_FREQUENCY_MHZ: Int = 5_180
+
         // Hard wall-clock cap for individual short tests. Real Socket I/O is
         // blocking, so we use [withTimeout] (not runTest's virtual scheduler)
         // to bound each scenario. 30 s leaves plenty of slack on slow CI.

--- a/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/medium/WifiDirectGroupController.kt
+++ b/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/medium/WifiDirectGroupController.kt
@@ -374,8 +374,13 @@ internal class WifiDirectGroupController(
                 teardown.close()
                 return null
             }
-        return WifiDirectTransport(socket = socket, teardown = teardown)
+        return WifiDirectTransport(socket, teardown, credentials.frequencyMhzOrNull())
     }
+
+    private fun UpgradePathCredentials.WifiDirect.frequencyMhzOrNull(): Int? =
+        frequency.takeIf {
+            it != UpgradePathCredentials.WifiDirect.FREQUENCY_NOT_SET && it > 0
+        }
 
     private suspend fun connectSocketToGroupOwner(
         address: InetAddress,

--- a/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/medium/WifiDirectMediumProvider.kt
+++ b/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/medium/WifiDirectMediumProvider.kt
@@ -253,8 +253,14 @@ public class WifiDirectMediumProvider internal constructor(
         return WifiDirectTransport(
             socket = socket,
             teardown = pending.handle.teardown,
+            frequencyMhz = pending.handle.credentials.frequencyMhzOrNull(),
         )
     }
+
+    private fun UpgradePathCredentials.WifiDirect.frequencyMhzOrNull(): Int? =
+        frequency.takeIf {
+            it != UpgradePathCredentials.WifiDirect.FREQUENCY_NOT_SET && it > 0
+        }
 
     /**
      * **Internal — for the orchestrator wired in #54.** Hands back the

--- a/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/medium/WifiDirectTransport.kt
+++ b/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/medium/WifiDirectTransport.kt
@@ -37,10 +37,13 @@ import java.net.Socket
  *   from this point on.
  * @property teardown Cleanup hook for the underlying P2P group.
  *   Idempotent; safe to call from any thread.
+ * @property frequencyMhz Operating channel frequency in MHz when the
+ *   Wi-Fi Direct credentials supplied it.
  */
 public data class WifiDirectTransport(
     val socket: Socket,
     val teardown: Closeable,
+    val frequencyMhz: Int? = null,
 ) : UpgradedTransport {
     override val medium: Medium = Medium.WIFI_DIRECT
 


### PR DESCRIPTION
## Summary
- add a default-off Settings toggle for expert transfer details
- render speed, ETA, active medium, and Wi-Fi Direct band on sender and receiver progress screens when enabled
- publish active medium and Wi-Fi Direct frequency flows from inbound and outbound connection paths

## Verification
- `./gradlew staticAnalysis :core-protocol:test :app:testDebugUnitTest :app:assembleDebug`

Closes #220