### PR TITLE
fix: retry receiver advertising after publish failure

### DIFF
--- a/service-android/src/main/kotlin/dev/bluehouse/bada/service/receiver/MdnsAdvertisementGate.kt
+++ b/service-android/src/main/kotlin/dev/bluehouse/bada/service/receiver/MdnsAdvertisementGate.kt
@@ -323,13 +323,19 @@ public class MdnsAdvertisementGate(
 
     private fun schedulePublishRetry(scope: CoroutineScope) {
         if (publishRetryJob?.isActive == true) return
-        publishRetryJob =
+        var retryJob: Job? = null
+        retryJob =
             scope.launch {
                 delay(publishRetryDelayMillis)
                 if (isActive) {
+                    if (publishRetryJob === retryJob) {
+                        publishRetryJob = null
+                    }
                     apply(currentDecision(), scope)
                 }
             }
+        publishRetryJob =
+            retryJob
     }
 
     /**

--- a/service-android/src/main/kotlin/dev/bluehouse/bada/service/receiver/MdnsAdvertisementGate.kt
+++ b/service-android/src/main/kotlin/dev/bluehouse/bada/service/receiver/MdnsAdvertisementGate.kt
@@ -86,7 +86,13 @@ import kotlinx.coroutines.launch
  * @param debounceIdleMillis time after the last "should publish" signal
  *   before the gate unpublishes the advertisement. 30 s by default per
  *   issue #34.
+ * @param publishRetryDelayMillis time after a failed mDNS publish before
+ *   retrying while any publish signal remains active. This covers radio
+ *   recovery cases where the first publish attempt happens while Wi-Fi
+ *   or Bluetooth is still unavailable, and Android does not emit a gate
+ *   input change after the radio becomes usable.
  */
+@Suppress("LongParameterList")
 public class MdnsAdvertisementGate(
     private val session: ReceiverSession,
     private val bleActivity: StateFlow<ScanActivity>,
@@ -94,6 +100,7 @@ public class MdnsAdvertisementGate(
     private val qrSessionActive: StateFlow<Boolean>,
     private val outboundSessionActive: StateFlow<Boolean> = MutableStateFlow(false),
     private val debounceIdleMillis: Long = DEFAULT_DEBOUNCE_IDLE_MILLIS,
+    private val publishRetryDelayMillis: Long = DEFAULT_PUBLISH_RETRY_DELAY_MILLIS,
     /**
      * Optional sink for the receiver-side BLE pulse advertiser (#121).
      *
@@ -117,6 +124,9 @@ public class MdnsAdvertisementGate(
 
     @Volatile
     private var debounceJob: Job? = null
+
+    @Volatile
+    private var publishRetryJob: Job? = null
 
     @Volatile
     private var bleAdvertising: Boolean = false
@@ -192,6 +202,8 @@ public class MdnsAdvertisementGate(
     public fun stop() {
         debounceJob?.cancel()
         debounceJob = null
+        publishRetryJob?.cancel()
+        publishRetryJob = null
         collectorJob?.cancel()
         collectorJob = null
     }
@@ -218,6 +230,8 @@ public class MdnsAdvertisementGate(
         if (decision.outboundActive) {
             debounceJob?.cancel()
             debounceJob = null
+            publishRetryJob?.cancel()
+            publishRetryJob = null
             if (session.isAdvertising) {
                 try {
                     session.unpublishAdvertisement()
@@ -252,18 +266,27 @@ public class MdnsAdvertisementGate(
             if (!session.isAdvertising) {
                 try {
                     session.publishAdvertisement()
+                    publishRetryJob?.cancel()
+                    publishRetryJob = null
                     DiagnosticLog.w(TAG, "publish: published mDNS (decision=$decision)")
                 } catch (t: Throwable) {
                     // The session may have been stopped between the
-                    // collector firing and the publish call. Treat as
-                    // benign — the decision will be re-evaluated if the
-                    // session is restarted.
+                    // collector firing and the publish call, or Android's
+                    // NSD stack may be temporarily unavailable while Wi-Fi
+                    // is still coming up. Keep retrying while the current
+                    // decision still wants us to be published.
                     DiagnosticLog.w(TAG, "publish: failed (decision=$decision)", t)
+                    schedulePublishRetry(scope)
                 }
+            } else {
+                publishRetryJob?.cancel()
+                publishRetryJob = null
             }
             return
         }
 
+        publishRetryJob?.cancel()
+        publishRetryJob = null
         // No "should publish" signal active: schedule an unpublish if
         // the advertisement is currently up. If the timer is already
         // running we leave it alone — re-arming it would extend the
@@ -294,6 +317,17 @@ public class MdnsAdvertisementGate(
                     // pulses, and so peers stop seeing us on both
                     // channels at the same wall-clock moment.
                     stopBleSafely(reason = "idle for ${debounceIdleMillis}ms")
+                }
+            }
+    }
+
+    private fun schedulePublishRetry(scope: CoroutineScope) {
+        if (publishRetryJob?.isActive == true) return
+        publishRetryJob =
+            scope.launch {
+                delay(publishRetryDelayMillis)
+                if (isActive) {
+                    apply(currentDecision(), scope)
                 }
             }
     }
@@ -360,6 +394,14 @@ public class MdnsAdvertisementGate(
          * avoid flapping if the BLE pulse is intermittent."
          */
         public const val DEFAULT_DEBOUNCE_IDLE_MILLIS: Long = 30_000L
+
+        /**
+         * Default delay before retrying a failed publish while a publish
+         * signal remains active. Short enough to recover after radio
+         * toggles without requiring user interaction, long enough to avoid
+         * hammering Android NSD when it is stuck.
+         */
+        public const val DEFAULT_PUBLISH_RETRY_DELAY_MILLIS: Long = 5_000L
     }
 }
 

--- a/service-android/src/test/kotlin/dev/bluehouse/bada/service/receiver/MdnsAdvertisementGateTest.kt
+++ b/service-android/src/test/kotlin/dev/bluehouse/bada/service/receiver/MdnsAdvertisementGateTest.kt
@@ -547,7 +547,7 @@ class MdnsAdvertisementGateTest {
                     bleBroadcaster = broadcaster,
                 )
             gate.start(this)
-            advanceUntilIdle()
+            runCurrent()
 
             assertThat(session.isAdvertising).isFalse()
             assertThat(broadcaster.startCount).isAtLeast(1)
@@ -555,6 +555,34 @@ class MdnsAdvertisementGateTest {
             override.value = false
             advanceUntilIdle()
             assertThat(broadcaster.stopCount).isEqualTo(1)
+
+            gate.stop()
+            session.stop()
+        }
+
+    @Test
+    fun `mDNS publish failure retries while publish signal remains active`() =
+        runTest {
+            val advertiser = FailOnceAdvertiser()
+            val session = startedGatedSession(advertiser = advertiser)
+            val ble = MutableStateFlow<ScanActivity>(ScanActivity.Idle)
+            val override = MutableStateFlow(true)
+            val qr = MutableStateFlow(false)
+
+            val gate =
+                MdnsAdvertisementGate(
+                    session = session,
+                    bleActivity = ble,
+                    alwaysVisibleOverride = override,
+                    qrSessionActive = qr,
+                    publishRetryDelayMillis = 1_000L,
+                )
+            gate.start(this)
+            advanceUntilIdle()
+
+            assertThat(advertiser.attempts).isEqualTo(2)
+            assertThat(advertiser.calls).hasSize(1)
+            assertThat(session.isAdvertising).isTrue()
 
             gate.stop()
             session.stop()
@@ -712,6 +740,32 @@ class MdnsAdvertisementGateTest {
             endpointInfo: EndpointInfo,
             port: Int,
         ): AdvertiseHandle = error("synthetic mDNS publish failure")
+    }
+
+    private class FailOnceAdvertiser : DiscoveryAdvertiser {
+        data class Call(
+            val endpointInfo: EndpointInfo,
+            val port: Int,
+            val handle: FakeAdvertiseHandle,
+        )
+
+        var attempts: Int = 0
+            private set
+
+        val calls: MutableList<Call> = mutableListOf()
+
+        override fun advertise(
+            endpointInfo: EndpointInfo,
+            port: Int,
+        ): AdvertiseHandle {
+            attempts += 1
+            if (attempts == 1) {
+                error("synthetic first mDNS publish failure")
+            }
+            val handle = FakeAdvertiseHandle(port = port)
+            calls += Call(endpointInfo, port, handle)
+            return handle
+        }
     }
 
     /**

--- a/service-android/src/test/kotlin/dev/bluehouse/bada/service/receiver/MdnsAdvertisementGateTest.kt
+++ b/service-android/src/test/kotlin/dev/bluehouse/bada/service/receiver/MdnsAdvertisementGateTest.kt
@@ -561,9 +561,9 @@ class MdnsAdvertisementGateTest {
         }
 
     @Test
-    fun `mDNS publish failure retries while publish signal remains active`() =
+    fun `mDNS publish retries until success while publish signal remains active`() =
         runTest {
-            val advertiser = FailOnceAdvertiser()
+            val advertiser = FailThenSucceedAdvertiser(failuresBeforeSuccess = 2)
             val session = startedGatedSession(advertiser = advertiser)
             val ble = MutableStateFlow<ScanActivity>(ScanActivity.Idle)
             val override = MutableStateFlow(true)
@@ -580,7 +580,7 @@ class MdnsAdvertisementGateTest {
             gate.start(this)
             advanceUntilIdle()
 
-            assertThat(advertiser.attempts).isEqualTo(2)
+            assertThat(advertiser.attempts).isEqualTo(3)
             assertThat(advertiser.calls).hasSize(1)
             assertThat(session.isAdvertising).isTrue()
 
@@ -742,7 +742,9 @@ class MdnsAdvertisementGateTest {
         ): AdvertiseHandle = error("synthetic mDNS publish failure")
     }
 
-    private class FailOnceAdvertiser : DiscoveryAdvertiser {
+    private class FailThenSucceedAdvertiser(
+        private val failuresBeforeSuccess: Int,
+    ) : DiscoveryAdvertiser {
         data class Call(
             val endpointInfo: EndpointInfo,
             val port: Int,
@@ -759,8 +761,8 @@ class MdnsAdvertisementGateTest {
             port: Int,
         ): AdvertiseHandle {
             attempts += 1
-            if (attempts == 1) {
-                error("synthetic first mDNS publish failure")
+            if (attempts <= failuresBeforeSuccess) {
+                error("synthetic mDNS publish failure $attempts")
             }
             val handle = FakeAdvertiseHandle(port = port)
             calls += Call(endpointInfo, port, handle)


### PR DESCRIPTION
## Summary
- Fixes #236.
- Retry receiver mDNS publish after a transient publish failure while BLE activity, always-visible override, or QR visibility still requests publishing.
- Cancel the retry when publish succeeds, the gate goes idle, outbound send veto activates, or the gate stops.
- Add a receiver-gate regression test for first publish failure followed by successful retry.

## Test plan
- `./gradlew :service-android:testDebugUnitTest --tests 'dev.bluehouse.bada.service.receiver.MdnsAdvertisementGateTest'`
- `./gradlew :app:assembleDebug`
- `./gradlew staticAnalysis`
- Installed the debug APK on vivo and relaunched Bada receiver mode.
- Verified Xiaomi Quick Share logs discovered Bada as `EndpointDiscovered(endpointId=ZisO)` with `deviceName=V2547A` after Bada BLE/mDNS publish became active.