### PR TITLE
Fix #200: don't send eager Disconnection to safe-to-disconnect v0 peers (Windows "Can't complete transfer")

### DIFF
--- a/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/InboundConnection.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/InboundConnection.kt
@@ -125,6 +125,14 @@ public class InboundConnection(
      */
     private val mediumRegistry: MediumRegistry = MediumRegistry.DefaultWifiLan,
     private val logger: (String) -> Unit = {},
+    /**
+     * `safe_to_disconnect_version` this receiver advertises on its
+     * `ConnectionResponseFrame` (field 7). Defaults to
+     * [OfflineFrames.SAFE_TO_DISCONNECT_VERSION] (1) for production; it is
+     * an in-module test seam to emulate a peer with safe-to-disconnect
+     * disabled (e.g. 0 = Windows Quick Share — see issue #200).
+     */
+    internal val safeToDisconnectVersion: Int = OfflineFrames.SAFE_TO_DISCONNECT_VERSION,
 ) {
     public constructor(
         socket: Socket,
@@ -265,6 +273,7 @@ public class InboundConnection(
                 mediumRegistry = mediumRegistry,
                 onHandshakeComplete = ::markHandshakeComplete,
                 logger = logger,
+                safeToDisconnectVersion = safeToDisconnectVersion,
             )
 
         return try {

--- a/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/InboundConnectionDriver.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/InboundConnectionDriver.kt
@@ -90,6 +90,14 @@ internal class InboundConnectionDriver(
      * sensitivity.
      */
     private val rateEstimator: TransferRateEstimator = TransferRateEstimator(),
+    /**
+     * `safe_to_disconnect_version` advertised on our outgoing
+     * `ConnectionResponseFrame` (field 7). Defaults to
+     * [OfflineFrames.SAFE_TO_DISCONNECT_VERSION] (1) in production; tests
+     * override it (e.g. 0) to emulate a peer with safe-to-disconnect
+     * disabled — see issue #200 / [OutboundConnectionDriver].
+     */
+    private val safeToDisconnectVersion: Int = OfflineFrames.SAFE_TO_DISCONNECT_VERSION,
 ) {
     private var framedConnection: FramedConnection? = null
     private var secureChannel: SecureChannel? = null
@@ -210,7 +218,7 @@ internal class InboundConnectionDriver(
         val handshake = Ukey2Server.performHandshake(framedTransport, secureRandom)
 
         // Step 3: send unencrypted ConnectionResponse{ACCEPT}.
-        framedTransport.sendFrame(OfflineFrames.connectionResponse().toByteArray())
+        framedTransport.sendFrame(OfflineFrames.connectionResponse(safeToDisconnectVersion).toByteArray())
 
         // Step 4: read peer's unencrypted ConnectionResponse.
         val peerResponse = readOfflineFrameUnencrypted(framedTransport)

--- a/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/OfflineFrames.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/OfflineFrames.kt
@@ -41,7 +41,7 @@ internal object OfflineFrames {
      * Version we advertise for the "safe to disconnect" handshake.
      * See [OutboundFrames.SAFE_TO_DISCONNECT_VERSION] for the full rationale.
      */
-    private const val SAFE_TO_DISCONNECT_VERSION: Int = 1
+    internal const val SAFE_TO_DISCONNECT_VERSION: Int = 1
 
     /**
      * Bitmask value that declares "no medium supports multiplexing".
@@ -75,8 +75,13 @@ internal object OfflineFrames {
      *   6. `keep_alive_timeout_millis = 600_000` — proto field 9, required
      *      by One UI 8.0.5 (verified on-device); see
      *      [OutboundFrames.connectionResponse] for the full rationale.
+     *
+     * @param safeToDisconnectVersion Value to advertise in field 7.
+     *   Defaults to [SAFE_TO_DISCONNECT_VERSION] (1) for production;
+     *   tests override it (e.g. 0, to emulate a Windows Quick Share peer
+     *   with safe-to-disconnect disabled — issue #200).
      */
-    fun connectionResponse(): OfflineFrame {
+    fun connectionResponse(safeToDisconnectVersion: Int = SAFE_TO_DISCONNECT_VERSION): OfflineFrame {
         @Suppress("DEPRECATION")
         val response =
             ConnectionResponseFrame
@@ -89,7 +94,7 @@ internal object OfflineFrames {
                         .setType(OsInfo.OsType.ANDROID)
                         .build(),
                 ).setMultiplexSocketBitmask(MULTIPLEX_SOCKET_BITMASK_NONE)
-                .setSafeToDisconnectVersion(SAFE_TO_DISCONNECT_VERSION)
+                .setSafeToDisconnectVersion(safeToDisconnectVersion)
                 .setKeepAliveTimeoutMillis(KEEP_ALIVE_TIMEOUT_MILLIS)
                 .build()
         return OfflineFrame

--- a/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnectionDriver.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnectionDriver.kt
@@ -129,6 +129,25 @@ internal class OutboundConnectionDriver(
     private var currentItemPayloadId: Long? = null
 
     /**
+     * The peer receiver's advertised `safe_to_disconnect_version`
+     * (ConnectionResponseFrame field 7), captured during the handshake.
+     *
+     * - `0` = the peer has safe-to-disconnect DISABLED — notably **Windows Quick
+     *   Share** (issue #200: it logs `[safe-to-disconnect]: Local enabled: false;
+     *   Version: 0`). Such a peer treats a sender-initiated `Disconnection` that
+     *   arrives BEFORE it reaches `kComplete` as a transfer FAILURE
+     *   ("Can't complete transfer"), even though every byte already arrived.
+     * - `>= 1` = it supports the safe-to-disconnect handshake (Samsung One UI 7+,
+     *   stock Android Quick Share, and this app, which advertises version 1).
+     *
+     * Gates the SUCCESS-path teardown in [streamFilesAndComplete]: for a version-0
+     * peer we do NOT proactively send the terminal `Disconnection`; instead we let
+     * the receiver finalize and close first (the existing safe-disconnect drain
+     * waits for the peer's FIN), mirroring stock Quick Share. Defaults to 0.
+     */
+    private var peerSafeToDisconnectVersion: Int = 0
+
+    /**
      * Drive the entire sender-side lifecycle. Returns the terminal
      * [OutboundResult]; throws on coroutine cancellation (handled by
      * the caller).
@@ -168,11 +187,18 @@ internal class OutboundConnectionDriver(
         if (peerResponse.v1.hasConnectionResponse()) {
             val cr = peerResponse.v1.connectionResponse
 
+            // Capture the peer's safe_to_disconnect_version (issue #200). 0 = the
+            // receiver has safe-to-disconnect DISABLED (e.g. Windows Quick Share) and
+            // must NOT be disconnected before it reaches kComplete; the success-path
+            // teardown in streamFilesAndComplete gates the eager Disconnection on this.
+            peerSafeToDisconnectVersion = cr.safeToDisconnectVersion
+
             @Suppress("DEPRECATION")
             val status = cr.status
             logger(
                 "step 4: peer.response=${cr.response} status=$status " +
-                    "osType=${if (cr.hasOsInfo()) cr.osInfo.type else "<none>"}",
+                    "osType=${if (cr.hasOsInfo()) cr.osInfo.type else "<none>"} " +
+                    "safeToDisconnectVersion=$peerSafeToDisconnectVersion",
             )
         }
         check(peerResponse.isConnectionResponse()) {
@@ -1362,9 +1388,29 @@ internal class OutboundConnectionDriver(
             logger("fsm: streamOneFile DONE name=${file.name}")
         }
 
-        // All files streamed. Emit Disconnection and complete.
-        logger("fsm: all files streamed, sending Disconnection")
-        runCatching { sendTerminalDisconnection(channel) }
+        // All files streamed (every byte delivered). TEARDOWN — issue #200:
+        // Only proactively send the terminal Disconnection when the peer supports the
+        // safe-to-disconnect handshake (safe_to_disconnect_version >= 1: Samsung One UI
+        // 7+, stock Android Quick Share, this app). For a version-0 peer (Windows Quick
+        // Share has safe-to-disconnect DISABLED), a sender-initiated Disconnection that
+        // lands before it reaches kComplete is treated as a FAILURE and the already-
+        // complete payload is discarded ("Can't complete transfer"). So for version 0 we
+        // do NOT send it; the existing safe-disconnect drain (shouldDrainForSafeDisconnect
+        // is true for Completed) instead waits for the receiver to finalize and close
+        // first, bounded by the grace timeout — mirroring stock Quick Share, whose sender
+        // never disconnects early. Receive direction and version>=1 senders are unchanged.
+        if (peerSafeToDisconnectVersion >= 1) {
+            logger(
+                "fsm: all files streamed, sending Disconnection " +
+                    "(peer safeToDisconnectVersion=$peerSafeToDisconnectVersion)",
+            )
+            runCatching { sendTerminalDisconnection(channel) }
+        } else {
+            logger(
+                "fsm: all files streamed; peer safeToDisconnectVersion=0 (e.g. Windows) — " +
+                    "NOT sending eager Disconnection; awaiting receiver close (issue #200)",
+            )
+        }
         return OutboundResult.Completed
     }
 

--- a/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnectionDriver.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnectionDriver.kt
@@ -184,23 +184,7 @@ internal class OutboundConnectionDriver(
         // Step 4: read receiver's unencrypted ConnectionResponse.
         val hasResp = peerResponse.v1.hasConnectionResponse()
         logger("step 4: received peer ConnectionResponse type=${peerResponse.v1.type} hasConnectionResponse=$hasResp")
-        if (peerResponse.v1.hasConnectionResponse()) {
-            val cr = peerResponse.v1.connectionResponse
-
-            // Capture the peer's safe_to_disconnect_version (issue #200). 0 = the
-            // receiver has safe-to-disconnect DISABLED (e.g. Windows Quick Share) and
-            // must NOT be disconnected before it reaches kComplete; the success-path
-            // teardown in streamFilesAndComplete gates the eager Disconnection on this.
-            peerSafeToDisconnectVersion = cr.safeToDisconnectVersion
-
-            @Suppress("DEPRECATION")
-            val status = cr.status
-            logger(
-                "step 4: peer.response=${cr.response} status=$status " +
-                    "osType=${if (cr.hasOsInfo()) cr.osInfo.type else "<none>"} " +
-                    "safeToDisconnectVersion=$peerSafeToDisconnectVersion",
-            )
-        }
+        capturePeerConnectionResponse(peerResponse)
         check(peerResponse.isConnectionResponse()) {
             "Expected ConnectionResponse, got ${peerResponse.v1.type}"
         }
@@ -287,6 +271,28 @@ internal class OutboundConnectionDriver(
         } else {
             runReceiveLoop(negotiated.channel, negotiationFsm, negotiated.initialWireFrames)
         }
+    }
+
+    /**
+     * Capture the receiver's unencrypted ConnectionResponse fields we care about —
+     * currently the `safe_to_disconnect_version` (issue #200). 0 = the receiver has
+     * safe-to-disconnect DISABLED (e.g. Windows Quick Share) and must NOT be
+     * disconnected before it reaches kComplete; the success-path teardown in
+     * [streamFilesAndComplete] gates the eager Disconnection on this value. No-op if
+     * the frame is not a ConnectionResponse (the caller's [check] handles that).
+     */
+    private fun capturePeerConnectionResponse(peerResponse: OfflineFrame) {
+        if (!peerResponse.v1.hasConnectionResponse()) return
+        val cr = peerResponse.v1.connectionResponse
+        peerSafeToDisconnectVersion = cr.safeToDisconnectVersion
+
+        @Suppress("DEPRECATION")
+        val status = cr.status
+        logger(
+            "step 4: peer.response=${cr.response} status=$status " +
+                "osType=${if (cr.hasOsInfo()) cr.osInfo.type else "<none>"} " +
+                "safeToDisconnectVersion=$peerSafeToDisconnectVersion",
+        )
     }
 
     private suspend fun openPreSecureTransport(): PreUkey2Negotiation {

--- a/core-protocol/src/test/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnectionTest.kt
+++ b/core-protocol/src/test/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnectionTest.kt
@@ -411,6 +411,76 @@ class OutboundConnectionTest {
             }
         }
 
+    /**
+     * Issue #200: a peer that advertises `safe_to_disconnect_version = 0`
+     * (e.g. Windows Quick Share, which has safe-to-disconnect disabled)
+     * must NOT receive an eager terminal `Disconnection` after the last
+     * byte — it treats a disconnect that arrives before it reaches
+     * kComplete as a failure and discards the already-complete payload.
+     *
+     * Drives the production [InboundConnection] but overrides its
+     * advertised version to 0, then asserts (a) the sender took the
+     * "do not send Disconnection" branch, (b) it did NOT log the
+     * Disconnection-sending branch, and (c) the transfer still completes
+     * with bytes intact (the sender's safe-disconnect drain returns on
+     * the receiver's FIN).
+     */
+    @Test
+    fun `accept path - version-0 peer does not get eager Disconnection and still completes`() =
+        runBlocking {
+            withTimeout(WALLCLOCK_TIMEOUT_MS) {
+                val (client, server) = connectedSocketPair()
+                val factory = InMemoryFactory()
+                val outboundLog = java.util.Collections.synchronizedList(mutableListOf<String>())
+                val outbound =
+                    OutboundConnection(
+                        transport = client.asConnectedTransport(Medium.WIFI_LAN),
+                        secureRandom = SecureRandom("outbound-v0".toByteArray()),
+                        logger = { outboundLog.add(it) },
+                    )
+
+                val fileBytes = ByteArray(4096) { (it and 0xFF).toByte() }
+                val payloadId = 0x6263L
+                val files = listOf(bytesSource("windows.bin", fileBytes, payloadId))
+
+                coroutineScope {
+                    val outboundJob = async { outbound.run(files) }
+                    // Emulate a Windows Quick Share receiver: advertise
+                    // safe_to_disconnect_version = 0 on the ConnectionResponse.
+                    val inbound =
+                        InboundConnection(
+                            transport = server.asConnectedTransport(Medium.WIFI_LAN),
+                            secureRandom = SecureRandom("inbound-v0".toByteArray()),
+                            safeToDisconnectVersion = 0,
+                        )
+
+                    launch {
+                        inbound.state.first { it is InboundConnectionState.WaitingForUserConsent }
+                        inbound.submitUserConsent(accepted = true)
+                    }
+
+                    val inboundResult = inbound.run(factory)
+                    val outboundResult = outboundJob.await()
+
+                    assertThat(outboundResult).isEqualTo(OutboundResult.Completed)
+                    assertThat(inboundResult).isInstanceOf(InboundResult.Completed::class.java)
+                }
+
+                // Bytes still round-tripped intact.
+                assertThat(factory.output[payloadId]?.toByteArray()).isEqualTo(fileBytes)
+                assertThat(outbound.state.value).isEqualTo(OutboundConnectionState.Completed)
+
+                // The sender captured the peer's version-0 advertisement...
+                val log = outboundLog.toList()
+                assertThat(log.any { it.contains("safeToDisconnectVersion=0") }).isTrue()
+                // ...took the "do NOT send eager Disconnection" branch...
+                assertThat(log.any { it.contains("NOT sending eager Disconnection") }).isTrue()
+                // ...and never took the Disconnection-sending success branch.
+                assertThat(log.any { it.contains("sending Disconnection (peer safeToDisconnectVersion") })
+                    .isFalse()
+            }
+        }
+
     @Test
     fun `accept path - bandwidth upgrade swaps to provider transport before file payload`() =
         runBlocking {


### PR DESCRIPTION
## Problem
Sending a file to **Windows Quick Share** transfers the entire file, but Windows shows **"Can't complete transfer"** (issue #200). Android↔Android and Windows→Android are unaffected.

## Root cause
The sender success path (`OutboundConnectionDriver.streamFilesAndComplete`) emits the terminal `Disconnection` immediately after the last payload byte. Windows advertises `safe_to_disconnect_version = 0` (safe-to-disconnect disabled) and treats a sender-initiated `Disconnection` that arrives **before** it reaches `kComplete` as `REMOTE_DISCONNECTION → kFailed`, discarding the already-complete payload. Stock Quick Share's sender never disconnects early — it lets the receiver finalize and close.

## Fix
Capture the peer's `safe_to_disconnect_version` from its `ConnectionResponseFrame` (field 7) at the handshake, then gate the terminal `Disconnection` in `streamFilesAndComplete`:

- **version ≥ 1** (Samsung One UI 7+, stock Android Quick Share, and this app, which advertises 1) → send it, **unchanged**.
- **version 0** (Windows) → **do not** send it; the existing safe-disconnect drain (`shouldDrainForSafeDisconnect` is already `true` for `Completed`) waits for the receiver to finalize and close (its FIN), bounded by the ack timeout — mirroring stock Quick Share.

