### PR TITLE
feat: show the device picker as a centered wrapping grid

### DIFF
--- a/app/src/main/kotlin/dev/bluehouse/bada/send/SendPeerPickerController.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/send/SendPeerPickerController.kt
@@ -7,7 +7,7 @@ package dev.bluehouse.bada.send
 
 import android.content.Context
 import android.view.View
-import android.widget.LinearLayout
+import android.view.ViewGroup
 import android.widget.TextView
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.repeatOnLifecycle
@@ -32,7 +32,7 @@ import dev.bluehouse.bada.discovery.diagnostics.DiagnosticLog as Log
 @Suppress("LongParameterList") // Every collaborator (UI, lifecycle, callbacks, sender id) is needed.
 internal class SendPeerPickerController(
     private val context: Context,
-    private val peerList: LinearLayout,
+    private val peerList: ViewGroup,
     private val emptyState: TextView,
     private val networkHint: View,
     private val subtitle: TextView,

--- a/app/src/main/kotlin/dev/bluehouse/bada/ui/sheet/DeviceIconView.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/ui/sheet/DeviceIconView.kt
@@ -51,7 +51,7 @@ public class DeviceIconView(
                 textSize = 13f
                 gravity = Gravity.CENTER
                 setPadding(0, (6 * d).toInt(), 0, 0)
-                maxLines = 1
+                maxLines = 2
                 ellipsize = android.text.TextUtils.TruncateAt.END
             }
         addView(nameView, LayoutParams((96 * d).toInt(), LayoutParams.WRAP_CONTENT))

--- a/app/src/main/kotlin/dev/bluehouse/bada/ui/sheet/DraggableSheetLayout.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/ui/sheet/DraggableSheetLayout.kt
@@ -376,13 +376,61 @@ public class DraggableSheetLayout
                     dragging = false
                 }
                 MotionEvent.ACTION_MOVE -> {
-                    if (e.rawY - downRawY > touchSlop) {
+                    // Only claim the downward drag for pull-to-dismiss when no
+                    // scrollable descendant under the pointer can still scroll
+                    // up. The device-picker grid is a vertical NestedScrollView;
+                    // without this guard the sheet would hijack every downward
+                    // swipe and dismiss instead of letting the list scroll back
+                    // toward its top. Once the list is at the top (can no longer
+                    // scroll up), the downward drag resumes its dismiss role.
+                    if (e.rawY - downRawY > touchSlop && !canScrollableChildScrollUp(e.rawX, e.rawY)) {
                         dragging = true
                         return true
                     }
                 }
             }
             return false
+        }
+
+        /**
+         * True when a visible scrollable descendant whose on-screen bounds
+         * contain the pointer can still scroll up (its content is not at the
+         * top). Used by [onInterceptTouchEvent] to yield the downward drag to
+         * an inner vertical scroll list before the sheet's pull-to-dismiss.
+         */
+        private fun canScrollableChildScrollUp(
+            rawX: Float,
+            rawY: Float,
+        ): Boolean = scrollableChildUnder(this, rawX, rawY)?.canScrollVertically(-1) == true
+
+        private fun scrollableChildUnder(
+            parent: ViewGroup,
+            rawX: Float,
+            rawY: Float,
+        ): View? =
+            (parent.childCount - 1 downTo 0)
+                .asSequence()
+                .map { parent.getChildAt(it) }
+                .filter { it.visibility == View.VISIBLE && containsPoint(it, rawX, rawY) }
+                .firstNotNullOfOrNull { child ->
+                    when {
+                        child.canScrollVertically(-1) -> child
+                        child is ViewGroup -> scrollableChildUnder(child, rawX, rawY)
+                        else -> null
+                    }
+                }
+
+        private fun containsPoint(
+            view: View,
+            rawX: Float,
+            rawY: Float,
+        ): Boolean {
+            val location = IntArray(2)
+            view.getLocationOnScreen(location)
+            return rawX >= location[0] &&
+                rawX <= location[0] + view.width &&
+                rawY >= location[1] &&
+                rawY <= location[1] + view.height
         }
 
         @Suppress("ClickableViewAccessibility")

