### PR TITLE
Send picker: show " device name" instead of a raw IP for nameless peers

### DIFF
--- a/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/NearbyPeer.kt
+++ b/discovery-android/src/main/kotlin/dev/bluehouse/bada/discovery/NearbyPeer.kt
@@ -139,7 +139,14 @@ public data class NearbyPeer(
         if (bleName != null) return bleName
         if (!endpointId.isNullOrBlank()) return "Quick Share device ($endpointId)"
         if (bleAdvertisement != null) return "Quick Share BLE device"
-        return stableId
+        // Never surface the raw stableId (a LAN address / synthetic discovery
+        // key) as a user-facing name. A peer advertising hidden — stock Quick
+        // Share always sets the visibility bit, so deviceName is omitted on the
+        // wire — legitimately has no name to show before negotiation; show a
+        // generic label instead of leaking its IP address into the picker.
+        // (Two Bada devices advertise hidden=false with their real names,
+        // so this fallback only hits stock/hidden peers.)
+        return "Quick Share device"
     }
 
     /** Diagnostic source for the label selected by [displayName]. */

--- a/discovery-android/src/test/kotlin/dev/bluehouse/bada/discovery/NearbyPeerDiscoveryTest.kt
+++ b/discovery-android/src/test/kotlin/dev/bluehouse/bada/discovery/NearbyPeerDiscoveryTest.kt
@@ -744,6 +744,31 @@ class NearbyPeerDiscoveryTest {
             collector.cancel()
         }
 
+    @Test
+    fun `displayName falls back to a generic label and never leaks the LAN address`() {
+        // A nameless LAN-only peer (hidden EndpointInfo → no device name on the
+        // wire, no endpointId, no BLE advertisement). The stableId is a raw LAN
+        // address tuple; displayName() must NOT surface it (issue: raw IP shown
+        // in the picker) and must fall back to a generic label instead.
+        val peer =
+            NearbyPeer(
+                stableId = "lan:192.168.1.50:41234",
+                endpointId = null,
+                endpointInfo = endpointInfo(name = null, hidden = true),
+                lanEndpoint =
+                    NearbyPeer.LanEndpoint(
+                        instanceNames = setOf("instance-x"),
+                        addresses = listOf(InetAddress.getByName("192.168.1.50")),
+                        port = 41234,
+                    ),
+            )
+
+        val name = peer.displayName()
+        assertThat(name).isEqualTo("Quick Share device")
+        assertThat(name).doesNotContain("192.168.1.50")
+        assertThat(name.startsWith("lan:")).isFalse()
+    }
+
     private fun endpointInfo(
         name: String?,
         hidden: Boolean = false,


### PR DESCRIPTION
## Problem
A nearby device that doesn't broadcast a name — a stock or "hidden" Quick Share phone (stock QS always sets the visibility bit, so `deviceName` is omitted on the wire) — is shown in the send picker by its internal `stableId`, which is a LAN address. That leaks a raw **IP address** into the UI.

## Fix
`NearbyPeer.displayName()`'s final fallback now returns a generic **"Quick Share device"** label instead of the raw `stableId`. Peers that do advertise a name are unaffected.

