### PR TITLE
Quick Settings tile that opens a receive sheet (visible + radios on)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -453,18 +453,19 @@
             android:label="@string/consent_activity_label" />
 
         <!--
-          Quick Settings tile: toggles the receiver's "always visible"
-          override straight from the system Quick Settings panel so the
-          user can make this device discoverable to nearby Quick Share
-          senders without opening the app.
+          Quick Settings tile: opens the receiver "Ready to receive" sheet
+          straight from the system Quick Settings panel — making this device
+          discoverable to nearby Quick Share senders and forcing Wi-Fi/Bluetooth
+          on for the receive (both restored when the sheet is dismissed) without
+          the user opening the app first.
 
           Required by the platform: exported=true plus the
           BIND_QUICK_SETTINGS_TILE permission (only system_server, which
           binds the tile, holds it) and the QS_TILE action filter. The
           icon must be a 24dp solid-white VectorDrawable.
 
-          TOGGLEABLE_TILE marks this as a two-state on/off switch for
-          accessibility and so the OS understands the tile's behavior.
+          TOGGLEABLE_TILE reflects the tile's active/inactive state (it tracks
+          the receiver's always-visible override) for accessibility.
         -->
         <service
             android:name=".tile.BadaQuickShareTileService"

--- a/app/src/main/kotlin/dev/bluehouse/bada/consent/ConsentTrampolineActivity.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/consent/ConsentTrampolineActivity.kt
@@ -38,15 +38,16 @@ import androidx.core.view.AccessibilityDelegateCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
 import androidx.lifecycle.lifecycleScope
-import com.google.android.material.progressindicator.CircularProgressIndicator
 import dev.bluehouse.bada.R
 import dev.bluehouse.bada.bugreport.BugReportFlowSupport
+import dev.bluehouse.bada.nfc.NfcPreferredService
 import dev.bluehouse.bada.protocol.connection.InboundConnection
 import dev.bluehouse.bada.protocol.connection.InboundConnectionState
 import dev.bluehouse.bada.protocol.connection.ReceivedItem
 import dev.bluehouse.bada.protocol.connection.TransferItem
 import dev.bluehouse.bada.protocol.connection.TransferProgress
 import dev.bluehouse.bada.protocol.medium.Medium
+import dev.bluehouse.bada.service.receiver.TileVisibilityElevationHolder
 import dev.bluehouse.bada.service.receiver.consent.ConsentBroadcastReceiver
 import dev.bluehouse.bada.service.receiver.consent.ConsentDiagnostic
 import dev.bluehouse.bada.service.receiver.consent.ConsentIntents
@@ -56,6 +57,7 @@ import dev.bluehouse.bada.service.receiver.consent.ConsentRegistry
 import dev.bluehouse.bada.transfer.KeepScreenOnPreferences
 import dev.bluehouse.bada.transfer.TransferExpertDetailsFormatter
 import dev.bluehouse.bada.transfer.TransferExpertViewPreferences
+import dev.bluehouse.bada.ui.sheet.RoundedProgressBar
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.combine
@@ -123,7 +125,7 @@ import kotlinx.coroutines.withTimeoutOrNull
  * raises the heads-up notification, and the user can resume from the
  * shade.
  */