--- a/app/src/main/kotlin/dev/bluehouse/bada/ui/sheet/FlowLayout.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/ui/sheet/FlowLayout.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.ui.sheet
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.ViewGroup
+
+/**
+ * Centered, uniform-column grid container for the send-side device
+ * picker (the circular [DeviceIconView] chips).
+ *
+ * All chips have the same width, so the layout behaves as a fixed grid:
+ * the column count is whatever the available width allows
+ * (`floor(width / chipWidth)`), the resulting grid block is centered
+ * horizontally, and chips fill that block left-to-right, top-to-bottom.
+ * A partial final row therefore stays left-aligned under the first
+ * columns rather than re-centering on its own — the block is centered,
+ * the items within it are not. Rows are top-aligned so every chip's icon
+ * lines up even when neighbouring chips wrap their names to two lines.
+ *
+ * The caller wraps this in a vertical scroll container so the grid
+ * scrolls once it grows past the visible area. Both the in-app
+ * full-screen picker (`activity_send_fullscreen.xml`) and the share-sheet
+ * picker (`activity_send.xml`) host this same view so the two pickers
+ * render identically; only the surrounding container differs.
+ *
+ * Per-chip spacing comes from each [DeviceIconView]'s own padding, so this
+ * container adds no inter-child margins of its own.
+ */
+public class FlowLayout
+    @JvmOverloads
+    constructor(
+        context: Context,
+        attrs: AttributeSet? = null,
+        defStyleAttr: Int = 0,
+    ) : ViewGroup(context, attrs, defStyleAttr) {
+        override fun onMeasure(
+            widthMeasureSpec: Int,
+            heightMeasureSpec: Int,
+        ) {
+            val widthSize = MeasureSpec.getSize(widthMeasureSpec)
+            val available = (widthSize - paddingLeft - paddingRight).coerceAtLeast(0)
+            val childWidthSpec = MeasureSpec.makeMeasureSpec(available, MeasureSpec.AT_MOST)
+            val childHeightSpec = MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED)
+
+            var maxChildWidth = 0
+            for (i in 0 until childCount) {
+                val child = getChildAt(i)
+                if (child.visibility == GONE) continue
+                measureChild(child, childWidthSpec, childHeightSpec)
+                maxChildWidth = maxOf(maxChildWidth, child.measuredWidth)
+            }
+
+            val columns = columnsFor(available, maxChildWidth)
+            var col = 0
+            var rowHeight = 0
+            var contentHeight = 0
+            for (i in 0 until childCount) {
+                val child = getChildAt(i)
+                if (child.visibility == GONE) continue
+                if (col == columns) {
+                    contentHeight += rowHeight
+                    rowHeight = 0
+                    col = 0
+                }
+                rowHeight = maxOf(rowHeight, child.measuredHeight)
+                col++
+            }
+            contentHeight += rowHeight
+
+            setMeasuredDimension(
+                resolveSize(maxChildWidth * columns + paddingLeft + paddingRight, widthMeasureSpec),
+                resolveSize(contentHeight + paddingTop + paddingBottom, heightMeasureSpec),
+            )
+        }
+
+        override fun onLayout(
+            changed: Boolean,
+            l: Int,
+            t: Int,
+            r: Int,
+            b: Int,
+        ) {
+            val available = (r - l - paddingLeft - paddingRight).coerceAtLeast(0)
+            var maxChildWidth = 0
+            for (i in 0 until childCount) {
+                val child = getChildAt(i)
+                if (child.visibility != GONE) maxChildWidth = maxOf(maxChildWidth, child.measuredWidth)
+            }
+            val columns = columnsFor(available, maxChildWidth)
+            // Center the full grid block; items then fill it from the left.
+            val blockLeft = paddingLeft + ((available - columns * maxChildWidth) / 2).coerceAtLeast(0)
+
+            var col = 0
+            var rowTop = paddingTop
+            var rowHeight = 0
+            for (i in 0 until childCount) {
+                val child = getChildAt(i)
+                if (child.visibility == GONE) continue
+                if (col == columns) {
+                    rowTop += rowHeight
+                    rowHeight = 0
+                    col = 0
+                }
+                val cw = child.measuredWidth
+                val ch = child.measuredHeight
+                // Left-align each chip within its fixed-width cell; top-align
+                // so icons stay on one baseline regardless of name line count.
+                val x = blockLeft + col * maxChildWidth
+                child.layout(x, rowTop, x + cw, rowTop + ch)
+                rowHeight = maxOf(rowHeight, ch)
+                col++
+            }
+        }
+
+        /** Number of equal-width columns that fit in [available]; at least 1. */
+        private fun columnsFor(
+            available: Int,
+            childWidth: Int,
+        ): Int = if (childWidth <= 0) 1 else (available / childWidth).coerceAtLeast(1)
+    }

