### PR TITLE
NFC tap-to-share: tap two phones to start a Quick Share transfer (backend)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -121,6 +121,16 @@
          as the helper. See the :radio-helper module + RadioHelperClient. -->
     <uses-permission android:name="dev.bluehouse.bada.radiohelper.permission.BIND_RADIO" />
 
+    <!-- NFC tap-to-share (#NFC). NFC is install-time normal protection;
+         BIND_NFC_SERVICE on the HCE service below is the actual gate and is
+         auto-granted to the system NFC service. The hce feature is
+         required=false so the app still installs on phones without NFC
+         hardware (the HCE service is simply never bound there). -->
+    <uses-permission android:name="android.permission.NFC" />
+    <uses-feature
+        android:name="android.hardware.nfc.hce"
+        android:required="false" />
+
     <!-- Wi-Fi local-only hotspot bandwidth-upgrade medium (#50). Both
          lines are required by WifiManager.startLocalOnlyHotspot on
          API 26+ — CHANGE_WIFI_STATE is install-time normal protection
@@ -334,6 +344,34 @@
             android:name=".send.ShowQrActivity"
             android:exported="false"
             android:label="@string/show_qr_title" />
+
+        <!--
+          Quick Share NFC tap-to-share HCE receiver (AID F00000FE2C).
+
+          A stock Quick Share sender in reader-mode (or Bada's own reader-mode)
+          tapped to this phone SELECTs F00000FE2C and reads our hhwv response
+          (deym NfcTag + Wi-Fi-LAN rxInstantConnectionAdv), then connects to our
+          live TcpReceiverServer over Wi-Fi-LAN. The HCE only emits a real tag
+          while a receiver is live (gated in code via NfcTapLinkHolder); a cold
+          tap pre-binds a socket and fires ACTION_NFC_WAKE so the session comes
+          up and adopts it (single cold tap == warm).
+
+          exported=true + BIND_NFC_SERVICE: only the system NFC service binds and
+          routes APDUs here, so this is not a third-party-callable surface. The
+          HOST_APDU_SERVICE intent-filter + host_apdu_service meta-data register
+          the AID group with the platform.
+        -->
+        <service
+            android:name=".nfc.BadaTapHceService"
+            android:exported="true"
+            android:permission="android.permission.BIND_NFC_SERVICE">
+            <intent-filter>
+                <action android:name="android.nfc.cardemulation.action.HOST_APDU_SERVICE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.nfc.cardemulation.host_apdu_service"
+                android:resource="@xml/bada_tap_apduservice" />
+        </service>
 
         <!--
           Consent trampoline (#22) — the screen-on, lock-screen-bypassing

--- a/app/src/main/kotlin/dev/bluehouse/bada/nfc/BadaTapHceService.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/nfc/BadaTapHceService.kt
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.nfc
+
+import android.content.Intent
+import android.nfc.cardemulation.HostApduService
+import android.os.Bundle
+import dev.bluehouse.bada.diag.DiagnosticUploader
+import dev.bluehouse.bada.discovery.diagnostics.DiagnosticLog
+import dev.bluehouse.bada.protocol.nfc.NfcTapLinkHolder
+import dev.bluehouse.bada.protocol.nfc.QuickShareNfcCodec
+import dev.bluehouse.bada.service.receiver.NfcColdReceiverPrimer
+import dev.bluehouse.bada.service.receiver.ReceiverForegroundService
+import java.security.SecureRandom
+
+/**
+ * Host Card Emulation service implementing the **Google Quick Share NFC
+ * tap-to-share** advertiser/receiver role on AID `F00000FE2C`.
+ *
+ * A stock Quick Share SENDER in reader-mode (or our own
+ * [dev.bluehouse.bada.send.SendActivity] reader-mode), tapped to the back of
+ * this phone while we are receiving, runs:
+ *
+ *  1. SELECT by name, AID `F00000FE2C` -> `9000`.
+ *  2. ADVERTISEMENT `80 01 00 00 <Lc> <hhww> 00 FF` -> we answer an
+ *     `hhwv` carrying our `deym` NfcTag + a Wi-Fi-LAN `rxInstantConnectionAdv`
+ *     advertising our live [dev.bluehouse.bada.protocol.server.TcpReceiverServer]
+ *     IP:port, then `9000`.
+ *
+ * The reader then injects us as a discovered peer (`onEndpointFound`) and
+ * connects over Wi-Fi-LAN — the transport we already host. NFC carries
+ * only the bootstrap identity + connectivity (verified
+ * `docs/NFC_INTEROP_BYTEMAP.md` §2).
+ *
+ * **Liveness gating.** The HCE only emits a real tag while
+ * [NfcTapLinkHolder.current] is non-null — i.e. the receiver service is up
+ * and advertising. The receiver service drives that holder per the user's
+ * [NfcTapSharePreferences] mode (SHEET_OPEN / APP_FOREGROUND / BACKGROUND),
+ * exactly like [NfcLinkHolder] gates the iPhone-link HCE. When the holder
+ * is null we still answer SELECT (so the reader's protocol does not error)
+ * but return an empty `hhwv` so a stray tap is a no-op.
+ *
+ * Separate AID from [BadaNdefApduService] (`D2760000850101`, the
+ * iPhone NDEF link), so the two HCE services coexist on the one controller.
+ *
+ * Public `android.nfc.cardemulation` APIs only + the auto-granted
+ * `BIND_NFC_SERVICE` permission. **NOT device-tested** (no NFC hardware in
+ * the build environment); the byte formats are smali-verified but the
+ * end-to-end tap is unvalidated.
+ */
+public class BadaTapHceService : HostApduService() {
+    private val secureRandom = SecureRandom()
+
+    override fun processCommandApdu(
+        apdu: ByteArray?,
+        extras: Bundle?,
+    ): ByteArray {
+        if (apdu == null || apdu.size < MIN_APDU_LEN) {
+            return QuickShareNfcCodec.SW_WRONG_LENGTH
+        }
+
+        // SELECT by name (00 A4 04 00 <Lc> <AID>).
+        if (apdu[1] == QuickShareNfcCodec.INS_SELECT && apdu[2] == P1_SELECT_BY_NAME) {
+            return if (apduSelectsAid(apdu, QuickShareNfcCodec.ADVERTISING_AID)) {
+                DiagnosticLog.w(TAG, "SELECT F00000FE2C -> 9000")
+                QuickShareNfcCodec.SW_OK
+            } else {
+                QuickShareNfcCodec.SW_FILE_NOT_FOUND
+            }
+        }
+
+        // ADVERTISEMENT (80 01 ..) — return our static tag.
+        if (apdu[0] == QuickShareNfcCodec.CLA_PROPRIETARY &&
+            apdu[1] == QuickShareNfcCodec.INS_ADVERTISEMENT
+        ) {
+            val response = handleAdvertisement(apdu)
+            // Auto-ship the receive-tap diagnostics (was our HCE invoked? did we
+            // prime a live tag or return empty?) so it's debuggable without adb.
+            DiagnosticUploader.upload(this, reason = "nfc-recv-tap")
+            return response
+        }
+
+        return QuickShareNfcCodec.SW_INS_NOT_SUPPORTED
+    }
+
+    override fun onDeactivated(reason: Int) {
+        // No per-session state to reset; the tag is rebuilt per ADVERTISEMENT.
+    }
+
+    /**
+     * Cold tap-to-receive wake. Android starts this [HostApduService] on a
+     * tap even if our process was dead, so this is the one cold-wake path a
+     * non-privileged app has (a BLE-scan wake needs the app already
+     * running). We ask [ReceiverForegroundService] to come up and open a
+     * bounded visibility window ([ReceiverForegroundService.ACTION_NFC_WAKE]);
+     * the tapping sender then connects and the normal inbound path posts the
+     * Accept consent notification — no app UI is forced to the foreground.
+     *
+     * Best-effort: a background foreground-service start can be refused on
+     * some OEMs/API levels (logged, not fatal). NOT device-verified.
+     */
+    private fun fireReceiveWake() {
+        runCatching {
+            val intent =
+                Intent(this, ReceiverForegroundService::class.java).apply {
+                    action = ReceiverForegroundService.ACTION_NFC_WAKE
+                }
+            startForegroundService(intent)
+        }.onFailure { DiagnosticLog.w(TAG, "receive wake failed: ${it.message}") }
+    }
+
+    /**
+     * Build the `hhwv` response for an ADVERTISEMENT APDU. Parses the
+     * reader's `hhww` (best-effort; we do not require a particular
+     * serviceId — Bada only advertises one service) and returns our
+     * live tag, or an empty response (no NfcTag field) when we are not a
+     * live receiver.
+     */
+    private fun handleAdvertisement(apdu: ByteArray): ByteArray {
+        // Warm: a live receiver already published its tag → answer it directly.
+        // Cold: PRIME a real, connectable tag synchronously NOW — bind a TCP
+        // listener + read the Wi-Fi-LAN IP in this callback so the FIRST tap
+        // answers exactly like a warm receiver (deym PCP=3 + Wi-Fi-LAN rxAdv),
+        // then fire the FGS wake so the session comes up and ADOPTS that same
+        // socket (its accept loop drains the kernel backlog on the identical
+        // port). This is what makes a single cold tap == warm, no second tap.
+        // If we cannot prime (no Wi-Fi-LAN IP yet — Wi-Fi off/connecting), fall
+        // back to the empty-tag + wake behaviour (the wake forces Wi-Fi/BT on
+        // via the radio-helper and BLE carries discovery while Wi-Fi settles).
+        val link =
+            NfcTapLinkHolder.current ?: run {
+                val primed = NfcColdReceiverPrimer.prime(this)
+                fireReceiveWake()
+                if (primed == null) {
+                    DiagnosticLog.w(TAG, "ADVERTISEMENT cold, no Wi-Fi IP -> wake + empty hhwv")
+                    return QuickShareNfcCodec.encodeHhwvResponse(
+                        QuickShareNfcCodec.HhwvResponse(nfcTag = ByteArray(0)),
+                    ) + QuickShareNfcCodec.SW_OK
+                }
+                DiagnosticLog.w(TAG, "ADVERTISEMENT cold -> primed live tag + wake (cold == warm, single tap)")
+                primed
+            }
+
+        // Parsing the request is informational; we always answer with our
+        // own single advertised service regardless of the requested id.
+        parseAdvertisementRequest(apdu)?.let { request ->
+            DiagnosticLog.w(TAG, "ADVERTISEMENT serviceId=${request.serviceId}")
+        }
+
+        val nfcTag =
+            QuickShareNfcCodec.encodeNfcTag(
+                endpointId = link.endpointId,
+                serviceIdHash = link.serviceIdHash,
+                endpointInfo = link.endpointInfo,
+                // BT MAC = all-zero sentinel: the Wi-Fi/LAN path needs no MAC.
+                btMac = ByteArray(BT_MAC_LEN),
+            )
+
+        val encryptionKey = ByteArray(NC_ENCRYPTION_KEY_LEN).also { secureRandom.nextBytes(it) }
+        val rxAdv =
+            QuickShareNfcCodec.encodeWifiLanRxAdv(
+                ip = link.address,
+                port = link.port,
+                encryptionKey = encryptionKey,
+            )
+
+        DiagnosticLog.w(TAG, "ADVERTISEMENT -> hhwv tag(${nfcTag.size}B) rxAdv(${rxAdv.size}B) ${link.address.hostAddress}:${link.port}")
+        return QuickShareNfcCodec.encodeHhwvResponse(
+            QuickShareNfcCodec.HhwvResponse(nfcTag = nfcTag, rxAdv = rxAdv),
+        ) + QuickShareNfcCodec.SW_OK
+    }
+
+    /**
+     * Extract the `hhww` payload from an ADVERTISEMENT APDU
+     * (`80 01 P1 P2 Lc <hhww> [00 FF trailer]`) and parse it. Returns
+     * `null` when the APDU has no parseable body — the response is the same
+     * either way, so this is purely diagnostic.
+     */
+    private fun parseAdvertisementRequest(apdu: ByteArray): QuickShareNfcCodec.HhwwRequest? {
+        if (apdu.size < ADVERTISEMENT_HEADER_LEN) return null
+        val lc = apdu[4].toInt() and 0xFF
+        val bodyStart = ADVERTISEMENT_HEADER_LEN
+        if (lc <= 0 || bodyStart + lc > apdu.size) return null
+        val body = apdu.copyOfRange(bodyStart, bodyStart + lc)
+        return QuickShareNfcCodec.parseHhwwRequest(body)
+    }
+
+    private companion object {
+        private const val TAG = "BadaTapHce"
+
+        private const val MIN_APDU_LEN = 4
+        private const val P1_SELECT_BY_NAME: Byte = 0x04
+
+        /** `80 01 P1 P2 Lc` before the hhww body. */
+        private const val ADVERTISEMENT_HEADER_LEN = 5
+
+        private const val NC_ENCRYPTION_KEY_LEN = 0x20
+        private const val BT_MAC_LEN = 6
+
+        /** True iff this SELECT-by-name APDU carries exactly [aid]. */
+        fun apduSelectsAid(
+            apdu: ByteArray,
+            aid: ByteArray,
+        ): Boolean {
+            // 00 A4 04 00 <Lc> <AID...> [Le]
+            if (apdu.size < 5 + aid.size) return false
+            val lc = apdu[4].toInt() and 0xFF
+            if (lc != aid.size) return false
+            for (i in aid.indices) {
+                if (apdu[5 + i] != aid[i]) return false
+            }
+            return true
+        }
+    }
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/nfc/BadaTapHceService.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/nfc/BadaTapHceService.kt
@@ -8,7 +8,6 @@ package dev.bluehouse.bada.nfc
 import android.content.Intent
 import android.nfc.cardemulation.HostApduService
 import android.os.Bundle
-import dev.bluehouse.bada.diag.DiagnosticUploader
 import dev.bluehouse.bada.discovery.diagnostics.DiagnosticLog
 import dev.bluehouse.bada.protocol.nfc.NfcTapLinkHolder
 import dev.bluehouse.bada.protocol.nfc.QuickShareNfcCodec
@@ -50,7 +49,11 @@ import java.security.SecureRandom
  * `BIND_NFC_SERVICE` permission. **NOT device-tested** (no NFC hardware in
  * the build environment); the byte formats are smali-verified but the
  * end-to-end tap is unvalidated.
+ *
+ * APDU parsing is inherently byte-index heavy and uses one guard-return per
+ * malformed-input case, so the class suppresses detekt's MagicNumber / ReturnCount.
  */
+@Suppress("MagicNumber", "ReturnCount")
 public class BadaTapHceService : HostApduService() {
     private val secureRandom = SecureRandom()
 
@@ -76,11 +79,7 @@ public class BadaTapHceService : HostApduService() {
         if (apdu[0] == QuickShareNfcCodec.CLA_PROPRIETARY &&
             apdu[1] == QuickShareNfcCodec.INS_ADVERTISEMENT
         ) {
-            val response = handleAdvertisement(apdu)
-            // Auto-ship the receive-tap diagnostics (was our HCE invoked? did we
-            // prime a live tag or return empty?) so it's debuggable without adb.
-            DiagnosticUploader.upload(this, reason = "nfc-recv-tap")
-            return response
+            return handleAdvertisement(apdu)
         }
 
         return QuickShareNfcCodec.SW_INS_NOT_SUPPORTED
@@ -167,7 +166,11 @@ public class BadaTapHceService : HostApduService() {
                 encryptionKey = encryptionKey,
             )
 
-        DiagnosticLog.w(TAG, "ADVERTISEMENT -> hhwv tag(${nfcTag.size}B) rxAdv(${rxAdv.size}B) ${link.address.hostAddress}:${link.port}")
+        DiagnosticLog.w(
+            TAG,
+            "ADVERTISEMENT -> hhwv tag(${nfcTag.size}B) rxAdv(${rxAdv.size}B) " +
+                "${link.address.hostAddress}:${link.port}",
+        )
         return QuickShareNfcCodec.encodeHhwvResponse(
             QuickShareNfcCodec.HhwvResponse(nfcTag = nfcTag, rxAdv = rxAdv),
         ) + QuickShareNfcCodec.SW_OK

--- a/app/src/main/kotlin/dev/bluehouse/bada/nfc/BadaTapReader.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/nfc/BadaTapReader.kt
@@ -1,0 +1,292 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.nfc
+
+import android.app.Activity
+import android.nfc.NfcAdapter
+import android.nfc.Tag
+import android.nfc.tech.IsoDep
+import dev.bluehouse.bada.diag.DiagnosticUploader
+import dev.bluehouse.bada.discovery.diagnostics.DiagnosticLog
+import dev.bluehouse.bada.protocol.endpoint.EndpointInfo
+import dev.bluehouse.bada.protocol.endpoint.NearbyServiceId
+import dev.bluehouse.bada.protocol.nfc.QuickShareNfcCodec
+import java.io.IOException
+import java.net.InetAddress
+
+/**
+ * Sender-side **Quick Share NFC tap-to-share reader** (reader-mode). While
+ * the send sheet is open (and the iPhone-link QR panel is NOT — the two
+ * share one NFC controller and are mutually exclusive), [enable] puts the
+ * adapter into reader-mode for ISO-DEP. On a tag, it transceives the Quick
+ * Share APDU exchange against the peer's HCE (`F00000FE2C`):
+ *
+ *  1. SELECT `00 A4 04 00 05 F00000FE2C 00` -> expect `9000`.
+ *  2. ADVERTISEMENT `80 01 00 00 <Lc> <hhww(serviceId="NearbySharing")> 00 FF`
+ *     -> parse the `hhwv` response: `deym` NfcTag + Wi-Fi-LAN rxAdv.
+ *
+ * The parsed identity (endpointId, EndpointInfo) + Wi-Fi-LAN IP:port are
+ * handed to [onPeerTapped] as a [TappedPeer], which [dev.bluehouse.bada.send.SendActivity]
+ * turns into a discovered peer and auto-connects to over the same path a
+ * tapped peer-icon uses.
+ *
+ * Public `android.nfc` APIs only. **NOT device-tested** (no NFC hardware
+ * in the build environment).
+ */
+public class BadaTapReader(
+    private val activity: Activity,
+    private val onPeerTapped: (TappedPeer) -> Unit,
+    private val onTapWake: () -> Unit = {},
+    /**
+     * One-line human-readable summary of EVERY tap (resolved / woke / failed) with the
+     * raw SELECT/ADVERTISEMENT bytes, so the send UI can surface it on-screen (Toast) —
+     * the on-device, no-internet observability path. Called on a binder thread; the
+     * activity marshals to the UI thread.
+     */
+    private val onTapDiagnostic: (String) -> Unit = {},
+) {
+    /** Raw SELECT/ADVERTISEMENT bytes of the in-flight exchange, for [onTapDiagnostic]. */
+    private var lastExchangeSummary: String = ""
+    /**
+     * A peer discovered via an NFC tap, ready to be injected into the send
+     * flow.
+     *
+     * @property endpointId the peer's 4-byte endpoint id (ASCII).
+     * @property endpointInfo the parsed Nearby EndpointInfo (device name etc.).
+     * @property address the peer's Wi-Fi-LAN address.
+     * @property port the peer's TCP port.
+     */
+    public data class TappedPeer(
+        val endpointId: String,
+        val endpointInfo: EndpointInfo,
+        val address: InetAddress,
+        val port: Int,
+    )
+
+    private val nfcAdapter: NfcAdapter? = NfcAdapter.getDefaultAdapter(activity)
+
+    /**
+     * Enter reader-mode. No-op when the device has no NFC adapter. Safe to
+     * call repeatedly (the platform replaces the prior reader-mode
+     * registration). Callers MUST ensure the iPhone-link NDEF HCE is not
+     * the intended NFC owner at the same time (reader-mode suppresses our
+     * own HCE while active anyway, but the QR panel should be closed).
+     */
+    public fun enable() {
+        val adapter = nfcAdapter ?: return
+        val flags =
+            NfcAdapter.FLAG_READER_NFC_A or
+                NfcAdapter.FLAG_READER_NFC_B or
+                NfcAdapter.FLAG_READER_SKIP_NDEF_CHECK
+        runCatching {
+            adapter.enableReaderMode(activity, ::onTag, flags, null)
+        }.onFailure { DiagnosticLog.w(TAG, "enableReaderMode failed: ${it.message}") }
+    }
+
+    /** Leave reader-mode. No-op when the device has no NFC adapter. */
+    public fun disable() {
+        val adapter = nfcAdapter ?: return
+        runCatching { adapter.disableReaderMode(activity) }
+    }
+
+    /**
+     * Reader-mode tag callback (runs on a binder thread). Drives the APDU
+     * exchange and, on success, posts the parsed peer back to the activity
+     * via [onPeerTapped]. The activity is responsible for marshalling onto
+     * the UI thread.
+     */
+    private fun onTag(tag: Tag) {
+        val isoDep = IsoDep.get(tag) ?: return
+        lastExchangeSummary = "no IsoDep exchange"
+        val result =
+            try {
+                isoDep.connect()
+                exchange(isoDep)
+            } catch (e: IOException) {
+                DiagnosticLog.w(TAG, "tap exchange failed: ${e.message}")
+                lastExchangeSummary += " IO=${e.message}"
+                TapResult.Failed
+            } finally {
+                runCatching { isoDep.close() }
+            }
+        // Auto-ship the tap diagnostics (SELECT/ADVERTISEMENT outcome) so a
+        // failed send-tap is debuggable without adb. Runs on this binder thread's
+        // caller via a background thread inside the uploader. Best-effort.
+        DiagnosticUploader.upload(activity, reason = "nfc-send-tap")
+        // On-screen, no-internet observability: surface EVERY tap outcome to the UI.
+        val outcome =
+            when (result) {
+                is TapResult.Resolved -> "RESOLVED ${result.peer.endpointId}"
+                TapResult.Woke -> "WOKE (receiver idle → handing off to discovery)"
+                TapResult.Failed -> "FAILED (no QS HCE / tag lost)"
+            }
+        DiagnosticLog.w(TAG, "tap outcome=$outcome | $lastExchangeSummary")
+        onTapDiagnostic("NFC tap: $outcome | $lastExchangeSummary")
+        when (result) {
+            // The HCE returned a real Quick Share advertisement tag (the receiver was
+            // already advertising) -> connect to its Wi-Fi-LAN endpoint directly.
+            is TapResult.Resolved -> onPeerTapped(result.peer)
+            // SELECT was accepted (it IS a Quick Share receiver) but the ADVERTISEMENT
+            // came back empty -> the receiver was idle and its HCE just fired the wake
+            // (djvf.f opens Quick Share). Exactly as stock Quick Share's reader does, we
+            // do NOT re-poll the NFC; we hand off to the already-running discovery so the
+            // now-waking receiver is found and connected over the normal Nearby channel.
+            TapResult.Woke -> {
+                DiagnosticLog.w(TAG, "tap: receiver idle, HCE woke it -> handing off to discovery")
+                onTapWake()
+            }
+            // SELECT failed / link error: not a Quick Share receiver, or the tag left the
+            // field. Nothing to do; reader stays armed for the next tap.
+            TapResult.Failed -> Unit
+        }
+    }
+
+    /**
+     * Outcome of one NFC tap exchange, mirroring stock Quick Share's one-shot read.
+     *
+     * @property Resolved the HCE returned a usable advertisement tag (receiver was
+     *   already advertising) -> connect to it.
+     * @property Woke SELECT succeeded but ADVERTISEMENT was empty -> the receiver was
+     *   idle and its HCE fired the wake; hand off to discovery (matches Quick Share).
+     * @property Failed SELECT rejected (not a QS receiver) or an IsoDep I/O error.
+     */
+    private sealed interface TapResult {
+        data class Resolved(val peer: TappedPeer) : TapResult
+
+        object Woke : TapResult
+
+        object Failed : TapResult
+    }
+
+    /**
+     * One-shot tap exchange, matching stock Quick Share's reader (`djkb.c`): SELECT,
+     * then ONE ADVERTISEMENT — NO re-poll loop. Quick Share verified (GMS 26.18.33)
+     * sends the ADVERTISEMENT exactly once per tag and relies on its concurrent Nearby
+     * discovery to finish the connection; re-polling the same IsoDep is unlike the
+     * original and just races the receiver's NFC reset on wake ("Tag was lost").
+     *
+     * - SELECT rejected -> [TapResult.Failed] (not a Quick Share HCE).
+     * - ADVERTISEMENT returns a usable tag (receiver already advertising) -> [TapResult.Resolved].
+     * - ADVERTISEMENT empty / `0000` (receiver idle; its HCE fired the wake) -> [TapResult.Woke].
+     */
+    @Suppress("ReturnCount")
+    private fun exchange(isoDep: IsoDep): TapResult {
+        // 1. SELECT the Quick Share advertising application.
+        val selectApdu = buildSelectApdu()
+        val selectResp = isoDep.transceive(selectApdu)
+        lastExchangeSummary = "SELECT=${hex(selectResp)}"
+        DiagnosticLog.w(TAG, "SELECT apdu=${hex(selectApdu)} resp=${hex(selectResp)}")
+        if (!endsWithOk(selectResp)) {
+            DiagnosticLog.w(TAG, "SELECT not OK (${selectResp.size}B) — not a Quick Share HCE")
+            return TapResult.Failed
+        }
+
+        // 2. ADVERTISEMENT — sent ONCE (Quick Share does not re-poll). If the HCE
+        // returns a real tag the receiver was already advertising; if it returns the
+        // empty `djvb.a()` (`0000`) the receiver was idle and its HCE just fired the
+        // wake (djvf.f -> opens Quick Share). SELECT having succeeded means this IS a
+        // Quick Share receiver, so an empty ADVERTISEMENT means "woke it" -> hand off
+        // to discovery rather than re-polling the NFC link.
+        val hhww =
+            QuickShareNfcCodec.encodeHhwwRequest(
+                QuickShareNfcCodec.HhwwRequest(serviceId = NearbyServiceId.VALUE),
+            )
+        val advApdu = buildAdvertisementApdu(hhww)
+        val advResp = isoDep.transceive(advApdu)
+        lastExchangeSummary += " ADV=${hex(advResp)}"
+        DiagnosticLog.w(TAG, "ADV apdu=${hex(advApdu)} resp=${hex(advResp)}")
+
+        val peer = parseTappedPeer(advResp)
+        return if (peer != null) TapResult.Resolved(peer) else TapResult.Woke
+    }
+
+    /**
+     * Parse an ADVERTISEMENT response into a [TappedPeer], or `null` if it is empty /
+     * `0000` / not a usable Wi-Fi-LAN tag (i.e. the receiver was idle, not advertising).
+     */
+    @Suppress("ReturnCount")
+    private fun parseTappedPeer(advResp: ByteArray): TappedPeer? {
+        if (!endsWithOk(advResp) || advResp.size <= STATUS_LEN) return null
+        val body = advResp.copyOfRange(0, advResp.size - STATUS_LEN)
+
+        val response = QuickShareNfcCodec.parseHhwvResponse(body) ?: return null
+        if (response.nfcTag.isEmpty()) return null
+        val nfcTag = QuickShareNfcCodec.parseNfcTag(response.nfcTag) ?: return null
+        val endpointInfo = EndpointInfo.parse(nfcTag.endpointInfo) ?: return null
+
+        // The Wi-Fi-LAN IP:port comes from the rxAdv. Without it we cannot
+        // connect (BT-Classic fallback is out of scope for the tap path).
+        val rxAdv = response.rxAdv ?: return null
+        val lan = QuickShareNfcCodec.parseWifiLanEndpoint(rxAdv) ?: return null
+
+        val endpointId = String(nfcTag.endpointId, Charsets.US_ASCII)
+        DiagnosticLog.w(
+            TAG,
+            "tap resolved endpointId=$endpointId ${lan.address.hostAddress}:${lan.port} " +
+                "name=${endpointInfo.deviceName}",
+        )
+        return TappedPeer(
+            endpointId = endpointId,
+            endpointInfo = endpointInfo,
+            address = lan.address,
+            port = lan.port,
+        )
+    }
+
+    private fun buildSelectApdu(): ByteArray {
+        // 00 A4 04 00 Lc <AID> 00
+        val aid = QuickShareNfcCodec.ADVERTISING_AID
+        val apdu = ByteArray(5 + aid.size + 1)
+        apdu[0] = 0x00
+        apdu[1] = QuickShareNfcCodec.INS_SELECT
+        apdu[2] = 0x04 // P1 = select by name
+        apdu[3] = 0x00
+        apdu[4] = aid.size.toByte()
+        System.arraycopy(aid, 0, apdu, 5, aid.size)
+        apdu[apdu.size - 1] = 0x00 // Le
+        return apdu
+    }
+
+    private fun buildAdvertisementApdu(hhww: ByteArray): ByteArray {
+        // 80 01 00 00 Lc <hhww> 00  (Le)
+        val apdu = ByteArray(5 + hhww.size + 1)
+        apdu[0] = QuickShareNfcCodec.CLA_PROPRIETARY
+        apdu[1] = QuickShareNfcCodec.INS_ADVERTISEMENT
+        apdu[2] = 0x00 // P1
+        apdu[3] = 0x00 // P2
+        apdu[4] = hhww.size.toByte()
+        System.arraycopy(hhww, 0, apdu, 5, hhww.size)
+        apdu[apdu.size - 1] = 0x00 // Le
+        return apdu
+    }
+
+    private fun endsWithOk(resp: ByteArray): Boolean {
+        if (resp.size < STATUS_LEN) return false
+        return resp[resp.size - 2] == QuickShareNfcCodec.SW_OK[0] &&
+            resp[resp.size - 1] == QuickShareNfcCodec.SW_OK[1]
+    }
+
+    private companion object {
+        private const val TAG = "BadaTapReader"
+        private const val STATUS_LEN = 2
+
+        /** Max bytes hex-dumped per diagnostic line (keeps uploads bounded). */
+        private const val HEX_DUMP_MAX = 80
+
+        /**
+         * `hex` — bounded uppercase hex dump of an APDU / response for the NFC-tap
+         * diagnostics (Round-2 instrumentation). Truncates past [HEX_DUMP_MAX] bytes
+         * with a `…(NB)` suffix so a stray large frame can't bloat the upload.
+         */
+        private fun hex(bytes: ByteArray): String {
+            val n = minOf(bytes.size, HEX_DUMP_MAX)
+            val sb = StringBuilder(n * 2 + 8)
+            for (i in 0 until n) sb.append("%02X".format(bytes[i].toInt() and 0xFF))
+            if (bytes.size > HEX_DUMP_MAX) sb.append("…(${bytes.size}B)")
+            return sb.toString()
+        }
+    }
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/nfc/BadaTapReader.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/nfc/BadaTapReader.kt
@@ -9,7 +9,6 @@ import android.app.Activity
 import android.nfc.NfcAdapter
 import android.nfc.Tag
 import android.nfc.tech.IsoDep
-import dev.bluehouse.bada.diag.DiagnosticUploader
 import dev.bluehouse.bada.discovery.diagnostics.DiagnosticLog
 import dev.bluehouse.bada.protocol.endpoint.EndpointInfo
 import dev.bluehouse.bada.protocol.endpoint.NearbyServiceId
@@ -35,7 +34,12 @@ import java.net.InetAddress
  *
  * Public `android.nfc` APIs only. **NOT device-tested** (no NFC hardware
  * in the build environment).
+ *
+ * The APDU builders/parsers are inherently byte-index heavy, so the class
+ * suppresses detekt's MagicNumber — the per-byte protocol comments document each
+ * value better than a named constant per offset would.
  */
+@Suppress("MagicNumber")
 public class BadaTapReader(
     private val activity: Activity,
     private val onPeerTapped: (TappedPeer) -> Unit,
@@ -50,6 +54,7 @@ public class BadaTapReader(
 ) {
     /** Raw SELECT/ADVERTISEMENT bytes of the in-flight exchange, for [onTapDiagnostic]. */
     private var lastExchangeSummary: String = ""
+
     /**
      * A peer discovered via an NFC tap, ready to be injected into the send
      * flow.
@@ -112,10 +117,6 @@ public class BadaTapReader(
             } finally {
                 runCatching { isoDep.close() }
             }
-        // Auto-ship the tap diagnostics (SELECT/ADVERTISEMENT outcome) so a
-        // failed send-tap is debuggable without adb. Runs on this binder thread's
-        // caller via a background thread inside the uploader. Best-effort.
-        DiagnosticUploader.upload(activity, reason = "nfc-send-tap")
         // On-screen, no-internet observability: surface EVERY tap outcome to the UI.
         val outcome =
             when (result) {
@@ -154,7 +155,9 @@ public class BadaTapReader(
      * @property Failed SELECT rejected (not a QS receiver) or an IsoDep I/O error.
      */
     private sealed interface TapResult {
-        data class Resolved(val peer: TappedPeer) : TapResult
+        data class Resolved(
+            val peer: TappedPeer,
+        ) : TapResult
 
         object Woke : TapResult
 

--- a/app/src/main/kotlin/dev/bluehouse/bada/nfc/NfcPreferredService.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/nfc/NfcPreferredService.kt
@@ -50,10 +50,11 @@ internal object NfcPreferredService {
         activity: Activity,
         prefer: Boolean,
     ): Boolean {
-        val adapter = NfcAdapter.getDefaultAdapter(activity) ?: run {
-            DiagnosticLog.w(TAG, "no NFC adapter -> cannot ${if (prefer) "claim" else "release"} tap AID")
-            return false
-        }
+        val adapter =
+            NfcAdapter.getDefaultAdapter(activity) ?: run {
+                DiagnosticLog.w(TAG, "no NFC adapter -> cannot ${if (prefer) "claim" else "release"} tap AID")
+                return false
+            }
         return runCatching {
             val cardEmulation = CardEmulation.getInstance(adapter)
             val name = ComponentName(activity, component)

--- a/app/src/main/kotlin/dev/bluehouse/bada/nfc/NfcPreferredService.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/nfc/NfcPreferredService.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.nfc
+
+import android.app.Activity
+import android.content.ComponentName
+import android.nfc.NfcAdapter
+import android.nfc.cardemulation.CardEmulation
+import dev.bluehouse.bada.discovery.diagnostics.DiagnosticLog
+
+/**
+ * NfcPreferredService — claims the Quick Share NFC AID (`F00000FE2C`) for our
+ * [BadaTapHceService] while a receive surface is in the foreground, so an
+ * NFC tap reaches US instead of stock Google Quick Share.
+ *
+ * ### Why this exists
+ *
+ * On a phone with stock Quick Share, both GMS and our app register the same
+ * `F00000FE2C` HCE AID. On Android 14 a tap shows a chooser; on Android 15 the
+ * OS routes the tap straight to Google (the default wallet/NFC handler) and our
+ * HCE is never invoked (confirmed on-device: a tap opened native Quick Share's
+ * receive screen). Per the HCE docs, the ONLY way to beat that for a shared AID
+ * is `CardEmulation.setPreferredService(activity, ourService)` called while one
+ * of our Activities is in the foreground — it overrides AID conflict resolution
+ * AND the wallet default. So while our receive sheet is up, WE win the tap;
+ * once it's closed we release the claim and taps fall back to native Quick Share.
+ *
+ * ### How it's used
+ * [ConsentTrampolineActivity] calls [prefer] from `onResume` and [release] from
+ * `onPause`. Best-effort: no NFC adapter / pre-conditions → logged no-op.
+ *
+ * ### Status
+ * Compile-built; the on-device "tap reaches us while the sheet is open" behaviour
+ * is the make-or-break to verify on an Android 15 phone with stock Quick Share.
+ */
+internal object NfcPreferredService {
+    private val component
+        get() = BadaTapHceService::class.java
+
+    /** Prefer our tap HCE while [activity] is foreground. Returns true if claimed. */
+    fun prefer(activity: Activity): Boolean = apply(activity, prefer = true)
+
+    /** Release the preference (call when leaving the foreground). */
+    fun release(activity: Activity): Boolean = apply(activity, prefer = false)
+
+    private fun apply(
+        activity: Activity,
+        prefer: Boolean,
+    ): Boolean {
+        val adapter = NfcAdapter.getDefaultAdapter(activity) ?: run {
+            DiagnosticLog.w(TAG, "no NFC adapter -> cannot ${if (prefer) "claim" else "release"} tap AID")
+            return false
+        }
+        return runCatching {
+            val cardEmulation = CardEmulation.getInstance(adapter)
+            val name = ComponentName(activity, component)
+            val ok =
+                if (prefer) {
+                    cardEmulation.setPreferredService(activity, name)
+                } else {
+                    cardEmulation.unsetPreferredService(activity)
+                }
+            DiagnosticLog.w(TAG, "${if (prefer) "setPreferredService" else "unsetPreferredService"} -> $ok")
+            ok
+        }.getOrElse {
+            DiagnosticLog.w(TAG, "preferred-service ${if (prefer) "set" else "unset"} failed: ${it.message}")
+            false
+        }
+    }
+
+    private const val TAG = "BadaNfcPreferred"
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/nfc/NfcTapDiagnosticsPreferences.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/nfc/NfcTapDiagnosticsPreferences.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.nfc
+
+import android.content.Context
+import android.content.SharedPreferences
+
+/**
+ * User toggle for the **on-screen NFC tap diagnostics** — the Toasts that the send
+ * sheet shows for every NFC tap (read outcome SELECT/ADV bytes, "WOKE", auto-connect
+ * target, "no receiver found in 15s", …). It gates ONLY the visible Toasts; the silent
+ * in-memory `DiagnosticLog` ring keeps recording regardless (so a bug report still has
+ * the full trace).
+ *
+ * What it's called: "Show NFC tap diagnostics" switch in Settings
+ * (`R.id.settings_nfc_diagnostics_switch`). Read at the single Toast choke point
+ * `SendActivity.nfcTapToast`. Default ON so existing behavior is preserved; flip it OFF
+ * for a clean, Toast-free tap once everything is working.
+ */
+internal class NfcTapDiagnosticsPreferences(
+    private val prefs: SharedPreferences,
+) {
+    fun isEnabled(): Boolean = prefs.getBoolean(KEY_ENABLED, DEFAULT_ENABLED)
+
+    fun setEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_ENABLED, enabled).apply()
+    }
+
+    internal companion object {
+        private const val PREFS_NAME = "bada.nfc_tap_diagnostics"
+        private const val KEY_ENABLED = "nfc_tap_diagnostics_enabled"
+
+        /** ON by default: preserve the current (post-fix) on-screen diagnostics. */
+        private const val DEFAULT_ENABLED = true
+
+        fun from(context: Context): NfcTapDiagnosticsPreferences =
+            NfcTapDiagnosticsPreferences(
+                context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE),
+            )
+    }
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/nfc/NfcTapSharePreferences.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/nfc/NfcTapSharePreferences.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.nfc
+
+import android.content.Context
+import android.content.SharedPreferences
+
+/**
+ * User choice for WHEN this device is tappable for NFC tap-to-share — the
+ * receiver-side window during which the tap-to-share HCE advertisement is
+ * live. This is a SEPARATE setting from the mDNS/BLE "visible" toggle (by
+ * user request); the NFC tap-to-share HCE reads this to decide its
+ * lifetime. Default is the most conservative mode.
+ *
+ * NOTE: the tap-to-share HCE itself is implemented in a later change; this
+ * preference + its Settings control exist now so the choice is visible and
+ * persisted, and the HCE wires to it when it lands.
+ */
+internal class NfcTapSharePreferences(
+    private val prefs: SharedPreferences,
+) {
+    /** When the receiver is tappable for NFC tap-to-share. */
+    internal enum class Mode {
+        /** Only while a receive sheet (the tile-opened / consent sheet) is open. */
+        SHEET_OPEN,
+
+        /** Whenever the app is in the foreground. */
+        APP_FOREGROUND,
+
+        /** Always, including while the app is backgrounded (persistent). */
+        BACKGROUND,
+    }
+
+    fun mode(): Mode =
+        when (prefs.getString(KEY_MODE, null)) {
+            Mode.APP_FOREGROUND.name -> Mode.APP_FOREGROUND
+            Mode.BACKGROUND.name -> Mode.BACKGROUND
+            else -> Mode.SHEET_OPEN
+        }
+
+    fun setMode(mode: Mode) {
+        prefs.edit().putString(KEY_MODE, mode.name).apply()
+    }
+
+    internal companion object {
+        private const val PREFS_NAME = "bada.nfc_tap_share"
+        private const val KEY_MODE = "nfc_tap_share_mode"
+
+        fun from(context: Context): NfcTapSharePreferences =
+            NfcTapSharePreferences(
+                context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE),
+            )
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -518,4 +518,8 @@
     <string name="qs_tile_subtitle_off">Off</string>
     <string name="qs_tile_content_desc_on">Bada is discoverable to nearby devices</string>
     <string name="qs_tile_content_desc_off">Bada is not discoverable</string>
+
+    <!-- NFC tap-to-share HCE service description, shown in the system NFC /
+         card-emulation settings list of registered apps. -->
+    <string name="nfc_tap_hce_service_description">Bada Quick Share tap-to-share</string>
 </resources>

--- a/app/src/main/res/xml/bada_tap_apduservice.xml
+++ b/app/src/main/res/xml/bada_tap_apduservice.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  HCE descriptor for the Bada Quick Share NFC tap-to-share receiver.
+
+  Declares the Nearby Connections NFC advertising AID F00000FE2C that a
+  Quick Share SENDER in reader-mode SELECTs, then reads our `hhwv`
+  response (deym NfcTag + Wi-Fi-LAN rxInstantConnectionAdv) to discover
+  our live receiver and connect over Wi-Fi-LAN.
+
+  Distinct AID from the iPhone NDEF-link service (D2760000850101), so the
+  two HostApduServices coexist on the one NFC controller.
+
+  category="other"  -> no default-payment role required.
+  requireDeviceUnlock="false" -> answered from the lock screen too; the
+  HCE only emits a real tag while a receiver is live (gated in code via
+  NfcTapLinkHolder, which the receiver service drives per the user's NFC
+  tap-to-share availability setting).
+-->
+<host-apdu-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:description="@string/nfc_tap_hce_service_description"
+    android:requireDeviceUnlock="false">
+    <aid-group android:description="@string/nfc_tap_hce_service_description"
+        android:category="other">
+        <aid-filter android:name="F00000FE2C" />
+    </aid-group>
+</host-apdu-service>

--- a/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/nfc/NfcTapLinkHolder.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/nfc/NfcTapLinkHolder.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.protocol.nfc
+
+import java.net.InetAddress
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Process-global handoff carrying the receiver's CURRENT tap-to-share
+ * identity from the receiver service ([dev.bluehouse.bada.service] —
+ * `ReceiverForegroundService`) to the Quick Share HCE
+ * (`BadaTapHceService` in `:app`).
+ *
+ * Mirrors the role of `NfcLinkHolder` (which carries the iPhone-link QR
+ * URL) but for the Quick Share tap path: the HCE service has no shared
+ * `Intent`/`Bundle` channel with the receiver service at tap time, so a
+ * single `@Volatile`/atomic field is the simplest correct bridge.
+ *
+ *  - The receiver service publishes [Link] whenever it (re)binds its TCP
+ *    listener / refreshes its advertised identity, and clears it to `null`
+ *    when the receiver stops.
+ *  - The HCE service reads [current] at the moment a reader SELECTs the
+ *    `F00000FE2C` application and on each ADVERTISEMENT APDU, building its
+ *    `hhwv` response from the live link. A `null` link means "we are not a
+ *    live receiver right now" and the HCE answers SELECT but returns no
+ *    tag (so a stray tap is a no-op rather than pointing at a dead port).
+ *
+ * The [serviceIdHash] is carried alongside the endpoint so the HCE never
+ * has to depend on the discovery/identity modules.
+ */
+public object NfcTapLinkHolder {
+    /**
+     * Snapshot of the receiver's live tap-to-share link, or `null` when no
+     * receiver is currently advertising.
+     *
+     * @property endpointId the receiver's 4-byte endpoint id (ASCII).
+     * @property serviceIdHash the 3-byte Nearby service-id hash prefix.
+     * @property endpointInfo the serialized Nearby EndpointInfo blob.
+     * @property address the receiver's Wi-Fi-LAN address.
+     * @property port the receiver's bound TCP port.
+     */
+    public data class Link(
+        val endpointId: ByteArray,
+        val serviceIdHash: ByteArray,
+        val endpointInfo: ByteArray,
+        val address: InetAddress,
+        val port: Int,
+    ) {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is Link) return false
+            return endpointId.contentEquals(other.endpointId) &&
+                serviceIdHash.contentEquals(other.serviceIdHash) &&
+                endpointInfo.contentEquals(other.endpointInfo) &&
+                address == other.address &&
+                port == other.port
+        }
+
+        override fun hashCode(): Int {
+            var result = endpointId.contentHashCode()
+            result = 31 * result + serviceIdHash.contentHashCode()
+            result = 31 * result + endpointInfo.contentHashCode()
+            result = 31 * result + address.hashCode()
+            result = 31 * result + port
+            return result
+        }
+    }
+
+    private val ref: AtomicReference<Link?> = AtomicReference(null)
+
+    /** The current receiver link, or `null` when no receiver is live. */
+    public val current: Link?
+        get() = ref.get()
+
+    /** Publish (or replace) the live receiver link. */
+    public fun set(link: Link) {
+        ref.set(link)
+    }
+
+    /** Clear the link (receiver stopped). */
+    public fun clear() {
+        ref.set(null)
+    }
+}

--- a/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/nfc/QuickShareNfcCodec.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/nfc/QuickShareNfcCodec.kt
@@ -34,7 +34,13 @@ import java.net.InetAddress
  * This object is pure-JVM (no `android.*`) so it lives in `:core-protocol`
  * and is reachable from both the HCE service (`:app`) and the receiver
  * service (`:service-android`).
+ *
+ * The wire constants here (APDU header bytes, TLV tags, fixed field offsets and
+ * lengths) are inherently numeric, so the object suppresses detekt's MagicNumber —
+ * the per-byte protocol comments document each value better than a named constant
+ * per offset would.
  */
+@Suppress("MagicNumber")
 public object QuickShareNfcCodec {
     // ---- AID + APDU constants (verified §memory: NfcAdvertisingChimeraService) ----
 
@@ -181,7 +187,7 @@ public object QuickShareNfcCodec {
      * skipped. Mirrors `dfga.a` (§4) but only extracts the LAN tuple we
      * use; we tolerate (skip) DE types we do not consume.
      */
-    @Suppress("ReturnCount", "CyclomaticComplexMethod")
+    @Suppress("ReturnCount", "CyclomaticComplexMethod", "NestedBlockDepth")
     public fun parseWifiLanEndpoint(rxAdv: ByteArray): WifiLanEndpoint? {
         var offset = 0
         while (offset + 2 <= rxAdv.size) {
@@ -380,6 +386,7 @@ public object QuickShareNfcCodec {
     }
 
     /** Parse an `hhww` request (§1). Returns `null` on malformed input. */
+    @Suppress("ReturnCount")
     public fun parseHhwwRequest(bytes: ByteArray): HhwwRequest? {
         val fields = parseProtoFields(bytes) ?: return null
         val serviceId = fields[1]?.let { decodeUtf8(it) } ?: return null
@@ -424,6 +431,7 @@ public object QuickShareNfcCodec {
     }
 
     /** Parse an `hhwv` response (§1). Returns `null` on malformed input. */
+    @Suppress("ReturnCount")
     public fun parseHhwvResponse(bytes: ByteArray): HhwvResponse? {
         val fields = parseProtoFields(bytes) ?: return null
         val nfcTag = fields[1] ?: return null

--- a/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/nfc/QuickShareNfcCodec.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/nfc/QuickShareNfcCodec.kt
@@ -1,0 +1,530 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.protocol.nfc
+
+import java.io.ByteArrayOutputStream
+import java.net.Inet4Address
+import java.net.Inet6Address
+import java.net.InetAddress
+
+/**
+ * Byte-level codec for Google Quick Share / Nearby Connections **NFC
+ * tap-to-share** (AID `F00000FE2C`). Hand-rolls the three wire shapes the
+ * tap exchanges, with no protobuf runtime dependency:
+ *
+ *  - [encodeHhwwRequest] / [HhwwRequest] — the reader→HCE ADVERTISEMENT
+ *    request (`Lhhww;`, 3 protobuf fields).
+ *  - [encodeHhwvResponse] / [parseHhwvResponse] — the HCE→reader response
+ *    (`Lhhwv;`, 3 protobuf fields) carrying the NfcTag + rxAdv blobs.
+ *  - [encodeNfcTag] / [parseNfcTag] — the `deym` NfcTag blob (fixed
+ *    big-endian framing).
+ *  - [encodeWifiLanRxAdv] / [parseWifiLanEndpoint] — the
+ *    `rxInstantConnectionAdv` Nearby Data-Element (DE) TLV stream
+ *    advertising a Wi-Fi-LAN IP:port.
+ *
+ * Every offset, tag, length, and the DE header form were verified against
+ * GMS 26.18.33 smali (see `docs/NFC_INTEROP_BYTEMAP.md` §1, §3, §4 for the
+ * file:line citations). Where a value could not be cross-verified from the
+ * reference (the PCP↔Strategy integer, the NC encryption-key contents) the
+ * KDoc flags it as best-effort.
+ *
+ * This object is pure-JVM (no `android.*`) so it lives in `:core-protocol`
+ * and is reachable from both the HCE service (`:app`) and the receiver
+ * service (`:service-android`).
+ */
+public object QuickShareNfcCodec {
+    // ---- AID + APDU constants (verified §memory: NfcAdvertisingChimeraService) ----
+
+    /** Nearby Connections NFC advertising AID. */
+    public val ADVERTISING_AID: ByteArray =
+        byteArrayOf(0xF0.toByte(), 0x00, 0x00, 0xFE.toByte(), 0x2C)
+
+    /** SELECT-by-name APDU header (`00 A4 04 00`). */
+    public const val INS_SELECT: Byte = 0xA4.toByte()
+
+    /** ADVERTISEMENT APDU class/instruction (`80 01`). Reads the static tag. */
+    public const val CLA_PROPRIETARY: Byte = 0x80.toByte()
+    public const val INS_ADVERTISEMENT: Byte = 0x01
+
+    /** ISO-7816 success / failure status words. */
+    public val SW_OK: ByteArray = byteArrayOf(0x90.toByte(), 0x00)
+    public val SW_FILE_NOT_FOUND: ByteArray = byteArrayOf(0x6A.toByte(), 0x82.toByte())
+    public val SW_INS_NOT_SUPPORTED: ByteArray = byteArrayOf(0x6D.toByte(), 0x00)
+    public val SW_WRONG_LENGTH: ByteArray = byteArrayOf(0x67.toByte(), 0x00)
+
+    // ---- Nearby Data-Element (DE) types (verified §4) ----
+    private const val DE_TYPE_ENCRYPTION_KEY = 0x17
+    private const val DE_TYPE_CONNECTIVITY_CAP = 0x15
+    private const val NC_ENCRYPTION_KEY_LEN = 0x20
+
+    // Connectivity-capability medium sub-types (first payload byte).
+    private const val MEDIUM_WIFI_LAN_IPV4 = 0x02
+    private const val MEDIUM_WIFI_LAN_IPV6 = 0x03
+
+    private const val IPV4_LEN = 4
+    private const val IPV6_LEN = 16
+    private const val PORT_LEN = 2
+    private const val BSSID_LEN = 6
+
+    // deym NfcTag framing (verified §3).
+    private const val PCP_MASK = 0x1F
+    private const val VERSION_SHIFT = 5
+    private const val ENDPOINT_ID_LEN = 4
+    private const val SERVICE_ID_HASH_LEN = 3
+    private const val BT_MAC_LEN = 6
+
+    /**
+     * Strategy/PCP value we advertise. Quick Share's file-transfer session
+     * uses Strategy **P2P_POINT_TO_POINT**, and the stock receiver's post-tap
+     * handler (`dfdo.run`) DISCARDS the tag unless its PCP equals
+     * `dfet.x(localStrategy)`. Verified from GMS 26.18.33 smali: `dfet.x`
+     * maps P2P_STAR=1, P2P_CLUSTER=2, P2P_POINT_TO_POINT=3, and the Quick
+     * Share Sharing connector pins `Strategy.c` (P2P_POINT_TO_POINT) -> PCP 3
+     * -> deym header byte `(1<<5)|3 = 0x23`. (The previous value `2` was both
+     * the wrong strategy — that's P2P_CLUSTER — and mislabeled "P2P_STAR".)
+     * The deserializer accepts {1,2,3}.
+     */
+    public const val PCP_P2P_POINT_TO_POINT: Int = 3
+
+    private const val NFC_TAG_VERSION = 1
+    private const val UNSIGNED_BYTE = 0xFF
+
+    // -----------------------------------------------------------------
+    // Nearby Data-Element (DE) header — `deme.g(length, type)` (§4)
+    //   byte0 = (length & 0x7F) | 0x80
+    //   byte1 =  type   & 0x7F
+    // -----------------------------------------------------------------
+
+    private fun writeDeHeader(
+        out: ByteArrayOutputStream,
+        length: Int,
+        type: Int,
+    ) {
+        out.write((length and 0x7F) or 0x80)
+        out.write(type and 0x7F)
+    }
+
+    // =================================================================
+    // §4 — rxInstantConnectionAdv (Wi-Fi-LAN)
+    // =================================================================
+
+    /**
+     * Build a `rxInstantConnectionAdv` advertising a single Wi-Fi-LAN
+     * endpoint (our live TCP receiver). Layout (verified `denp.g()` §4):
+     *
+     * ```
+     * [EncryptionKey DE: 0xA0,0x17, <32 key bytes>]
+     * [Wi-Fi-LAN ConnectivityCapability DE:
+     *    0x80|size, 0x15, version, ip[4|16], port[2 BE], bssid[6]]
+     * ```
+     *
+     * @param ip the receiver's Wi-Fi LAN address (IPv4 or IPv6).
+     * @param port the receiver's bound TCP port.
+     * @param encryptionKey 32-byte NC public key. The stock parser only
+     *   checks size==32 + type==0x17 (best-effort: contents not validated
+     *   end-to-end). Callers may pass random bytes.
+     * @param bssid optional 6-byte AP BSSID; defaults to all-zero (unknown,
+     *   accepted by the length check).
+     */
+    public fun encodeWifiLanRxAdv(
+        ip: InetAddress,
+        port: Int,
+        encryptionKey: ByteArray,
+        bssid: ByteArray = ByteArray(BSSID_LEN),
+    ): ByteArray {
+        require(encryptionKey.size == NC_ENCRYPTION_KEY_LEN) {
+            "encryptionKey must be $NC_ENCRYPTION_KEY_LEN bytes, got ${encryptionKey.size}"
+        }
+        require(bssid.size == BSSID_LEN) { "bssid must be $BSSID_LEN bytes, got ${bssid.size}" }
+        val ipBytes = ip.address
+        val (medium, ipLen) =
+            when (ip) {
+                is Inet4Address -> MEDIUM_WIFI_LAN_IPV4 to IPV4_LEN
+                is Inet6Address -> MEDIUM_WIFI_LAN_IPV6 to IPV6_LEN
+                else -> error("unsupported InetAddress type ${ip.javaClass.name}")
+            }
+        require(ipBytes.size == ipLen) { "ip address length mismatch: ${ipBytes.size} != $ipLen" }
+
+        val out = ByteArrayOutputStream()
+
+        // EncryptionKey DE.
+        writeDeHeader(out, NC_ENCRYPTION_KEY_LEN, DE_TYPE_ENCRYPTION_KEY)
+        out.write(encryptionKey)
+
+        // Wi-Fi-LAN ConnectivityCapability DE.
+        val capLen = 1 + ipLen + PORT_LEN + BSSID_LEN
+        writeDeHeader(out, capLen, DE_TYPE_CONNECTIVITY_CAP)
+        out.write(medium)
+        out.write(ipBytes)
+        out.write((port ushr 8) and UNSIGNED_BYTE)
+        out.write(port and UNSIGNED_BYTE)
+        out.write(bssid)
+
+        return out.toByteArray()
+    }
+
+    /**
+     * A Wi-Fi-LAN endpoint parsed out of a peer's rxAdv.
+     */
+    public data class WifiLanEndpoint(
+        val address: InetAddress,
+        val port: Int,
+    )
+
+    /**
+     * Scan a `rxInstantConnectionAdv` DE stream and return the first
+     * Wi-Fi-LAN endpoint, or `null` if none is present / the stream is
+     * malformed. The EncryptionKey DE and any non-LAN capability DEs are
+     * skipped. Mirrors `dfga.a` (§4) but only extracts the LAN tuple we
+     * use; we tolerate (skip) DE types we do not consume.
+     */
+    @Suppress("ReturnCount", "CyclomaticComplexMethod")
+    public fun parseWifiLanEndpoint(rxAdv: ByteArray): WifiLanEndpoint? {
+        var offset = 0
+        while (offset + 2 <= rxAdv.size) {
+            val length = rxAdv[offset].toInt() and 0x7F
+            val type = rxAdv[offset + 1].toInt() and 0x7F
+            val payloadStart = offset + 2
+            val payloadEnd = payloadStart + length
+            if (payloadEnd > rxAdv.size) return null
+
+            if (type == DE_TYPE_CONNECTIVITY_CAP && length >= 1) {
+                val medium = rxAdv[payloadStart].toInt() and UNSIGNED_BYTE
+                if (medium == MEDIUM_WIFI_LAN_IPV4 || medium == MEDIUM_WIFI_LAN_IPV6) {
+                    val ipLen = if (medium == MEDIUM_WIFI_LAN_IPV4) IPV4_LEN else IPV6_LEN
+                    val need = 1 + ipLen + PORT_LEN
+                    if (length >= need) {
+                        var p = payloadStart + 1
+                        val ipBytes = rxAdv.copyOfRange(p, p + ipLen)
+                        p += ipLen
+                        val port =
+                            ((rxAdv[p].toInt() and UNSIGNED_BYTE) shl 8) or
+                                (rxAdv[p + 1].toInt() and UNSIGNED_BYTE)
+                        val address =
+                            runCatching { InetAddress.getByAddress(ipBytes) }.getOrNull()
+                                ?: return null
+                        return WifiLanEndpoint(address, port)
+                    }
+                }
+            }
+            offset = payloadEnd
+        }
+        return null
+    }
+
+    // =================================================================
+    // §3 — deym NfcTag blob
+    // =================================================================
+
+    /**
+     * Build the `deym` NfcTag blob (§3). Big-endian fixed framing:
+     *
+     * ```
+     * [headerByte = (version<<5)|(pcp&0x1F)]
+     * [endpointId: 4 ASCII]
+     * [serviceIdHash: 3]
+     * [infoLen: 1][endpointInfo: infoLen]
+     * [btMac: 6]   (all-zero = no MAC)
+     * [flags: 1]
+     * ```
+     *
+     * @param endpointId exactly 4 ASCII bytes.
+     * @param serviceIdHash exactly 3 bytes (NearbyServiceId hash prefix).
+     * @param endpointInfo the Nearby EndpointInfo blob (same as mDNS/BLE).
+     * @param btMac optional 6-byte BT-Classic MAC; defaults to all-zero
+     *   (the "no MAC" sentinel — the Wi-Fi/multi-medium path needs no MAC).
+     * @param pcp Strategy/PCP int (default [PCP_P2P_POINT_TO_POINT]).
+     */
+    public fun encodeNfcTag(
+        endpointId: ByteArray,
+        serviceIdHash: ByteArray,
+        endpointInfo: ByteArray,
+        btMac: ByteArray = ByteArray(BT_MAC_LEN),
+        pcp: Int = PCP_P2P_POINT_TO_POINT,
+    ): ByteArray {
+        require(endpointId.size == ENDPOINT_ID_LEN) {
+            "endpointId must be $ENDPOINT_ID_LEN bytes, got ${endpointId.size}"
+        }
+        require(serviceIdHash.size == SERVICE_ID_HASH_LEN) {
+            "serviceIdHash must be $SERVICE_ID_HASH_LEN bytes, got ${serviceIdHash.size}"
+        }
+        require(btMac.size == BT_MAC_LEN) { "btMac must be $BT_MAC_LEN bytes, got ${btMac.size}" }
+        require(endpointInfo.size <= UNSIGNED_BYTE) {
+            "endpointInfo must fit in a 1-byte length, got ${endpointInfo.size}"
+        }
+        require(pcp and PCP_MASK == pcp) { "pcp must fit in 5 bits, got $pcp" }
+
+        val out = ByteArrayOutputStream()
+        out.write(((NFC_TAG_VERSION shl VERSION_SHIFT) or (pcp and PCP_MASK)) and UNSIGNED_BYTE)
+        out.write(endpointId)
+        out.write(serviceIdHash)
+        out.write(endpointInfo.size and UNSIGNED_BYTE)
+        out.write(endpointInfo)
+        out.write(btMac)
+        out.write(0x00) // flags
+        return out.toByteArray()
+    }
+
+    /**
+     * A parsed NfcTag (§3). [btMac] is `null` when the on-wire MAC is the
+     * all-zero "no MAC" sentinel.
+     */
+    public data class NfcTag(
+        val version: Int,
+        val pcp: Int,
+        val endpointId: ByteArray,
+        val serviceIdHash: ByteArray,
+        val endpointInfo: ByteArray,
+        val btMac: ByteArray?,
+    ) {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is NfcTag) return false
+            return version == other.version &&
+                pcp == other.pcp &&
+                endpointId.contentEquals(other.endpointId) &&
+                serviceIdHash.contentEquals(other.serviceIdHash) &&
+                endpointInfo.contentEquals(other.endpointInfo) &&
+                (btMac?.contentEquals(other.btMac ?: ByteArray(0)) ?: (other.btMac == null))
+        }
+
+        override fun hashCode(): Int {
+            var result = version
+            result = 31 * result + pcp
+            result = 31 * result + endpointId.contentHashCode()
+            result = 31 * result + serviceIdHash.contentHashCode()
+            result = 31 * result + endpointInfo.contentHashCode()
+            result = 31 * result + (btMac?.contentHashCode() ?: 0)
+            return result
+        }
+    }
+
+    /**
+     * Parse a `deym` NfcTag blob (§3). Returns `null` on any truncation /
+     * unsupported PCP. The endpointInfo length is the explicit byte at
+     * offset 8; the trailing 6-byte MAC + 1 flags byte are optional (a tag
+     * may omit them — we treat a missing MAC as `null`).
+     */
+    @Suppress("ReturnCount")
+    public fun parseNfcTag(blob: ByteArray): NfcTag? {
+        val fixedHeader = 1 + ENDPOINT_ID_LEN + SERVICE_ID_HASH_LEN + 1
+        if (blob.size < fixedHeader) return null
+        var offset = 0
+        val header = blob[offset].toInt() and UNSIGNED_BYTE
+        offset += 1
+        val version = header ushr VERSION_SHIFT
+        val pcp = header and PCP_MASK
+        if (pcp != 1 && pcp != 2 && pcp != 3) return null
+
+        val endpointId = blob.copyOfRange(offset, offset + ENDPOINT_ID_LEN)
+        offset += ENDPOINT_ID_LEN
+        val serviceIdHash = blob.copyOfRange(offset, offset + SERVICE_ID_HASH_LEN)
+        offset += SERVICE_ID_HASH_LEN
+        val infoLen = blob[offset].toInt() and UNSIGNED_BYTE
+        offset += 1
+        if (offset + infoLen > blob.size) return null
+        val endpointInfo = blob.copyOfRange(offset, offset + infoLen)
+        offset += infoLen
+
+        val btMac: ByteArray? =
+            if (offset + BT_MAC_LEN <= blob.size) {
+                val mac = blob.copyOfRange(offset, offset + BT_MAC_LEN)
+                offset += BT_MAC_LEN
+                if (mac.all { it == 0.toByte() }) null else mac
+            } else {
+                null
+            }
+        // Trailing flags byte (if present) is ignored.
+        return NfcTag(version, pcp, endpointId, serviceIdHash, endpointInfo, btMac)
+    }
+
+    // =================================================================
+    // §1 — hhww request / hhwv response (protobuf-lite, hand-rolled)
+    // =================================================================
+
+    /** The reader→HCE ADVERTISEMENT request (`Lhhww;`). */
+    public data class HhwwRequest(
+        val serviceId: String,
+        val field2: String? = null,
+        val field3: ByteArray? = null,
+    ) {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is HhwwRequest) return false
+            return serviceId == other.serviceId &&
+                field2 == other.field2 &&
+                (field3?.contentEquals(other.field3 ?: ByteArray(0)) ?: (other.field3 == null))
+        }
+
+        override fun hashCode(): Int {
+            var result = serviceId.hashCode()
+            result = 31 * result + (field2?.hashCode() ?: 0)
+            result = 31 * result + (field3?.contentHashCode() ?: 0)
+            return result
+        }
+    }
+
+    /**
+     * Encode an `hhww` request (§1): field1=serviceId (string, tag 0x0A),
+     * field2=string (tag 0x12), field3=bytes (tag 0x1A).
+     */
+    public fun encodeHhwwRequest(request: HhwwRequest): ByteArray {
+        val out = ByteArrayOutputStream()
+        writeProtoString(out, fieldNumber = 1, value = request.serviceId)
+        request.field2?.let { writeProtoString(out, fieldNumber = 2, value = it) }
+        request.field3?.let { writeProtoBytes(out, fieldNumber = 3, value = it) }
+        return out.toByteArray()
+    }
+
+    /** Parse an `hhww` request (§1). Returns `null` on malformed input. */
+    public fun parseHhwwRequest(bytes: ByteArray): HhwwRequest? {
+        val fields = parseProtoFields(bytes) ?: return null
+        val serviceId = fields[1]?.let { decodeUtf8(it) } ?: return null
+        val field2 = fields[2]?.let { decodeUtf8(it) }
+        val field3 = fields[3]
+        return HhwwRequest(serviceId, field2, field3)
+    }
+
+    /** The HCE→reader response (`Lhhwv;`). */
+    public data class HhwvResponse(
+        val nfcTag: ByteArray,
+        val rxAdv: ByteArray? = null,
+        val field3: ByteArray? = null,
+    ) {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is HhwvResponse) return false
+            return nfcTag.contentEquals(other.nfcTag) &&
+                (rxAdv?.contentEquals(other.rxAdv ?: ByteArray(0)) ?: (other.rxAdv == null)) &&
+                (field3?.contentEquals(other.field3 ?: ByteArray(0)) ?: (other.field3 == null))
+        }
+
+        override fun hashCode(): Int {
+            var result = nfcTag.contentHashCode()
+            result = 31 * result + (rxAdv?.contentHashCode() ?: 0)
+            result = 31 * result + (field3?.contentHashCode() ?: 0)
+            return result
+        }
+    }
+
+    /**
+     * Encode an `hhwv` response (§1): field1=nfcTag (bytes, tag 0x0A),
+     * field2=rxAdv (bytes, tag 0x12), field3=bytes (tag 0x1A). Optional
+     * fields are emitted only when non-null.
+     */
+    public fun encodeHhwvResponse(response: HhwvResponse): ByteArray {
+        val out = ByteArrayOutputStream()
+        writeProtoBytes(out, fieldNumber = 1, value = response.nfcTag)
+        response.rxAdv?.let { writeProtoBytes(out, fieldNumber = 2, value = it) }
+        response.field3?.let { writeProtoBytes(out, fieldNumber = 3, value = it) }
+        return out.toByteArray()
+    }
+
+    /** Parse an `hhwv` response (§1). Returns `null` on malformed input. */
+    public fun parseHhwvResponse(bytes: ByteArray): HhwvResponse? {
+        val fields = parseProtoFields(bytes) ?: return null
+        val nfcTag = fields[1] ?: return null
+        return HhwvResponse(nfcTag, fields[2], fields[3])
+    }
+
+    // -----------------------------------------------------------------
+    // Minimal protobuf wire helpers (length-delimited fields 1..3 only)
+    // -----------------------------------------------------------------
+
+    private const val WIRE_TYPE_LEN_DELIMITED = 2
+    private const val VARINT_CONTINUATION = 0x80
+    private const val VARINT_PAYLOAD = 0x7F
+    private const val VARINT_SHIFT = 7
+
+    private fun writeProtoString(
+        out: ByteArrayOutputStream,
+        fieldNumber: Int,
+        value: String,
+    ) {
+        writeProtoBytes(out, fieldNumber, value.toByteArray(Charsets.UTF_8))
+    }
+
+    private fun writeProtoBytes(
+        out: ByteArrayOutputStream,
+        fieldNumber: Int,
+        value: ByteArray,
+    ) {
+        writeVarint(out, (fieldNumber shl 3) or WIRE_TYPE_LEN_DELIMITED)
+        writeVarint(out, value.size)
+        out.write(value)
+    }
+
+    private fun writeVarint(
+        out: ByteArrayOutputStream,
+        value: Int,
+    ) {
+        var v = value
+        while (true) {
+            val b = v and VARINT_PAYLOAD
+            v = v ushr VARINT_SHIFT
+            if (v == 0) {
+                out.write(b)
+                return
+            }
+            out.write(b or VARINT_CONTINUATION)
+        }
+    }
+
+    /**
+     * Parse a protobuf message into a map of field-number → last-seen
+     * length-delimited value. Only length-delimited fields are retained;
+     * other wire types are skipped. Returns `null` on truncation.
+     */
+    @Suppress("ReturnCount")
+    private fun parseProtoFields(bytes: ByteArray): Map<Int, ByteArray>? {
+        val result = mutableMapOf<Int, ByteArray>()
+        var offset = 0
+        while (offset < bytes.size) {
+            val (tag, afterTag) = readVarint(bytes, offset) ?: return null
+            offset = afterTag
+            val fieldNumber = tag ushr 3
+            when (tag and 0x7) {
+                WIRE_TYPE_LEN_DELIMITED -> {
+                    val (len, afterLen) = readVarint(bytes, offset) ?: return null
+                    offset = afterLen
+                    if (offset + len > bytes.size) return null
+                    result[fieldNumber] = bytes.copyOfRange(offset, offset + len)
+                    offset += len
+                }
+                0 -> { // varint — skip
+                    val (_, after) = readVarint(bytes, offset) ?: return null
+                    offset = after
+                }
+                5 -> offset += 4 // fixed32
+                1 -> offset += 8 // fixed64
+                else -> return null
+            }
+        }
+        return result
+    }
+
+    /** Read a base-128 varint; returns (value, nextOffset) or `null`. */
+    @Suppress("ReturnCount")
+    private fun readVarint(
+        bytes: ByteArray,
+        start: Int,
+    ): Pair<Int, Int>? {
+        var result = 0
+        var shift = 0
+        var offset = start
+        while (offset < bytes.size) {
+            val b = bytes[offset].toInt() and UNSIGNED_BYTE
+            result = result or ((b and VARINT_PAYLOAD) shl shift)
+            offset += 1
+            if (b and VARINT_CONTINUATION == 0) return result to offset
+            shift += VARINT_SHIFT
+            if (shift >= 32) return null
+        }
+        return null
+    }
+
+    private fun decodeUtf8(bytes: ByteArray): String = String(bytes, Charsets.UTF_8)
+}

--- a/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/server/TcpReceiverServer.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/server/TcpReceiverServer.kt
@@ -119,6 +119,14 @@ import java.util.concurrent.atomic.AtomicLong
  *   (`InetAddress.getByName("0.0.0.0")` -- accept on every interface).
  *   Tests typically pass `InetAddress.getLoopbackAddress()` to avoid
  *   binding to the host's external NIC.
+ * @param preBoundSocket Optional already-bound listener to ADOPT instead
+ *   of binding a fresh one. Used by the NFC cold tap-to-receive path
+ *   (`NfcColdReceiverPrimer`): the HCE callback binds a [ServerSocket]
+ *   synchronously and advertises its port in the NFC tag, then the
+ *   receiver session adopts that exact socket here so the accept loop
+ *   drains the connection the sender already queued on the advertised
+ *   port. When non-null, [bindAddress] is ignored (the socket is already
+ *   bound) and the server takes ownership: [stop] closes it.
  * @param logger diagnostic sink for per-connection protocol events.
  */
 public class TcpReceiverServer(
@@ -127,6 +135,7 @@ public class TcpReceiverServer(
     private val secureRandomProvider: () -> SecureRandom = { SecureRandom() },
     private val mediumRegistry: MediumRegistry = MediumRegistry.DefaultWifiLan,
     private val bindAddress: InetAddress? = null,
+    private val preBoundSocket: ServerSocket? = null,
     private val logger: (String) -> Unit = {},
 ) {
     /**
@@ -307,18 +316,19 @@ public class TcpReceiverServer(
             check(!stopped) { "TcpReceiverServer has already been stopped" }
             started = true
 
-            // Open the listener on the IO dispatcher; bind() can block
-            // briefly on slow systems, and constructing ServerSocket
-            // itself performs the bind eagerly.
+            // Adopt a pre-bound listener (NFC cold-tap primer) when supplied;
+            // otherwise open one on the IO dispatcher (bind() can block briefly
+            // on slow systems, and constructing ServerSocket binds eagerly).
             val socket =
-                withContext(Dispatchers.IO) {
-                    // Args: port = 0 (kernel-assigned ephemeral), backlog = ACCEPT_BACKLOG.
-                    if (bindAddress != null) {
-                        ServerSocket(0, ACCEPT_BACKLOG, bindAddress)
-                    } else {
-                        ServerSocket(0, ACCEPT_BACKLOG)
+                preBoundSocket
+                    ?: withContext(Dispatchers.IO) {
+                        // Args: port = 0 (kernel-assigned ephemeral), backlog = ACCEPT_BACKLOG.
+                        if (bindAddress != null) {
+                            ServerSocket(0, ACCEPT_BACKLOG, bindAddress)
+                        } else {
+                            ServerSocket(0, ACCEPT_BACKLOG)
+                        }
                     }
-                }
             serverSocket = socket
 
             acceptJob =

--- a/core-protocol/src/test/kotlin/dev/bluehouse/bada/protocol/nfc/QuickShareNfcCodecTest.kt
+++ b/core-protocol/src/test/kotlin/dev/bluehouse/bada/protocol/nfc/QuickShareNfcCodecTest.kt
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.protocol.nfc
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import java.net.Inet4Address
+import java.net.InetAddress
+
+/**
+ * Byte-layout + round-trip tests for [QuickShareNfcCodec]. The golden-byte
+ * assertions pin the layout verified from GMS 26.18.33 smali
+ * (`docs/NFC_INTEROP_BYTEMAP.md` §1/§3/§4) so a future refactor cannot
+ * silently break interop.
+ */
+class QuickShareNfcCodecTest {
+    @Test
+    fun wifiLanRxAdv_hasVerifiedGoldenBytes_ipv4() {
+        val ip = InetAddress.getByName("192.168.1.42") as Inet4Address
+        val key = ByteArray(0x20) { 0x11 }
+        val rxAdv = QuickShareNfcCodec.encodeWifiLanRxAdv(ip = ip, port = 0x1F90, encryptionKey = key)
+
+        // EncryptionKey DE header: [0x80|0x20, 0x17] = [0xA0, 0x17] + 32 key bytes.
+        assertThat(rxAdv[0]).isEqualTo(0xA0.toByte())
+        assertThat(rxAdv[1]).isEqualTo(0x17.toByte())
+        // Wi-Fi-LAN cap DE begins at 2 + 32 = 34.
+        val cap = 34
+        // size byte = 0x0D (13 = 1 ver + 4 ip + 2 port + 6 bssid).
+        assertThat(rxAdv[cap]).isEqualTo((0x80 or 0x0D).toByte())
+        assertThat(rxAdv[cap + 1]).isEqualTo(0x15.toByte()) // type 0x15
+        assertThat(rxAdv[cap + 2]).isEqualTo(0x02.toByte()) // medium IPv4
+        // ip 192.168.1.42
+        assertThat(rxAdv[cap + 3]).isEqualTo(192.toByte())
+        assertThat(rxAdv[cap + 4]).isEqualTo(168.toByte())
+        assertThat(rxAdv[cap + 5]).isEqualTo(1.toByte())
+        assertThat(rxAdv[cap + 6]).isEqualTo(42.toByte())
+        // port 0x1F90 big-endian
+        assertThat(rxAdv[cap + 7]).isEqualTo(0x1F.toByte())
+        assertThat(rxAdv[cap + 8]).isEqualTo(0x90.toByte())
+        // bssid 6 zero bytes
+        for (i in 0 until 6) assertThat(rxAdv[cap + 9 + i]).isEqualTo(0.toByte())
+        assertThat(rxAdv.size).isEqualTo(cap + 15)
+    }
+
+    @Test
+    fun wifiLanRxAdv_roundTrips() {
+        val ip = InetAddress.getByName("10.0.0.7")
+        val key = ByteArray(0x20) { it.toByte() }
+        val rxAdv = QuickShareNfcCodec.encodeWifiLanRxAdv(ip = ip, port = 52999, encryptionKey = key)
+        val parsed = QuickShareNfcCodec.parseWifiLanEndpoint(rxAdv)
+        assertThat(parsed).isNotNull()
+        assertThat(parsed!!.address).isEqualTo(ip)
+        assertThat(parsed.port).isEqualTo(52999)
+    }
+
+    @Test
+    fun nfcTag_hasVerifiedGoldenBytes() {
+        val endpointId = "ABCD".toByteArray(Charsets.US_ASCII)
+        val serviceIdHash = byteArrayOf(0x01, 0x02, 0x03)
+        val endpointInfo = byteArrayOf(0x10, 0x20, 0x30)
+        val tag =
+            QuickShareNfcCodec.encodeNfcTag(
+                endpointId = endpointId,
+                serviceIdHash = serviceIdHash,
+                endpointInfo = endpointInfo,
+            )
+        // header = (1<<5)|3 = 0x23 (PCP 3 = P2P_POINT_TO_POINT, Quick Share's strategy).
+        assertThat(tag[0]).isEqualTo(0x23.toByte())
+        // endpointId bytes 1..4.
+        assertThat(tag.copyOfRange(1, 5)).isEqualTo(endpointId)
+        // serviceIdHash bytes 5..7.
+        assertThat(tag.copyOfRange(5, 8)).isEqualTo(serviceIdHash)
+        // infoLen byte 8.
+        assertThat(tag[8]).isEqualTo(3.toByte())
+        // endpointInfo bytes 9..11.
+        assertThat(tag.copyOfRange(9, 12)).isEqualTo(endpointInfo)
+        // btMac 6 zero bytes + 1 flags byte.
+        assertThat(tag.copyOfRange(12, 18)).isEqualTo(ByteArray(6))
+        assertThat(tag[18]).isEqualTo(0.toByte())
+        assertThat(tag.size).isEqualTo(19)
+    }
+
+    @Test
+    fun nfcTag_roundTrips_noMac() {
+        val endpointId = "WXYZ".toByteArray(Charsets.US_ASCII)
+        val serviceIdHash = byteArrayOf(0x0A, 0x0B, 0x0C)
+        val endpointInfo = ByteArray(20) { it.toByte() }
+        val tag =
+            QuickShareNfcCodec.encodeNfcTag(
+                endpointId = endpointId,
+                serviceIdHash = serviceIdHash,
+                endpointInfo = endpointInfo,
+            )
+        val parsed = QuickShareNfcCodec.parseNfcTag(tag)
+        assertThat(parsed).isNotNull()
+        assertThat(parsed!!.version).isEqualTo(1)
+        assertThat(parsed.pcp).isEqualTo(QuickShareNfcCodec.PCP_P2P_POINT_TO_POINT)
+        assertThat(parsed.endpointId).isEqualTo(endpointId)
+        assertThat(parsed.serviceIdHash).isEqualTo(serviceIdHash)
+        assertThat(parsed.endpointInfo).isEqualTo(endpointInfo)
+        assertThat(parsed.btMac).isNull()
+    }
+
+    @Test
+    fun nfcTag_rejectsUnsupportedPcp() {
+        val endpointId = "ABCD".toByteArray(Charsets.US_ASCII)
+        val tag =
+            QuickShareNfcCodec.encodeNfcTag(
+                endpointId = endpointId,
+                serviceIdHash = byteArrayOf(1, 2, 3),
+                endpointInfo = byteArrayOf(9),
+            )
+        // Corrupt PCP to 0 (unsupported — only {1,2,3} accepted).
+        tag[0] = (tag[0].toInt() and 0xE0).toByte()
+        assertThat(QuickShareNfcCodec.parseNfcTag(tag)).isNull()
+    }
+
+    @Test
+    fun hhwwRequest_roundTrips_andHasVerifiedTags() {
+        val req = QuickShareNfcCodec.HhwwRequest(serviceId = "NearbySharing")
+        val bytes = QuickShareNfcCodec.encodeHhwwRequest(req)
+        // field 1 = string => tag byte 0x0A, then length 13.
+        assertThat(bytes[0]).isEqualTo(0x0A.toByte())
+        assertThat(bytes[1]).isEqualTo(13.toByte())
+        val parsed = QuickShareNfcCodec.parseHhwwRequest(bytes)
+        assertThat(parsed).isEqualTo(req)
+    }
+
+    @Test
+    fun hhwvResponse_roundTrips_andHasVerifiedTags() {
+        val nfcTag = byteArrayOf(0x23, 1, 2, 3, 4)
+        val rxAdv = byteArrayOf(0x55, 0x66)
+        val resp = QuickShareNfcCodec.HhwvResponse(nfcTag = nfcTag, rxAdv = rxAdv)
+        val bytes = QuickShareNfcCodec.encodeHhwvResponse(resp)
+        // field 1 = bytes => tag 0x0A; field 2 = bytes => tag 0x12.
+        assertThat(bytes[0]).isEqualTo(0x0A.toByte())
+        assertThat(bytes[1]).isEqualTo(nfcTag.size.toByte())
+        val parsed = QuickShareNfcCodec.parseHhwvResponse(bytes)
+        assertThat(parsed).isNotNull()
+        assertThat(parsed!!.nfcTag).isEqualTo(nfcTag)
+        assertThat(parsed.rxAdv).isEqualTo(rxAdv)
+        assertThat(parsed.field3).isNull()
+    }
+
+    @Test
+    fun fullExchange_hceToReader_roundTrips() {
+        // Simulate the HCE building a response and the reader parsing it.
+        val endpointInfo = ByteArray(17) { (it + 1).toByte() }
+        val nfcTag =
+            QuickShareNfcCodec.encodeNfcTag(
+                endpointId = "QShr".toByteArray(Charsets.US_ASCII),
+                serviceIdHash = byteArrayOf(0x7A, 0x55, 0x12),
+                endpointInfo = endpointInfo,
+            )
+        val rxAdv =
+            QuickShareNfcCodec.encodeWifiLanRxAdv(
+                ip = InetAddress.getByName("172.16.5.9"),
+                port = 8959,
+                encryptionKey = ByteArray(0x20),
+            )
+        val response =
+            QuickShareNfcCodec.encodeHhwvResponse(
+                QuickShareNfcCodec.HhwvResponse(nfcTag = nfcTag, rxAdv = rxAdv),
+            )
+
+        val parsedResp = QuickShareNfcCodec.parseHhwvResponse(response)!!
+        val parsedTag = QuickShareNfcCodec.parseNfcTag(parsedResp.nfcTag)!!
+        val lan = QuickShareNfcCodec.parseWifiLanEndpoint(parsedResp.rxAdv!!)!!
+
+        assertThat(String(parsedTag.endpointId, Charsets.US_ASCII)).isEqualTo("QShr")
+        assertThat(parsedTag.endpointInfo).isEqualTo(endpointInfo)
+        assertThat(lan.address).isEqualTo(InetAddress.getByName("172.16.5.9"))
+        assertThat(lan.port).isEqualTo(8959)
+    }
+}

--- a/core-protocol/src/test/kotlin/dev/bluehouse/bada/protocol/server/TcpReceiverServerTest.kt
+++ b/core-protocol/src/test/kotlin/dev/bluehouse/bada/protocol/server/TcpReceiverServerTest.kt
@@ -100,6 +100,42 @@ class TcpReceiverServerTest {
         }
 
     @Test
+    fun `start adopts a pre-bound ServerSocket on its existing port`() =
+        runBlocking {
+            // Mirror the NFC cold-tap primer: bind a listener up front (e.g. in
+            // the HCE callback) and advertise its port, then hand that exact
+            // socket to the server, which must accept on the SAME port rather
+            // than binding a fresh one.
+            val preBound = java.net.ServerSocket(0, 8, InetAddress.getLoopbackAddress())
+            val advertisedPort = preBound.localPort
+
+            val scope = makeScope()
+            val server =
+                TcpReceiverServer(
+                    parentScope = scope,
+                    factoryProvider = { TempFileDestinationFactory() },
+                    secureRandomProvider = { SecureRandom() },
+                    bindAddress = InetAddress.getLoopbackAddress(),
+                    preBoundSocket = preBound,
+                )
+            servers += server
+
+            val port = server.start()
+            assertThat(port).isEqualTo(advertisedPort)
+            assertThat(server.boundPort).isEqualTo(advertisedPort)
+
+            // A client connecting to the advertised port is accepted by the
+            // adopted listener.
+            Socket(InetAddress.getLoopbackAddress(), advertisedPort).use { sock ->
+                assertThat(sock.isConnected).isTrue()
+            }
+
+            server.stop()
+            // The server owns the adopted socket: stop() must close it.
+            assertThat(preBound.isClosed).isTrue()
+        }
+
+    @Test
     fun `boundPort throws before start`() {
         val server = makeServer()
         runCatching { server.boundPort }.also { result ->

--- a/service-android/src/main/kotlin/dev/bluehouse/bada/service/receiver/NfcColdReceiverPrimer.kt
+++ b/service-android/src/main/kotlin/dev/bluehouse/bada/service/receiver/NfcColdReceiverPrimer.kt
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.service.receiver
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import dev.bluehouse.bada.discovery.diagnostics.DiagnosticLog
+import dev.bluehouse.bada.protocol.endpoint.NearbyServiceId
+import dev.bluehouse.bada.protocol.nfc.NfcTapLinkHolder
+import java.net.Inet4Address
+import java.net.InetAddress
+import java.net.ServerSocket
+
+/**
+ * `NfcColdReceiverPrimer` — makes a COLD NFC tap behave like a WARM one (single
+ * tap, no second tap, no button) for the Quick Share tap-to-receive path.
+ *
+ * ## What it is / what it's called
+ * Invoked as `NfcColdReceiverPrimer.prime(context)` from
+ * [dev.bluehouse.bada.nfc.BadaTapHceService]'s `processCommandApdu` ADVERTISEMENT
+ * branch when the receiver is NOT already live ([NfcTapLinkHolder.current] ==
+ * null). There is no UI; it runs inside the HCE binder callback that the OS
+ * starts on the tap (even from a dead process).
+ *
+ * ## What it does (the warm-parity trick)
+ * A WARM receiver answers the very first ADVERTISEMENT with a real
+ * `deym(PCP=3) + Wi-Fi-LAN rxAdv(IP:port)` because its TCP listener is already
+ * bound and [NfcTapLinkHolder] is populated. A COLD receiver normally has
+ * neither, so it used to answer an EMPTY tag and rely on the sender re-scanning.
+ * This primer removes that dependency:
+ *
+ *  1. Reads the device's Wi-Fi-LAN IPv4 (fast, in-memory `ConnectivityManager`).
+ *  2. Binds a [ServerSocket] on `0.0.0.0:0` SYNCHRONOUSLY (fast local syscall) —
+ *     the SAME shape the production [TcpServerFactory.default] would bind. Even
+ *     before any accept loop runs, a bound socket completes the TCP handshake
+ *     and QUEUES the sender's connect in the kernel backlog, so the port we
+ *     advertise is immediately connectable.
+ *  3. Builds the live [NfcTapLinkHolder.Link] (same identity the session will
+ *     advertise: [BleEndpointIdHolder] id, [NearbyServiceId.hashPrefix],
+ *     [EndpointIdentityHolder] endpoint-info, the Wi-Fi IP, the bound port) and
+ *     publishes it so the HCE answers a REAL tag on the FIRST tap.
+ *  4. Stashes the bound socket for the about-to-start [ReceiverSession] to ADOPT
+ *     (via [TcpServerFactory.default] → [takePreBoundSocket]) so the accept loop
+ *     drains the kernel backlog on the IDENTICAL port the tag advertised.
+ *
+ * The HCE still fires the foreground-service wake; the session comes up, adopts
+ * this socket, advertises (BLE + mDNS), and accepts the queued connection.
+ *
+ * ## Preconditions / failure paths
+ * - **No Wi-Fi-LAN IPv4** (Wi-Fi off / still connecting) → [prime] returns
+ *   `null`; the HCE answers an empty tag for that round and relies on the wake +
+ *   the radio-helper turning Wi-Fi on + BLE discovery. (The radios are forced on
+ *   by the wake in [ReceiverForegroundService] via the radio-helper.)
+ * - **Foreground-service wake refused** (e.g. ColorOS background-FGS-start
+ *   limit) → the session never starts and never adopts the socket; the kernel
+ *   queues the connect but nothing drains it → it times out. The next tap
+ *   re-primes: [prime] CLOSES any prior unadopted socket first, so the leak is
+ *   bounded to one socket. [ReceiverForegroundService] also calls
+ *   [discardUnadopted] on teardown.
+ *
+ * ## Threading
+ * [prime] runs on the HCE main/binder thread, so it does only fast local work
+ * (a `ConnectivityManager` read + a `ServerSocket(0)` bind). The one
+ * potentially-heavier step is building the endpoint identity the FIRST time the
+ * process is cold ([AdvertisedDeviceNames.createEndpointInfo] reads the device
+ * name); we reuse the cached [EndpointIdentityHolder] snapshot when present to
+ * avoid it.
+ *
+ * ## Status
+ * Compile-only / device-UNVERIFIED — there is no NFC hardware in the build env.
+ * The kernel-backlog + socket-adoption mechanism is unit-tested in
+ * `TcpReceiverServerTest` ("start adopts a pre-bound ServerSocket…"); the real
+ * single-cold-tap transfer is the on-device test.
+ */
+object NfcColdReceiverPrimer {
+    private const val TAG = "BadaNfcColdPrime"
+
+    /** Matches `TcpReceiverServer.ACCEPT_BACKLOG` so the adopted socket is identical. */
+    private const val ACCEPT_BACKLOG = 8
+
+    private val socketLock = Any()
+
+    @Volatile
+    private var preBoundSocket: ServerSocket? = null
+
+    /**
+     * Bind a listener + publish the live [NfcTapLinkHolder.Link] so a cold tap
+     * answers a real, connectable tag on the FIRST round. Returns the link, or
+     * `null` when there is no Wi-Fi-LAN IPv4 to advertise yet.
+     */
+    fun prime(context: Context): NfcTapLinkHolder.Link? {
+        val ip = firstWifiLanIpv4(context)
+        if (ip == null) {
+            DiagnosticLog.w(TAG, "prime: no Wi-Fi-LAN IPv4 yet -> empty tag this round (wake + radios + BLE)")
+            return null
+        }
+
+        // Same identity the session will advertise (reuse the cached snapshot so
+        // we don't re-read device-name settings on the HCE thread when possible).
+        val identity =
+            EndpointIdentityHolder.snapshot.get()
+                ?: AdvertisedDeviceNames.createEndpointInfo(context).also {
+                    EndpointIdentityHolder.snapshot.compareAndSet(null, it)
+                }
+        val effectiveIdentity = EndpointIdentityHolder.snapshot.get() ?: identity
+
+        val socket =
+            synchronized(socketLock) {
+                // Close any prior primed-but-never-adopted socket (e.g. a previous
+                // tap whose FGS wake was refused) so the leak is bounded to one.
+                preBoundSocket?.let { runCatching { it.close() } }
+                ServerSocket(0, ACCEPT_BACKLOG).also { preBoundSocket = it }
+            }
+
+        val link =
+            NfcTapLinkHolder.Link(
+                endpointId = BleEndpointIdHolder.bytesFor(),
+                serviceIdHash = NearbyServiceId.hashPrefix,
+                endpointInfo = effectiveIdentity.serialize(),
+                address = ip,
+                port = socket.localPort,
+            )
+        NfcTapLinkHolder.set(link)
+        DiagnosticLog.w(TAG, "prime: live tag ready ${ip.hostAddress}:${socket.localPort} (cold tap == warm)")
+        return link
+    }
+
+    /**
+     * Hand the primed listener to the about-to-start [ReceiverSession] (called
+     * once by [TcpServerFactory.default]). Returns `null` when no cold tap
+     * primed a socket — production then binds a fresh ephemeral one as before.
+     */
+    fun takePreBoundSocket(): ServerSocket? =
+        synchronized(socketLock) {
+            val s = preBoundSocket
+            preBoundSocket = null
+            s
+        }
+
+    /**
+     * Release a primed-but-unadopted socket (the FGS wake never brought the
+     * session up). Called from [ReceiverForegroundService] teardown so a refused
+     * cold wake does not leak the listener until the next tap.
+     */
+    fun discardUnadopted() {
+        synchronized(socketLock) {
+            preBoundSocket?.let { runCatching { it.close() } }
+            preBoundSocket = null
+        }
+    }
+
+    /**
+     * First non-local Wi-Fi-LAN IPv4, via `ConnectivityManager.LinkProperties`
+     * (mirrors `ReceiverForegroundService.firstWifiLanIpv4`). Uses
+     * `LinkProperties`, NOT the deprecated `WifiManager.connectionInfo`, which
+     * returns sentinel `0.0.0.0` on API 31+ without precise-location permission.
+     */
+    private fun firstWifiLanIpv4(context: Context): Inet4Address? {
+        val cm =
+            context.applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE)
+                as? ConnectivityManager ?: return null
+        return cm.allNetworks
+            .asSequence()
+            .filter { network ->
+                cm.getNetworkCapabilities(network)
+                    ?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true
+            }.mapNotNull { network -> cm.getLinkProperties(network) }
+            .flatMap { linkProperties -> linkProperties.linkAddresses.asSequence() }
+            .map { linkAddress -> linkAddress.address }
+            .filterIsInstance<Inet4Address>()
+            .filterNot { addr: InetAddress ->
+                addr.isAnyLocalAddress || addr.isLoopbackAddress || addr.isLinkLocalAddress
+            }.sortedBy(InetAddress::getHostAddress)
+            .firstOrNull()
+    }
+}

--- a/service-android/src/main/kotlin/dev/bluehouse/bada/service/receiver/NfcColdReceiverPrimer.kt
+++ b/service-android/src/main/kotlin/dev/bluehouse/bada/service/receiver/NfcColdReceiverPrimer.kt
@@ -99,15 +99,6 @@ object NfcColdReceiverPrimer {
             return null
         }
 
-        // Same identity the session will advertise (reuse the cached snapshot so
-        // we don't re-read device-name settings on the HCE thread when possible).
-        val identity =
-            EndpointIdentityHolder.snapshot.get()
-                ?: AdvertisedDeviceNames.createEndpointInfo(context).also {
-                    EndpointIdentityHolder.snapshot.compareAndSet(null, it)
-                }
-        val effectiveIdentity = EndpointIdentityHolder.snapshot.get() ?: identity
-
         val socket =
             synchronized(socketLock) {
                 // Close any prior primed-but-never-adopted socket (e.g. a previous
@@ -116,17 +107,54 @@ object NfcColdReceiverPrimer {
                 ServerSocket(0, ACCEPT_BACKLOG).also { preBoundSocket = it }
             }
 
-        val link =
-            NfcTapLinkHolder.Link(
-                endpointId = BleEndpointIdHolder.bytesFor(),
-                serviceIdHash = NearbyServiceId.hashPrefix,
-                endpointInfo = effectiveIdentity.serialize(),
-                address = ip,
-                port = socket.localPort,
-            )
+        val link = buildLink(context, ip, socket.localPort)
         NfcTapLinkHolder.set(link)
         DiagnosticLog.w(TAG, "prime: live tag ready ${ip.hostAddress}:${socket.localPort} (cold tap == warm)")
         return link
+    }
+
+    /**
+     * Publish the live receiver link for a WARM session — one already running with
+     * its TCP listener bound on [port] — so an NFC tap answers a real
+     * `deym + Wi-Fi-LAN rxAdv` tag without cold-priming a second socket. Called by
+     * [ReceiverForegroundService] right after the session binds. Returns the
+     * published link, or `null` when there is no Wi-Fi-LAN IPv4 to advertise (the
+     * receiver isn't reachable over Wi-Fi-LAN, so we leave the tag empty).
+     */
+    fun publishWarmLink(
+        context: Context,
+        port: Int,
+    ): NfcTapLinkHolder.Link? {
+        val ip = firstWifiLanIpv4(context) ?: return null
+        val link = buildLink(context, ip, port)
+        NfcTapLinkHolder.set(link)
+        DiagnosticLog.w(TAG, "publishWarmLink: live tag ${ip.hostAddress}:$port")
+        return link
+    }
+
+    /**
+     * Build the [NfcTapLinkHolder.Link] advertised over NFC for the given live
+     * [ip]/[port], reusing the cached [EndpointIdentityHolder] snapshot so we
+     * don't re-read device-name settings on the HCE thread when possible.
+     */
+    private fun buildLink(
+        context: Context,
+        ip: Inet4Address,
+        port: Int,
+    ): NfcTapLinkHolder.Link {
+        val identity =
+            EndpointIdentityHolder.snapshot.get()
+                ?: AdvertisedDeviceNames.createEndpointInfo(context).also {
+                    EndpointIdentityHolder.snapshot.compareAndSet(null, it)
+                }
+        val effectiveIdentity = EndpointIdentityHolder.snapshot.get() ?: identity
+        return NfcTapLinkHolder.Link(
+            endpointId = BleEndpointIdHolder.bytesFor(),
+            serviceIdHash = NearbyServiceId.hashPrefix,
+            endpointInfo = effectiveIdentity.serialize(),
+            address = ip,
+            port = port,
+        )
     }
 
     /**
@@ -166,7 +194,8 @@ object NfcColdReceiverPrimer {
         return cm.allNetworks
             .asSequence()
             .filter { network ->
-                cm.getNetworkCapabilities(network)
+                cm
+                    .getNetworkCapabilities(network)
                     ?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true
             }.mapNotNull { network -> cm.getLinkProperties(network) }
             .flatMap { linkProperties -> linkProperties.linkAddresses.asSequence() }

--- a/service-android/src/main/kotlin/dev/bluehouse/bada/service/receiver/ReceiverForegroundService.kt
+++ b/service-android/src/main/kotlin/dev/bluehouse/bada/service/receiver/ReceiverForegroundService.kt
@@ -32,6 +32,7 @@ import dev.bluehouse.bada.discovery.diagnostics.DiagnosticLog
 import dev.bluehouse.bada.discovery.medium.MediumRegistries
 import dev.bluehouse.bada.protocol.endpoint.BleServiceData
 import dev.bluehouse.bada.protocol.endpoint.EndpointInfo
+import dev.bluehouse.bada.protocol.nfc.NfcTapLinkHolder
 import dev.bluehouse.bada.service.downloads.DownloadsWriterFactory
 import dev.bluehouse.bada.service.receiver.consent.ConsentBroadcastReceiver
 import dev.bluehouse.bada.service.receiver.consent.ConsentCoordinator
@@ -412,6 +413,13 @@ public class ReceiverForegroundService : Service() {
                 // longer needed: NsdManager owns the system mDNS
                 // responder, which has its own multicast filter
                 // exemption.
+                //
+                // Publish the live NFC tap-to-receive link (#NFC) so a tap on
+                // this already-running receiver answers a real tag pointing at
+                // the bound port — the warm counterpart of NfcColdReceiverPrimer.
+                // A cold tap that primed + adopted a socket lands on the same
+                // port, so this is consistent either way; no-op without Wi-Fi-LAN.
+                NfcColdReceiverPrimer.publishWarmLink(applicationContext, newSession.boundPort)
                 startMdnsGate(newSession)
             } catch (
                 @Suppress("SwallowedException") t: Throwable,
@@ -895,6 +903,12 @@ public class ReceiverForegroundService : Service() {
         stopActiveReceiverSession()
         unregisterConsentReceiverIfNeeded()
 
+        // The receiver is no longer live: clear the NFC tap-to-receive link so a
+        // tap answers an empty tag (no stale port), and release any cold-tap
+        // primed-but-unadopted socket so a refused FGS wake doesn't leak it.
+        NfcTapLinkHolder.clear()
+        NfcColdReceiverPrimer.discardUnadopted()
+
         // Detach the ProcessLifecycleOwner observer first — once the
         // scanner is stopped, any late foreground/background callback
         // would just be a no-op on a stopped scanner, but holding the
@@ -929,6 +943,17 @@ public class ReceiverForegroundService : Service() {
          * is hardcoded into the package, not exported.
          */
         public const val ACTION_STOP: String = "dev.bluehouse.bada.service.receiver.ACTION_STOP"
+
+        /**
+         * Action string for the NFC cold tap-to-receive wake. Fired by
+         * [dev.bluehouse.bada.nfc.BadaTapHceService] when a tap arrives while no
+         * receiver is live: the HCE callback pre-binds + advertises a socket via
+         * [NfcColdReceiverPrimer] and starts this service with this action, which
+         * (like any non-stop start) brings up the receiver session — the session
+         * then ADOPTS the primed socket so the sender's already-queued connection
+         * is accepted on the advertised port. Not exported.
+         */
+        public const val ACTION_NFC_WAKE: String = "dev.bluehouse.bada.service.receiver.ACTION_NFC_WAKE"
 
         /**
          * Intent extra carrying a serialized [EndpointInfo] when the

--- a/service-android/src/main/kotlin/dev/bluehouse/bada/service/receiver/ReceiverSession.kt
+++ b/service-android/src/main/kotlin/dev/bluehouse/bada/service/receiver/ReceiverSession.kt
@@ -469,6 +469,13 @@ public interface TcpServerFactory {
         /**
          * Production factory: builds a stock [TcpReceiverServer] bound
          * on `0.0.0.0` (all interfaces) so any Wi-Fi peer can connect.
+         *
+         * If an NFC cold tap pre-bound a listener via [NfcColdReceiverPrimer]
+         * (the HCE callback advertised that socket's port in the NFC tag), the
+         * server ADOPTS it so the accept loop drains the connection the sender
+         * already queued on the advertised port — making a single cold tap
+         * behave like a warm receiver. [takePreBoundSocket] returns `null` on
+         * the normal (non-NFC) path, so a fresh ephemeral port is bound as before.
          */
         @JvmStatic
         public fun default(logger: (String) -> Unit = {}): TcpServerFactory =
@@ -484,6 +491,7 @@ public interface TcpServerFactory {
                         factoryProvider = factoryProvider,
                         secureRandomProvider = secureRandomProvider,
                         mediumRegistry = mediumRegistry,
+                        preBoundSocket = NfcColdReceiverPrimer.takePreBoundSocket(),
                         logger = logger,
                     )
             }


### PR DESCRIPTION
## What
Adds **NFC tap-to-share**: tap two phones together to start a transfer even with native quick shar. The receiver runs a Host Card Emulation (HCE) service on the Nearby Connections AID `F00000FE2C`; the sender uses NFC reader-mode. On tap the sender sends `SELECT` + an `ADVERTISEMENT`:
- If the other phone is actively visible as a receiver, its HCE answers with its endpoint info + a Wi-Fi-LAN address (IP:port) packed in Quick Share's own NFC blob, and the sender connects straight to it.
- If the other phone is idle/closed, the tap **wakes** it (Android launches its HCE even when the process is dead), which opens a short receive window; the sender lets normal Wi-Fi discovery find the now-advertising receiver.

NFC only does the handoff; the file transfer rides the normal Wi-Fi (mDNS/TCP) path. Mirrors stock Quick Share (advertisement once, then discovery — not a blocking re-read).

## What the stock Quick Share decompile showed (GMS 26.18.33)
This backend mirrors how stock Quick Share actually does the tap, mapped from the Google Play services decompile:
- **Roles:** the QS **sender** (the share sheet) is the NFC **reader/initiator** — it arms `NfcAdapter.enableReaderMode`, and on tap `onTagDiscovered` hands the tapped tag into GMS, which runs the ISO-DEP exchange. The **receiver** runs the HCE. This PR puts the app in those same two roles.
- **AID + commands:** the receiver HCE (`NfcAdvertisingChimeraService.processCommandApdu`) sits on AID `F00000FE2C` and handles four APDUs — `SELECT` (`00 A4…`), `ADVERTISEMENT` (`80 01…`), `CONNECT` (`80 02…`), `DATA` (`80 03…`). Our `SELECT` (`00 A4 04 00 05 F0 00 00 FE 2C 00`) is byte-identical to the one GMS sends.
- **ADVERTISEMENT exchange:** the reader sends `SELECT` then an `ADVERTISEMENT` carrying a protobuf (`serviceId = "NearbySharing"`, plus the sender's endpoint id/info). The HCE looks `serviceId` up in its registry: if the phone is currently NFC-advertising it returns its endpoint tag (the blob with the Wi-Fi-LAN address); if not, it returns a 2-byte `0000` **and fires a wake PendingIntent**.
- **When a tag is actually exposed (the key constraint we found):** the endpoint tag is registered **only while the phone is in NFC-enabled discovery — i.e. on the QS send sheet scanning for recipients** (`startNfcAdvertising` ← `startDiscovery`). An idle/receiving phone returns `0000` but gets **woken** — the wake PendingIntent is registered by FastInitiation scanning, gated on screen-unlocked + Bluetooth + location + battery-ok. That's why a tap on an idle phone wakes it instead of handing back a tag, and the sender then falls through to normal Wi-Fi discovery (exactly the two-branch behavior above).
- **NFC bootstraps only:** the real transfer rides Wi-Fi-LAN; the receiver is found over mDNS `_FC9F5ED42C8A._tcp` (`FC9F5E` = SHA-256("NearbySharing")[:3]). Stock QS's true proximity trigger for an idle receiver is a separate BLE FastInitiation advertisement (service UUID `FE2C`), not this NFC AID exchange.

## This PR — the tap backend
- **`protocol/nfc/QuickShareNfcCodec`** — encodes/decodes the Quick Share NFC `ADVERTISEMENT` + the "deym" P2P endpoint blob (with unit tests).
- **`nfc/BadaTapReader`** — NFC reader-mode driver (`SELECT` + `ADVERTISEMENT`, wake handling, re-arm after each tap).
- **`nfc/BadaTapHceService`** — the receiver HCE service on AID `F00000FE2C`.
- **`nfc/NfcPreferredService`** — claims the shared NFC ID on Android 15 (`CardEmulation.setPreferredService`) while the receive sheet is up.
- **`service/receiver/NfcColdReceiverPrimer`** — primes the receiver HCE on a cold (idle/closed) tap-wake.
- preferences for the tap on/off switch + on-screen tap diagnostics.

## ⚠️ Note for the maintainer — connected files
The **manifest HCE service registration** (AID `F00000FE2C`) and the **`SendActivity` reader-mode wiring** (`tapReader`, `onNfcTapWake`) ride in the **send-sheet PR** — they share `SendActivity.kt` and the manifest. These classes also use shared infra (`ReceiverForegroundService`, the on-device `DiagnosticLog`) carried in the related PRs. Merge the set together.

Note on the Accept prompt: between two phones on the SAME Google account, stock Quick Share auto-accepts (its self-share trust check — not forgeable cross-account); across accounts the receiver taps Accept once, same as any cross-account Quick Share transfer.