-@Suppress("TooManyFunctions")
+@Suppress("TooManyFunctions", "LargeClass")
 class ConsentTrampolineActivity : AppCompatActivity() {
     private var connectionId: Long = ConsentIntents.MISSING_CONNECTION_ID
     private var decisionSubmitted: Boolean = false
@@ -158,12 +160,6 @@ class ConsentTrampolineActivity : AppCompatActivity() {
         // flags via the shim below.
         applyIncomingCallFlags()
         super.onCreate(savedInstanceState)
-        // Soft alpha + scale-up entrance so the popup feels like it's
-        // emerging from its centre rather than snapping into place.
-        // Paired with `popup_fade_out` in [finish] for a symmetric
-        // dismiss.
-        @Suppress("DEPRECATION")
-        overridePendingTransition(R.anim.popup_fade_in, 0)
         setContentView(R.layout.activity_consent_trampoline)
         bugReportFlowSupport = BugReportFlowSupport.install(this)
 
@@ -186,10 +182,16 @@ class ConsentTrampolineActivity : AppCompatActivity() {
      * (back-compat shim is still wired in the framework) and is
      * trivially correct for our minSdk = 24 floor.
      */
-    @Suppress("DEPRECATION")
     override fun finish() {
+        // If this sheet was opened by the Quick Settings tile in waiting
+        // mode (which temporarily bumped receiver visibility), restore
+        // the exact prior visibility / service state now that the sheet
+        // is going away. No-op when the sheet was raised by an incoming
+        // transfer (the holder is only armed by the tile path). Done
+        // before super.finish() so the restore runs even if the platform
+        // tears the activity down immediately.
+        TileVisibilityElevationHolder.restoreIfArmed(applicationContext)
         super.finish()
-        overridePendingTransition(0, R.anim.popup_fade_out)
     }
 
     override fun onNewIntent(intent: Intent) {
@@ -212,16 +214,44 @@ class ConsentTrampolineActivity : AppCompatActivity() {
     override fun onResume() {
         super.onResume()
         ConsentDiagnostic.log(this, "trampoline.onResume id=$connectionId")
+        // While the receive sheet is foreground, claim the Quick Share NFC AID so
+        // a tap reaches US instead of stock Google Quick Share (the only way to win
+        // a shared AID on Android 15). Released in onPause -> taps fall back to
+        // native Quick Share when the sheet is closed.
+        NfcPreferredService.prefer(this)
     }
 
     override fun onPause() {
         super.onPause()
         ConsentDiagnostic.log(this, "trampoline.onPause id=$connectionId finishing=$isFinishing")
+        NfcPreferredService.release(this)
     }
 
     override fun onStop() {
         super.onStop()
         ConsentDiagnostic.log(this, "trampoline.onStop id=$connectionId finishing=$isFinishing")
+    }
+
+    override fun onUserLeaveHint() {
+        super.onUserLeaveHint()
+        // The tile-opened receive sheet is transient: when the user leaves the
+        // still-WAITING sheet (Home / Recents) before any transfer has bound,
+        // dismiss it so the temporary visibility bump is restored (finish() ->
+        // restoreIfArmed). Without this, leaving via Home never calls finish()
+        // and the receiver stays discoverable with the tile stuck on.
+        //
+        // Gated on a still-empty connection id (no transfer bound yet) so that
+        // once a real transfer arrives — the waiting panel swaps to the consent
+        // prompt via onNewIntent and connectionId is set — backgrounding does NOT
+        // tear the receiver down. That bound-but-undecided case is left to the
+        // notification path (the modal dismisses, the heads-up re-raises) so the
+        // in-flight transfer is never dropped. Notification-raised consent sheets
+        // are not tile-armed, so they are also left in place.
+        val waitingWithNoBoundTransfer = connectionId == ConsentIntents.MISSING_CONNECTION_ID
+        if (TileVisibilityElevationHolder.isArmed && !decisionSubmitted && waitingWithNoBoundTransfer) {
+            ConsentDiagnostic.log(this, "trampoline.onUserLeaveHint finishing waiting sheet id=$connectionId")
+            finish()
+        }
     }
 
     private fun incomingId(intent: Intent?): Long =
@@ -254,6 +284,18 @@ class ConsentTrampolineActivity : AppCompatActivity() {
         )
 
         if (entry == null) {
+            if (intent?.action == ConsentIntents.ACTION_OPEN_RECEIVE_SHEET) {
+                // Tile-opened "waiting for sender" sheet (Phase 2). No
+                // transfer is pending yet; show the waiting panel and
+                // stay foreground. When an incoming transfer arrives the
+                // ConsentCoordinator's foreground path re-launches this
+                // singleTop activity with a real connection id, which
+                // lands in onNewIntent -> bindIntent and swaps the
+                // waiting panel for the consent prompt in place.
+                ConsentDiagnostic.log(this, "trampoline.waiting open (no pending entry)")
+                showWaitingPanel()
+                return
+            }
             // The notification fired but the underlying connection has
             // already terminated (e.g. the peer cancelled). Show a brief
             // toast and finish — the surface keeps its incoming-call
@@ -272,7 +314,29 @@ class ConsentTrampolineActivity : AppCompatActivity() {
         registerModal()
     }
 
+    /**
+     * Show the Phase 2 "ready to receive / waiting for sender" panel.
+     * Hides every other panel so a re-bind from waiting back to waiting
+     * (e.g. a second tile tap) is idempotent, and animates the swap with
+     * the same [ChangeBounds] transition the consent→receiving→completed
+     * path uses so the sheet resizes smoothly if it was showing another
+     * state.
+     */
+    private fun showWaitingPanel() {
+        beginPanelTransition()
+        findViewById<View>(R.id.consent_panel).visibility = View.GONE
+        findViewById<View>(R.id.consent_receiving_panel).visibility = View.GONE
+        findViewById<View>(R.id.consent_completed_panel).visibility = View.GONE
+        findViewById<View>(R.id.consent_failed_panel).visibility = View.GONE
+        findViewById<View>(R.id.consent_waiting_panel).visibility = View.VISIBLE
+    }
+
     override fun onDestroy() {
+        // Backstop for the tile's temporary visibility bump: restore on
+        // any teardown that didn't run through finish() (recents swipe,
+        // system kill while finishing). Idempotent with finish()'s call
+        // (restoreIfArmed compare-and-sets the armed flag).
+        TileVisibilityElevationHolder.restoreIfArmed(applicationContext)
         setTransferKeepScreenOn(active = false)
         // If the user dismissed the activity without an explicit
         // decision (e.g. swipe-back, screen lock), DO NOT auto-reject —
@@ -315,6 +379,19 @@ class ConsentTrampolineActivity : AppCompatActivity() {
     }
 
     private fun renderEntry(entry: ConsentRegistry.Entry) {
+        // Ensure the consent prompt is the visible panel. This matters
+        // when the sheet was previously showing the Phase 2 waiting panel
+        // (tile-opened) and an incoming transfer just arrived via
+        // onNewIntent — swap waiting → consent in place. The other
+        // post-decision panels are always GONE at this point but are
+        // reset defensively in case of an unusual re-bind ordering.
+        beginPanelTransition()
+        findViewById<View>(R.id.consent_waiting_panel).visibility = View.GONE
+        findViewById<View>(R.id.consent_receiving_panel).visibility = View.GONE
+        findViewById<View>(R.id.consent_completed_panel).visibility = View.GONE
+        findViewById<View>(R.id.consent_failed_panel).visibility = View.GONE
+        findViewById<View>(R.id.consent_panel).visibility = View.VISIBLE
+
         val titleView = findViewById<TextView>(R.id.consent_title)
         val pinView = findViewById<TextView>(R.id.consent_pin)
         val list = findViewById<LinearLayout>(R.id.consent_files_list)
@@ -617,7 +694,7 @@ class ConsentTrampolineActivity : AppCompatActivity() {
         activeMedium: Medium,
         wifiFrequencyMhz: Int?,
     ) {
-        val progressBar = findViewById<CircularProgressIndicator>(R.id.consent_receiving_progress) ?: return
+        val progressBar = findViewById<RoundedProgressBar>(R.id.consent_receiving_progress) ?: return
         val percentText = findViewById<TextView>(R.id.consent_receiving_progress_pct)
         val pct =
             if (progress.totalSize > 0) {
@@ -627,13 +704,10 @@ class ConsentTrampolineActivity : AppCompatActivity() {
             } else {
                 0
             }
-        if (progress.totalSize > 0) {
-            // Once we know the total, switch from the spinning
-            // indeterminate state to a deterministic ratio so the user
-            // can see the bar fill up frame by frame.
-            if (progressBar.isIndeterminate) progressBar.isIndeterminate = false
-            progressBar.setProgressCompat(pct, true)
-        }
+        // The RoundedProgressBar animates the blue pill fill toward
+        // the target fraction; before the total is known we hold it at 0%
+        // (the bar still shows a dot so the panel reads as "started").
+        progressBar.setProgress(pct)
         percentText?.text = getString(R.string.transfer_progress_percent, pct)
         findViewById<TextView>(R.id.consent_receiving_progress_text)?.text =
             getString(

--- a/app/src/main/kotlin/dev/bluehouse/bada/tile/BadaQuickShareTileService.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/tile/BadaQuickShareTileService.kt
@@ -14,39 +14,55 @@ import android.service.quicksettings.TileService
 import android.util.Log
 import dev.bluehouse.bada.MainActivity
 import dev.bluehouse.bada.R
+import dev.bluehouse.bada.consent.ConsentTrampolineActivity
 import dev.bluehouse.bada.onboarding.PermissionRequirements
 import dev.bluehouse.bada.service.receiver.MdnsVisibilityOverrideHolder
 import dev.bluehouse.bada.service.receiver.ReceiverForegroundService
+import dev.bluehouse.bada.service.receiver.TileVisibilityElevationHolder
+import dev.bluehouse.bada.service.receiver.consent.ConsentIntents
 
 /**
- * Quick Settings tile that turns Bada "on" — i.e. forces the receiver to
- * be discoverable to nearby Quick Share senders — straight from the
- * system Quick Settings panel, without opening the app.
+ * Quick Settings tile that opens the **receive bottom sheet**
+ * straight from the system Quick Settings panel, making the
+ * device discoverable to nearby Quick Share senders for the duration of
+ * the sheet without permanently flipping any switch.
  *
- * Tapping the tile toggles the same process-wide
- * [MdnsVisibilityOverrideHolder] "always visible" override that the
- * in-app Send/Receive pill drives (see `SendReceiveFragment`), and brings
- * the [ReceiverForegroundService] up/down to back it. ON publishes the
- * mDNS + BLE fast advertisement unconditionally; OFF clears the override
- * and stops the receiver.
+ * ### Behaviour (replaces the old persistent on/off toggle)
  *
- * State model: the tile mirrors [MdnsVisibilityOverrideHolder.isActive].
- * The override lives in memory only and resets on process death, so a
- * cold Quick Settings panel correctly shows the tile OFF (nothing is
- * actually advertising). [onStartListening] re-syncs every time the panel
- * opens, which keeps the tile consistent with the in-app pill even though
- * one cannot change the override while the other is on screen.
+ * On click the tile:
  *
- * This is a standard (listening) tile rather than an active tile: the
- * override has no cross-module way to push `requestListeningState`, and
- * re-reading the holder in [onStartListening] is enough for eventual
- * consistency.
+ *  1. Captures the current receiver visibility from
+ *     [MdnsVisibilityOverrideHolder.isActive].
+ *  2. If visibility is below "visible" (override off), raises it to
+ *     visible AND starts [ReceiverForegroundService] — but only
+ *     temporarily, recording the prior state in
+ *     [TileVisibilityElevationHolder] so it can be restored.
+ *  3. Launches [ConsentTrampolineActivity] in waiting mode (the receive
+ *     sheet) as a foreground activity.
+ *  4. When the sheet is dismissed / finished, the activity calls
+ *     [TileVisibilityElevationHolder.restoreIfArmed] which restores the
+ *     exact prior visibility (and stops the service if the tile started
+ *     it). If visibility was ALREADY active when the tile fired, nothing
+ *     is changed and nothing is restored.
+ *
+ * The tile is therefore momentary in effect: it never leaves the
+ * receiver discoverable after the user closes the sheet (unless it was
+ * already discoverable before, which it leaves untouched).
+ *
+ * ### Tile visual state
+ *
+ * The tile still mirrors [MdnsVisibilityOverrideHolder.isActive] in
+ * [syncTile] so that, while the sheet is open and visibility is bumped,
+ * the tile reads ACTIVE; once the sheet is dismissed and visibility
+ * restored, the next [onStartListening] re-syncs it back to INACTIVE.
+ * The override lives in memory only and resets on process death.
  */
 internal class BadaQuickShareTileService : TileService() {
     /**
      * Fires each time the Quick Settings panel becomes visible. Re-read
      * the current override so the tile reflects state changed elsewhere
-     * (the in-app pill, or a process restart that reset the override).
+     * (the in-app pill, the receive sheet bumping/restoring visibility,
+     * or a process restart that reset the override).
      */
     override fun onStartListening() {
         super.onStartListening()
@@ -55,18 +71,19 @@ internal class BadaQuickShareTileService : TileService() {
 
     override fun onClick() {
         super.onClick()
-        if (MdnsVisibilityOverrideHolder.isActive) {
-            turnOff()
-        } else {
-            turnOn()
-        }
+        openReceiveSheet()
         syncTile()
     }
 
-    private fun turnOn() {
+    /**
+     * Capture → bump → open the receive sheet. The restore half runs
+     * later from [ConsentTrampolineActivity.finish] via
+     * [TileVisibilityElevationHolder.restoreIfArmed].
+     */
+    private fun openReceiveSheet() {
         // Being discoverable needs the mandatory discovery permission
         // (NEARBY_WIFI_DEVICES on API 33+). If it isn't granted yet,
-        // toggling the override would light up a switch that can never
+        // bumping visibility would light up a receiver that can never
         // actually advertise — so bounce the user into the app instead,
         // which routes to the permissions onboarding. This mirrors
         // MainActivity's own service-start gate.
@@ -77,29 +94,92 @@ internal class BadaQuickShareTileService : TileService() {
             return
         }
 
-        MdnsVisibilityOverrideHolder.setAlwaysVisible(true)
+        // (a) Capture the prior visibility BEFORE touching anything.
+        val priorOverrideActive = MdnsVisibilityOverrideHolder.isActive
+
+        // (b) If below "visible", raise it AND start the service — only
+        // for the duration of the sheet. When already visible, change
+        // nothing (the user is in a persistent always-on state we must
+        // not disturb).
+        var startedService = false
+        if (!priorOverrideActive) {
+            MdnsVisibilityOverrideHolder.setAlwaysVisible(true)
+            try {
+                // startWithRadios (not start): opening the receive sheet from
+                // the tile also forces Wi-Fi + Bluetooth on via the radio-helper
+                // for the duration of the receive; they are restored when the
+                // sheet closes and stops this service (TileVisibilityElevationHolder
+                // -> ReceiverForegroundService.stop -> restoreRadiosAfterShare).
+                ReceiverForegroundService.startWithRadios(this)
+                startedService = true
+            } catch (e: IllegalStateException) {
+                // Android 12+ forbids most background foreground-service
+                // starts; ForegroundServiceStartNotAllowedException
+                // (API 31+) extends IllegalStateException, and a Quick
+                // Settings tap is NOT one of the platform's documented
+                // start exemptions. When Bada is fully backgrounded the
+                // start can be rejected — roll back the override bump we
+                // just made and bounce into the app, which starts the
+                // receiver from a visible (exempt) context.
+                Log.w(TAG, "Foreground-service start from tile rejected; opening app instead", e)
+                MdnsVisibilityOverrideHolder.setAlwaysVisible(false)
+                openApp()
+                return
+            }
+        }
+
+        // Record what we did so the sheet's dismissal restores it. Arm
+        // even when nothing was bumped (priorOverrideActive=true) so the
+        // activity's restore call is a clean no-op rather than acting on
+        // a stale prior elevation.
+        TileVisibilityElevationHolder.arm(
+            priorOverride = priorOverrideActive,
+            startedService = startedService,
+        )
+
+        // (c) Launch the receive sheet in waiting mode.
         try {
-            ReceiverForegroundService.start(this)
+            launchReceiveSheet()
         } catch (e: IllegalStateException) {
-            // Android 12+ forbids most background foreground-service
-            // starts; ForegroundServiceStartNotAllowedException (API 31+)
-            // extends IllegalStateException, and a Quick Settings tap is
-            // NOT one of the platform's documented start exemptions. When
-            // Bada is fully backgrounded the start can therefore be
-            // rejected. Fall back to opening the app: MainActivity starts
-            // the receiver from a visible (exempt) context, and the
-            // override we just set makes the gate advertise immediately.
-            Log.w(TAG, "Foreground-service start from tile rejected; opening app instead", e)
-            openApp()
+            // Launching the activity from the tile failed (rare vendor
+            // background-activity-launch restriction). Undo the bump so
+            // we don't leave the receiver discoverable with no sheet to
+            // dismiss it.
+            Log.w(TAG, "Receive-sheet launch from tile failed; restoring visibility", e)
+            TileVisibilityElevationHolder.restoreIfArmed(this)
         }
     }
 
-    private fun turnOff() {
-        MdnsVisibilityOverrideHolder.setAlwaysVisible(false)
-        // stop() delivers ACTION_STOP through startService to the
-        // already-running service. Re-delivering to a running service is
-        // allowed from the background, so this needs no FGS-start handling.
-        ReceiverForegroundService.stop(this)
+    /**
+     * Start [ConsentTrampolineActivity] in Phase 2 waiting mode. The
+     * `ACTION_OPEN_RECEIVE_SHEET` action with no connection id tells the
+     * activity to show the "waiting for sender" panel. The visibility bump and
+     * its restore are tracked by [TileVisibilityElevationHolder], not by an
+     * intent extra.
+     *
+     * `startActivityAndCollapse` collapses the Quick Settings shade as the
+     * sheet rises. API 34 made the bare-`Intent` overload throw, so we use
+     * the `PendingIntent` overload there and the `Intent` form below it.
+     */
+    private fun launchReceiveSheet() {
+        val intent =
+            Intent(this, ConsentTrampolineActivity::class.java).apply {
+                action = ConsentIntents.ACTION_OPEN_RECEIVE_SHEET
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+            }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            val pending =
+                PendingIntent.getActivity(
+                    this,
+                    RECEIVE_SHEET_REQUEST_CODE,
+                    intent,
+                    PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+                )
+            startActivityAndCollapse(pending)
+        } else {
+            @Suppress("DEPRECATION", "StartActivityAndCollapseDeprecated")
+            startActivityAndCollapse(intent)
+        }
     }
 
     /**
@@ -159,5 +239,12 @@ internal class BadaQuickShareTileService : TileService() {
 
     private companion object {
         const val TAG = "BadaQsTile"
+
+        /**
+         * Stable PendingIntent request code for the receive-sheet launch
+         * on API 34+. Distinct from the openApp PendingIntent's code so
+         * FLAG_UPDATE_CURRENT updates the right cached intent.
+         */
+        const val RECEIVE_SHEET_REQUEST_CODE = 1
     }
 }

--- a/app/src/main/kotlin/dev/bluehouse/bada/ui/sheet/RoundedProgressBar.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/ui/sheet/RoundedProgressBar.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.ui.sheet
+
+import android.animation.ValueAnimator
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.RectF
+import android.util.AttributeSet
+import android.view.View
+import android.view.animation.DecelerateInterpolator
+import kotlin.math.max
+import kotlin.math.min
+
+/**
+ * A horizontal rounded "pill" determinate progress bar: a light track with a
+ * Bada-blue fill whose width tracks [setProgress] (0..100), animated toward each
+ * new target. Used by the consent receive sheet's Receiving panel.
+ *
+ * Even at 0% a short rounded dot is drawn at the left so the bar reads as
+ * "started" before the transfer total is known, matching the dot the consent
+ * panel shows while it waits for the first chunk.
+ *
+ * Programmatic custom view: corner radii, stroke widths, and ARGB colour
+ * components are inherently numeric drawing constants, so MagicNumber is suppressed.
+ */
+@Suppress("MagicNumber")
+public class RoundedProgressBar
+    @JvmOverloads
+    constructor(
+        context: Context,
+        attrs: AttributeSet? = null,
+        defStyleAttr: Int = 0,
+    ) : View(context, attrs, defStyleAttr) {
+        private val density = context.resources.displayMetrics.density
+
+        private val trackPaint =
+            Paint(Paint.ANTI_ALIAS_FLAG).apply { color = TRACK_COLOR }
+        private val fillPaint =
+            Paint(Paint.ANTI_ALIAS_FLAG).apply { color = FILL_COLOR }
+
+        /** Current displayed fill fraction in [0, 1]; animated toward the target. */
+        private var fraction: Float = 0f
+        private var animator: ValueAnimator? = null
+
+        private val trackRect = RectF()
+        private val fillRect = RectF()
+
+        /**
+         * Set the progress fill to [percent] (0..100), animating from the current
+         * fill. Clamped to the valid range; safe to call on every progress tick.
+         */
+        public fun setProgress(percent: Int) {
+            val target = (percent.coerceIn(0, 100)) / 100f
+            animator?.cancel()
+            animator =
+                ValueAnimator.ofFloat(fraction, target).apply {
+                    duration = ANIM_MS
+                    interpolator = DecelerateInterpolator()
+                    addUpdateListener {
+                        fraction = it.animatedValue as Float
+                        invalidate()
+                    }
+                    start()
+                }
+        }
+
+        override fun onDetachedFromWindow() {
+            animator?.cancel()
+            animator = null
+            super.onDetachedFromWindow()
+        }
+
+        override fun onMeasure(
+            widthMeasureSpec: Int,
+            heightMeasureSpec: Int,
+        ) {
+            // Track height defaults to BAR_HEIGHT_DP when the layout left it as
+            // wrap_content; width is whatever the parent grants.
+            val h = resolveSize((BAR_HEIGHT_DP * density).toInt(), heightMeasureSpec)
+            val w = resolveSize(suggestedMinimumWidth, widthMeasureSpec)
+            setMeasuredDimension(w, h)
+        }
+
+        override fun onDraw(canvas: Canvas) {
+            val w = width.toFloat()
+            val h = height.toFloat()
+            val radius = h / 2f
+
+            trackRect.set(0f, 0f, w, h)
+            canvas.drawRoundRect(trackRect, radius, radius, trackPaint)
+
+            // Keep a minimum visible cap (a "dot") so 0% still reads as started.
+            val fillWidth = max(h, min(w, w * fraction))
+            fillRect.set(0f, 0f, fillWidth, h)
+            canvas.drawRoundRect(fillRect, radius, radius, fillPaint)
+        }
+
+        private companion object {
+            private const val BAR_HEIGHT_DP = 8f
+            private const val ANIM_MS = 240L
+
+            // Light neutral track; Bada blue (#0A84FF) fill — same accent the
+            // ring progress + device badges use.
+            private const val TRACK_COLOR = 0xFFE3E6EC.toInt()
+            private const val FILL_COLOR = 0xFF0A84FF.toInt()
+        }
+    }

--- a/app/src/main/res/layout/activity_consent_trampoline.xml
+++ b/app/src/main/res/layout/activity_consent_trampoline.xml
@@ -206,6 +206,40 @@
 
         </LinearLayout>
 
+        <!--
+          Waiting state — shown when the receive sheet is opened from the
+          Quick Settings tile with no transfer yet pending (ACTION_OPEN_RECEIVE_SHEET).
+          The device is now discoverable and waiting for a nearby sender; when a
+          transfer arrives the panel swaps to the consent prompt in place.
+        -->
+        <LinearLayout
+            android:id="@+id/consent_waiting_panel"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:gravity="center"
+            android:orientation="vertical"
+            android:padding="24dp"
+            android:visibility="gone">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:text="@string/consent_state_waiting_title"
+                android:textAppearance="@style/TextAppearance.AppCompat.Headline"
+                android:textStyle="bold" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:gravity="center"
+                android:text="@string/consent_state_waiting_body"
+                android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+                android:textColor="?android:attr/textColorSecondary" />
+
+        </LinearLayout>
+
         <!-- Receiving state. -->
         <LinearLayout
             android:id="@+id/consent_receiving_panel"
@@ -224,29 +258,22 @@
                 android:textAppearance="@style/TextAppearance.AppCompat.Headline"
                 android:textStyle="bold" />
 
-            <FrameLayout
+            <TextView
+                android:id="@+id/consent_receiving_progress_pct"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="24dp">
+                android:layout_marginTop="24dp"
+                android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+                android:textStyle="bold"
+                tools:text="42%" />
 
-                <com.google.android.material.progressindicator.CircularProgressIndicator
-                    android:id="@+id/consent_receiving_progress"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:indeterminate="true"
-                    app:indicatorSize="72dp"
-                    app:trackThickness="6dp" />
-
-                <TextView
-                    android:id="@+id/consent_receiving_progress_pct"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center"
-                    android:textAppearance="@style/TextAppearance.AppCompat.Body1"
-                    android:textStyle="bold"
-                    tools:text="42%" />
-
-            </FrameLayout>
+            <!-- Horizontal "pill" determinate bar; ConsentTrampolineActivity
+                 animates the blue fill toward each progress fraction. -->
+            <dev.bluehouse.bada.ui.sheet.RoundedProgressBar
+                android:id="@+id/consent_receiving_progress"
+                android:layout_width="220dp"
+                android:layout_height="8dp"
+                android:layout_marginTop="12dp" />
 
             <TextView
                 android:id="@+id/consent_receiving_progress_text"

--- a/service-android/src/main/kotlin/dev/bluehouse/bada/service/receiver/NfcColdReceiverPrimer.kt
+++ b/service-android/src/main/kotlin/dev/bluehouse/bada/service/receiver/NfcColdReceiverPrimer.kt
@@ -114,25 +114,6 @@ object NfcColdReceiverPrimer {
     }
 
     /**
-     * Publish the live receiver link for a WARM session — one already running with
-     * its TCP listener bound on [port] — so an NFC tap answers a real
-     * `deym + Wi-Fi-LAN rxAdv` tag without cold-priming a second socket. Called by
-     * [ReceiverForegroundService] right after the session binds. Returns the
-     * published link, or `null` when there is no Wi-Fi-LAN IPv4 to advertise (the
-     * receiver isn't reachable over Wi-Fi-LAN, so we leave the tag empty).
-     */
-    fun publishWarmLink(
-        context: Context,
-        port: Int,
-    ): NfcTapLinkHolder.Link? {
-        val ip = firstWifiLanIpv4(context) ?: return null
-        val link = buildLink(context, ip, port)
-        NfcTapLinkHolder.set(link)
-        DiagnosticLog.w(TAG, "publishWarmLink: live tag ${ip.hostAddress}:$port")
-        return link
-    }
-
-    /**
      * Build the [NfcTapLinkHolder.Link] advertised over NFC for the given live
      * [ip]/[port], reusing the cached [EndpointIdentityHolder] snapshot so we
      * don't re-read device-name settings on the HCE thread when possible.

--- a/service-android/src/main/kotlin/dev/bluehouse/bada/service/receiver/ReceiverForegroundService.kt
+++ b/service-android/src/main/kotlin/dev/bluehouse/bada/service/receiver/ReceiverForegroundService.kt
@@ -32,8 +32,11 @@ import dev.bluehouse.bada.discovery.diagnostics.DiagnosticLog
 import dev.bluehouse.bada.discovery.medium.MediumRegistries
 import dev.bluehouse.bada.protocol.endpoint.BleServiceData
 import dev.bluehouse.bada.protocol.endpoint.EndpointInfo
+import dev.bluehouse.bada.protocol.endpoint.NearbyServiceId
 import dev.bluehouse.bada.protocol.nfc.NfcTapLinkHolder
 import dev.bluehouse.bada.service.downloads.DownloadsWriterFactory
+import dev.bluehouse.bada.service.radio.RadioHelperClient
+import dev.bluehouse.bada.service.radio.ShareRadioController
 import dev.bluehouse.bada.service.receiver.consent.ConsentBroadcastReceiver
 import dev.bluehouse.bada.service.receiver.consent.ConsentCoordinator
 import dev.bluehouse.bada.service.receiver.consent.ConsentDiagnostic
@@ -59,6 +62,8 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
+import java.net.Inet4Address
+import java.net.InetAddress
 import java.util.concurrent.atomic.AtomicReference
 
 /**
@@ -123,6 +128,7 @@ import java.util.concurrent.atomic.AtomicReference
  * (see [ReceiverSession]) so the service body remains the only
  * Android-coupled surface.
  */
+@Suppress("TooManyFunctions") // Aggregates the receiver, consent, progress, NFC, and tile-wake glue.
 public class ReceiverForegroundService : Service() {
     private val serviceJob: Job = SupervisorJob()
     private val serviceScope: CoroutineScope = CoroutineScope(serviceJob + Dispatchers.IO)
@@ -169,6 +175,28 @@ public class ReceiverForegroundService : Service() {
 
     @Volatile
     private var mdnsGate: MdnsAdvertisementGate? = null
+
+    /**
+     * Bounded cold-tap wake window (NFC tap-to-receive). Cancelled/replaced
+     * on each [ACTION_NFC_WAKE]; on expiry it restores the visibility
+     * override unless the user already had it on before the tap.
+     */
+    @Volatile
+    private var nfcWakeJob: Job? = null
+
+    /** Visibility-override state captured when a fresh wake window opened. */
+    private var nfcWakePriorOverride: Boolean = false
+
+    /**
+     * Shared radio lease used to force Wi-Fi + Bluetooth ON for an NFC
+     * tap-to-receive wake or a Quick Settings tile open, restored at teardown.
+     * The same [ShareRadioController] type backs the sender too — see
+     * [ensureRadiosForWake] / [restoreRadiosAfterShare]. All calls on the main
+     * thread per the client's threading contract.
+     */
+    private val shareRadios: ShareRadioController by lazy {
+        ShareRadioController(this, logTag = NFC_WAKE_TAG)
+    }
 
     @Volatile
     private var discoveryDiagnosticsJob: Job? = null
@@ -252,7 +280,83 @@ public class ReceiverForegroundService : Service() {
             startReceiverSession()
         }
 
+        // Cold NFC tap-to-receive: a tap on our idle HCE starts the service
+        // with this action. Force a bounded visibility window so we
+        // advertise and the tapping sender can connect; the normal inbound
+        // path then posts the Accept consent notification (no app takeover).
+        if (intent?.action == ACTION_NFC_WAKE) {
+            ensureRadiosForWake()
+            armNfcWakeWindow()
+        }
+
+        // Quick Settings tile tap (open receive sheet). The tile already
+        // manages the visibility bump + its restore; here we only force
+        // Wi-Fi + Bluetooth on for the receive. They are restored by
+        // [restoreRadiosAfterShare] when the sheet closes and stops the
+        // service the tile started (see [TileVisibilityElevationHolder]).
+        if (intent?.action == ACTION_TILE_WAKE) {
+            ensureRadiosForWake()
+        }
+
         return START_STICKY
+    }
+
+    /**
+     * Open a bounded visibility window in response to a cold NFC tap
+     * (mirrors stock Quick Share's `djvf.f` -> `PendingIntent.send`: the
+     * tapped-while-idle HCE wakes the receiver into a discoverable state).
+     * Forces [MdnsVisibilityOverrideHolder] on so the
+     * [MdnsAdvertisementGate] publishes immediately, then auto-restores
+     * after [NFC_WAKE_WINDOW_MILLIS] — unless the user already had
+     * always-visible on before the tap, in which case it is left untouched.
+     * A transfer that starts inside the window keeps its own session alive
+     * regardless of the override, so expiring the window does not interrupt
+     * an in-flight receive.
+     */
+    private fun armNfcWakeWindow() {
+        if (nfcWakeJob?.isActive != true) {
+            nfcWakePriorOverride = MdnsVisibilityOverrideHolder.isActive
+        }
+        MdnsVisibilityOverrideHolder.setAlwaysVisible(true)
+        DiagnosticLog.w(NFC_WAKE_TAG, "nfc-wake: visibility forced for ${NFC_WAKE_WINDOW_MILLIS}ms")
+        nfcWakeJob?.cancel()
+        nfcWakeJob =
+            serviceScope.launch {
+                delay(NFC_WAKE_WINDOW_MILLIS)
+                if (!nfcWakePriorOverride) {
+                    MdnsVisibilityOverrideHolder.setAlwaysVisible(false)
+                    DiagnosticLog.w(NFC_WAKE_TAG, "nfc-wake: window expired -> visibility restored")
+                }
+            }
+    }
+
+    /**
+     * Force Wi-Fi + Bluetooth ON for an NFC tap-to-receive, routed through the
+     * universal `:radio-helper` via [RadioHelperClient] SESSION mode. The helper
+     * captures the user's original radio state, enables only what's OFF, and
+     * restores it on [restoreRadiosAfterShare] (teardown) — this app tracks
+     * nothing. The transfer can't happen without Wi-Fi (Wi-Fi-LAN connect) and
+     * benefits from BLE (discovery + GATT initial-control), and the headless
+     * wake can't pop a dialog — hence the silent helper.
+     *
+     * Best-effort + fully logged: helper not installed / bind denied (wrong key)
+     * / OEM force-stop / 5 s timeout → log and continue (BLE + mDNS advertise
+     * still come up). Called on the main thread from [onStartCommand] per the
+     * client's threading contract. NOT device-verified — whether the helper
+     * actually flips the radios on the target OEM is the make-or-break.
+     */
+    private fun ensureRadiosForWake() {
+        shareRadios.requestRadiosOn(RadioHelperClient.RADIO_BOTH)
+    }
+
+    /**
+     * Tell the radio-helper the share is over so it restores ONLY the radios it
+     * turned on, then unbind. Called from [stopReceiverAndExit]. Fires the
+     * restore message before unbinding so the helper (a separate process) still
+     * runs its restore even as this service goes away. Main-thread (teardown).
+     */
+    private fun restoreRadiosAfterShare() {
+        shareRadios.restoreRadios(finishSession = true)
     }
 
     /**
@@ -414,12 +518,9 @@ public class ReceiverForegroundService : Service() {
                 // responder, which has its own multicast filter
                 // exemption.
                 //
-                // Publish the live NFC tap-to-receive link (#NFC) so a tap on
-                // this already-running receiver answers a real tag pointing at
-                // the bound port — the warm counterpart of NfcColdReceiverPrimer.
-                // A cold tap that primed + adopted a socket lands on the same
-                // port, so this is consistent either way; no-op without Wi-Fi-LAN.
-                NfcColdReceiverPrimer.publishWarmLink(applicationContext, newSession.boundPort)
+                // The live NFC tap-to-receive link is published reactively by
+                // [startNfcTapLinkPublisher] (tracks the advertise state), so no
+                // one-shot publish is needed here.
                 startMdnsGate(newSession)
             } catch (
                 @Suppress("SwallowedException") t: Throwable,
@@ -439,6 +540,81 @@ public class ReceiverForegroundService : Service() {
         // debug screen. The cadence is intentionally slow (every 10s)
         // so we don't spam logcat in the steady state.
         startDiscoveryDiagnosticsLogger()
+
+        // Publish / clear the Quick Share NFC tap-to-share link in
+        // lock-step with the receiver's mDNS advertise state so the HCE
+        // (BadaTapHceService) only emits a live tag while we are
+        // actually a reachable receiver.
+        startNfcTapLinkPublisher(newSession)
+    }
+
+    /**
+     * Drive [NfcTapLinkHolder] from the receiver's advertise state.
+     *
+     * When the receiver starts advertising (mDNS publish — gated by the
+     * same foreground/sheet/visibility signals as the
+     * [MdnsAdvertisementGate]), build a [NfcTapLinkHolder.Link] from the
+     * live identity (endpointId + EndpointInfo), the Nearby service-id
+     * hash, the device's Wi-Fi-LAN IPv4 address, and the session's bound
+     * TCP port, and publish it so the HCE can serve it to a tapping Quick
+     * Share sender. When advertising stops, clear the holder so a tap
+     * becomes a no-op rather than pointing at a dead port.
+     *
+     * The bound port and LAN IP are re-read on each transition so a Wi-Fi
+     * reconnect (new IP) is reflected the next time advertising flips on.
+     */
+    private fun startNfcTapLinkPublisher(activeSession: ReceiverSession) {
+        serviceScope.launch {
+            ReceiverAdvertisementStateHolder.advertisingFlow.collect { advertising ->
+                if (!advertising || !activeSession.isRunning) {
+                    NfcTapLinkHolder.clear()
+                    return@collect
+                }
+                val endpointInfo = EndpointIdentityHolder.snapshot.get()
+                val ip = firstWifiLanIpv4()
+                val port = runCatching { activeSession.boundPort }.getOrNull()
+                if (endpointInfo == null || ip == null || port == null) {
+                    NfcTapLinkHolder.clear()
+                    return@collect
+                }
+                NfcTapLinkHolder.set(
+                    NfcTapLinkHolder.Link(
+                        endpointId = BleEndpointIdHolder.bytesFor(),
+                        serviceIdHash = NearbyServiceId.hashPrefix,
+                        endpointInfo = endpointInfo.serialize(),
+                        address = ip,
+                        port = port,
+                    ),
+                )
+            }
+        }
+    }
+
+    /**
+     * First non-loopback, non-link-local IPv4 address on a Wi-Fi
+     * transport, matching the address `Discovery` advertises over mDNS.
+     * Returns `null` when Wi-Fi has no usable IPv4 (e.g. cellular-only),
+     * in which case the tap-to-share holder is left cleared.
+     */
+    @Suppress("DEPRECATION")
+    private fun firstWifiLanIpv4(): Inet4Address? {
+        val cm =
+            applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE)
+                as? android.net.ConnectivityManager ?: return null
+        return cm.allNetworks
+            .asSequence()
+            .filter { network ->
+                cm
+                    .getNetworkCapabilities(network)
+                    ?.hasTransport(android.net.NetworkCapabilities.TRANSPORT_WIFI) == true
+            }.mapNotNull { network -> cm.getLinkProperties(network) }
+            .flatMap { linkProperties -> linkProperties.linkAddresses.asSequence() }
+            .map { linkAddress -> linkAddress.address }
+            .filterIsInstance<Inet4Address>()
+            .filterNot { addr: InetAddress ->
+                addr.isAnyLocalAddress || addr.isLoopbackAddress || addr.isLinkLocalAddress
+            }.sortedBy(InetAddress::getHostAddress)
+            .firstOrNull()
     }
 
     /**
@@ -900,14 +1076,24 @@ public class ReceiverForegroundService : Service() {
     }
 
     private fun stopReceiverAndExit() {
+        // Clear any outstanding tile-elevation record: the receiver is
+        // being torn down (explicit stop or process teardown), so a later
+        // receive-sheet dismissal must not try to "restore" by stopping a
+        // service that is already gone or re-toggling an override the user
+        // may have since changed by other means. Best-effort, idempotent.
+        TileVisibilityElevationHolder.disarm()
+        // The receiver is going away — make sure a tap can no longer read
+        // a stale tag pointing at the about-to-close TCP listener. The
+        // advertising-flow collector also clears this, but the scope is
+        // cancelled below so we clear eagerly here.
+        NfcTapLinkHolder.clear()
+        // Cold-tap cleanup: tell the radio-helper the share is over (restore the
+        // radios it enabled) and release any primer listener that was bound for a
+        // cold tap but never adopted (e.g. a refused FGS wake).
+        restoreRadiosAfterShare()
+        NfcColdReceiverPrimer.discardUnadopted()
         stopActiveReceiverSession()
         unregisterConsentReceiverIfNeeded()
-
-        // The receiver is no longer live: clear the NFC tap-to-receive link so a
-        // tap answers an empty tag (no stale port), and release any cold-tap
-        // primed-but-unadopted socket so a refused FGS wake doesn't leak it.
-        NfcTapLinkHolder.clear()
-        NfcColdReceiverPrimer.discardUnadopted()
 
         // Detach the ProcessLifecycleOwner observer first — once the
         // scanner is stopped, any late foreground/background callback
@@ -954,6 +1140,30 @@ public class ReceiverForegroundService : Service() {
          * is accepted on the advertised port. Not exported.
          */
         public const val ACTION_NFC_WAKE: String = "dev.bluehouse.bada.service.receiver.ACTION_NFC_WAKE"
+
+        /**
+         * Action sent by [dev.bluehouse.bada.tile.BadaQuickShareTileService] when the
+         * Quick Settings tile is tapped to open the receive sheet. The tile owns
+         * the visibility bump itself (via [MdnsVisibilityOverrideHolder] +
+         * [TileVisibilityElevationHolder]); this action additionally asks us to
+         * force Wi-Fi + Bluetooth ON for the receive through the radio-helper,
+         * restored on teardown ([restoreRadiosAfterShare] from
+         * [stopReceiverAndExit] when the sheet closes and stops the service the
+         * tile started). Not exported (package-internal control intent).
+         */
+        public const val ACTION_TILE_WAKE: String = "dev.bluehouse.bada.service.receiver.ACTION_TILE_WAKE"
+
+        /** Logcat tag for cold NFC / tile wake lifecycle lines. */
+        private const val NFC_WAKE_TAG: String = "BadaNfcWake"
+
+        /**
+         * How long a cold NFC / tile wake keeps the receiver forcibly visible/
+         * advertising so the sender can connect. After this the visibility
+         * override is restored (unless the user had it on already). 60 s
+         * mirrors the [MdnsAdvertisementGate] debounce so a tap that lands
+         * just before a sender's first connect attempt still rendezvous.
+         */
+        private const val NFC_WAKE_WINDOW_MILLIS: Long = 60_000L
 
         /**
          * Intent extra carrying a serialized [EndpointInfo] when the
@@ -1070,6 +1280,26 @@ public class ReceiverForegroundService : Service() {
          */
         public fun start(context: Context) {
             val intent = Intent(context, ReceiverForegroundService::class.java)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(intent)
+            } else {
+                context.startService(intent)
+            }
+        }
+
+        /**
+         * Bring up the foreground service AND force Wi-Fi + Bluetooth on for
+         * the receive (via the radio-helper), restored when the service is
+         * later stopped. Used by [dev.bluehouse.bada.tile.BadaQuickShareTileService]
+         * so opening the receive sheet from the Quick Settings tile also turns
+         * the radios on. Same platform-call wrapping as [start]; differs only
+         * by tagging the start intent with [ACTION_TILE_WAKE].
+         */
+        public fun startWithRadios(context: Context) {
+            val intent =
+                Intent(context, ReceiverForegroundService::class.java).apply {
+                    action = ACTION_TILE_WAKE
+                }
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 context.startForegroundService(intent)
             } else {

--- a/service-android/src/main/kotlin/dev/bluehouse/bada/service/receiver/TileVisibilityElevationHolder.kt
+++ b/service-android/src/main/kotlin/dev/bluehouse/bada/service/receiver/TileVisibilityElevationHolder.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.service.receiver
+
+import android.content.Context
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Process-wide one-shot record of a **temporary** receiver-visibility
+ * elevation performed by the Quick Settings tile (Phase 2).
+ *
+ * ### Why
+ *
+ * The Phase 2 tile no longer toggles the persistent "always visible"
+ * override. Instead a tap opens the receive bottom sheet
+ * ([dev.bluehouse.bada.consent.ConsentTrampolineActivity]) and bumps the
+ * receiver to visible **only for the lifetime of that sheet**. When the
+ * sheet is dismissed the prior state must be restored exactly:
+ *
+ *  - if the override was already active (the device was already
+ *    discoverable), the tile changes nothing and there is nothing to
+ *    restore;
+ *  - if the override was off and no receiver service was running, the
+ *    tile turns the override on + starts the service, and on dismissal
+ *    turns the override back off + stops the service it started.
+ *
+ * The sheet activity lives in `:app` and the tile in `:app`, but the
+ * restore must survive the activity reporting its own dismissal back
+ * without either side holding a reference to the other. This holder is
+ * that rendezvous: the tile [arm]s it with the captured prior state at
+ * elevation time, and the activity calls [restoreIfArmed] from its
+ * `finish` path. It is also disarmed by the receiver service's own
+ * teardown so a process that dies with the sheet open does not leave a
+ * stale armed flag that would later stop a legitimately-running service.
+ *
+ * ### Robustness to process death
+ *
+ * The record is in-memory only. If the process is killed while the sheet
+ * is open, the [MdnsVisibilityOverrideHolder] override (also in-memory)
+ * resets to `false` on the next process start anyway, so the elevation
+ * does not persist — the system is in the same place a fresh process
+ * would be. Best-effort by design.
+ */
+public object TileVisibilityElevationHolder {
+    /** `true` between [arm] and [restoreIfArmed] / [disarm]. */
+    private val armed = AtomicBoolean(false)
+
+    /**
+     * Snapshot of [MdnsVisibilityOverrideHolder.isActive] captured at
+     * [arm] time. Only meaningful while [armed] is `true`.
+     */
+    @Volatile
+    private var priorOverrideActive: Boolean = false
+
+    /**
+     * `true` when [arm] actually started the receiver service (i.e. the
+     * override was off when the tile fired). Drives whether
+     * [restoreIfArmed] stops the service. Only meaningful while [armed].
+     */
+    @Volatile
+    private var elevatedService: Boolean = false
+
+    /**
+     * Record a tile elevation. [priorOverride] is the override state the
+     * tile observed *before* it bumped visibility; [startedService] is
+     * whether the tile started the receiver service as part of the bump.
+     *
+     * Idempotent against a double-arm (e.g. a rapid double tap): the
+     * first armed snapshot wins so the restore still targets the true
+     * pre-elevation state.
+     */
+    public fun arm(
+        priorOverride: Boolean,
+        startedService: Boolean,
+    ) {
+        if (armed.compareAndSet(false, true)) {
+            priorOverrideActive = priorOverride
+            elevatedService = startedService
+        }
+    }
+
+    /** `true` while an elevation is outstanding. */
+    public val isArmed: Boolean
+        get() = armed.get()
+
+    /**
+     * Restore the pre-elevation receiver state if an elevation is
+     * outstanding, then disarm. No-op when not armed (so a duplicate
+     * dismissal, or a dismissal of a sheet that was opened by an
+     * incoming transfer rather than the tile, does nothing).
+     *
+     * When the prior override was already active, nothing is changed —
+     * the device was discoverable before the tile fired and stays so.
+     * Otherwise the override is set back to `false`; if the tile also
+     * started the service, the service is stopped.
+     */
+    public fun restoreIfArmed(context: Context) {
+        if (!armed.compareAndSet(true, false)) return
+        if (priorOverrideActive) {
+            // Was already visible before the tile — leave everything be.
+            return
+        }
+        MdnsVisibilityOverrideHolder.setAlwaysVisible(false)
+        if (elevatedService) {
+            ReceiverForegroundService.stop(context)
+        }
+    }
+
+    /**
+     * Clear the armed flag without restoring. Used by the receiver
+     * service's own teardown so a later sheet dismissal cannot stop /
+     * re-toggle a service the user has since controlled by other means.
+     */
+    public fun disarm() {
+        armed.set(false)
+    }
+}

--- a/service-android/src/main/kotlin/dev/bluehouse/bada/service/receiver/consent/ConsentIntents.kt
+++ b/service-android/src/main/kotlin/dev/bluehouse/bada/service/receiver/consent/ConsentIntents.kt
@@ -74,6 +74,18 @@ public object ConsentIntents {
     public const val ACTION_SHOW_CONSENT: String = "dev.bluehouse.bada.consent.SHOW"
 
     /**
+     * Activity action used by the Quick Settings tile to open the
+     * receive bottom sheet in **waiting** mode (Phase 2). The activity
+     * shows a "ready to receive / waiting for sender" state in the same
+     * sheet — no [EXTRA_CONNECTION_ID] is attached because no transfer
+     * is pending yet. When an incoming transfer then arrives while the
+     * sheet is foreground, the [ConsentCoordinator]'s foreground path
+     * routes that consent into this already-open activity via
+     * `onNewIntent` (the activity is `singleTop`).
+     */
+    public const val ACTION_OPEN_RECEIVE_SHEET: String = "dev.bluehouse.bada.consent.OPEN_RECEIVE_SHEET"
+
+    /**
      * `Long` extra carrying the connection id this consent applies to.
      * The broadcast receiver and the trampoline activity both parse
      * this off the intent before consulting [ConsentRegistry].


### PR DESCRIPTION
## What
A **Quick Settings tile** that opens a receive sheet and makes you discoverable to nearby phones, so they can send to you immediately — no opening the app and hunting for a button. Tapping the tile also turns Wi-Fi + Bluetooth on (and restores them when the sheet closes) and collapses the notification shade so you can see the screen.

![Quick Settings tile → receive sheet](https://raw.githubusercontent.com/IvanChanPing/Bada/fork/superdrop-ui/docs/pr-images/receive-tile-sheet.png)

## How
- **`BadaQuickShareTileService`** (`TileService`) — on tap it forces the receiver "visible" override on, starts the foreground receiver with `ACTION_TILE_WAKE`, and uses `startActivityAndCollapse` to drop the shade and surface the receive sheet.
- **`TileVisibilityElevationHolder`** — captures the prior visibility + radio state and restores it when the sheet closes (so a momentary tile-tap doesn't leave you permanently discoverable).
- Wires into the existing receive flow: `ConsentTrampolineActivity` (`ACTION_OPEN_RECEIVE_SHEET`) and `ReceiverForegroundService.startWithRadios`.

## ⚠️ Note for the maintainer — connected files
`ConsentTrampolineActivity` and `ReceiverForegroundService` are **shared** with the receive-sheet and prettier-notification work, so they're carried **whole** here and include changes beyond the tile (and reference receive-sheet UI classes that ship in the related PRs). The Wi-Fi/BT toggling on tile-tap routes through a separate companion radio-helper (its own change). The manifest here also declares other features' services. Integrate the set however suits you.