--- a/app/src/main/res/layout-land/activity_send.xml
+++ b/app/src/main/res/layout-land/activity_send.xml
@@ -242,33 +242,28 @@
                         android:layout_width="0dp"
                         android:layout_height="match_parent"
                         android:layout_weight="1"
-                        android:clipChildren="false"
-                        android:clipToPadding="false">
+                        android:clipChildren="true"
+                        android:clipToPadding="true">
+
+                        <androidx.core.widget.NestedScrollView
+                            android:id="@+id/send_peer_scroll"
+                            android:layout_width="match_parent"
+                            android:layout_height="match_parent"
+                            android:fadingEdgeLength="32dp"
+                            android:fillViewport="true"
+                            android:overScrollMode="never"
+                            android:requiresFadingEdge="vertical">
 
                         <LinearLayout
                             android:layout_width="match_parent"
-                            android:layout_height="match_parent"
+                            android:layout_height="wrap_content"
                             android:gravity="center_horizontal"
                             android:orientation="vertical">
 
-                            <HorizontalScrollView
-                                android:id="@+id/send_peer_scroll"
+                            <dev.bluehouse.bada.ui.sheet.FlowLayout
+                                android:id="@+id/send_peer_list"
                                 android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:fadingEdgeLength="32dp"
-                                android:overScrollMode="never"
-                                android:requiresFadingEdge="horizontal"
-                                android:scrollbars="none">
-
-                                <LinearLayout
-                                    android:id="@+id/send_peer_list"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:gravity="center_vertical"
-                                    android:minWidth="0dp"
-                                    android:orientation="horizontal" />
-
-                            </HorizontalScrollView>
+                                android:layout_height="wrap_content" />
 
                             <TextView
                                 android:id="@+id/send_empty_state"
@@ -317,6 +312,8 @@
                             </LinearLayout>
 
                         </LinearLayout>
+
+                        </androidx.core.widget.NestedScrollView>
 
                         <!-- Status panel (sending / awaiting PIN / terminal),
                              centered in the right half. -->

--- a/app/src/main/res/layout/activity_send.xml
+++ b/app/src/main/res/layout/activity_send.xml
@@ -209,94 +209,94 @@
                     android:layout_height="0dp"
                     android:layout_marginTop="16dp"
                     android:layout_weight="1"
-                    android:clipChildren="false"
-                    android:clipToPadding="false">
+                    android:clipChildren="true"
+                    android:clipToPadding="true">
 
                     <!--
-                      Picker container. Vertical stack: a HORIZONTAL row
-                      of circular DeviceIconView icons (added at runtime
-                      to send_peer_list, wrapped in a HorizontalScrollView)
-                      over the empty-state line + same-Wi-Fi hint card.
-                      send_peer_scroll keeps its id (View-level toggles
-                      only in code) but is now the horizontal device
-                      scroller; the empty-state / hint live in a separate
-                      column below so the chips scroll independently.
+                      Device picker grid. A vertical NestedScrollView wraps
+                      a centered, wrapping FlowLayout grid of circular
+                      DeviceIconView chips (added at runtime to
+                      send_peer_list) over the empty-state line + same-Wi-Fi
+                      hint card. The grid shows as many icons per row as the
+                      sheet width allows and grows downward, so the list
+                      scrolls vertically once the device count overflows the
+                      fixed 480dp card. DraggableSheetLayout yields its
+                      pull-to-dismiss drag to this list until it is scrolled
+                      to the top. Identical to the in-app picker
+                      (activity_send_fullscreen.xml); only the surrounding
+                      container differs.
                     -->
