### PR TITLE
(enable tap to share with iOS) QR button doubles as an NFC tag that auto-opens the link

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -369,6 +369,32 @@
             android:label="@string/show_qr_title" />
 
         <!--
+          NFC link broadcast HCE service (NDEF Tag Application D2760000850101).
+
+          Emulates an NFC Forum Type-4 NDEF tag whose single URI record is the
+          current Bada pairing link (NfcLinkHolder.currentUrl, set by the Send UI
+          while the QR/link panel is showing). An iPhone tapped to the back of
+          this phone background-reads the URI and opens it in Safari (the URL is
+          an ordinary web link, not an App Store / universal link).
+
+          Distinct AID from the Quick Share tap-to-share service below, so both
+          HostApduServices coexist on the one NFC controller. exported=true +
+          BIND_NFC_SERVICE: only the system NFC service binds and routes APDUs
+          here, so this is not a third-party-callable surface.
+        -->
+        <service
+            android:name=".nfc.BadaNdefApduService"
+            android:exported="true"
+            android:permission="android.permission.BIND_NFC_SERVICE">
+            <intent-filter>
+                <action android:name="android.nfc.cardemulation.action.HOST_APDU_SERVICE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.nfc.cardemulation.host_apdu_service"
+                android:resource="@xml/bada_apduservice" />
+        </service>
+
+        <!--
           Quick Share NFC tap-to-share HCE receiver (AID F00000FE2C).
 
           A stock Quick Share sender in reader-mode (or Bada's own reader-mode)

--- a/app/src/main/kotlin/dev/bluehouse/bada/nfc/BadaNdefApduService.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/nfc/BadaNdefApduService.kt
@@ -1,0 +1,282 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.nfc
+
+import android.nfc.cardemulation.HostApduService
+import android.os.Bundle
+import android.util.Log
+import java.nio.charset.StandardCharsets
+
+/**
+ * Host Card Emulation service that exposes the current Bada pairing
+ * link (the QR URL) as an NFC Forum **Type-4 Tag** carrying a single NDEF
+ * **URI** record. When an iPhone (XS+/iOS 13+, screen-on/unlocked) is
+ * tapped to the back of this phone, iOS CoreNFC background-reads the NDEF
+ * URI and offers to open it — and because the URI is an ordinary
+ * `https://quickshare.google/qrcode#…` web link (not an App Store /
+ * universal link), iOS opens it **in Safari**, not the App Store.
+ *
+ * Ported from `oshare-nfc-tap`'s `NdefAppStoreApduService`, which emulated
+ * the OnePlus Share iOS tap with a *static* App-Store universal link. The
+ * Type-4 state machine (SELECT AID / SELECT CC / READ CC / SELECT NDEF /
+ * READ BINARY) is identical; the only change is that the served URI is
+ * **dynamic** — read from [NfcLinkHolder.currentUrl] at the moment the
+ * reader SELECTs the NDEF application, so each tap broadcasts whatever
+ * pairing link the Send screen is currently showing. When the holder is
+ * `null` (no QR session active) we serve an empty NDEF message (NLEN = 0)
+ * so a stray tap does nothing rather than opening a stale link.
+ *
+ * Implemented with only public `android.nfc.cardemulation` APIs + the
+ * auto-granted `BIND_NFC_SERVICE` permission — no OEM privilege.
+ *
+ * ## Type-4 Tag protocol (NFC Forum T4T Operation + ISO 7816-4)
+ * A Type-4 reader (the iPhone) runs, and we answer, this sequence:
+ *
+ *  1. SELECT by name, NDEF Tag App AID `D2760000850101` -> `90 00`.
+ *     We snapshot [NfcLinkHolder.currentUrl] here and build the NDEF +
+ *     CC files for this read session.
+ *  2. SELECT (by file id) the Capability Container `E103` -> `90 00`.
+ *  3. READ_BINARY the CC -> 15-byte CC describing the NDEF file
+ *     (id `E104`, max read, max NDEF len) + `90 00`.
+ *  4. SELECT the NDEF file `E104` -> `90 00`.
+ *  5. READ_BINARY offset 0, len 2 -> the 2-byte NLEN.
+ *  6. READ_BINARY offset 2.. -> the NDEF message bytes.
+ *
+ * VERIFIED-vs-ASSUMED: the NDEF byte layout is built per the public NFC
+ * Forum Type-4 Tag + NDEF URI RTD specs, and the AID is the NFC Forum NDEF
+ * Tag Application AID. Whether a real iPhone tapping a real device performs
+ * exactly this T4T read sequence and follows the URI into Safari is NOT
+ * proven here (needs an actual iPhone + NFC hardware to confirm).
+ */
+public class BadaNdefApduService : HostApduService() {
+    /** Which file the reader currently has selected. */
+    private enum class Selected { NONE, CC, NDEF }
+
+    private var selected: Selected = Selected.NONE
+
+    /**
+     * The NDEF file (NLEN prefix + message) and CC for the *current* read
+     * session. Rebuilt on each SELECT-AID from [NfcLinkHolder.currentUrl]
+     * so a tap always serves the link on screen at tap time. Initialised
+     * to the empty-NDEF form for the case where a reader issues a
+     * READ_BINARY before any SELECT-AID (defensive — a compliant reader
+     * always selects first).
+     */
+    private var ndefFile: ByteArray = buildNdefFile(EMPTY_NDEF_MESSAGE)
+    private var ccFile: ByteArray = buildCapabilityContainer(ndefFile.size)
+
+    override fun processCommandApdu(
+        apdu: ByteArray?,
+        extras: Bundle?,
+    ): ByteArray {
+        if (apdu == null || apdu.size < 4) {
+            return SW_WRONG_LENGTH
+        }
+
+        // SELECT (INS A4).
+        if (apdu[0] == 0x00.toByte() && apdu[1] == 0xA4.toByte()) {
+            // SELECT by name (P1=04): match the NDEF Tag Application AID.
+            if (apdu[2] == 0x04.toByte()) {
+                if (apduSelectsAid(apdu, NDEF_TAG_APP_AID)) {
+                    refreshNdefForCurrentLink()
+                    selected = Selected.NONE // app selected; no file selected yet
+                    return SW_OK
+                }
+                return SW_FILE_NOT_FOUND
+            }
+            // SELECT by file id (P1=00, P2=0C, Lc=02, fid).
+            if (apdu[2] == 0x00.toByte() && apdu.size >= 7) {
+                val hi = apdu[5]
+                val lo = apdu[6]
+                if (hi == CC_FILE_ID[0] && lo == CC_FILE_ID[1]) {
+                    selected = Selected.CC
+                    return SW_OK
+                }
+                if (hi == NDEF_FILE_ID[0] && lo == NDEF_FILE_ID[1]) {
+                    selected = Selected.NDEF
+                    return SW_OK
+                }
+                return SW_FILE_NOT_FOUND
+            }
+            return SW_FILE_NOT_FOUND
+        }
+
+        // READ_BINARY (INS B0): P1P2 = offset, Le (last byte) = length.
+        if (apdu[1] == INS_READ_BINARY) {
+            val offset = ((apdu[2].toInt() and 0xFF) shl 8) or (apdu[3].toInt() and 0xFF)
+            var le = if (apdu.size >= 5) apdu[4].toInt() and 0xFF else 0
+            if (le == 0) le = 256 // Le=00 means 256 in short form
+
+            val file =
+                when (selected) {
+                    Selected.CC -> ccFile
+                    Selected.NDEF -> ndefFile
+                    Selected.NONE -> return SW_FILE_NOT_FOUND
+                }
+
+            if (offset > file.size) {
+                return SW_WRONG_LENGTH
+            }
+            val len = minOf(le, file.size - offset)
+            val resp = ByteArray(len + 2)
+            System.arraycopy(file, offset, resp, 0, len)
+            resp[len] = SW_OK[0]
+            resp[len + 1] = SW_OK[1]
+            return resp
+        }
+
+        return SW_INS_NOT_SUPPORTED
+    }
+
+    override fun onDeactivated(reason: Int) {
+        selected = Selected.NONE
+    }
+
+    /**
+     * Snapshot [NfcLinkHolder.currentUrl] and (re)build the NDEF + CC
+     * files for this read session. A non-null URL becomes a URI record; a
+     * null/blank URL becomes the empty NDEF message (NLEN = 0) so the tap
+     * is a no-op rather than opening a stale link.
+     */
+    private fun refreshNdefForCurrentLink() {
+        val url = NfcLinkHolder.currentUrl
+        val message =
+            if (url.isNullOrBlank()) {
+                Log.d(TAG, "SELECT NDEF app AID -> OK; no current link, serving empty NDEF")
+                EMPTY_NDEF_MESSAGE
+            } else {
+                Log.d(TAG, "SELECT NDEF app AID -> OK; will serve $url")
+                buildUriNdefMessage(url)
+            }
+        ndefFile = buildNdefFile(message)
+        ccFile = buildCapabilityContainer(ndefFile.size)
+    }
+
+    public companion object {
+        private const val TAG = "BadaNfc"
+
+        // ---- Status words (ISO 7816-4) ----
+        private val SW_OK = byteArrayOf(0x90.toByte(), 0x00)
+        private val SW_FILE_NOT_FOUND = byteArrayOf(0x6A.toByte(), 0x82.toByte())
+        private val SW_WRONG_LENGTH = byteArrayOf(0x67.toByte(), 0x00)
+        private val SW_INS_NOT_SUPPORTED = byteArrayOf(0x6D.toByte(), 0x00)
+
+        // ---- File identifiers ----
+        private val CC_FILE_ID = byteArrayOf(0xE1.toByte(), 0x03)
+        private val NDEF_FILE_ID = byteArrayOf(0xE1.toByte(), 0x04)
+
+        // NDEF Tag Application AID (NFC Forum). The same AID an iPhone
+        // SELECTs to read a Type-4 NDEF tag.
+        private val NDEF_TAG_APP_AID =
+            byteArrayOf(0xD2.toByte(), 0x76, 0x00, 0x00, 0x85.toByte(), 0x01, 0x01)
+
+        // READ_BINARY INS.
+        private const val INS_READ_BINARY: Byte = 0xB0.toByte()
+
+        /** A valid empty NDEF message (single empty record, TNF=0x00). */
+        private val EMPTY_NDEF_MESSAGE = byteArrayOf(0xD0.toByte(), 0x00, 0x00)
+
+        /** True iff this SELECT-by-name APDU carries exactly [aid] in its data. */
+        internal fun apduSelectsAid(
+            apdu: ByteArray,
+            aid: ByteArray,
+        ): Boolean {
+            // 00 A4 04 00 <Lc> <AID...> [Le]
+            if (apdu.size < 5 + aid.size) return false
+            val lc = apdu[4].toInt() and 0xFF
+            if (lc != aid.size) return false
+            for (i in aid.indices) {
+                if (apdu[5 + i] != aid[i]) return false
+            }
+            return true
+        }
+
+        /**
+         * Build the 15-byte Capability Container per NFC Forum T4T:
+         * ```
+         * 00 0F  CCLEN = 15
+         * 20     mapping version 2.0
+         * 00 3B  MLe (max R-APDU data, 59)
+         * 00 34  MLc (max C-APDU data, 52)
+         * 04 06  NDEF File Control TLV: T=04, L=06
+         *   E1 04            NDEF file id
+         *   <max ndef len hi/lo>
+         *   00               read access granted
+         *   FF               write access denied (read-only tag)
+         * ```
+         */
+        internal fun buildCapabilityContainer(ndefFileLen: Int): ByteArray =
+            byteArrayOf(
+                0x00, 0x0F, // CCLEN = 15
+                0x20, // mapping version 2.0
+                0x00, 0x3B, // MLe
+                0x00, 0x34, // MLc
+                0x04, 0x06, // NDEF File Control TLV (T=04,L=06)
+                NDEF_FILE_ID[0], NDEF_FILE_ID[1],
+                ((ndefFileLen shr 8) and 0xFF).toByte(),
+                (ndefFileLen and 0xFF).toByte(),
+                0x00, // read access granted
+                0xFF.toByte(), // write access denied
+            )
+
+        /** NDEF file = 2-byte NLEN (big-endian message length) + message. */
+        internal fun buildNdefFile(ndefMessage: ByteArray): ByteArray {
+            val file = ByteArray(2 + ndefMessage.size)
+            file[0] = ((ndefMessage.size shr 8) and 0xFF).toByte()
+            file[1] = (ndefMessage.size and 0xFF).toByte()
+            System.arraycopy(ndefMessage, 0, file, 2, ndefMessage.size)
+            return file
+        }
+
+        /**
+         * Build a single-record NDEF message containing one Well-Known URI
+         * record (RTD-U).
+         * ```
+         * Record header byte = 0xD1 : MB=1 ME=1 CF=0 SR=1 IL=0 TNF=001(Well Known)
+         * Type Length = 01
+         * Payload Length = 1 (URI prefix code) + URI-body bytes (short record)
+         * Type = 'U' (0x55)
+         * Payload[0] = URI identifier code (prefix), Payload[1..] = URI body
+         * ```
+         * We pick the longest matching NFC Forum URI prefix to shorten the
+         * body; `https://` maps to identifier code 0x04. The Bada
+         * pairing link is a normal `https://quickshare.google/qrcode#…`
+         * web URL, so iOS opens it in Safari rather than the App Store.
+         */
+        internal fun buildUriNdefMessage(uri: String): ByteArray {
+            var prefixCode = 0x00
+            var body = uri
+            // Longest-prefix match against the NFC Forum URI prefix table (subset).
+            val prefixes =
+                arrayOf(
+                    "https://www." to 0x01,
+                    "http://www." to 0x02,
+                    "https://" to 0x04,
+                    "http://" to 0x03,
+                )
+            for ((prefix, code) in prefixes) {
+                if (uri.startsWith(prefix)) {
+                    prefixCode = code
+                    body = uri.substring(prefix.length)
+                    break
+                }
+            }
+            val bodyBytes = body.toByteArray(StandardCharsets.UTF_8)
+            val payloadLen = 1 + bodyBytes.size // +1 for the prefix code
+
+            // Short record (SR=1): payload length fits in 1 byte. The
+            // pairing URL is well under 255 bytes, so SR is valid.
+            val rec = ByteArray(4 + payloadLen)
+            rec[0] = 0xD1.toByte() // MB=1,ME=1,SR=1,TNF=Well-Known
+            rec[1] = 0x01 // type length = 1 ('U')
+            rec[2] = payloadLen.toByte()
+            rec[3] = 0x55 // 'U'
+            rec[4] = prefixCode.toByte()
+            System.arraycopy(bodyBytes, 0, rec, 5, bodyBytes.size)
+            return rec
+        }
+    }
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/nfc/BadaNdefApduService.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/nfc/BadaNdefApduService.kt
@@ -11,45 +11,34 @@ import android.util.Log
 import java.nio.charset.StandardCharsets
 
 /**
- * Host Card Emulation service that exposes the current Bada pairing
- * link (the QR URL) as an NFC Forum **Type-4 Tag** carrying a single NDEF
- * **URI** record. When an iPhone (XS+/iOS 13+, screen-on/unlocked) is
- * tapped to the back of this phone, iOS CoreNFC background-reads the NDEF
- * URI and offers to open it — and because the URI is an ordinary
- * `https://quickshare.google/qrcode#…` web link (not an App Store /
- * universal link), iOS opens it **in Safari**, not the App Store.
+ * Host Card Emulation service that exposes the current Bada pairing link
+ * (the QR URL) as an NFC Forum **Type-4 Tag** carrying a single NDEF **URI**
+ * record. When a phone is tapped to the back of this device, it
+ * background-reads the NDEF URI and offers to open it — so a phone that does
+ * not run the app can open the pairing link by tapping, without scanning the
+ * QR code.
  *
- * Ported from `oshare-nfc-tap`'s `NdefAppStoreApduService`, which emulated
- * the OnePlus Share iOS tap with a *static* App-Store universal link. The
- * Type-4 state machine (SELECT AID / SELECT CC / READ CC / SELECT NDEF /
- * READ BINARY) is identical; the only change is that the served URI is
- * **dynamic** — read from [NfcLinkHolder.currentUrl] at the moment the
- * reader SELECTs the NDEF application, so each tap broadcasts whatever
- * pairing link the Send screen is currently showing. When the holder is
- * `null` (no QR session active) we serve an empty NDEF message (NLEN = 0)
- * so a stray tap does nothing rather than opening a stale link.
+ * The served URI is read from [NfcLinkHolder.currentUrl] at the moment the
+ * reader SELECTs the NDEF application, so each tap serves whatever pairing
+ * link the Send/QR screen is currently showing. When the holder is `null`
+ * (no QR on screen) an empty NDEF message (NLEN = 0) is served, so a stray
+ * tap does nothing rather than opening a stale link.
  *
  * Implemented with only public `android.nfc.cardemulation` APIs + the
  * auto-granted `BIND_NFC_SERVICE` permission — no OEM privilege.
  *
  * ## Type-4 Tag protocol (NFC Forum T4T Operation + ISO 7816-4)
- * A Type-4 reader (the iPhone) runs, and we answer, this sequence:
+ * The reader runs, and this service answers, the standard T4T sequence:
  *
- *  1. SELECT by name, NDEF Tag App AID `D2760000850101` -> `90 00`.
- *     We snapshot [NfcLinkHolder.currentUrl] here and build the NDEF +
- *     CC files for this read session.
+ *  1. SELECT by name, NDEF Tag App AID `D2760000850101` -> `90 00`
+ *     (the URL is snapshotted here and the NDEF + CC files built for this
+ *     read session).
  *  2. SELECT (by file id) the Capability Container `E103` -> `90 00`.
  *  3. READ_BINARY the CC -> 15-byte CC describing the NDEF file
  *     (id `E104`, max read, max NDEF len) + `90 00`.
  *  4. SELECT the NDEF file `E104` -> `90 00`.
  *  5. READ_BINARY offset 0, len 2 -> the 2-byte NLEN.
  *  6. READ_BINARY offset 2.. -> the NDEF message bytes.
- *
- * VERIFIED-vs-ASSUMED: the NDEF byte layout is built per the public NFC
- * Forum Type-4 Tag + NDEF URI RTD specs, and the AID is the NFC Forum NDEF
- * Tag Application AID. Whether a real iPhone tapping a real device performs
- * exactly this T4T read sequence and follows the URI into Safari is NOT
- * proven here (needs an actual iPhone + NFC hardware to confirm).
  */
 public class BadaNdefApduService : HostApduService() {
     /** Which file the reader currently has selected. */
@@ -242,9 +231,7 @@ public class BadaNdefApduService : HostApduService() {
          * Payload[0] = URI identifier code (prefix), Payload[1..] = URI body
          * ```
          * We pick the longest matching NFC Forum URI prefix to shorten the
-         * body; `https://` maps to identifier code 0x04. The Bada
-         * pairing link is a normal `https://quickshare.google/qrcode#…`
-         * web URL, so iOS opens it in Safari rather than the App Store.
+         * body; `https://` maps to identifier code 0x04.
          */
         internal fun buildUriNdefMessage(uri: String): ByteArray {
             var prefixCode = 0x00

--- a/app/src/main/kotlin/dev/bluehouse/bada/nfc/BadaNdefApduService.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/nfc/BadaNdefApduService.kt
@@ -8,7 +8,6 @@ package dev.bluehouse.bada.nfc
 import android.nfc.cardemulation.HostApduService
 import android.os.Bundle
 import android.util.Log
-import java.nio.charset.StandardCharsets
 
 /**
  * Host Card Emulation service that exposes the current Bada pairing link
@@ -39,7 +38,12 @@ import java.nio.charset.StandardCharsets
  *  4. SELECT the NDEF file `E104` -> `90 00`.
  *  5. READ_BINARY offset 0, len 2 -> the 2-byte NLEN.
  *  6. READ_BINARY offset 2.. -> the NDEF message bytes.
+ *
+ * The APDU state machine is inherently byte-index heavy and branches per
+ * command/file, so MagicNumber / ReturnCount / CyclomaticComplexMethod are
+ * suppressed; the pure byte encoders live in [NdefTagCodec].
  */
+@Suppress("MagicNumber", "ReturnCount", "CyclomaticComplexMethod")
 public class BadaNdefApduService : HostApduService() {
     /** Which file the reader currently has selected. */
     private enum class Selected { NONE, CC, NDEF }
@@ -54,8 +58,8 @@ public class BadaNdefApduService : HostApduService() {
      * READ_BINARY before any SELECT-AID (defensive — a compliant reader
      * always selects first).
      */
-    private var ndefFile: ByteArray = buildNdefFile(EMPTY_NDEF_MESSAGE)
-    private var ccFile: ByteArray = buildCapabilityContainer(ndefFile.size)
+    private var ndefFile: ByteArray = NdefTagCodec.buildNdefFile(EMPTY_NDEF_MESSAGE)
+    private var ccFile: ByteArray = NdefTagCodec.buildCapabilityContainer(ndefFile.size)
 
     override fun processCommandApdu(
         apdu: ByteArray?,
@@ -69,7 +73,7 @@ public class BadaNdefApduService : HostApduService() {
         if (apdu[0] == 0x00.toByte() && apdu[1] == 0xA4.toByte()) {
             // SELECT by name (P1=04): match the NDEF Tag Application AID.
             if (apdu[2] == 0x04.toByte()) {
-                if (apduSelectsAid(apdu, NDEF_TAG_APP_AID)) {
+                if (NdefTagCodec.apduSelectsAid(apdu, NDEF_TAG_APP_AID)) {
                     refreshNdefForCurrentLink()
                     selected = Selected.NONE // app selected; no file selected yet
                     return SW_OK
@@ -84,7 +88,7 @@ public class BadaNdefApduService : HostApduService() {
                     selected = Selected.CC
                     return SW_OK
                 }
-                if (hi == NDEF_FILE_ID[0] && lo == NDEF_FILE_ID[1]) {
+                if (hi == NdefTagCodec.NDEF_FILE_ID[0] && lo == NdefTagCodec.NDEF_FILE_ID[1]) {
                     selected = Selected.NDEF
                     return SW_OK
                 }
@@ -138,10 +142,10 @@ public class BadaNdefApduService : HostApduService() {
                 EMPTY_NDEF_MESSAGE
             } else {
                 Log.d(TAG, "SELECT NDEF app AID -> OK; will serve $url")
-                buildUriNdefMessage(url)
+                NdefTagCodec.buildUriNdefMessage(url)
             }
-        ndefFile = buildNdefFile(message)
-        ccFile = buildCapabilityContainer(ndefFile.size)
+        ndefFile = NdefTagCodec.buildNdefFile(message)
+        ccFile = NdefTagCodec.buildCapabilityContainer(ndefFile.size)
     }
 
     public companion object {
@@ -155,7 +159,6 @@ public class BadaNdefApduService : HostApduService() {
 
         // ---- File identifiers ----
         private val CC_FILE_ID = byteArrayOf(0xE1.toByte(), 0x03)
-        private val NDEF_FILE_ID = byteArrayOf(0xE1.toByte(), 0x04)
 
         // NDEF Tag Application AID (NFC Forum). The same AID an iPhone
         // SELECTs to read a Type-4 NDEF tag.
@@ -167,103 +170,5 @@ public class BadaNdefApduService : HostApduService() {
 
         /** A valid empty NDEF message (single empty record, TNF=0x00). */
         private val EMPTY_NDEF_MESSAGE = byteArrayOf(0xD0.toByte(), 0x00, 0x00)
-
-        /** True iff this SELECT-by-name APDU carries exactly [aid] in its data. */
-        internal fun apduSelectsAid(
-            apdu: ByteArray,
-            aid: ByteArray,
-        ): Boolean {
-            // 00 A4 04 00 <Lc> <AID...> [Le]
-            if (apdu.size < 5 + aid.size) return false
-            val lc = apdu[4].toInt() and 0xFF
-            if (lc != aid.size) return false
-            for (i in aid.indices) {
-                if (apdu[5 + i] != aid[i]) return false
-            }
-            return true
-        }
-
-        /**
-         * Build the 15-byte Capability Container per NFC Forum T4T:
-         * ```
-         * 00 0F  CCLEN = 15
-         * 20     mapping version 2.0
-         * 00 3B  MLe (max R-APDU data, 59)
-         * 00 34  MLc (max C-APDU data, 52)
-         * 04 06  NDEF File Control TLV: T=04, L=06
-         *   E1 04            NDEF file id
-         *   <max ndef len hi/lo>
-         *   00               read access granted
-         *   FF               write access denied (read-only tag)
-         * ```
-         */
-        internal fun buildCapabilityContainer(ndefFileLen: Int): ByteArray =
-            byteArrayOf(
-                0x00, 0x0F, // CCLEN = 15
-                0x20, // mapping version 2.0
-                0x00, 0x3B, // MLe
-                0x00, 0x34, // MLc
-                0x04, 0x06, // NDEF File Control TLV (T=04,L=06)
-                NDEF_FILE_ID[0], NDEF_FILE_ID[1],
-                ((ndefFileLen shr 8) and 0xFF).toByte(),
-                (ndefFileLen and 0xFF).toByte(),
-                0x00, // read access granted
-                0xFF.toByte(), // write access denied
-            )
-
-        /** NDEF file = 2-byte NLEN (big-endian message length) + message. */
-        internal fun buildNdefFile(ndefMessage: ByteArray): ByteArray {
-            val file = ByteArray(2 + ndefMessage.size)
-            file[0] = ((ndefMessage.size shr 8) and 0xFF).toByte()
-            file[1] = (ndefMessage.size and 0xFF).toByte()
-            System.arraycopy(ndefMessage, 0, file, 2, ndefMessage.size)
-            return file
-        }
-
-        /**
-         * Build a single-record NDEF message containing one Well-Known URI
-         * record (RTD-U).
-         * ```
-         * Record header byte = 0xD1 : MB=1 ME=1 CF=0 SR=1 IL=0 TNF=001(Well Known)
-         * Type Length = 01
-         * Payload Length = 1 (URI prefix code) + URI-body bytes (short record)
-         * Type = 'U' (0x55)
-         * Payload[0] = URI identifier code (prefix), Payload[1..] = URI body
-         * ```
-         * We pick the longest matching NFC Forum URI prefix to shorten the
-         * body; `https://` maps to identifier code 0x04.
-         */
-        internal fun buildUriNdefMessage(uri: String): ByteArray {
-            var prefixCode = 0x00
-            var body = uri
-            // Longest-prefix match against the NFC Forum URI prefix table (subset).
-            val prefixes =
-                arrayOf(
-                    "https://www." to 0x01,
-                    "http://www." to 0x02,
-                    "https://" to 0x04,
-                    "http://" to 0x03,
-                )
-            for ((prefix, code) in prefixes) {
-                if (uri.startsWith(prefix)) {
-                    prefixCode = code
-                    body = uri.substring(prefix.length)
-                    break
-                }
-            }
-            val bodyBytes = body.toByteArray(StandardCharsets.UTF_8)
-            val payloadLen = 1 + bodyBytes.size // +1 for the prefix code
-
-            // Short record (SR=1): payload length fits in 1 byte. The
-            // pairing URL is well under 255 bytes, so SR is valid.
-            val rec = ByteArray(4 + payloadLen)
-            rec[0] = 0xD1.toByte() // MB=1,ME=1,SR=1,TNF=Well-Known
-            rec[1] = 0x01 // type length = 1 ('U')
-            rec[2] = payloadLen.toByte()
-            rec[3] = 0x55 // 'U'
-            rec[4] = prefixCode.toByte()
-            System.arraycopy(bodyBytes, 0, rec, 5, bodyBytes.size)
-            return rec
-        }
     }
 }

--- a/app/src/main/kotlin/dev/bluehouse/bada/nfc/NdefTagCodec.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/nfc/NdefTagCodec.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.nfc
+
+import java.nio.charset.StandardCharsets
+
+/**
+ * Pure byte encoders/parsers for the NFC Forum Type-4 NDEF tag that
+ * [BadaNdefApduService] serves to a tapped iPhone. Split out of the
+ * `HostApduService` so the deterministic, `android.*`-free logic (Capability
+ * Container, NDEF file framing, the Well-Known URI record, and the SELECT-by-AID
+ * matcher) is unit-testable on a host JVM — the Android service body only handles
+ * the APDU state machine and delegates the byte work here.
+ *
+ * The wire constants (CC layout, NDEF record header, fixed offsets/lengths, and
+ * NFC Forum URI prefix codes) are inherently numeric, so MagicNumber is suppressed.
+ */
+@Suppress("MagicNumber")
+internal object NdefTagCodec {
+    /** NDEF file identifier (E1 04) advertised in the Capability Container. */
+    val NDEF_FILE_ID: ByteArray = byteArrayOf(0xE1.toByte(), 0x04)
+
+    /** True iff this SELECT-by-name APDU carries exactly [aid] in its data. */
+    @Suppress("ReturnCount")
+    fun apduSelectsAid(
+        apdu: ByteArray,
+        aid: ByteArray,
+    ): Boolean {
+        // 00 A4 04 00 <Lc> <AID...> [Le]
+        if (apdu.size < 5 + aid.size) return false
+        val lc = apdu[4].toInt() and 0xFF
+        if (lc != aid.size) return false
+        for (i in aid.indices) {
+            if (apdu[5 + i] != aid[i]) return false
+        }
+        return true
+    }
+
+    /**
+     * Build the 15-byte Capability Container per NFC Forum T4T:
+     * ```
+     * 00 0F  CCLEN = 15
+     * 20     mapping version 2.0
+     * 00 3B  MLe (max R-APDU data, 59)
+     * 00 34  MLc (max C-APDU data, 52)
+     * 04 06  NDEF File Control TLV: T=04, L=06
+     *   E1 04            NDEF file id
+     *   <max ndef len hi/lo>
+     *   00               read access granted
+     *   FF               write access denied (read-only tag)
+     * ```
+     */
+    fun buildCapabilityContainer(ndefFileLen: Int): ByteArray =
+        byteArrayOf(
+            0x00,
+            0x0F, // CCLEN = 15
+            0x20, // mapping version 2.0
+            0x00,
+            0x3B, // MLe
+            0x00,
+            0x34, // MLc
+            0x04,
+            0x06, // NDEF File Control TLV (T=04,L=06)
+            NDEF_FILE_ID[0],
+            NDEF_FILE_ID[1],
+            ((ndefFileLen shr 8) and 0xFF).toByte(),
+            (ndefFileLen and 0xFF).toByte(),
+            0x00, // read access granted
+            0xFF.toByte(), // write access denied
+        )
+
+    /** NDEF file = 2-byte NLEN (big-endian message length) + message. */
+    fun buildNdefFile(ndefMessage: ByteArray): ByteArray {
+        val file = ByteArray(2 + ndefMessage.size)
+        file[0] = ((ndefMessage.size shr 8) and 0xFF).toByte()
+        file[1] = (ndefMessage.size and 0xFF).toByte()
+        System.arraycopy(ndefMessage, 0, file, 2, ndefMessage.size)
+        return file
+    }
+
+    /**
+     * Build a single-record NDEF message containing one Well-Known URI record
+     * (RTD-U).
+     * ```
+     * Record header byte = 0xD1 : MB=1 ME=1 CF=0 SR=1 IL=0 TNF=001(Well Known)
+     * Type Length = 01
+     * Payload Length = 1 (URI prefix code) + URI-body bytes (short record)
+     * Type = 'U' (0x55)
+     * Payload[0] = URI identifier code (prefix), Payload[1..] = URI body
+     * ```
+     * The longest matching NFC Forum URI prefix shortens the body; identifier
+     * codes are fixed by the spec: 0x01 = http://www., 0x02 = https://www.,
+     * 0x03 = http://, 0x04 = https://.
+     */
+    fun buildUriNdefMessage(uri: String): ByteArray {
+        var prefixCode = 0x00
+        var body = uri
+        val prefixes =
+            arrayOf(
+                "https://www." to 0x02,
+                "http://www." to 0x01,
+                "https://" to 0x04,
+                "http://" to 0x03,
+            )
+        for ((prefix, code) in prefixes) {
+            if (uri.startsWith(prefix)) {
+                prefixCode = code
+                body = uri.substring(prefix.length)
+                break
+            }
+        }
+        val bodyBytes = body.toByteArray(StandardCharsets.UTF_8)
+        val payloadLen = 1 + bodyBytes.size // +1 for the prefix code
+
+        // Short record (SR=1): payload length fits in 1 byte. The pairing URL is
+        // well under 255 bytes, so SR is valid.
+        val rec = ByteArray(4 + payloadLen)
+        rec[0] = 0xD1.toByte() // MB=1,ME=1,SR=1,TNF=Well-Known
+        rec[1] = 0x01 // type length = 1 ('U')
+        rec[2] = payloadLen.toByte()
+        rec[3] = 0x55 // 'U'
+        rec[4] = prefixCode.toByte()
+        System.arraycopy(bodyBytes, 0, rec, 5, bodyBytes.size)
+        return rec
+    }
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/send/ShowQrActivity.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/send/ShowQrActivity.kt
@@ -9,6 +9,7 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import dev.bluehouse.bada.bugreport.BugReportFlowSupport
 import dev.bluehouse.bada.databinding.ActivityShowQrBinding
+import dev.bluehouse.bada.nfc.NfcLinkHolder
 import dev.bluehouse.bada.protocol.qr.QrKeyData
 import dev.bluehouse.bada.protocol.qr.QrUrl
 import kotlin.math.min
@@ -45,6 +46,14 @@ public class ShowQrActivity : AppCompatActivity() {
     private lateinit var binding: ActivityShowQrBinding
     private lateinit var bugReportFlowSupport: BugReportFlowSupport
 
+    /**
+     * The pairing URL currently shown as the QR code. Also published to the NDEF
+     * Host Card Emulation tag ([NfcLinkHolder.currentUrl], served by
+     * [dev.bluehouse.bada.nfc.BadaNdefApduService]) while this screen is in the
+     * foreground, so the in-app QR works as an NFC tag too — not just the send sheet.
+     */
+    private var pairingUrl: String? = null
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityShowQrBinding.inflate(layoutInflater)
@@ -53,6 +62,7 @@ public class ShowQrActivity : AppCompatActivity() {
 
         val generated = QrKeyData.generate()
         val url = QrUrl.build(generated.qrKeyData)
+        pairingUrl = url
         binding.showQrUrl.text = url
 
         // Size the QR bitmap to ~75% of the shorter screen edge so it
@@ -70,6 +80,25 @@ public class ShowQrActivity : AppCompatActivity() {
             }
 
         binding.showQrDone.setOnClickListener { finish() }
+    }
+
+    /**
+     * Arm the NDEF Host Card Emulation tag with the displayed pairing URL while this
+     * QR screen is in the foreground, so tapping an iPhone (or any phone) to the back
+     * opens the same link in its browser — the in-app QR works as an NFC tag, not just
+     * the send sheet. [dev.bluehouse.bada.nfc.BadaNdefApduService] reads
+     * [NfcLinkHolder.currentUrl] on each NFC SELECT; no scanning needed.
+     */
+    override fun onResume() {
+        super.onResume()
+        NfcLinkHolder.currentUrl = pairingUrl
+    }
+
+    /** Disarm the NDEF tag when the QR screen leaves the foreground, so it only ever
+     * carries the URL while the QR is actually on screen. */
+    override fun onPause() {
+        super.onPause()
+        NfcLinkHolder.currentUrl = null
     }
 
     private companion object {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -562,4 +562,8 @@
     <!-- NFC tap-to-share HCE service description, shown in the system NFC /
          card-emulation settings list of registered apps. -->
     <string name="nfc_tap_hce_service_description">Bada Quick Share tap-to-share</string>
+    <!-- HCE service description shown in system NFC settings. The Type-4 NDEF
+         service broadcasts the current pairing link to a tapped iPhone so it
+         opens that link in Safari. -->
+    <string name="nfc_hce_service_description">Bada NFC link</string>
 </resources>

--- a/app/src/main/res/xml/bada_apduservice.xml
+++ b/app/src/main/res/xml/bada_apduservice.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  HCE descriptor for the Bada NFC link broadcast.
+
+  Declares the NFC Forum NDEF Type-4 Tag Application AID D2760000850101
+  that a tapping iPhone SELECTs to read our NDEF URI record. The served URI
+  is the current Bada pairing link (the QR URL), so an iPhone tapped
+  to the back of this phone opens that link in Safari.
+
+  category="other"   -> no default-payment role required.
+  requireDeviceUnlock="false" -> a tap is answered from the lock screen too,
+  matching the iOS background NDEF read. (The iPhone, not this phone, must
+  be unlocked for iOS to act on the URI.)
+-->
+<host-apdu-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:description="@string/nfc_hce_service_description"
+    android:requireDeviceUnlock="false">
+    <aid-group android:description="@string/nfc_hce_service_description"
+        android:category="other">
+        <aid-filter android:name="D2760000850101" />
+    </aid-group>
+</host-apdu-service>

--- a/app/src/test/kotlin/dev/bluehouse/bada/nfc/NdefTagCodecTest.kt
+++ b/app/src/test/kotlin/dev/bluehouse/bada/nfc/NdefTagCodecTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.nfc
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.nio.charset.StandardCharsets
+
+/**
+ * Pure-JVM tests for [NdefTagCodec]'s byte encoders. The encoders are
+ * deterministic companion functions with no Android dependency, so they run on a
+ * host JVM without Robolectric.
+ */
+class NdefTagCodecTest {
+    @Test
+    fun `buildUriNdefMessage uses the correct NFC Forum URI prefix codes`() {
+        // NFC Forum URI RTD identifier codes: 0x01=http://www., 0x02=https://www.,
+        // 0x03=http://, 0x04=https://. The prefix code is the first payload byte.
+        assertEquals(0x04, prefixCodeOf("https://quickshare.google/qrcode#key=abc"))
+        assertEquals(0x03, prefixCodeOf("http://example.com/x"))
+        assertEquals(0x02, prefixCodeOf("https://www.example.com/x"))
+        assertEquals(0x01, prefixCodeOf("http://www.example.com/x"))
+    }
+
+    @Test
+    fun `buildUriNdefMessage strips the matched prefix from the body`() {
+        val url = "https://quickshare.google/qrcode#key=abc"
+        val msg = NdefTagCodec.buildUriNdefMessage(url)
+        // 0x04 = https://, so the body is the URL minus the "https://" prefix.
+        assertEquals("quickshare.google/qrcode#key=abc", uriBodyOf(msg))
+    }
+
+    @Test
+    fun `buildUriNdefMessage emits a well-formed short well-known U record`() {
+        val msg = NdefTagCodec.buildUriNdefMessage("https://a")
+        // Record header: MB=1,ME=1,SR=1,TNF=Well-Known(0x01) -> 0xD1.
+        assertEquals(0xD1.toByte(), msg[0])
+        // Type length = 1, then payload length, then type 'U' (0x55).
+        assertEquals(0x01.toByte(), msg[1])
+        assertEquals('U'.code.toByte(), msg[3])
+        // Payload length byte == 1 (prefix code) + body bytes == total minus 4-byte header.
+        assertEquals(msg.size - 4, msg[2].toInt() and 0xFF)
+    }
+
+    @Test
+    fun `apduSelectsAid matches the NDEF Tag Application AID and rejects others`() {
+        val ndefAid = byteArrayOf(0xD2.toByte(), 0x76, 0x00, 0x00, 0x85.toByte(), 0x01, 0x01)
+        val select = byteArrayOf(0x00, 0xA4.toByte(), 0x04, 0x00, ndefAid.size.toByte()) + ndefAid
+        assertTrue(NdefTagCodec.apduSelectsAid(select, ndefAid))
+
+        val wrong = byteArrayOf(0x00, 0xA4.toByte(), 0x04, 0x00, 0x02, 0x11, 0x22)
+        assertFalse(NdefTagCodec.apduSelectsAid(wrong, ndefAid))
+    }
+
+    private fun prefixCodeOf(uri: String): Int {
+        // Layout: [hdr][typeLen][payloadLen]['U'][prefixCode][body...]
+        return NdefTagCodec.buildUriNdefMessage(uri)[4].toInt() and 0xFF
+    }
+
+    private fun uriBodyOf(msg: ByteArray): String = String(msg.copyOfRange(5, msg.size), StandardCharsets.UTF_8)
+}


### PR DESCRIPTION
## What — enable tap-to-share with iOS (QR button → NFC tag)
Clicking the QR code button turns on a tappable **NFC tag** that auto-opens the pairing link in a browse. While the QR is showing, your phone publishes the same single-use pairing URL the QR encodes to an NDEF Host Card Emulation tag. Tap an iPhone (or any phone) to the back and it opens the link in that phone's browser — a simple hand-off to a device that doesn't run the app, no QR scanning needed. **Works for the in-app QR screen too, not just the send-sheet "Show QR".**

## How
- **`nfc/BadaNdefApduService`** — an NDEF HCE service (AID `D2760000850101`) that serves whatever URL is currently published, so iOS reads the NDEF tag without an app and offers to open it.
- **`nfc/NfcLinkHolder`** — the single-source holder for the currently-armed URL (`currentUrl`); the NDEF service snapshots it on each NFC `SELECT`.
- **`send/ShowQrActivity`** — the in-app QR screen now arms the tag (`NfcLinkHolder.currentUrl`) in `onResume` and clears it in `onPause`, so the tag only carries the URL while the QR is actually on screen.

Because one NFC radio can't be a reader and a tag at once, arming the NDEF tag drops the Quick Share tap reader-mode while it's active. This is a plain NDEF URL tag, separate from the tap-to-share AID exchange.

## ⚠️ Note for the maintainer — connected files
The **send-sheet "Show QR"** arming (`NfcLinkHolder.currentUrl` set/cleared in `SendActivity`) and the **manifest NDEF service registration** ride in the **send-sheet PR** — they share `SendActivity.kt` / the manifest. Merge the set together.