### PR TITLE
fix: open the GitHub release page from the update screen

### DIFF
--- a/app/src/main/kotlin/dev/bluehouse/bada/update/CheckForUpdatesActivity.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/update/CheckForUpdatesActivity.kt
@@ -5,11 +5,13 @@
  */
 package dev.bluehouse.bada.update
 
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import android.widget.TextView
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -17,6 +19,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.button.MaterialButton
 import dev.bluehouse.bada.R
+import dev.bluehouse.bada.discovery.diagnostics.DiagnosticLog
 import kotlinx.coroutines.launch
 
 /**
@@ -113,10 +116,22 @@ internal class CheckForUpdatesActivity : AppCompatActivity() {
             Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
                 addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             }
-        // resolveActivity guards the rare case where no browser is
-        // installed; without it the explicit intent throws ActivityNotFound.
-        if (intent.resolveActivity(packageManager) != null) {
+        // Launch the browser directly and fall back to a toast if nothing
+        // can handle the intent. The previous `resolveActivity` guard
+        // returned null on Android 11+ (package-visibility filtering hides
+        // browsers unless we declare a matching <queries> intent), so the
+        // release page never opened even though a browser was installed.
+        // try/catch is the visibility-independent pattern used elsewhere
+        // (see BugReportFlowSupport).
+        try {
             startActivity(intent)
+        } catch (e: ActivityNotFoundException) {
+            DiagnosticLog.w(TAG, "Could not open release page: $url", e)
+            Toast.makeText(this, R.string.update_open_release_failed, Toast.LENGTH_LONG).show()
         }
+    }
+
+    private companion object {
+        private const val TAG = "BadaUpdate"
     }
 }

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -48,6 +48,7 @@
     <string name="update_subtitle_latest_version">%1$s</string>
     <string name="update_button_check_again">再確認</string>
     <string name="update_button_update">アップデート</string>
+    <string name="update_open_release_failed">リリースページを開けませんでした。</string>
 
     <!-- `credit_section_developer`, `credit_section_polisher`,
          `credit_section_qa`, `credit_section_thanks` are intentionally

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -49,6 +49,7 @@
     <string name="update_subtitle_latest_version">%1$s</string>
     <string name="update_button_check_again">다시 확인</string>
     <string name="update_button_update">업데이트</string>
+    <string name="update_open_release_failed">릴리스 페이지를 열 수 없습니다.</string>
 
     <!-- `credit_section_developer`, `credit_section_polisher`,
          `credit_section_qa`, `credit_section_thanks` are intentionally

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -335,5 +335,6 @@
     <string name="update_subtitle_latest_version">%1$s</string>
     <string name="update_button_check_again">再次檢查</string>
     <string name="update_button_update">更新</string>
+    <string name="update_open_release_failed">無法開啟發行頁面。</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,6 +29,7 @@
     <string name="update_subtitle_latest_version">%1$s</string>
     <string name="update_button_check_again">Check again</string>
     <string name="update_button_update">Update</string>
+    <string name="update_open_release_failed">Couldn\'t open the release page.</string>
     <string name="credit_placeholder_text">credit</string>
 
     <!--


### PR DESCRIPTION
## Summary

Tapping "Update" on the Check for updates screen did nothing. `openReleasePage` guarded `startActivity` with `intent.resolveActivity(packageManager)`, which returns null on Android 11+ unless the app declares a matching `<queries>` entry. We don't, so the guard always failed and `startActivity` never ran, even with a browser installed.

The fix launches the `ACTION_VIEW` intent directly and catches `ActivityNotFoundException` with a toast, the same pattern `BugReportFlowSupport` uses. `startActivity` itself isn't subject to the package-visibility filter, so the release page opens reliably.

## Changes

- `update/CheckForUpdatesActivity.kt`: replace the `resolveActivity` guard with try/catch.
- `values{,-ja,-ko,-zh-rTW}/strings.xml`: add `update_open_release_failed`.

## Test plan

Lowered the app `versionName` so the check reported an update, then on a vivo device opened the overflow menu, went to Check for updates, and tapped Update. It opened the GitHub release page (`kyujin-cho/Bada`, latest tag); before the fix nothing happened.

`ktlintCheck`, `detekt` and `assembleDebug` all pass.