-                    <LinearLayout
+                    <androidx.core.widget.NestedScrollView
+                        android:id="@+id/send_peer_scroll"
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"
-                        android:gravity="center_horizontal"
-                        android:orientation="vertical">
-
-                        <HorizontalScrollView
-                            android:id="@+id/send_peer_scroll"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:fadingEdgeLength="32dp"
-                            android:overScrollMode="never"
-                            android:requiresFadingEdge="horizontal"
-                            android:scrollbars="none">
-
-                            <LinearLayout
-                                android:id="@+id/send_peer_list"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:gravity="center_vertical"
-                                android:minWidth="0dp"
-                                android:orientation="horizontal" />
-
-                        </HorizontalScrollView>
-
-                        <TextView
-                            android:id="@+id/send_empty_state"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_marginTop="24dp"
-                            android:paddingHorizontal="16dp"
-                            android:gravity="center"
-                            android:text="@string/send_empty_state"
-                            android:textAppearance="@style/TextAppearance.AppCompat.Body1"
-                            android:visibility="gone" />
+                        android:fadingEdgeLength="48dp"
+                        android:fillViewport="true"
+                        android:overScrollMode="never"
+                        android:requiresFadingEdge="vertical">
 
                         <LinearLayout
-                            android:id="@+id/send_network_hint"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:layout_marginStart="16dp"
-                            android:layout_marginEnd="16dp"
-                            android:layout_marginTop="16dp"
-                            android:background="?android:attr/colorBackgroundFloating"
-                            android:orientation="vertical"
-                            android:padding="16dp"
-                            android:visibility="gone">
+                            android:orientation="vertical">
+
+                            <dev.bluehouse.bada.ui.sheet.FlowLayout
+                                android:id="@+id/send_peer_list"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content" />
 
                             <TextView
-                                android:id="@+id/send_network_hint_title"
+                                android:id="@+id/send_empty_state"
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
-                                android:text="@string/send_network_hint_title"
-                                android:textAppearance="@style/TextAppearance.AppCompat.Subhead"
-                                android:textStyle="bold" />
+                                android:layout_marginTop="24dp"
+                                android:paddingHorizontal="16dp"
+                                android:gravity="center"
+                                android:text="@string/send_empty_state"
+                                android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+                                android:visibility="gone" />
 
-                            <TextView
-                                android:id="@+id/send_network_hint_body"
+                            <LinearLayout
+                                android:id="@+id/send_network_hint"
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
-                                android:layout_marginTop="8dp"
-                                android:text="@string/send_network_hint_body"
-                                android:textAppearance="@style/TextAppearance.AppCompat.Body1" />
+                                android:layout_marginStart="16dp"
+                                android:layout_marginEnd="16dp"
+                                android:layout_marginTop="16dp"
+                                android:background="?android:attr/colorBackgroundFloating"
+                                android:orientation="vertical"
+                                android:padding="16dp"
+                                android:visibility="gone">
 
-                            <Button
-                                android:id="@+id/send_network_hint_dismiss"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:layout_gravity="end"
-                                android:layout_marginTop="8dp"
-                                android:text="@string/send_network_hint_dismiss" />
+                                <TextView
+                                    android:id="@+id/send_network_hint_title"
+                                    android:layout_width="match_parent"
+                                    android:layout_height="wrap_content"
+                                    android:text="@string/send_network_hint_title"
+                                    android:textAppearance="@style/TextAppearance.AppCompat.Subhead"
+                                    android:textStyle="bold" />
+
+                                <TextView
+                                    android:id="@+id/send_network_hint_body"
+                                    android:layout_width="match_parent"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginTop="8dp"
+                                    android:text="@string/send_network_hint_body"
+                                    android:textAppearance="@style/TextAppearance.AppCompat.Body1" />
+
+                                <Button
+                                    android:id="@+id/send_network_hint_dismiss"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_gravity="end"
+                                    android:layout_marginTop="8dp"
+                                    android:text="@string/send_network_hint_dismiss" />
+
+                            </LinearLayout>
 
                         </LinearLayout>
 
-                    </LinearLayout>
+                    </androidx.core.widget.NestedScrollView>
 
                     <LinearLayout
                         android:id="@+id/send_status_panel"

--- a/app/src/main/res/layout/activity_send_fullscreen.xml
+++ b/app/src/main/res/layout/activity_send_fullscreen.xml
@@ -313,22 +313,31 @@
                       vertically centered inside this slot rather than
                       hugging the slot's top edge.
                     -->
