### PR TITLE
feat: show contextual radio-state hint when send peer list is empty (#209)

### DIFF
--- a/app/src/main/kotlin/dev/bluehouse/bada/send/EmptyPeerRadioHint.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/send/EmptyPeerRadioHint.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.send
+
+import androidx.annotation.StringRes
+import dev.bluehouse.bada.R
+
+/**
+ * Pure-JVM helper that maps the current radio state to the appropriate
+ * contextual empty-state string resource for the send picker (#209).
+ *
+ * When both Bluetooth and Wi-Fi are unavailable the user has no discovery
+ * path at all and needs the strongest nudge. When only one radio is
+ * missing the hint is scoped to that gap while noting the remaining path
+ * still works. When both radios are available the generic message suffices.
+ *
+ * The mapping is a plain function with no Android imports so it can be
+ * driven by JVM unit tests without Robolectric. Radio state is read by the
+ * Android-side [RadioStateReader] and passed in as plain Booleans.
+ */
+internal object EmptyPeerRadioHint {
+    /**
+     * Return the [StringRes] that best describes why no peers have been
+     * found given the current radio state.
+     *
+     * @param bluetoothEnabled `true` when the Bluetooth adapter is
+     *   present and enabled. A null adapter (no BT hardware) counts as
+     *   `false`.
+     * @param wifiConnected `true` when the active network has
+     *   [android.net.NetworkCapabilities.TRANSPORT_WIFI].
+     */
+    @StringRes
+    fun stringResFor(
+        bluetoothEnabled: Boolean,
+        wifiConnected: Boolean,
+    ): Int =
+        when {
+            !bluetoothEnabled && !wifiConnected ->
+                R.string.send_empty_state_no_bt_no_wifi
+            !bluetoothEnabled ->
+                R.string.send_empty_state_no_bt
+            !wifiConnected ->
+                R.string.send_empty_state_no_wifi
+            else ->
+                R.string.send_empty_state
+        }
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/send/RadioStateReader.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/send/RadioStateReader.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.send
+
+import android.bluetooth.BluetoothManager
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+
+/**
+ * Lightweight Android helper that reads the current Bluetooth and Wi-Fi
+ * state without requiring extra permissions (#209).
+ *
+ * - **Bluetooth**: [BluetoothManager.adapter]?.[isEnabled][android.bluetooth.BluetoothAdapter.isEnabled]
+ *   does NOT require BLUETOOTH_CONNECT — no new permission is added. A
+ *   null adapter (device has no BT hardware) is treated as "not enabled".
+ *
+ * - **Wi-Fi**: [ConnectivityManager.getNetworkCapabilities] with
+ *   [NetworkCapabilities.TRANSPORT_WIFI] requires only ACCESS_NETWORK_STATE,
+ *   which is already declared in the manifest.
+ */
+internal class RadioStateReader(
+    private val context: Context,
+) {
+    /** `true` when the Bluetooth adapter exists and is currently on. */
+    fun isBluetoothEnabled(): Boolean {
+        val manager = context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
+        return manager?.adapter?.isEnabled == true
+    }
+
+    /** `true` when the active network is a Wi-Fi connection. */
+    fun isWifiConnected(): Boolean {
+        val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+        val caps = cm?.getNetworkCapabilities(cm.activeNetwork)
+        return caps?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true
+    }
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/send/SendActivity.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/send/SendActivity.kt
@@ -313,6 +313,13 @@ public class SendActivity : AppCompatActivity() {
         OutboundSessionActiveHolder.setOutboundSessionActive(false)
     }
 
+    override fun onResume() {
+        super.onResume()
+        // Re-evaluate the contextual empty-state hint when the user returns
+        // from system settings after toggling Bluetooth or Wi-Fi (#209).
+        peerPickerController.onRadioStateChanged()
+    }
+
     @Suppress("ReturnCount")
     private suspend fun buildOutboundConnection(
         route: NearbyPeerRoute,

--- a/app/src/main/kotlin/dev/bluehouse/bada/send/SendPeerPickerController.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/send/SendPeerPickerController.kt
@@ -440,8 +440,15 @@ internal class SendPeerPickerController(
      * state. Called from [SendActivity.onResume] so that toggling
      * Bluetooth or Wi-Fi in system settings and returning to the picker
      * reflects immediately (#209).
+     *
+     * No-op once the picker is no longer actively discovering (after
+     * [suspendPicker] or [stop] null out [discoveryJob]): the empty-state
+     * hint is only meaningful while discovery is running, so resuming
+     * during an in-progress transfer must not re-surface it over the
+     * status panel.
      */
     fun onRadioStateChanged() {
+        if (discoveryJob == null) return
         updateEmptyPeerHintVisibility()
     }
 

--- a/app/src/main/kotlin/dev/bluehouse/bada/send/SendPeerPickerController.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/send/SendPeerPickerController.kt
@@ -50,6 +50,12 @@ internal class SendPeerPickerController(
      * `type=SILENT` pulse.
      */
     private val senderEndpointId: String,
+    /**
+     * Reads the current Bluetooth and Wi-Fi state so the empty-state
+     * text can surface a contextual hint (#209). Defaults to a real
+     * reader backed by the system services; override in tests if needed.
+     */
+    private val radioStateReader: RadioStateReader = RadioStateReader(context),
 ) {
     private val peers: MutableList<NearbyPeer> = mutableListOf()
 
@@ -404,12 +410,19 @@ internal class SendPeerPickerController(
         // expires with no peers found.
         val now = System.currentTimeMillis()
         val isEmpty = peers.isEmpty()
-        binding.sendEmptyState.visibility =
-            if (emptyPeerHintTimer.shouldShowEmptyState(now, isEmpty)) {
-                View.VISIBLE
-            } else {
-                View.GONE
-            }
+        if (emptyPeerHintTimer.shouldShowEmptyState(now, isEmpty)) {
+            // Pick a contextual message based on the current radio state
+            // so the user understands why no peers appeared (#209).
+            val hintRes =
+                EmptyPeerRadioHint.stringResFor(
+                    bluetoothEnabled = radioStateReader.isBluetoothEnabled(),
+                    wifiConnected = radioStateReader.isWifiConnected(),
+                )
+            binding.sendEmptyState.setText(hintRes)
+            binding.sendEmptyState.visibility = View.VISIBLE
+        } else {
+            binding.sendEmptyState.visibility = View.GONE
+        }
 
         // The "Same Wi-Fi network required" inline card is intentionally
         // disabled in favour of the help link + bottom-sheet flow added
@@ -420,6 +433,16 @@ internal class SendPeerPickerController(
         // guidance (and adds the QR fallback section), so the inline
         // card is kept in the layout for now but never raised.
         binding.sendNetworkHint.visibility = View.GONE
+    }
+
+    /**
+     * Re-evaluate the contextual empty-state text with the latest radio
+     * state. Called from [SendActivity.onResume] so that toggling
+     * Bluetooth or Wi-Fi in system settings and returning to the picker
+     * reflects immediately (#209).
+     */
+    fun onRadioStateChanged() {
+        updateEmptyPeerHintVisibility()
     }
 
     @Suppress("MissingPermission")

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -231,6 +231,10 @@
     <string name="send_subtitle_pick_peer">기기를 눌러 보내세요.</string>
     <string name="send_subtitle_no_usable_route">근처 기기가 발견되었지만 아직 지원되는 전송 경로가 없습니다.</string>
     <string name="send_empty_state">근처에 기기가 없습니다. 받는 기기에서 Quick Share가 열려 있는지 확인하세요.</string>
+    <!-- Contextual empty-state variants (#209). -->
+    <string name="send_empty_state_no_bt_no_wifi">기기를 찾지 못했습니다. Bluetooth를 켜고 받는 기기와 같은 Wi-Fi 네트워크에 연결한 후, 받는 기기에서 Quick Share가 열려 있는지 확인하세요.</string>
+    <string name="send_empty_state_no_bt">Wi-Fi로 기기를 찾지 못했습니다. Bluetooth를 켜면 같은 Wi-Fi에 없는 기기도 검색할 수 있습니다. 받는 기기에서 Quick Share가 열려 있는지 확인하세요.</string>
+    <string name="send_empty_state_no_wifi">기기를 찾지 못했습니다. 두 기기를 같은 Wi-Fi 네트워크에 연결하면 더 안정적으로 검색할 수 있습니다. 받는 기기에서 Quick Share가 열려 있는지 확인하세요.</string>
 
     <!-- Same-Wi-Fi-network hint card (#85). -->
     <string name="send_network_hint_title">근처 검색 요건</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -305,6 +305,11 @@
     <string name="send_subtitle_pick_peer">Tap a device to send.</string>
     <string name="send_subtitle_no_usable_route">Nearby device found, but no supported transfer route is available yet.</string>
     <string name="send_empty_state">No devices nearby yet. Make sure the receiver has Quick Share open.</string>
+    <!-- Contextual empty-state variants surfaced by EmptyPeerRadioHint
+         when one or both radios are unavailable (#209). -->
+    <string name="send_empty_state_no_bt_no_wifi">No devices found. Turn on Bluetooth and connect to the same Wi-Fi network as the receiver, then make sure Quick Share is open on the receiver.</string>
+    <string name="send_empty_state_no_bt">No devices found over Wi-Fi. Turn on Bluetooth to also reach devices not on this Wi-Fi network, and make sure Quick Share is open on the receiver.</string>
+    <string name="send_empty_state_no_wifi">No devices found. Connect both devices to the same Wi-Fi network for the most reliable discovery, and make sure Quick Share is open on the receiver.</string>
 
     <!-- Same-Wi-Fi-network hint card (#85). Surfaced after a few seconds
          of empty peer list so the user understands why nothing has

--- a/app/src/test/kotlin/dev/bluehouse/bada/send/EmptyPeerRadioHintTest.kt
+++ b/app/src/test/kotlin/dev/bluehouse/bada/send/EmptyPeerRadioHintTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.send
+
+import dev.bluehouse.bada.R
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pure-JVM tests for [EmptyPeerRadioHint], the helper that maps the
+ * current radio state to a contextual empty-state string resource (#209).
+ *
+ * No Android framework is involved — the mapping is a plain function that
+ * takes two Booleans and returns an @StringRes Int, so Robolectric is not
+ * needed and the test runs on the JVM directly.
+ */
+class EmptyPeerRadioHintTest {
+    @Test
+    fun `both radios off returns strongest hint`() {
+        val resId =
+            EmptyPeerRadioHint.stringResFor(
+                bluetoothEnabled = false,
+                wifiConnected = false,
+            )
+        assertEquals(R.string.send_empty_state_no_bt_no_wifi, resId)
+    }
+
+    @Test
+    fun `bluetooth off wifi on returns bluetooth hint`() {
+        val resId =
+            EmptyPeerRadioHint.stringResFor(
+                bluetoothEnabled = false,
+                wifiConnected = true,
+            )
+        assertEquals(R.string.send_empty_state_no_bt, resId)
+    }
+
+    @Test
+    fun `bluetooth on wifi off returns wifi hint`() {
+        val resId =
+            EmptyPeerRadioHint.stringResFor(
+                bluetoothEnabled = true,
+                wifiConnected = false,
+            )
+        assertEquals(R.string.send_empty_state_no_wifi, resId)
+    }
+
+    @Test
+    fun `both radios on returns generic message`() {
+        val resId =
+            EmptyPeerRadioHint.stringResFor(
+                bluetoothEnabled = true,
+                wifiConnected = true,
+            )
+        assertEquals(R.string.send_empty_state, resId)
+    }
+}


### PR DESCRIPTION
## Summary

- Add `EmptyPeerRadioHint` — a pure-JVM object that maps `(bluetoothEnabled, wifiConnected)` to the appropriate `@StringRes`. No `android.*` imports; fully JVM-testable. Four cases:
  - BT off + Wi-Fi off → "Turn on Bluetooth AND connect to Wi-Fi…" (the bug-report scenario)
  - BT off, Wi-Fi on → "Turn on Bluetooth to reach devices not on this Wi-Fi…"
  - BT on, Wi-Fi off → "Connect to the same Wi-Fi for best results…"
  - Both on → existing generic `send_empty_state` message (unchanged)
- Add `RadioStateReader` — Android helper that reads BT/Wi-Fi state using only permissions already in the manifest (`ACCESS_NETWORK_STATE`). No `BLUETOOTH_CONNECT` or location permission added.
- Wire into `SendPeerPickerController.updateEmptyPeerHintVisibility()` to set `sendEmptyState.setText()` with the contextual string each time the empty-state is evaluated.
- Add `SendPeerPickerController.onRadioStateChanged()` called from `SendActivity.onResume()` so returning from system settings (e.g. after toggling Bluetooth or Wi-Fi) immediately reflects the updated hint. Guarded to no-op once `discoveryJob` is null (i.e. after `suspendPicker()` or `stop()`) so resuming during an in-progress transfer does not re-surface the empty-state hint over the status panel.
- Add English strings (`send_empty_state_no_bt_no_wifi`, `send_empty_state_no_bt`, `send_empty_state_no_wifi`) and matching Korean translations.
- Add `EmptyPeerRadioHintTest` — four JVM unit tests, one per radio-state combination.
- `send_network_hint` inline card remains intentionally `View.GONE` (no change).

## Fixes

Closes #209