-                    <!-- Negative side margins cancel the picker's 16dp side
-                         padding so the peer list (and its press ripple) spans
-                         the full card width to the rounded edges. Each row's
-                         own 16dp padding then aligns the row text with the
-                         16dp-inset header above. -->
                     <FrameLayout
                         android:layout_width="match_parent"
                         android:layout_height="0dp"
-                        android:layout_marginStart="-16dp"
-                        android:layout_marginEnd="-16dp"
                         android:layout_marginTop="16dp"
                         android:layout_weight="1"
-                        android:clipChildren="false"
-                        android:clipToPadding="false">
+                        android:clipChildren="true"
+                        android:clipToPadding="true">
 
-                        <ScrollView
+                        <!--
+                          Device picker grid. A vertical NestedScrollView
+                          (not a plain ScrollView: this slot lives inside
+                          the activity's outer NestedScrollView, and a
+                          plain ScrollView would be starved of every
+                          vertical drag by the parent) wraps a centered,
+                          wrapping FlowLayout grid of circular
+                          DeviceIconView chips. The grid shows as many
+                          icons per row as the card width allows and grows
+                          downward, so the list scrolls vertically once the
+                          device count overflows the ~480dp card. The
+                          empty-state line + same-Wi-Fi hint sit below the
+                          grid in the same scrolling column. This mirrors
+                          the share-sheet picker (activity_send.xml) so the
+                          two pickers render identically.
+                        -->
+                        <androidx.core.widget.NestedScrollView
                             android:id="@+id/send_peer_scroll"
                             android:layout_width="match_parent"
                             android:layout_height="match_parent"
@@ -341,11 +350,10 @@
                                 android:layout_height="wrap_content"
                                 android:orientation="vertical">
 
-                                <LinearLayout
+                                <dev.bluehouse.bada.ui.sheet.FlowLayout
                                     android:id="@+id/send_peer_list"
                                     android:layout_width="match_parent"
-                                    android:layout_height="wrap_content"
-                                    android:orientation="vertical" />
+                                    android:layout_height="wrap_content" />
 
                                 <!--
                                   Initial visibility = gone. The send-side
@@ -413,7 +421,7 @@
 
                             </LinearLayout>
 
-                        </ScrollView>
+                        </androidx.core.widget.NestedScrollView>
 
                         <LinearLayout
                             android:id="@+id/send_status_panel"


### PR DESCRIPTION
## Summary

The in-app picker rendered discovered devices as a single vertical column, and the share-sheet picker as a single horizontal row. Neither used the width well, and the in-app list couldn't scroll once the device count overflowed the card (chips drew over the help link and the Cancel button).

Both pickers now share a `FlowLayout`, a centered wrapping grid:

- Fits as many chips per row as the width allows (3 on the test device).
- Chips fill rows left to right, so a partial last row stays left-aligned instead of recentering.
- Grows downward inside a vertical `NestedScrollView`, so it scrolls once devices overflow the card.
- Device names wrap to two lines before ellipsizing.
- `DraggableSheetLayout` yields its pull-to-dismiss drag to the inner scroll list until the list is at the top.

## Changes

- `ui/sheet/FlowLayout.kt` (new): the centered wrapping grid.
- `ui/sheet/DeviceIconView.kt`: name `maxLines = 2`.
- `ui/sheet/DraggableSheetLayout.kt`: scroll-up guard so the sheet yields to the inner list.
- `send/SendPeerPickerController.kt`: container type `LinearLayout` to `ViewGroup`.
- `layout/activity_send.xml`, `layout/activity_send_fullscreen.xml`, `layout-land/activity_send.xml`: peer list is now a vertical `NestedScrollView` + `FlowLayout`.

## Test plan

Injected synthetic peers on a vivo device:

- 3-column centered grid in both pickers, rendering identically.
- Partial last row left-aligned (single item under column 0).
- Two-line names with ellipsis (Latin and CJK), nothing past the card.
- Vertical scroll works in both; pull-to-dismiss still works once scrolled to the top.

`ktlintCheck`, `detekt` and `assembleDebug` all pass.


Closes #225
