### PR TITLE
Automatic update check + notification (download directly or open GitHub)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ Networking notes:
 
 ## Permissions
 
-Bada asks only for permissions tied to receiving, discovery, and transfer
-visibility:
+Bada asks for permissions tied to receiving, discovery, and transfer
+visibility, plus one for its own update flow:
 
 - **Nearby Wi-Fi devices**: discovers and advertises Quick Share peers on the
   local network.
@@ -122,6 +122,13 @@ visibility:
   use physical location.
 - **Battery optimization exemption**: optional, but useful on OEM builds that
   aggressively stop background foreground services.
+- **Install unknown apps** (`REQUEST_INSTALL_PACKAGES`): lets the in-app
+  self-update install a newer Bada APK downloaded from GitHub releases; the
+  system still shows its own confirm dialog, and the grant is opt-in.
+
+Bada also polls GitHub releases every 6 hours in the background to notify you
+of new versions; this can be turned off with the **Automatic update check**
+toggle in Settings.
 
 ## Troubleshooting
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -169,6 +169,12 @@ dependencies {
     // ZXing (`zxing-android-embedded`) is intentionally not used.
     implementation(libs.zxing.core)
 
+    // WorkManager — runs the automatic update check (UpdateCheckWorker): a
+    // 6-hourly PeriodicWork, scheduled in BadaApplication.onCreate, that polls
+    // GitHub Releases and posts an "update available" notification. WorkManager
+    // persists the schedule across reboots with no user action.
+    implementation(libs.androidx.work.runtime.ktx)
+
     // NOTE: the self-ADB Wi-Fi stack (libadb-android + Conscrypt + BouncyCastle)
     // was MOVED OUT of :app into :radio-helper. The radios are toggled by the
     // standalone helper APK (which targets API 28 for the legacy capability and

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -127,6 +127,13 @@
          downloaded APK via PackageInstaller (a true drop-in self-update). The
          "install unknown apps" grant it gates on is one-time (not per-boot). -->
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+
+    <!-- The update-download worker (UpdateInstallWorker) runs as expedited
+         WorkManager work, which is executed inside WorkManager's foreground
+         service on pre-API-31 devices. API 34+ requires the service's FGS
+         type (dataSync, declared on SystemForegroundService below) to be
+         backed by this typed permission. -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
 
     <!-- Bind the radio-helper companion APK's RadioService (signature-protected
@@ -506,10 +513,20 @@
         <!-- Receives PackageInstaller status for the auto-update "Download &
              install" flow (UpdateDownloadInstaller). Not exported — only the
              app's own session PendingIntent targets it; it launches the system
-             install confirm dialog and toasts the result. -->
+             install confirm dialog (or a shade notification when backgrounded)
+             and toasts the result. -->
         <receiver
             android:name=".update.UpdateInstallReceiver"
             android:exported="false" />
+
+        <!-- WorkManager's foreground-service host. The merge override pins the
+             dataSync FGS type so the expedited update-download worker
+             (UpdateInstallWorker) can foreground itself on API 34+, where an
+             FGS without a declared type crashes at startForeground(). -->
+        <service
+            android:name="androidx.work.impl.foreground.SystemForegroundService"
+            android:foregroundServiceType="dataSync"
+            tools:node="merge" />
 
     </application>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -122,6 +122,11 @@
     <!-- General networking (compile-time). -->
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
+    <!-- Lets the automatic update's "Download & install" action install the
+         downloaded APK via PackageInstaller (a true drop-in self-update). The
+         "install unknown apps" grant it gates on is one-time (not per-boot). -->
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
 
     <!-- Bind the radio-helper companion APK's RadioService (signature-protected
@@ -316,6 +321,23 @@
             android:parentActivityName=".MainActivity" />
 
         <!--
+          Invisible trampoline for the update notification's
+          "Download & install" action. Has NO UI of its own (translucent
+          theme); it only gates the one-time "install unknown apps" grant and
+          then kicks off UpdateDownloadInstaller (download → system installer).
+          noHistory + excludeFromRecents so it never lingers in the task list.
+          exported=false: only the app's own notification PendingIntent
+          launches it.
+        -->
+        <activity
+            android:name=".update.UpdateInstallActivity"
+            android:exported="false"
+            android:excludeFromRecents="true"
+            android:noHistory="true"
+            android:taskAffinity=""
+            android:theme="@android:style/Theme.Translucent.NoTitleBar" />
+
+        <!--
           Sender share-intent target (#24).
 
           ACTION_SEND (single attachment) and ACTION_SEND_MULTIPLE
@@ -480,6 +502,14 @@
                 android:name="android.service.quicksettings.TOGGLEABLE_TILE"
                 android:value="true" />
         </service>
+
+        <!-- Receives PackageInstaller status for the auto-update "Download &
+             install" flow (UpdateDownloadInstaller). Not exported — only the
+             app's own session PendingIntent targets it; it launches the system
+             install confirm dialog and toasts the result. -->
+        <receiver
+            android:name=".update.UpdateInstallReceiver"
+            android:exported="false" />
 
     </application>
 

--- a/app/src/main/kotlin/dev/bluehouse/bada/BadaApplication.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/BadaApplication.kt
@@ -6,6 +6,7 @@
 package dev.bluehouse.bada
 
 import android.app.Application
+import android.content.Context
 import androidx.work.Constraints
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.NetworkType
@@ -15,6 +16,7 @@ import dev.bluehouse.bada.consent.ConsentTrampolineActivity
 import dev.bluehouse.bada.discovery.diagnostics.DiagnosticLog
 import dev.bluehouse.bada.service.receiver.ReceiverForegroundService
 import dev.bluehouse.bada.update.UpdateCheckWorker
+import dev.bluehouse.bada.update.UpdatePreferences
 import java.util.concurrent.TimeUnit
 
 /**
@@ -48,40 +50,52 @@ class BadaApplication : Application() {
         // the collector never picks up.
         getExternalFilesDir(null)?.let { DiagnosticLog.configureFileSink(it) }
 
-        scheduleAutomaticUpdateCheck()
+        applyAutoUpdateCheckPolicy(this)
     }
 
-    /**
-     * Enqueue the 6-hourly automatic GitHub update check ([UpdateCheckWorker]).
-     *
-     * Uses a UNIQUE PeriodicWork so re-running onCreate (every process start)
-     * never stacks duplicate jobs, and `ExistingPeriodicWorkPolicy.UPDATE` so a
-     * future interval/constraint change is picked up without losing the
-     * persisted schedule. The CONNECTED network constraint means a run only
-     * fires when there is connectivity to reach GitHub. WorkManager persists the
-     * schedule across reboots, so the poll self-restarts on boot with no user
-     * action.
-     */
-    private fun scheduleAutomaticUpdateCheck() {
-        val request =
-            PeriodicWorkRequestBuilder<UpdateCheckWorker>(UPDATE_CHECK_INTERVAL_HOURS, TimeUnit.HOURS)
-                .setConstraints(
-                    Constraints
-                        .Builder()
-                        .setRequiredNetworkType(NetworkType.CONNECTED)
-                        .build(),
-                ).build()
-        WorkManager
-            .getInstance(this)
-            .enqueueUniquePeriodicWork(
+    companion object {
+        /** How often the automatic update check runs, in hours. */
+        private const val UPDATE_CHECK_INTERVAL_HOURS = 6L
+
+        /**
+         * Reconcile the 6-hourly automatic GitHub update check
+         * ([UpdateCheckWorker]) with the user's Settings toggle
+         * ([UpdatePreferences.autoCheckEnabled]).
+         *
+         * Enabled → enqueue a UNIQUE PeriodicWork so re-running onCreate
+         * (every process start) never stacks duplicate jobs, with
+         * `ExistingPeriodicWorkPolicy.UPDATE` so a future interval/constraint
+         * change is picked up without losing the persisted schedule. The
+         * CONNECTED network constraint means a run only fires when there is
+         * connectivity to reach GitHub. WorkManager persists the schedule
+         * across reboots, so the poll self-restarts on boot with no user
+         * action.
+         *
+         * Disabled → cancel the unique work so the poll fully stops (the
+         * worker's own preference check is only a belt-and-braces fallback).
+         *
+         * Called from [onCreate] and from the Settings toggle
+         * ([dev.bluehouse.bada.ui.SettingsFragment]) whenever it flips.
+         */
+        fun applyAutoUpdateCheckPolicy(context: Context) {
+            val workManager = WorkManager.getInstance(context.applicationContext)
+            if (!UpdatePreferences.from(context).autoCheckEnabled()) {
+                workManager.cancelUniqueWork(UpdateCheckWorker.UNIQUE_WORK_NAME)
+                return
+            }
+            val request =
+                PeriodicWorkRequestBuilder<UpdateCheckWorker>(UPDATE_CHECK_INTERVAL_HOURS, TimeUnit.HOURS)
+                    .setConstraints(
+                        Constraints
+                            .Builder()
+                            .setRequiredNetworkType(NetworkType.CONNECTED)
+                            .build(),
+                    ).build()
+            workManager.enqueueUniquePeriodicWork(
                 UpdateCheckWorker.UNIQUE_WORK_NAME,
                 ExistingPeriodicWorkPolicy.UPDATE,
                 request,
             )
-    }
-
-    private companion object {
-        /** How often the automatic update check runs, in hours. */
-        private const val UPDATE_CHECK_INTERVAL_HOURS = 6L
+        }
     }
 }

--- a/app/src/main/kotlin/dev/bluehouse/bada/BadaApplication.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/BadaApplication.kt
@@ -6,9 +6,16 @@
 package dev.bluehouse.bada
 
 import android.app.Application
+import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
 import dev.bluehouse.bada.consent.ConsentTrampolineActivity
 import dev.bluehouse.bada.discovery.diagnostics.DiagnosticLog
 import dev.bluehouse.bada.service.receiver.ReceiverForegroundService
+import dev.bluehouse.bada.update.UpdateCheckWorker
+import java.util.concurrent.TimeUnit
 
 /**
  * Application bootstrap that wires the `:app`-side activity classes
@@ -40,5 +47,36 @@ class BadaApplication : Application() {
         // (getExternalFilesDir(null)); a filesDir fallback would write logs
         // the collector never picks up.
         getExternalFilesDir(null)?.let { DiagnosticLog.configureFileSink(it) }
+
+        scheduleAutomaticUpdateCheck()
+    }
+
+    /**
+     * Enqueue the 6-hourly automatic GitHub update check ([UpdateCheckWorker]).
+     *
+     * Uses a UNIQUE PeriodicWork so re-running onCreate (every process start)
+     * never stacks duplicate jobs, and `ExistingPeriodicWorkPolicy.UPDATE` so a
+     * future interval/constraint change is picked up without losing the
+     * persisted schedule. The CONNECTED network constraint means a run only
+     * fires when there is connectivity to reach GitHub. WorkManager persists the
+     * schedule across reboots, so the poll self-restarts on boot with no user
+     * action.
+     */
+    private fun scheduleAutomaticUpdateCheck() {
+        val request =
+            PeriodicWorkRequestBuilder<UpdateCheckWorker>(6, TimeUnit.HOURS)
+                .setConstraints(
+                    Constraints
+                        .Builder()
+                        .setRequiredNetworkType(NetworkType.CONNECTED)
+                        .build(),
+                ).build()
+        WorkManager
+            .getInstance(this)
+            .enqueueUniquePeriodicWork(
+                UpdateCheckWorker.UNIQUE_WORK_NAME,
+                ExistingPeriodicWorkPolicy.UPDATE,
+                request,
+            )
     }
 }

--- a/app/src/main/kotlin/dev/bluehouse/bada/BadaApplication.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/BadaApplication.kt
@@ -64,7 +64,7 @@ class BadaApplication : Application() {
      */
     private fun scheduleAutomaticUpdateCheck() {
         val request =
-            PeriodicWorkRequestBuilder<UpdateCheckWorker>(6, TimeUnit.HOURS)
+            PeriodicWorkRequestBuilder<UpdateCheckWorker>(UPDATE_CHECK_INTERVAL_HOURS, TimeUnit.HOURS)
                 .setConstraints(
                     Constraints
                         .Builder()
@@ -78,5 +78,10 @@ class BadaApplication : Application() {
                 ExistingPeriodicWorkPolicy.UPDATE,
                 request,
             )
+    }
+
+    private companion object {
+        /** How often the automatic update check runs, in hours. */
+        private const val UPDATE_CHECK_INTERVAL_HOURS = 6L
     }
 }

--- a/app/src/main/kotlin/dev/bluehouse/bada/MainActivity.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/MainActivity.kt
@@ -122,6 +122,15 @@ class MainActivity : AppCompatActivity() {
      */
     private var mainToolbar: MaterialToolbar? = null
 
+    /**
+     * Bottom-nav reference kept on the instance so the [UpdateRepository]
+     * state observer can also paint a small red dot on the **Settings** tab
+     * ([R.id.nav_settings]) when a new GitHub release is detected — so the
+     * "update available" hint is visible without opening the overflow menu —
+     * and remove it once up to date.
+     */
+    private var mainBottomNav: BottomNavigationView? = null
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
@@ -164,6 +173,9 @@ class MainActivity : AppCompatActivity() {
         }
 
         val bottomNav = findViewById<BottomNavigationView>(R.id.main_bottom_nav)
+        // Keep a reference so applyUpdateBadge() can toggle the Settings-tab
+        // red dot from the UpdateRepository state flow.
+        mainBottomNav = bottomNav
         bottomNav.setOnItemSelectedListener { item ->
             val fragment =
                 when (item.itemId) {
@@ -339,14 +351,37 @@ class MainActivity : AppCompatActivity() {
      * transition without the user having to close and re-open the popup.
      */
     private fun applyUpdateBadge(state: UpdateState) {
+        val updateAvailable = state is UpdateState.UpdateAvailable
         val drawableRes =
-            if (state is UpdateState.UpdateAvailable) {
+            if (updateAvailable) {
                 R.drawable.ic_overflow_kebab_with_dot_24
             } else {
                 R.drawable.ic_overflow_kebab_24
             }
         mainToolbar?.overflowIcon = ContextCompat.getDrawable(this, drawableRes)
+        applySettingsTabDot(updateAvailable)
         invalidateOptionsMenu()
+    }
+
+    /**
+     * Show or hide a small red dot on the bottom-nav **Settings** tab
+     * ([R.id.nav_settings]) — a Material [com.google.android.material.badge.BadgeDrawable]
+     * with no number, anchored to the tab icon's top-right. Mirrors the
+     * overflow-menu kebab dot so a pending update is visible even when the
+     * overflow menu is closed. Cleared (badge removed) once up to date.
+     *
+     * No-op until [mainBottomNav] is assigned (set in onCreate before the
+     * lifecycle-STARTED state collector first emits), so the safe call never
+     * misses the badge.
+     */
+    private fun applySettingsTabDot(show: Boolean) {
+        val nav = mainBottomNav ?: return
+        if (show) {
+            // getOrCreateBadge with no .number renders as a plain red dot.
+            nav.getOrCreateBadge(R.id.nav_settings).isVisible = true
+        } else {
+            nav.removeBadge(R.id.nav_settings)
+        }
     }
 
     override fun onSaveInstanceState(outState: Bundle) {

--- a/app/src/main/kotlin/dev/bluehouse/bada/ui/SettingsFragment.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/ui/SettingsFragment.kt
@@ -17,6 +17,7 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.widget.SwitchCompat
 import androidx.fragment.app.Fragment
+import dev.bluehouse.bada.BadaApplication
 import dev.bluehouse.bada.MainActivity
 import dev.bluehouse.bada.R
 import dev.bluehouse.bada.battery.BatteryOptimizationOemHelper
@@ -28,6 +29,7 @@ import dev.bluehouse.bada.service.receiver.AdvertisedDeviceNames
 import dev.bluehouse.bada.service.receiver.ReceiverForegroundService
 import dev.bluehouse.bada.transfer.KeepScreenOnPreferences
 import dev.bluehouse.bada.transfer.TransferExpertViewPreferences
+import dev.bluehouse.bada.update.UpdatePreferences
 
 /**
  * Settings tab content for the bottom-navigation shell in
@@ -144,6 +146,17 @@ internal class SettingsFragment : Fragment(R.layout.fragment_settings) {
         expertViewSwitch.setOnCheckedChangeListener { _, checked ->
             expertViewPreferences.setExpertViewEnabled(checked)
         }
+
+        val autoUpdateSwitch = view.findViewById<SwitchCompat>(R.id.settings_auto_update_switch)
+        val updatePreferences = UpdatePreferences.from(requireContext())
+        autoUpdateSwitch.isChecked = updatePreferences.autoCheckEnabled()
+        autoUpdateSwitch.setOnCheckedChangeListener { _, checked ->
+            updatePreferences.setAutoCheckEnabled(checked)
+            // Re-apply immediately: enabling enqueues the periodic worker,
+            // disabling cancels the persisted schedule (not just a soft
+            // short-circuit inside the worker).
+            BadaApplication.applyAutoUpdateCheckPolicy(requireContext())
+        }
     }
 
     override fun onStart() {
@@ -213,6 +226,9 @@ internal class SettingsFragment : Fragment(R.layout.fragment_settings) {
         v
             .findViewById<SwitchCompat>(R.id.main_transfer_expert_switch)
             ?.refreshChecked(TransferExpertViewPreferences.from(requireContext()).isExpertViewEnabled())
+        v
+            .findViewById<SwitchCompat>(R.id.settings_auto_update_switch)
+            ?.refreshChecked(UpdatePreferences.from(requireContext()).autoCheckEnabled())
     }
 
     private fun SwitchCompat.refreshChecked(enabled: Boolean) {

--- a/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateApkAssets.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateApkAssets.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.update
+
+/**
+ * Picks the installable app APK out of a GitHub release's asset list.
+ *
+ * Releases can carry more than one `.apk` (e.g. the radio-helper companion
+ * app), so "first `.apk` wins" is not safe. The app APK is deterministically
+ * named `<applicationId>-<versionName>.apk` by the release build
+ * (`app/build.gradle.kts` sets `outputFileName = "$applicationId-$versionName.apk"`),
+ * so we match on that prefix and treat "no match" as "release has no
+ * installable app APK" (the caller then offers the GitHub page only).
+ */
+internal object UpdateApkAssets {
+    /** Release APK naming rule — see `app/build.gradle.kts` output renaming. */
+    private const val APP_APK_PREFIX = "dev.bluehouse.bada-"
+
+    fun selectAppApkUrl(assets: List<ReleaseAsset>): String? =
+        assets
+            .firstOrNull { asset ->
+                asset.name.startsWith(APP_APK_PREFIX, ignoreCase = true) &&
+                    asset.name.endsWith(".apk", ignoreCase = true) &&
+                    asset.url.isNotBlank()
+            }?.url
+}
+
+/** One GitHub release asset: its file `name` + `browser_download_url`. */
+internal data class ReleaseAsset(
+    val name: String,
+    val url: String,
+)

--- a/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateCheckWorker.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateCheckWorker.kt
@@ -42,9 +42,6 @@ import dev.bluehouse.bada.BuildConfig
  * ---------------
  * PeriodicWork survives reboots with zero user action (the schedule is persisted
  * and re-enqueued by the OS) — no BootReceiver needed.
- *
- * STATUS: compile-only / DEVICE-UNVERIFIED. The version-comparison + dedup logic
- * is plain and unit-testable.
  */
 internal class UpdateCheckWorker(
     appContext: Context,
@@ -59,7 +56,7 @@ internal class UpdateCheckWorker(
                 // Keep the red-dot badge source-of-truth current regardless of notify.
                 prefs.saveLatestRelease(release.version, release.releaseUrl)
 
-                if (isNewer(release.version, BuildConfig.VERSION_NAME) &&
+                if (UpdateVersions.isNewer(release.version, BuildConfig.VERSION_NAME) &&
                     release.version != prefs.lastNotifiedVersion()
                 ) {
                     UpdateNotifier.notifyUpdateAvailable(
@@ -74,17 +71,6 @@ internal class UpdateCheckWorker(
         }
         return Result.success()
     }
-
-    /**
-     * Strict-greater comparison. Works for the project's fixed `YYYYMMDD.NN`
-     * versionName because every field is zero-padded to a fixed width, so a
-     * plain lexicographic compare is monotonic with release order. Matches
-     * [UpdateRepository]'s identical helper.
-     */
-    private fun isNewer(
-        candidate: String,
-        installed: String,
-    ): Boolean = candidate > installed
 
     internal companion object {
         /** Unique name for the periodic work (see BadaApplication). */

--- a/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateCheckWorker.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateCheckWorker.kt
@@ -52,29 +52,26 @@ internal class UpdateCheckWorker(
 ) : CoroutineWorker(appContext, params) {
     override suspend fun doWork(): Result {
         val prefs = UpdatePreferences.from(applicationContext)
-        if (!prefs.autoCheckEnabled()) return Result.success()
+        if (prefs.autoCheckEnabled()) {
+            // A fetch failure (offline / no release / JSON mismatch) is a no-op:
+            // onSuccess is skipped and we still return success (no retry-spam).
+            UpdateChecker.fetchLatestRelease().onSuccess { release ->
+                // Keep the red-dot badge source-of-truth current regardless of notify.
+                prefs.saveLatestRelease(release.version, release.releaseUrl)
 
-        val release =
-            UpdateChecker.fetchLatestRelease().getOrElse {
-                // Transient/absent release: try again on the next periodic run.
-                return Result.success()
+                if (isNewer(release.version, BuildConfig.VERSION_NAME) &&
+                    release.version != prefs.lastNotifiedVersion()
+                ) {
+                    UpdateNotifier.notifyUpdateAvailable(
+                        context = applicationContext,
+                        version = release.version,
+                        releaseUrl = release.releaseUrl,
+                        apkAssetUrl = release.apkAssetUrl,
+                    )
+                    prefs.saveNotifiedVersion(release.version)
+                }
             }
-
-        // Keep the red-dot badge source-of-truth current regardless of notify.
-        prefs.saveLatestRelease(release.version, release.releaseUrl)
-
-        if (isNewer(release.version, BuildConfig.VERSION_NAME) &&
-            release.version != prefs.lastNotifiedVersion()
-        ) {
-            UpdateNotifier.notifyUpdateAvailable(
-                context = applicationContext,
-                version = release.version,
-                releaseUrl = release.releaseUrl,
-                apkAssetUrl = release.apkAssetUrl,
-            )
-            prefs.saveNotifiedVersion(release.version)
         }
-
         return Result.success()
     }
 

--- a/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateCheckWorker.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateCheckWorker.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.update
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import dev.bluehouse.bada.BuildConfig
+
+/**
+ * WHAT THIS IS
+ * -----------
+ * `UpdateCheckWorker` — the background job behind the AUTOMATIC update check. A
+ * WorkManager [CoroutineWorker] scheduled by [dev.bluehouse.bada.BadaApplication]
+ * as a unique PeriodicWork ("bada-update-check", every 6 hours,
+ * network-connected). Each run polls GitHub Releases (kyujin-cho/Bada via
+ * [UpdateChecker]) and, when a newer version exists, posts the [UpdateNotifier]
+ * "update available" notification.
+ *
+ * WHAT IT DOES (one run)
+ * ----------------------
+ * 1. If the user disabled auto-check ([UpdatePreferences.autoCheckEnabled] false)
+ *    → no-op success.
+ * 2. Fetch `releases/latest` via the shared [UpdateChecker].
+ * 3. If the release version is strictly newer than `BuildConfig.VERSION_NAME`
+ *    (lexicographic on the project's fixed `YYYYMMDD.NN` scheme) AND we have not
+ *    already notified for that exact version → notify + remember it. The
+ *    notification adapts to whether the release carries a downloadable `.apk`.
+ * 4. Persist the latest-release snapshot so the in-app red-dot badge stays in
+ *    sync ([UpdateRepository] reads the same prefs).
+ *
+ * FAILURE HANDLING
+ * ----------------
+ * A fetch failure (offline, HTTP 404 when no release is published, JSON
+ * mismatch) returns [Result.success] — NOT retry — so WorkManager does not
+ * back-off-spam GitHub; the next scheduled run simply tries again.
+ *
+ * WHY WorkManager
+ * ---------------
+ * PeriodicWork survives reboots with zero user action (the schedule is persisted
+ * and re-enqueued by the OS) — no BootReceiver needed.
+ *
+ * STATUS: compile-only / DEVICE-UNVERIFIED. The version-comparison + dedup logic
+ * is plain and unit-testable.
+ */
+internal class UpdateCheckWorker(
+    appContext: Context,
+    params: WorkerParameters,
+) : CoroutineWorker(appContext, params) {
+    override suspend fun doWork(): Result {
+        val prefs = UpdatePreferences.from(applicationContext)
+        if (!prefs.autoCheckEnabled()) return Result.success()
+
+        val release =
+            UpdateChecker.fetchLatestRelease().getOrElse {
+                // Transient/absent release: try again on the next periodic run.
+                return Result.success()
+            }
+
+        // Keep the red-dot badge source-of-truth current regardless of notify.
+        prefs.saveLatestRelease(release.version, release.releaseUrl)
+
+        if (isNewer(release.version, BuildConfig.VERSION_NAME) &&
+            release.version != prefs.lastNotifiedVersion()
+        ) {
+            UpdateNotifier.notifyUpdateAvailable(
+                context = applicationContext,
+                version = release.version,
+                releaseUrl = release.releaseUrl,
+                apkAssetUrl = release.apkAssetUrl,
+            )
+            prefs.saveNotifiedVersion(release.version)
+        }
+
+        return Result.success()
+    }
+
+    /**
+     * Strict-greater comparison. Works for the project's fixed `YYYYMMDD.NN`
+     * versionName because every field is zero-padded to a fixed width, so a
+     * plain lexicographic compare is monotonic with release order. Matches
+     * [UpdateRepository]'s identical helper.
+     */
+    private fun isNewer(
+        candidate: String,
+        installed: String,
+    ): Boolean = candidate > installed
+
+    internal companion object {
+        /** Unique name for the periodic work (see BadaApplication). */
+        const val UNIQUE_WORK_NAME = "bada-update-check"
+    }
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateChecker.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateChecker.kt
@@ -65,7 +65,7 @@ internal object UpdateChecker {
                     LatestRelease(
                         version = stripVPrefix(tag),
                         releaseUrl = htmlUrl,
-                        apkAssetUrl = firstApkAssetUrl(json.optJSONArray("assets")),
+                        apkAssetUrl = UpdateApkAssets.selectAppApkUrl(parseAssets(json.optJSONArray("assets"))),
                     )
                 } finally {
                     connection.disconnect()
@@ -74,25 +74,29 @@ internal object UpdateChecker {
         }
 
     /**
-     * Scan the release's `assets` array for the first uploaded `.apk` and
-     * return its `browser_download_url` (a direct, redirecting download
-     * link), or `null` when the release has no APK attached.
+     * Project the release's `assets` array into plain [ReleaseAsset]s for
+     * [UpdateApkAssets.selectAppApkUrl], which picks the app's own APK by
+     * its `dev.bluehouse.bada-` filename prefix (releases can also ship
+     * companion APKs, so "first `.apk`" is not safe) or `null` when the
+     * release carries no installable app APK.
      *
      * This is what makes the update NOTIFICATION adaptive: when a release
      * has the installable APK attached, the notification can offer a direct
      * "Download & install" drop-in update; when no APK is present, the
      * caller falls back to only sending the user to the GitHub release page.
      */
-    private fun firstApkAssetUrl(assets: JSONArray?): String? =
-        assets?.let { array ->
-            (0 until array.length())
-                .asSequence()
-                .mapNotNull { array.optJSONObject(it) }
-                .map { it.optString("browser_download_url") to it.optString("name") }
-                .firstOrNull { (url, name) ->
-                    name.endsWith(".apk", ignoreCase = true) && url.isNotBlank()
-                }?.first
-        }
+    private fun parseAssets(assets: JSONArray?): List<ReleaseAsset> =
+        assets
+            ?.let { array ->
+                (0 until array.length())
+                    .mapNotNull { array.optJSONObject(it) }
+                    .map {
+                        ReleaseAsset(
+                            name = it.optString("name"),
+                            url = it.optString("browser_download_url"),
+                        )
+                    }
+            }.orEmpty()
 
     private fun openConnection(): HttpURLConnection {
         val connection = URL(RELEASES_LATEST_URL).openConnection() as HttpURLConnection
@@ -116,9 +120,10 @@ internal object UpdateChecker {
  *                   stripped), compared against `BuildConfig.VERSION_NAME`.
  * @param releaseUrl the human GitHub release page (`html_url`) — the
  *                   "View on GitHub" destination; always present.
- * @param apkAssetUrl direct `browser_download_url` of the release's first
- *                   `.apk` asset, or `null` when no APK is attached. When
- *                   non-null the update notification can offer a direct
+ * @param apkAssetUrl direct `browser_download_url` of the release's app APK
+ *                   asset (matched by the `dev.bluehouse.bada-` filename
+ *                   prefix), or `null` when none is attached. When non-null
+ *                   the update notification can offer a direct
  *                   "Download & install"; when null it offers GitHub only.
  */
 internal data class LatestRelease(

--- a/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateChecker.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateChecker.kt
@@ -7,6 +7,7 @@ package dev.bluehouse.bada.update
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.json.JSONArray
 import org.json.JSONObject
 import java.net.HttpURLConnection
 import java.net.URL
@@ -61,12 +62,39 @@ internal object UpdateChecker {
                     val htmlUrl =
                         json.optString("html_url").takeIf { it.isNotBlank() }
                             ?: error("`html_url` missing from GitHub response")
-                    LatestRelease(version = stripVPrefix(tag), releaseUrl = htmlUrl)
+                    LatestRelease(
+                        version = stripVPrefix(tag),
+                        releaseUrl = htmlUrl,
+                        apkAssetUrl = firstApkAssetUrl(json.optJSONArray("assets")),
+                    )
                 } finally {
                     connection.disconnect()
                 }
             }
         }
+
+    /**
+     * Scan the release's `assets` array for the first uploaded `.apk` and
+     * return its `browser_download_url` (a direct, redirecting download
+     * link), or `null` when the release has no APK attached.
+     *
+     * This is what makes the update NOTIFICATION adaptive: when a release
+     * has the installable APK attached, the notification can offer a direct
+     * "Download & install" drop-in update; when no APK is present, the
+     * caller falls back to only sending the user to the GitHub release page.
+     */
+    private fun firstApkAssetUrl(assets: JSONArray?): String? {
+        if (assets == null) return null
+        for (index in 0 until assets.length()) {
+            val asset = assets.optJSONObject(index) ?: continue
+            val name = asset.optString("name")
+            val downloadUrl = asset.optString("browser_download_url")
+            if (name.endsWith(".apk", ignoreCase = true) && downloadUrl.isNotBlank()) {
+                return downloadUrl
+            }
+        }
+        return null
+    }
 
     private fun openConnection(): HttpURLConnection {
         val connection = URL(RELEASES_LATEST_URL).openConnection() as HttpURLConnection
@@ -84,11 +112,19 @@ internal object UpdateChecker {
 }
 
 /**
- * Minimal `releases/latest` projection: just the version string the
- * UI needs to render, and the URL the user is sent to when they tap
- * "Update".
+ * Minimal `releases/latest` projection.
+ *
+ * @param version    the release version (`tag_name` with any leading `v`
+ *                   stripped), compared against `BuildConfig.VERSION_NAME`.
+ * @param releaseUrl the human GitHub release page (`html_url`) — the
+ *                   "View on GitHub" destination; always present.
+ * @param apkAssetUrl direct `browser_download_url` of the release's first
+ *                   `.apk` asset, or `null` when no APK is attached. When
+ *                   non-null the update notification can offer a direct
+ *                   "Download & install"; when null it offers GitHub only.
  */
 internal data class LatestRelease(
     val version: String,
     val releaseUrl: String,
+    val apkAssetUrl: String?,
 )

--- a/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateChecker.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateChecker.kt
@@ -83,18 +83,16 @@ internal object UpdateChecker {
      * "Download & install" drop-in update; when no APK is present, the
      * caller falls back to only sending the user to the GitHub release page.
      */
-    private fun firstApkAssetUrl(assets: JSONArray?): String? {
-        if (assets == null) return null
-        for (index in 0 until assets.length()) {
-            val asset = assets.optJSONObject(index) ?: continue
-            val name = asset.optString("name")
-            val downloadUrl = asset.optString("browser_download_url")
-            if (name.endsWith(".apk", ignoreCase = true) && downloadUrl.isNotBlank()) {
-                return downloadUrl
-            }
+    private fun firstApkAssetUrl(assets: JSONArray?): String? =
+        assets?.let { array ->
+            (0 until array.length())
+                .asSequence()
+                .mapNotNull { array.optJSONObject(it) }
+                .map { it.optString("browser_download_url") to it.optString("name") }
+                .firstOrNull { (url, name) ->
+                    name.endsWith(".apk", ignoreCase = true) && url.isNotBlank()
+                }?.first
         }
-        return null
-    }
 
     private fun openConnection(): HttpURLConnection {
         val connection = URL(RELEASES_LATEST_URL).openConnection() as HttpURLConnection

--- a/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateDownloadInstaller.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateDownloadInstaller.kt
@@ -5,16 +5,21 @@
  */
 package dev.bluehouse.bada.update
 
-import android.app.NotificationChannel
-import android.app.NotificationManager
+import android.app.Notification
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageInstaller
+import android.content.pm.ServiceInfo
 import android.os.Build
-import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import androidx.work.ExistingWorkPolicy
+import androidx.work.ForegroundInfo
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.OutOfQuotaPolicy
+import androidx.work.WorkManager
+import androidx.work.workDataOf
 import dev.bluehouse.bada.R
 import java.net.HttpURLConnection
 import java.net.URL
@@ -30,30 +35,30 @@ import java.net.URL
  * WHO CALLS IT
  * ------------
  * [UpdateInstallActivity] (the trampoline launched by the notification's
- * "Download & install" action), AFTER it has confirmed
+ * "Download & install" action) calls [enqueue] AFTER it has confirmed
  * `canRequestPackageInstalls()`.
  *
  * THREADING
  * ---------
- * Runs the network read + session write on a dedicated worker thread — the APK
- * is multiple MB, so it must never touch the main thread (ANR). The system
- * install-confirm dialog is launched later by [UpdateInstallReceiver] from the
- * session's status callback.
+ * [enqueue] hands the work to [UpdateInstallWorker] — an expedited unique
+ * WorkManager job — so the multi-MB network read + session write survives the
+ * trampoline activity finishing immediately and never touches the main
+ * thread. The system install-confirm dialog is launched later by
+ * [UpdateInstallReceiver] from the session's status callback.
  *
  * OBSERVABILITY
  * -------------
- * Posts a quiet, indeterminate **"Downloading update…"** notification while the
- * stream is in flight, swaps it for a **"Download failed"** notification on any
- * IO error (and logs), and cancels it once the session is committed (the system
- * installer UI takes over). No silent failure path.
- *
- * STATUS: compile-only / DEVICE-UNVERIFIED — the HTTP stream → PackageInstaller
- * commit → confirm-dialog path needs an on-device run.
+ * Posts an indeterminate **"Downloading update…"** notification while the
+ * stream is in flight (as the worker's foreground notification where the
+ * platform allows), posts a **"Download failed"** notification on a DISTINCT
+ * id on any IO error (so cancelling the progress id never hides the
+ * failure), and abandons the staged [PackageInstaller] session on every
+ * failure path so repeated failures cannot leak sessions until
+ * `createSession` starts throwing.
  */
 internal object UpdateDownloadInstaller {
-    private const val TAG = "UpdateDownloadInstaller"
-    private const val CHANNEL_ID = "app_update"
-    private const val PROGRESS_NOTIFICATION_ID = 0x5544_4C44 // "UDLD"
+    const val PROGRESS_NOTIFICATION_ID = 0x5544_4C44 // "UDLD"
+    const val FAILURE_NOTIFICATION_ID = 0x5544_4C46 // "UDLF"
     private const val CONNECT_TIMEOUT_MS = 15_000
     private const val READ_TIMEOUT_MS = 30_000
 
@@ -61,28 +66,38 @@ internal object UpdateDownloadInstaller {
     const val ACTION_INSTALL_STATUS = "dev.bluehouse.bada.update.INSTALL_STATUS"
 
     /**
-     * Download [apkUrl] and hand it to the system installer. [version] is used
-     * only for the progress notification text. Safe to call only after the
-     * caller has verified `canRequestPackageInstalls()`.
+     * Enqueue the download+install of [apkUrl] as an expedited unique
+     * [UpdateInstallWorker]. [version] is used only for the progress
+     * notification text. Safe to call only after the caller has verified
+     * `canRequestPackageInstalls()`. `ExistingWorkPolicy.KEEP` means a
+     * re-tap while a download is already running is a no-op.
      */
-    fun installFromUrl(
+    fun enqueue(
         context: Context,
         apkUrl: String,
         version: String,
     ) {
-        val appContext = context.applicationContext
-        showDownloadingNotification(appContext, version)
-        Thread({
-            runCatching { streamInstall(appContext, apkUrl) }
-                .onFailure { error ->
-                    Log.e(TAG, "Update download/install failed", error)
-                    showFailedNotification(appContext)
-                }
-            NotificationManagerCompat.from(appContext).cancel(PROGRESS_NOTIFICATION_ID)
-        }, "update-install").start()
+        val request =
+            OneTimeWorkRequestBuilder<UpdateInstallWorker>()
+                .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+                .setInputData(
+                    workDataOf(
+                        UpdateInstallWorker.KEY_APK_URL to apkUrl,
+                        UpdateInstallWorker.KEY_VERSION to version,
+                    ),
+                ).build()
+        WorkManager
+            .getInstance(context.applicationContext)
+            .enqueueUniqueWork(UpdateInstallWorker.UNIQUE_WORK_NAME, ExistingWorkPolicy.KEEP, request)
     }
 
-    private fun streamInstall(
+    /**
+     * Blocking download → [PackageInstaller] commit. Runs inside
+     * [UpdateInstallWorker] on [kotlinx.coroutines.Dispatchers.IO]. Throws on
+     * any failure; the staged session (if one was created) is abandoned
+     * before the rethrow so failures never leak installer sessions.
+     */
+    fun streamInstall(
         appContext: Context,
         apkUrl: String,
     ) {
@@ -114,33 +129,49 @@ internal object UpdateDownloadInstaller {
                         setAppPackageName(appContext.packageName)
                     }
             val sessionId = installer.createSession(params)
-            installer.openSession(sessionId).use { session ->
-                writeApkToSession(session, connection, declaredLength)
-                val statusIntent =
-                    Intent(appContext, UpdateInstallReceiver::class.java)
-                        .setAction(ACTION_INSTALL_STATUS)
-                        .setPackage(appContext.packageName)
-                // MUTABLE so the platform can fill in EXTRA_INTENT (the confirm
-                // dialog) on API 31+.
-                val flags =
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                        PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
-                    } else {
-                        PendingIntent.FLAG_UPDATE_CURRENT
-                    }
-                val pending =
-                    PendingIntent.getBroadcast(appContext, sessionId, statusIntent, flags)
-                session.commit(pending.intentSender)
-            }
+            // Any failure between createSession and commit leaves a staged
+            // session behind; abandon it or repeated failures accumulate
+            // until createSession itself starts throwing.
+            runCatching { commitSession(appContext, installer, sessionId, connection, declaredLength) }
+                .onFailure { runCatching { installer.abandonSession(sessionId) } }
+                .getOrThrow()
         } finally {
             connection.disconnect()
         }
     }
 
+    private fun commitSession(
+        appContext: Context,
+        installer: PackageInstaller,
+        sessionId: Int,
+        connection: HttpURLConnection,
+        declaredLength: Long,
+    ) {
+        installer.openSession(sessionId).use { session ->
+            writeApkToSession(session, connection, declaredLength)
+            val statusIntent =
+                Intent(appContext, UpdateInstallReceiver::class.java)
+                    .setAction(ACTION_INSTALL_STATUS)
+                    .setPackage(appContext.packageName)
+            // MUTABLE so the platform can fill in EXTRA_INTENT (the confirm
+            // dialog) on API 31+.
+            val flags =
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+                } else {
+                    PendingIntent.FLAG_UPDATE_CURRENT
+                }
+            val pending =
+                PendingIntent.getBroadcast(appContext, sessionId, statusIntent, flags)
+            session.commit(pending.intentSender)
+        }
+    }
+
     /**
      * Stream the connection's body into the installer session and fsync it.
-     * Extracted from [streamInstall] to keep that method's block nesting shallow
-     * (detekt NestedBlockDepth) — the three nested `use {}` scopes live here.
+     * Extracted from [commitSession] to keep that method's block nesting
+     * shallow (detekt NestedBlockDepth) — the three nested `use {}` scopes
+     * live here.
      */
     private fun writeApkToSession(
         session: PackageInstaller.Session,
@@ -155,48 +186,69 @@ internal object UpdateDownloadInstaller {
         }
     }
 
-    private fun showDownloadingNotification(
+    /**
+     * The progress notification wrapped as [ForegroundInfo] for the
+     * expedited worker. `dataSync` is the closest FGS type for "stream a
+     * file from the network" and is what the manifest declares for
+     * WorkManager's SystemForegroundService.
+     */
+    fun progressForegroundInfo(
+        appContext: Context,
+        version: String,
+    ): ForegroundInfo {
+        UpdateNotificationChannel.ensure(appContext)
+        val notification = progressNotification(appContext, version)
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            ForegroundInfo(
+                PROGRESS_NOTIFICATION_ID,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+            )
+        } else {
+            ForegroundInfo(PROGRESS_NOTIFICATION_ID, notification)
+        }
+    }
+
+    /** Plain-notification fallback when foregrounding the worker is refused. */
+    fun showDownloadingNotification(
         appContext: Context,
         version: String,
     ) {
-        ensureChannel(appContext)
-        val notification =
-            NotificationCompat
-                .Builder(appContext, CHANNEL_ID)
-                .setSmallIcon(android.R.drawable.stat_sys_download)
-                .setContentTitle(appContext.getString(R.string.update_downloading_title))
-                .setContentText(
-                    appContext.getString(R.string.update_downloading_text, version),
-                ).setOngoing(true)
-                .setProgress(0, 0, true) // indeterminate horizontal bar
-                .build()
-        NotificationManagerCompat.from(appContext).notify(PROGRESS_NOTIFICATION_ID, notification)
+        UpdateNotificationChannel.ensure(appContext)
+        NotificationManagerCompat
+            .from(appContext)
+            .notify(PROGRESS_NOTIFICATION_ID, progressNotification(appContext, version))
     }
 
-    private fun showFailedNotification(appContext: Context) {
-        ensureChannel(appContext)
+    private fun progressNotification(
+        appContext: Context,
+        version: String,
+    ): Notification =
+        NotificationCompat
+            .Builder(appContext, UpdateNotificationChannel.ID)
+            .setSmallIcon(android.R.drawable.stat_sys_download)
+            .setContentTitle(appContext.getString(R.string.update_downloading_title))
+            .setContentText(
+                appContext.getString(R.string.update_downloading_text, version),
+            ).setOngoing(true)
+            .setProgress(0, 0, true) // indeterminate horizontal bar
+            .build()
+
+    /**
+     * Posted on [FAILURE_NOTIFICATION_ID] — deliberately DISTINCT from
+     * [PROGRESS_NOTIFICATION_ID], which the worker cancels on completion.
+     * Posting both on the same id made every failure invisible.
+     */
+    fun showFailedNotification(appContext: Context) {
+        UpdateNotificationChannel.ensure(appContext)
         val notification =
             NotificationCompat
-                .Builder(appContext, CHANNEL_ID)
+                .Builder(appContext, UpdateNotificationChannel.ID)
                 .setSmallIcon(android.R.drawable.stat_notify_error)
                 .setContentTitle(appContext.getString(R.string.update_download_failed_title))
                 .setContentText(appContext.getString(R.string.update_download_failed_text))
                 .setAutoCancel(true)
                 .build()
-        NotificationManagerCompat.from(appContext).notify(PROGRESS_NOTIFICATION_ID, notification)
-    }
-
-    private fun ensureChannel(context: Context) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
-        val manager = context.getSystemService(NotificationManager::class.java) ?: return
-        if (manager.getNotificationChannel(CHANNEL_ID) == null) {
-            manager.createNotificationChannel(
-                NotificationChannel(
-                    CHANNEL_ID,
-                    context.getString(R.string.update_notification_channel_name),
-                    NotificationManager.IMPORTANCE_DEFAULT,
-                ).apply { description = context.getString(R.string.update_notification_channel_desc) },
-            )
-        }
+        NotificationManagerCompat.from(appContext).notify(FAILURE_NOTIFICATION_ID, notification)
     }
 }

--- a/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateDownloadInstaller.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateDownloadInstaller.kt
@@ -86,16 +86,17 @@ internal object UpdateDownloadInstaller {
         appContext: Context,
         apkUrl: String,
     ) {
-        val connection = (URL(apkUrl).openConnection() as HttpURLConnection).apply {
-            requestMethod = "GET"
-            connectTimeout = CONNECT_TIMEOUT_MS
-            readTimeout = READ_TIMEOUT_MS
-            // GitHub release assets 302-redirect to a CDN host (same https
-            // scheme); HttpURLConnection follows same-protocol redirects.
-            instanceFollowRedirects = true
-            setRequestProperty("User-Agent", "Bada-Android-UpdateInstaller")
-            setRequestProperty("Accept", "application/octet-stream")
-        }
+        val connection =
+            (URL(apkUrl).openConnection() as HttpURLConnection).apply {
+                requestMethod = "GET"
+                connectTimeout = CONNECT_TIMEOUT_MS
+                readTimeout = READ_TIMEOUT_MS
+                // GitHub release assets 302-redirect to a CDN host (same https
+                // scheme); HttpURLConnection follows same-protocol redirects.
+                instanceFollowRedirects = true
+                setRequestProperty("User-Agent", "Bada-Android-UpdateInstaller")
+                setRequestProperty("Accept", "application/octet-stream")
+            }
         try {
             val responseCode = connection.responseCode
             if (responseCode !in 200..299) {
@@ -105,7 +106,8 @@ internal object UpdateDownloadInstaller {
 
             val installer = appContext.packageManager.packageInstaller
             val params =
-                PackageInstaller.SessionParams(PackageInstaller.SessionParams.MODE_FULL_INSTALL)
+                PackageInstaller
+                    .SessionParams(PackageInstaller.SessionParams.MODE_FULL_INSTALL)
                     .apply {
                         // This APK IS our own package — declaring it lets the
                         // installer treat the operation as an update of us.

--- a/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateDownloadInstaller.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateDownloadInstaller.kt
@@ -113,12 +113,7 @@ internal object UpdateDownloadInstaller {
                     }
             val sessionId = installer.createSession(params)
             installer.openSession(sessionId).use { session ->
-                connection.inputStream.use { input ->
-                    session.openWrite("update", 0, declaredLength).use { output ->
-                        input.copyTo(output)
-                        session.fsync(output)
-                    }
-                }
+                writeApkToSession(session, connection, declaredLength)
                 val statusIntent =
                     Intent(appContext, UpdateInstallReceiver::class.java)
                         .setAction(ACTION_INSTALL_STATUS)
@@ -137,6 +132,24 @@ internal object UpdateDownloadInstaller {
             }
         } finally {
             connection.disconnect()
+        }
+    }
+
+    /**
+     * Stream the connection's body into the installer session and fsync it.
+     * Extracted from [streamInstall] to keep that method's block nesting shallow
+     * (detekt NestedBlockDepth) — the three nested `use {}` scopes live here.
+     */
+    private fun writeApkToSession(
+        session: PackageInstaller.Session,
+        connection: HttpURLConnection,
+        declaredLength: Long,
+    ) {
+        connection.inputStream.use { input ->
+            session.openWrite("update", 0, declaredLength).use { output ->
+                input.copyTo(output)
+                session.fsync(output)
+            }
         }
     }
 
@@ -174,13 +187,14 @@ internal object UpdateDownloadInstaller {
     private fun ensureChannel(context: Context) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
         val manager = context.getSystemService(NotificationManager::class.java) ?: return
-        if (manager.getNotificationChannel(CHANNEL_ID) != null) return
-        manager.createNotificationChannel(
-            NotificationChannel(
-                CHANNEL_ID,
-                context.getString(R.string.update_notification_channel_name),
-                NotificationManager.IMPORTANCE_DEFAULT,
-            ).apply { description = context.getString(R.string.update_notification_channel_desc) },
-        )
+        if (manager.getNotificationChannel(CHANNEL_ID) == null) {
+            manager.createNotificationChannel(
+                NotificationChannel(
+                    CHANNEL_ID,
+                    context.getString(R.string.update_notification_channel_name),
+                    NotificationManager.IMPORTANCE_DEFAULT,
+                ).apply { description = context.getString(R.string.update_notification_channel_desc) },
+            )
+        }
     }
 }

--- a/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateDownloadInstaller.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateDownloadInstaller.kt
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.update
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageInstaller
+import android.os.Build
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import dev.bluehouse.bada.R
+import java.net.HttpURLConnection
+import java.net.URL
+
+/**
+ * WHAT THIS IS
+ * -----------
+ * `UpdateDownloadInstaller` — the "download directly" half of the auto-update
+ * feature. Given a GitHub release `.apk` `browser_download_url`, it STREAMS the
+ * APK over HTTP straight into a [PackageInstaller] session (no temp file, no
+ * FileProvider) and commits it, producing a drop-in in-place update.
+ *
+ * WHO CALLS IT
+ * ------------
+ * [UpdateInstallActivity] (the trampoline launched by the notification's
+ * "Download & install" action), AFTER it has confirmed
+ * `canRequestPackageInstalls()`.
+ *
+ * THREADING
+ * ---------
+ * Runs the network read + session write on a dedicated worker thread — the APK
+ * is multiple MB, so it must never touch the main thread (ANR). The system
+ * install-confirm dialog is launched later by [UpdateInstallReceiver] from the
+ * session's status callback.
+ *
+ * OBSERVABILITY
+ * -------------
+ * Posts a quiet, indeterminate **"Downloading update…"** notification while the
+ * stream is in flight, swaps it for a **"Download failed"** notification on any
+ * IO error (and logs), and cancels it once the session is committed (the system
+ * installer UI takes over). No silent failure path.
+ *
+ * STATUS: compile-only / DEVICE-UNVERIFIED — the HTTP stream → PackageInstaller
+ * commit → confirm-dialog path needs an on-device run.
+ */
+internal object UpdateDownloadInstaller {
+    private const val TAG = "UpdateDownloadInstaller"
+    private const val CHANNEL_ID = "app_update"
+    private const val PROGRESS_NOTIFICATION_ID = 0x5544_4C44 // "UDLD"
+    private const val CONNECT_TIMEOUT_MS = 15_000
+    private const val READ_TIMEOUT_MS = 30_000
+
+    /** Action used by the PackageInstaller status [PendingIntent]. */
+    const val ACTION_INSTALL_STATUS = "dev.bluehouse.bada.update.INSTALL_STATUS"
+
+    /**
+     * Download [apkUrl] and hand it to the system installer. [version] is used
+     * only for the progress notification text. Safe to call only after the
+     * caller has verified `canRequestPackageInstalls()`.
+     */
+    fun installFromUrl(
+        context: Context,
+        apkUrl: String,
+        version: String,
+    ) {
+        val appContext = context.applicationContext
+        showDownloadingNotification(appContext, version)
+        Thread({
+            runCatching { streamInstall(appContext, apkUrl) }
+                .onFailure { error ->
+                    Log.e(TAG, "Update download/install failed", error)
+                    showFailedNotification(appContext)
+                }
+            NotificationManagerCompat.from(appContext).cancel(PROGRESS_NOTIFICATION_ID)
+        }, "update-install").start()
+    }
+
+    private fun streamInstall(
+        appContext: Context,
+        apkUrl: String,
+    ) {
+        val connection = (URL(apkUrl).openConnection() as HttpURLConnection).apply {
+            requestMethod = "GET"
+            connectTimeout = CONNECT_TIMEOUT_MS
+            readTimeout = READ_TIMEOUT_MS
+            // GitHub release assets 302-redirect to a CDN host (same https
+            // scheme); HttpURLConnection follows same-protocol redirects.
+            instanceFollowRedirects = true
+            setRequestProperty("User-Agent", "Bada-Android-UpdateInstaller")
+            setRequestProperty("Accept", "application/octet-stream")
+        }
+        try {
+            val responseCode = connection.responseCode
+            if (responseCode !in 200..299) {
+                error("APK download failed: HTTP $responseCode")
+            }
+            val declaredLength = connection.contentLengthLong.takeIf { it > 0L } ?: -1L
+
+            val installer = appContext.packageManager.packageInstaller
+            val params =
+                PackageInstaller.SessionParams(PackageInstaller.SessionParams.MODE_FULL_INSTALL)
+                    .apply {
+                        // This APK IS our own package — declaring it lets the
+                        // installer treat the operation as an update of us.
+                        setAppPackageName(appContext.packageName)
+                    }
+            val sessionId = installer.createSession(params)
+            installer.openSession(sessionId).use { session ->
+                connection.inputStream.use { input ->
+                    session.openWrite("update", 0, declaredLength).use { output ->
+                        input.copyTo(output)
+                        session.fsync(output)
+                    }
+                }
+                val statusIntent =
+                    Intent(appContext, UpdateInstallReceiver::class.java)
+                        .setAction(ACTION_INSTALL_STATUS)
+                        .setPackage(appContext.packageName)
+                // MUTABLE so the platform can fill in EXTRA_INTENT (the confirm
+                // dialog) on API 31+.
+                val flags =
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                        PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+                    } else {
+                        PendingIntent.FLAG_UPDATE_CURRENT
+                    }
+                val pending =
+                    PendingIntent.getBroadcast(appContext, sessionId, statusIntent, flags)
+                session.commit(pending.intentSender)
+            }
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    private fun showDownloadingNotification(
+        appContext: Context,
+        version: String,
+    ) {
+        ensureChannel(appContext)
+        val notification =
+            NotificationCompat
+                .Builder(appContext, CHANNEL_ID)
+                .setSmallIcon(android.R.drawable.stat_sys_download)
+                .setContentTitle(appContext.getString(R.string.update_downloading_title))
+                .setContentText(
+                    appContext.getString(R.string.update_downloading_text, version),
+                ).setOngoing(true)
+                .setProgress(0, 0, true) // indeterminate horizontal bar
+                .build()
+        NotificationManagerCompat.from(appContext).notify(PROGRESS_NOTIFICATION_ID, notification)
+    }
+
+    private fun showFailedNotification(appContext: Context) {
+        ensureChannel(appContext)
+        val notification =
+            NotificationCompat
+                .Builder(appContext, CHANNEL_ID)
+                .setSmallIcon(android.R.drawable.stat_notify_error)
+                .setContentTitle(appContext.getString(R.string.update_download_failed_title))
+                .setContentText(appContext.getString(R.string.update_download_failed_text))
+                .setAutoCancel(true)
+                .build()
+        NotificationManagerCompat.from(appContext).notify(PROGRESS_NOTIFICATION_ID, notification)
+    }
+
+    private fun ensureChannel(context: Context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val manager = context.getSystemService(NotificationManager::class.java) ?: return
+        if (manager.getNotificationChannel(CHANNEL_ID) != null) return
+        manager.createNotificationChannel(
+            NotificationChannel(
+                CHANNEL_ID,
+                context.getString(R.string.update_notification_channel_name),
+                NotificationManager.IMPORTANCE_DEFAULT,
+            ).apply { description = context.getString(R.string.update_notification_channel_desc) },
+        )
+    }
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateInstallActivity.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateInstallActivity.kt
@@ -11,6 +11,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
+import android.util.Log
 import android.widget.Toast
 import dev.bluehouse.bada.R
 
@@ -25,19 +26,19 @@ import dev.bluehouse.bada.R
  * WHAT IT DOES (no visible screen of its own)
  * -------------------------------------------
  * 1. Clears the "update available" notification.
- * 2. If this app may not yet install packages (`!canInstallPackages`) → opens
+ * 2. On DEBUG builds (`.debug` applicationIdSuffix) → opens the GitHub
+ *    release page instead: the release APK's package never matches a debug
+ *    install, so the direct-install path can only fail.
+ * 3. If this app may not yet install packages (`!canInstallPackages`) → opens
  *    the system "allow this source to install apps" settings page (ONE-TIME
  *    grant, not per-boot), shows a short toast, and finishes.
- * 3. Otherwise → kicks off [UpdateDownloadInstaller.installFromUrl] (download
- *    on a worker thread → system installer) and finishes immediately.
+ * 4. Otherwise → enqueues [UpdateDownloadInstaller.enqueue] (an expedited
+ *    WorkManager download → system installer) and finishes immediately.
  *
  * INVOKED BY: PendingIntent in [UpdateNotifier.downloadAndInstallIntent].
  * Manifest: registered transparent, `exported=false`, `excludeFromRecents`,
  * `noHistory` so it never lingers in the task list. Needs the
  * `REQUEST_INSTALL_PACKAGES` manifest permission.
- *
- * STATUS: compile-only / DEVICE-UNVERIFIED — the grant gate + install launch
- * need an on-device run.
  */
 internal class UpdateInstallActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -45,29 +46,65 @@ internal class UpdateInstallActivity : Activity() {
 
         val apkUrl = intent?.getStringExtra(EXTRA_APK_URL)
         val version = intent?.getStringExtra(EXTRA_VERSION).orEmpty()
+        val releaseUrl = intent?.getStringExtra(EXTRA_RELEASE_URL)
 
         // Dismiss the alert that launched us so it does not linger after action.
         UpdateNotifier.cancel(this)
 
-        if (apkUrl.isNullOrBlank()) {
-            finish()
-            return
-        }
-
-        if (!canInstallPackages()) {
-            // One-time grant: send the user to enable "install unknown apps",
-            // then have them tap Download again.
-            runCatching { startActivity(unknownSourcesSettingsIntent()) }
-            Toast
-                .makeText(this, R.string.update_install_need_unknown_sources, Toast.LENGTH_LONG)
-                .show()
-            finish()
-            return
-        }
-
-        UpdateDownloadInstaller.installFromUrl(applicationContext, apkUrl, version)
-        Toast.makeText(this, R.string.update_install_started, Toast.LENGTH_SHORT).show()
+        handleDownloadRequest(apkUrl, version, releaseUrl)
         finish()
+    }
+
+    private fun handleDownloadRequest(
+        apkUrl: String?,
+        version: String,
+        releaseUrl: String?,
+    ) {
+        when {
+            apkUrl.isNullOrBlank() -> Unit
+
+            isDebugBuild() -> {
+                // applicationIdSuffix ".debug": the downloaded release APK's
+                // package (dev.bluehouse.bada) can never update this install
+                // (dev.bluehouse.bada.debug), so route to the release page.
+                Log.i(
+                    TAG,
+                    "Debug build ($packageName) cannot self-install the release APK; opening the release page",
+                )
+                openReleasePage(releaseUrl)
+            }
+
+            !canInstallPackages() -> {
+                // One-time grant: send the user to enable "install unknown
+                // apps", then have them tap Download again.
+                runCatching { startActivity(unknownSourcesSettingsIntent()) }
+                Toast
+                    .makeText(this, R.string.update_install_need_unknown_sources, Toast.LENGTH_LONG)
+                    .show()
+            }
+
+            else -> {
+                UpdateDownloadInstaller.enqueue(applicationContext, apkUrl, version)
+                Toast.makeText(this, R.string.update_install_started, Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    /** `true` on debug installs, which carry the `.debug` applicationIdSuffix. */
+    private fun isDebugBuild(): Boolean = packageName.endsWith(".debug")
+
+    private fun openReleasePage(releaseUrl: String?) {
+        val opened =
+            !releaseUrl.isNullOrBlank() &&
+                runCatching {
+                    startActivity(
+                        Intent(Intent.ACTION_VIEW, Uri.parse(releaseUrl))
+                            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+                    )
+                }.isSuccess
+        if (!opened) {
+            Toast.makeText(this, R.string.update_open_release_failed, Toast.LENGTH_LONG).show()
+        }
     }
 
     /**
@@ -89,7 +126,9 @@ internal class UpdateInstallActivity : Activity() {
         )
 
     internal companion object {
+        private const val TAG = "UpdateInstallActivity"
         const val EXTRA_APK_URL = "dev.bluehouse.bada.update.extra.APK_URL"
         const val EXTRA_VERSION = "dev.bluehouse.bada.update.extra.VERSION"
+        const val EXTRA_RELEASE_URL = "dev.bluehouse.bada.update.extra.RELEASE_URL"
     }
 }

--- a/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateInstallActivity.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateInstallActivity.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.update
+
+import android.app.Activity
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.os.Bundle
+import android.provider.Settings
+import android.widget.Toast
+import dev.bluehouse.bada.R
+
+/**
+ * WHAT THIS IS
+ * -----------
+ * `UpdateInstallActivity` — an invisible (transparent, no-UI) trampoline
+ * Activity launched by the **"Download & install"** action on the
+ * [UpdateNotifier] update notification. It exists only because the
+ * "install unknown apps" permission flow needs an Activity context.
+ *
+ * WHAT IT DOES (no visible screen of its own)
+ * -------------------------------------------
+ * 1. Clears the "update available" notification.
+ * 2. If this app may not yet install packages (`!canInstallPackages`) → opens
+ *    the system "allow this source to install apps" settings page (ONE-TIME
+ *    grant, not per-boot), shows a short toast, and finishes.
+ * 3. Otherwise → kicks off [UpdateDownloadInstaller.installFromUrl] (download
+ *    on a worker thread → system installer) and finishes immediately.
+ *
+ * INVOKED BY: PendingIntent in [UpdateNotifier.downloadAndInstallIntent].
+ * Manifest: registered transparent, `exported=false`, `excludeFromRecents`,
+ * `noHistory` so it never lingers in the task list. Needs the
+ * `REQUEST_INSTALL_PACKAGES` manifest permission.
+ *
+ * STATUS: compile-only / DEVICE-UNVERIFIED — the grant gate + install launch
+ * need an on-device run.
+ */
+internal class UpdateInstallActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val apkUrl = intent?.getStringExtra(EXTRA_APK_URL)
+        val version = intent?.getStringExtra(EXTRA_VERSION).orEmpty()
+
+        // Dismiss the alert that launched us so it does not linger after action.
+        UpdateNotifier.cancel(this)
+
+        if (apkUrl.isNullOrBlank()) {
+            finish()
+            return
+        }
+
+        if (!canInstallPackages()) {
+            // One-time grant: send the user to enable "install unknown apps",
+            // then have them tap Download again.
+            runCatching { startActivity(unknownSourcesSettingsIntent()) }
+            Toast
+                .makeText(this, R.string.update_install_need_unknown_sources, Toast.LENGTH_LONG)
+                .show()
+            finish()
+            return
+        }
+
+        UpdateDownloadInstaller.installFromUrl(applicationContext, apkUrl, version)
+        Toast.makeText(this, R.string.update_install_started, Toast.LENGTH_SHORT).show()
+        finish()
+    }
+
+    /**
+     * `true` when this app may install APKs without bouncing the user to the
+     * "install unknown apps" settings page first. Always true below API 26.
+     */
+    private fun canInstallPackages(): Boolean =
+        Build.VERSION.SDK_INT < Build.VERSION_CODES.O ||
+            packageManager.canRequestPackageInstalls()
+
+    /**
+     * Intent that opens the system "allow this source to install apps" screen
+     * for this app. The grant is ONE-TIME (it persists; not per-boot).
+     */
+    private fun unknownSourcesSettingsIntent(): Intent =
+        Intent(
+            Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES,
+            Uri.parse("package:$packageName"),
+        )
+
+    internal companion object {
+        const val EXTRA_APK_URL = "dev.bluehouse.bada.update.extra.APK_URL"
+        const val EXTRA_VERSION = "dev.bluehouse.bada.update.extra.VERSION"
+    }
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateInstallReceiver.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateInstallReceiver.kt
@@ -5,6 +5,8 @@
  */
 package dev.bluehouse.bada.update
 
+import android.app.ActivityManager
+import android.app.PendingIntent
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
@@ -12,26 +14,29 @@ import android.content.pm.PackageInstaller
 import android.os.Build
 import android.util.Log
 import android.widget.Toast
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
 import dev.bluehouse.bada.R
 
 /**
  * WHAT THIS IS
  * -----------
  * `UpdateInstallReceiver` — the [PackageInstaller] status sink for the
- * self-update install started by [UpdateDownloadInstaller.installFromUrl].
- * Manifest-registered, NOT exported (only the app's own session
- * PendingIntent targets it).
+ * self-update install started by [UpdateDownloadInstaller]. Manifest-
+ * registered, NOT exported (only the app's own session PendingIntent
+ * targets it).
  *
  * WHAT IT DOES
  * ------------
  * - `STATUS_PENDING_USER_ACTION` → launches the system install-confirm dialog
- *   (the only step the user sees) with FLAG_ACTIVITY_NEW_TASK.
+ *   (the only step the user sees). Android 14+ background-activity-launch
+ *   restrictions can block a startActivity from a background receiver, so
+ *   when the app is not foregrounded (or the launch throws) it instead posts
+ *   a high-priority notification whose tap fires the same confirm intent —
+ *   the user completes the install from the shade.
  * - `STATUS_SUCCESS` → brief "Bada updated" toast (may not render if the
  *   process is replaced by the new APK — best-effort).
  * - anything else → "Update install failed" toast + logs the reason.
- *
- * STATUS: compile-only / DEVICE-UNVERIFIED — the confirm-dialog launch and the
- * success/failure path need an on-device run.
  */
 internal class UpdateInstallReceiver : BroadcastReceiver() {
     override fun onReceive(
@@ -40,16 +45,7 @@ internal class UpdateInstallReceiver : BroadcastReceiver() {
     ) {
         if (intent.action != UpdateDownloadInstaller.ACTION_INSTALL_STATUS) return
         when (val status = intent.getIntExtra(PackageInstaller.EXTRA_STATUS, Int.MIN_VALUE)) {
-            PackageInstaller.STATUS_PENDING_USER_ACTION -> {
-                val confirm = extractConfirmIntent(intent)
-                if (confirm != null) {
-                    confirm.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                    runCatching { context.startActivity(confirm) }
-                        .onFailure { Log.e(TAG, "Could not launch install confirm dialog", it) }
-                } else {
-                    Log.e(TAG, "PENDING_USER_ACTION with no confirm intent")
-                }
-            }
+            PackageInstaller.STATUS_PENDING_USER_ACTION -> handlePendingUserAction(context, intent)
 
             PackageInstaller.STATUS_SUCCESS ->
                 Toast.makeText(context, R.string.update_install_success, Toast.LENGTH_SHORT).show()
@@ -62,6 +58,68 @@ internal class UpdateInstallReceiver : BroadcastReceiver() {
         }
     }
 
+    private fun handlePendingUserAction(
+        context: Context,
+        intent: Intent,
+    ) {
+        val confirm = extractConfirmIntent(intent)
+        if (confirm == null) {
+            Log.e(TAG, "PENDING_USER_ACTION with no confirm intent")
+            return
+        }
+        confirm.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        // Android 14+ blocks background activity launches from receivers, so
+        // only try a direct launch when the app is visibly foregrounded;
+        // otherwise (and when the launch itself throws) fall back to a
+        // notification the user can act on from the shade.
+        val launched =
+            isAppInForeground() &&
+                runCatching { context.startActivity(confirm) }
+                    .onFailure { Log.w(TAG, "Could not launch install confirm dialog directly", it) }
+                    .isSuccess
+        if (!launched) {
+            postConfirmNotification(context, confirm)
+        }
+    }
+
+    private fun isAppInForeground(): Boolean {
+        val processInfo = ActivityManager.RunningAppProcessInfo()
+        ActivityManager.getMyMemoryState(processInfo)
+        return processInfo.importance <=
+            ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
+    }
+
+    /**
+     * High-priority "confirm the install" notification whose contentIntent
+     * carries the PackageInstaller confirm dialog — tapping a notification is
+     * always an allowed activity-launch path, so this sidesteps the BAL
+     * restriction entirely.
+     */
+    private fun postConfirmNotification(
+        context: Context,
+        confirm: Intent,
+    ) {
+        UpdateNotificationChannel.ensure(context)
+        val pending =
+            PendingIntent.getActivity(
+                context,
+                REQ_CONFIRM,
+                confirm,
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+            )
+        val notification =
+            NotificationCompat
+                .Builder(context, UpdateNotificationChannel.ID)
+                .setSmallIcon(android.R.drawable.stat_sys_download)
+                .setContentTitle(context.getString(R.string.update_confirm_notification_title))
+                .setContentText(context.getString(R.string.update_confirm_notification_text))
+                .setPriority(NotificationCompat.PRIORITY_HIGH)
+                .setAutoCancel(true)
+                .setContentIntent(pending)
+                .build()
+        NotificationManagerCompat.from(context).notify(CONFIRM_NOTIFICATION_ID, notification)
+    }
+
     @Suppress("DEPRECATION")
     private fun extractConfirmIntent(intent: Intent): Intent? =
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
@@ -72,5 +130,7 @@ internal class UpdateInstallReceiver : BroadcastReceiver() {
 
     private companion object {
         private const val TAG = "UpdateInstallReceiver"
+        private const val CONFIRM_NOTIFICATION_ID = 0x5544_434E // "UDCN"
+        private const val REQ_CONFIRM = 4
     }
 }

--- a/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateInstallReceiver.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateInstallReceiver.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.update
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageInstaller
+import android.os.Build
+import android.util.Log
+import android.widget.Toast
+import dev.bluehouse.bada.R
+
+/**
+ * WHAT THIS IS
+ * -----------
+ * `UpdateInstallReceiver` — the [PackageInstaller] status sink for the
+ * self-update install started by [UpdateDownloadInstaller.installFromUrl].
+ * Manifest-registered, NOT exported (only the app's own session
+ * PendingIntent targets it).
+ *
+ * WHAT IT DOES
+ * ------------
+ * - `STATUS_PENDING_USER_ACTION` → launches the system install-confirm dialog
+ *   (the only step the user sees) with FLAG_ACTIVITY_NEW_TASK.
+ * - `STATUS_SUCCESS` → brief "Bada updated" toast (may not render if the
+ *   process is replaced by the new APK — best-effort).
+ * - anything else → "Update install failed" toast + logs the reason.
+ *
+ * STATUS: compile-only / DEVICE-UNVERIFIED — the confirm-dialog launch and the
+ * success/failure path need an on-device run.
+ */
+internal class UpdateInstallReceiver : BroadcastReceiver() {
+    override fun onReceive(
+        context: Context,
+        intent: Intent,
+    ) {
+        if (intent.action != UpdateDownloadInstaller.ACTION_INSTALL_STATUS) return
+        when (val status = intent.getIntExtra(PackageInstaller.EXTRA_STATUS, Int.MIN_VALUE)) {
+            PackageInstaller.STATUS_PENDING_USER_ACTION -> {
+                val confirm = extractConfirmIntent(intent)
+                if (confirm != null) {
+                    confirm.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    runCatching { context.startActivity(confirm) }
+                        .onFailure { Log.e(TAG, "Could not launch install confirm dialog", it) }
+                } else {
+                    Log.e(TAG, "PENDING_USER_ACTION with no confirm intent")
+                }
+            }
+
+            PackageInstaller.STATUS_SUCCESS ->
+                Toast.makeText(context, R.string.update_install_success, Toast.LENGTH_SHORT).show()
+
+            else -> {
+                val message = intent.getStringExtra(PackageInstaller.EXTRA_STATUS_MESSAGE)
+                Log.w(TAG, "Update install failed: status=$status message=$message")
+                Toast.makeText(context, R.string.update_install_failed, Toast.LENGTH_LONG).show()
+            }
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun extractConfirmIntent(intent: Intent): Intent? =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            intent.getParcelableExtra(Intent.EXTRA_INTENT, Intent::class.java)
+        } else {
+            intent.getParcelableExtra(Intent.EXTRA_INTENT)
+        }
+
+    private companion object {
+        private const val TAG = "UpdateInstallReceiver"
+    }
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateInstallWorker.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateInstallWorker.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.update
+
+import android.content.Context
+import android.util.Log
+import androidx.core.app.NotificationManagerCompat
+import androidx.work.CoroutineWorker
+import androidx.work.ForegroundInfo
+import androidx.work.WorkerParameters
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * WHAT THIS IS
+ * -----------
+ * `UpdateInstallWorker` — the WorkManager job that downloads a release APK
+ * and stages it into a [android.content.pm.PackageInstaller] session
+ * ([UpdateDownloadInstaller.streamInstall]). Enqueued (expedited, unique) by
+ * [UpdateDownloadInstaller.enqueue] when the user taps the notification's
+ * "Download & install" action via [UpdateInstallActivity].
+ *
+ * WHY A WORKER, NOT A THREAD
+ * --------------------------
+ * The trampoline activity finishes immediately, so a bare `Thread` would
+ * leave a multi-MB download running in a process the OS is free to freeze or
+ * kill — with the sticky "Downloading…" notification orphaned forever.
+ * WorkManager owns the process lifetime for the duration of the job:
+ * expedited work runs as a foreground service pre-API-31 (via
+ * [getForegroundInfo]) and as an expedited job on API 31+.
+ *
+ * CLEANUP GUARANTEES
+ * ------------------
+ * The progress notification is cancelled in a `finally` block, so it is
+ * removed on success, failure, AND worker cancellation. Failures surface on
+ * a distinct notification ID so the failure alert is never clobbered.
+ */
+internal class UpdateInstallWorker(
+    appContext: Context,
+    params: WorkerParameters,
+) : CoroutineWorker(appContext, params) {
+    override suspend fun doWork(): Result {
+        val apkUrl = inputData.getString(KEY_APK_URL)
+        if (apkUrl.isNullOrBlank()) return Result.failure()
+        val version = inputData.getString(KEY_VERSION).orEmpty()
+
+        // Expedited work MUST run foregrounded pre-API-31. On API 31+
+        // setForeground can be refused while the app is backgrounded
+        // (ForegroundServiceStartNotAllowedException) — fall back to a plain
+        // progress notification so the download stays observable either way.
+        runCatching { setForeground(getForegroundInfo()) }
+            .onFailure { UpdateDownloadInstaller.showDownloadingNotification(applicationContext, version) }
+
+        try {
+            val outcome =
+                runCatching {
+                    withContext(Dispatchers.IO) {
+                        UpdateDownloadInstaller.streamInstall(applicationContext, apkUrl)
+                    }
+                }
+            return when (val error = outcome.exceptionOrNull()) {
+                null -> Result.success()
+                is CancellationException -> throw error
+                else -> {
+                    Log.e(TAG, "Update download/install failed", error)
+                    UpdateDownloadInstaller.showFailedNotification(applicationContext)
+                    Result.failure()
+                }
+            }
+        } finally {
+            // Runs on success, failure, and cancellation alike: the ongoing
+            // progress notification must never outlive the download.
+            NotificationManagerCompat
+                .from(applicationContext)
+                .cancel(UpdateDownloadInstaller.PROGRESS_NOTIFICATION_ID)
+        }
+    }
+
+    override suspend fun getForegroundInfo(): ForegroundInfo =
+        UpdateDownloadInstaller.progressForegroundInfo(
+            applicationContext,
+            inputData.getString(KEY_VERSION).orEmpty(),
+        )
+
+    internal companion object {
+        private const val TAG = "UpdateInstallWorker"
+
+        /** Unique name so re-taps while a download runs do not stack jobs. */
+        const val UNIQUE_WORK_NAME = "bada-update-install"
+        const val KEY_APK_URL = "apk_url"
+        const val KEY_VERSION = "version"
+    }
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateNotificationChannel.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateNotificationChannel.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.update
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.os.Build
+import dev.bluehouse.bada.R
+
+/**
+ * The single `app_update` notification channel shared by every auto-update
+ * surface: the "update available" alert ([UpdateNotifier]), the download
+ * progress / failure notifications ([UpdateDownloadInstaller]), and the
+ * install-confirm fallback ([UpdateInstallReceiver]).
+ */
+internal object UpdateNotificationChannel {
+    const val ID = "app_update"
+
+    /** Idempotent create — safe to call before every notify(). */
+    fun ensure(context: Context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val manager = context.getSystemService(NotificationManager::class.java) ?: return
+        if (manager.getNotificationChannel(ID) == null) {
+            manager.createNotificationChannel(
+                NotificationChannel(
+                    ID,
+                    context.getString(R.string.update_notification_channel_name),
+                    NotificationManager.IMPORTANCE_DEFAULT,
+                ).apply { description = context.getString(R.string.update_notification_channel_desc) },
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateNotifier.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateNotifier.kt
@@ -5,13 +5,10 @@
  */
 package dev.bluehouse.bada.update
 
-import android.app.NotificationChannel
-import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import dev.bluehouse.bada.R
@@ -41,12 +38,10 @@ import dev.bluehouse.bada.R
  * Extends the pre-existing MANUAL update flow (overflow-menu → screen, #211)
  * with a proactive "a new version is out" alert.
  *
- * STATUS: compile-only / DEVICE-UNVERIFIED. POST_NOTIFICATIONS (API 33+) is
- * already requested by onboarding; if denied the notification is silently
- * dropped (degraded, by design).
+ * POST_NOTIFICATIONS (API 33+) is already requested by onboarding; if denied
+ * the notification is silently dropped (degraded, by design).
  */
 internal object UpdateNotifier {
-    private const val CHANNEL_ID = "app_update"
     private const val NOTIFICATION_ID = 0x5544_4154 // "UDAT"
 
     /**
@@ -64,11 +59,11 @@ internal object UpdateNotifier {
         apkAssetUrl: String?,
     ) {
         val appContext = context.applicationContext
-        ensureChannel(appContext)
+        UpdateNotificationChannel.ensure(appContext)
 
         val builder =
             NotificationCompat
-                .Builder(appContext, CHANNEL_ID)
+                .Builder(appContext, UpdateNotificationChannel.ID)
                 .setSmallIcon(android.R.drawable.stat_sys_download)
                 .setContentTitle(appContext.getString(R.string.update_notification_title))
                 .setContentText(
@@ -86,7 +81,7 @@ internal object UpdateNotifier {
             builder.addAction(
                 0,
                 appContext.getString(R.string.update_notification_action_download),
-                downloadAndInstallIntent(appContext, apkAssetUrl, version),
+                downloadAndInstallIntent(appContext, apkAssetUrl, version, releaseUrl),
             )
         }
 
@@ -97,20 +92,6 @@ internal object UpdateNotifier {
     /** Clear the alert once the user has acted on it from the trampoline. */
     fun cancel(context: Context) {
         NotificationManagerCompat.from(context.applicationContext).cancel(NOTIFICATION_ID)
-    }
-
-    private fun ensureChannel(context: Context) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
-        val manager = context.getSystemService(NotificationManager::class.java) ?: return
-        if (manager.getNotificationChannel(CHANNEL_ID) == null) {
-            manager.createNotificationChannel(
-                NotificationChannel(
-                    CHANNEL_ID,
-                    context.getString(R.string.update_notification_channel_name),
-                    NotificationManager.IMPORTANCE_DEFAULT,
-                ).apply { description = context.getString(R.string.update_notification_channel_desc) },
-            )
-        }
     }
 
     /** Body tap → the in-app "Check for updates" screen. */
@@ -132,17 +113,23 @@ internal object UpdateNotifier {
         return PendingIntent.getActivity(context, REQ_VIEW_GITHUB, intent, immutableFlags())
     }
 
-    /** "Download & install" → the trampoline that gates + starts the install. */
+    /**
+     * "Download & install" → the trampoline that gates + starts the install.
+     * The release URL rides along so debug builds (which cannot self-install
+     * the release APK) can fall back to opening the release page.
+     */
     private fun downloadAndInstallIntent(
         context: Context,
         apkAssetUrl: String,
         version: String,
+        releaseUrl: String,
     ): PendingIntent {
         val intent =
             Intent(context, UpdateInstallActivity::class.java)
                 .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                 .putExtra(UpdateInstallActivity.EXTRA_APK_URL, apkAssetUrl)
                 .putExtra(UpdateInstallActivity.EXTRA_VERSION, version)
+                .putExtra(UpdateInstallActivity.EXTRA_RELEASE_URL, releaseUrl)
         return PendingIntent.getActivity(context, REQ_DOWNLOAD, intent, immutableFlags())
     }
 

--- a/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateNotifier.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateNotifier.kt
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.update
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import dev.bluehouse.bada.R
+
+/**
+ * WHAT THIS IS
+ * -----------
+ * `UpdateNotifier` — builds and posts the **"Update available"** status-bar
+ * notification for the automatic update check. Invoked by [UpdateCheckWorker]
+ * when its periodic GitHub poll finds a release newer than the installed
+ * `BuildConfig.VERSION_NAME`.
+ *
+ * WHAT THE USER SEES (the notification)
+ * -------------------------------------
+ * - Small icon: the platform download glyph (`stat_sys_download`).
+ * - Title "Bada update available", text "Version <v> is ready to install".
+ * - Tapping the BODY opens the in-app [CheckForUpdatesActivity].
+ * - Action **"View on GitHub"** — always present — opens the release page
+ *   (`html_url`) in a browser.
+ * - Action **"Download & install"** — present ONLY when the release has an
+ *   `.apk` asset attached. Launches [UpdateInstallActivity], which downloads
+ *   that APK and fires the system installer for a drop-in update. When no APK
+ *   is attached the notification offers GitHub-only.
+ *
+ * WHY IT EXISTS
+ * -------------
+ * Extends the pre-existing MANUAL update flow (overflow-menu → screen, #211)
+ * with a proactive "a new version is out" alert.
+ *
+ * STATUS: compile-only / DEVICE-UNVERIFIED. POST_NOTIFICATIONS (API 33+) is
+ * already requested by onboarding; if denied the notification is silently
+ * dropped (degraded, by design).
+ */
+internal object UpdateNotifier {
+    private const val CHANNEL_ID = "app_update"
+    private const val NOTIFICATION_ID = 0x5544_4154 // "UDAT"
+
+    /**
+     * Post (or refresh) the "update available" notification.
+     *
+     * @param version     the newer release version, e.g. `20260701.01`.
+     * @param releaseUrl  GitHub release page — the "View on GitHub" target.
+     * @param apkAssetUrl direct `.apk` download URL, or `null` when the release
+     *                    has no APK attached (then no "Download & install").
+     */
+    fun notifyUpdateAvailable(
+        context: Context,
+        version: String,
+        releaseUrl: String,
+        apkAssetUrl: String?,
+    ) {
+        val appContext = context.applicationContext
+        ensureChannel(appContext)
+
+        val builder =
+            NotificationCompat
+                .Builder(appContext, CHANNEL_ID)
+                .setSmallIcon(android.R.drawable.stat_sys_download)
+                .setContentTitle(appContext.getString(R.string.update_notification_title))
+                .setContentText(
+                    appContext.getString(R.string.update_notification_text, version),
+                ).setAutoCancel(true)
+                .setContentIntent(openUpdateScreenIntent(appContext))
+                .addAction(
+                    0,
+                    appContext.getString(R.string.update_notification_action_github),
+                    viewOnGitHubIntent(appContext, releaseUrl),
+                )
+
+        // Adaptive: only offer a direct install when the release hosts the APK.
+        if (apkAssetUrl != null) {
+            builder.addAction(
+                0,
+                appContext.getString(R.string.update_notification_action_download),
+                downloadAndInstallIntent(appContext, apkAssetUrl, version),
+            )
+        }
+
+        // notify() no-ops if POST_NOTIFICATIONS is not granted on 33+.
+        NotificationManagerCompat.from(appContext).notify(NOTIFICATION_ID, builder.build())
+    }
+
+    /** Clear the alert once the user has acted on it from the trampoline. */
+    fun cancel(context: Context) {
+        NotificationManagerCompat.from(context.applicationContext).cancel(NOTIFICATION_ID)
+    }
+
+    private fun ensureChannel(context: Context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val manager = context.getSystemService(NotificationManager::class.java) ?: return
+        if (manager.getNotificationChannel(CHANNEL_ID) != null) return
+        manager.createNotificationChannel(
+            NotificationChannel(
+                CHANNEL_ID,
+                context.getString(R.string.update_notification_channel_name),
+                NotificationManager.IMPORTANCE_DEFAULT,
+            ).apply { description = context.getString(R.string.update_notification_channel_desc) },
+        )
+    }
+
+    /** Body tap → the in-app "Check for updates" screen. */
+    private fun openUpdateScreenIntent(context: Context): PendingIntent {
+        val intent =
+            Intent(context, CheckForUpdatesActivity::class.java)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+        return PendingIntent.getActivity(context, REQ_OPEN_SCREEN, intent, immutableFlags())
+    }
+
+    /** "View on GitHub" → release page in a browser. */
+    private fun viewOnGitHubIntent(
+        context: Context,
+        releaseUrl: String,
+    ): PendingIntent {
+        val intent =
+            Intent(Intent.ACTION_VIEW, Uri.parse(releaseUrl))
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        return PendingIntent.getActivity(context, REQ_VIEW_GITHUB, intent, immutableFlags())
+    }
+
+    /** "Download & install" → the trampoline that gates + starts the install. */
+    private fun downloadAndInstallIntent(
+        context: Context,
+        apkAssetUrl: String,
+        version: String,
+    ): PendingIntent {
+        val intent =
+            Intent(context, UpdateInstallActivity::class.java)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                .putExtra(UpdateInstallActivity.EXTRA_APK_URL, apkAssetUrl)
+                .putExtra(UpdateInstallActivity.EXTRA_VERSION, version)
+        return PendingIntent.getActivity(context, REQ_DOWNLOAD, intent, immutableFlags())
+    }
+
+    private fun immutableFlags(): Int =
+        PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+
+    private const val REQ_OPEN_SCREEN = 1
+    private const val REQ_VIEW_GITHUB = 2
+    private const val REQ_DOWNLOAD = 3
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateNotifier.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateNotifier.kt
@@ -102,14 +102,15 @@ internal object UpdateNotifier {
     private fun ensureChannel(context: Context) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
         val manager = context.getSystemService(NotificationManager::class.java) ?: return
-        if (manager.getNotificationChannel(CHANNEL_ID) != null) return
-        manager.createNotificationChannel(
-            NotificationChannel(
-                CHANNEL_ID,
-                context.getString(R.string.update_notification_channel_name),
-                NotificationManager.IMPORTANCE_DEFAULT,
-            ).apply { description = context.getString(R.string.update_notification_channel_desc) },
-        )
+        if (manager.getNotificationChannel(CHANNEL_ID) == null) {
+            manager.createNotificationChannel(
+                NotificationChannel(
+                    CHANNEL_ID,
+                    context.getString(R.string.update_notification_channel_name),
+                    NotificationManager.IMPORTANCE_DEFAULT,
+                ).apply { description = context.getString(R.string.update_notification_channel_desc) },
+            )
+        }
     }
 
     /** Body tap → the in-app "Check for updates" screen. */

--- a/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateNotifier.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateNotifier.kt
@@ -146,8 +146,7 @@ internal object UpdateNotifier {
         return PendingIntent.getActivity(context, REQ_DOWNLOAD, intent, immutableFlags())
     }
 
-    private fun immutableFlags(): Int =
-        PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+    private fun immutableFlags(): Int = PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
 
     private const val REQ_OPEN_SCREEN = 1
     private const val REQ_VIEW_GITHUB = 2

--- a/app/src/main/kotlin/dev/bluehouse/bada/update/UpdatePreferences.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/update/UpdatePreferences.kt
@@ -53,8 +53,10 @@ internal class UpdatePreferences(
 
     /**
      * Whether the automatic background GitHub update check runs. Defaults to
-     * `true`; a future Settings toggle can flip [setAutoCheckEnabled] off so
-     * the worker short-circuits without polling or notifying.
+     * `true`; the Settings tab's "Automatic update check" toggle flips
+     * [setAutoCheckEnabled], which cancels/re-enqueues the periodic worker
+     * (via `BadaApplication.applyAutoUpdateCheckPolicy`) — the worker's own
+     * check of this flag is only a fallback.
      */
     fun autoCheckEnabled(): Boolean = prefs.getBoolean(KEY_AUTO_CHECK_ENABLED, true)
 

--- a/app/src/main/kotlin/dev/bluehouse/bada/update/UpdatePreferences.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/update/UpdatePreferences.kt
@@ -13,10 +13,14 @@ import android.content.SharedPreferences
  * so the red-dot indicator on the toolbar overflow can stay accurate
  * across cold starts even when the device is offline.
  *
- * Only a single tuple is stored: the most recent version + the URL
- * for the release page. Comparison against `BuildConfig.VERSION_NAME`
- * happens at read time so an app upgrade automatically clears the
- * "update available" badge without needing an explicit clear.
+ * Stores:
+ *  - the most recent release version + release-page URL (for the red-dot
+ *    badge; comparison against `BuildConfig.VERSION_NAME` happens at read
+ *    time so an app upgrade auto-clears the badge);
+ *  - the version we LAST posted an "update available" notification for, so
+ *    the periodic background [UpdateCheckWorker] does not re-notify for the
+ *    same release every run (only when a strictly newer one appears);
+ *  - whether the automatic background check is enabled (default `true`).
  */
 internal class UpdatePreferences(
     private val prefs: SharedPreferences,
@@ -36,10 +40,34 @@ internal class UpdatePreferences(
             .apply()
     }
 
+    /**
+     * The release version the background worker most recently raised a
+     * notification for, or `null` if it never has. De-duplicates the
+     * "update available" alert across periodic polls.
+     */
+    fun lastNotifiedVersion(): String? = prefs.getString(KEY_NOTIFIED_VERSION, null)
+
+    fun saveNotifiedVersion(version: String) {
+        prefs.edit().putString(KEY_NOTIFIED_VERSION, version).apply()
+    }
+
+    /**
+     * Whether the automatic background GitHub update check runs. Defaults to
+     * `true`; a future Settings toggle can flip [setAutoCheckEnabled] off so
+     * the worker short-circuits without polling or notifying.
+     */
+    fun autoCheckEnabled(): Boolean = prefs.getBoolean(KEY_AUTO_CHECK_ENABLED, true)
+
+    fun setAutoCheckEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_AUTO_CHECK_ENABLED, enabled).apply()
+    }
+
     internal companion object {
         private const val PREFS_NAME = "bada.update"
         private const val KEY_LATEST_VERSION = "latest_release_version"
         private const val KEY_LATEST_URL = "latest_release_url"
+        private const val KEY_NOTIFIED_VERSION = "last_notified_version"
+        private const val KEY_AUTO_CHECK_ENABLED = "auto_check_enabled"
 
         fun from(context: Context): UpdatePreferences =
             UpdatePreferences(

--- a/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateRepository.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateRepository.kt
@@ -53,7 +53,7 @@ internal object UpdateRepository {
         val cachedUrl = prefs.latestKnownReleaseUrl()
         if (cachedVersion != null && cachedUrl != null) {
             _state.value =
-                if (isNewer(cachedVersion, BuildConfig.VERSION_NAME)) {
+                if (UpdateVersions.isNewer(cachedVersion, BuildConfig.VERSION_NAME)) {
                     UpdateState.UpdateAvailable(cachedVersion, cachedUrl)
                 } else {
                     UpdateState.UpToDate(BuildConfig.VERSION_NAME)
@@ -76,7 +76,7 @@ internal object UpdateRepository {
                         UpdatePreferences
                             .from(context)
                             .saveLatestRelease(release.version, release.releaseUrl)
-                        if (isNewer(release.version, BuildConfig.VERSION_NAME)) {
+                        if (UpdateVersions.isNewer(release.version, BuildConfig.VERSION_NAME)) {
                             UpdateState.UpdateAvailable(release.version, release.releaseUrl)
                         } else {
                             UpdateState.UpToDate(BuildConfig.VERSION_NAME)
@@ -95,14 +95,4 @@ internal object UpdateRepository {
      * indicator to decide whether to paint a red dot.
      */
     fun hasPendingUpdate(): Boolean = _state.value is UpdateState.UpdateAvailable
-
-    /**
-     * Strict-greater string comparison. Works for the project's fixed
-     * `YYYYMMDD.NN` versionName scheme because every field is
-     * zero-padded to a fixed width.
-     */
-    private fun isNewer(
-        candidate: String,
-        installed: String,
-    ): Boolean = candidate > installed
 }

--- a/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateVersions.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/update/UpdateVersions.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.update
+
+/**
+ * Single shared implementation of the release-version comparison used by
+ * both the foreground red-dot surface ([UpdateRepository]) and the
+ * background periodic poll ([UpdateCheckWorker]).
+ */
+internal object UpdateVersions {
+    /**
+     * Strict-greater comparison. Works for the project's fixed `YYYYMMDD.NN`
+     * versionName scheme because every field is zero-padded to a fixed
+     * width, so a plain lexicographic compare is monotonic with release
+     * order — no Semver parsing required.
+     */
+    fun isNewer(
+        candidate: String,
+        installed: String,
+    ): Boolean = candidate > installed
+}

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -470,6 +470,49 @@
 
         </LinearLayout>
 
+        <!-- ============ Card 7: Automatic update check ============ -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:background="@drawable/settings_card_background"
+            android:orientation="vertical"
+            android:padding="20dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/settings_auto_update_title"
+                    android:textAppearance="@style/TextAppearance.AppCompat.Subhead"
+                    android:textColor="?android:attr/textColorPrimary"
+                    android:textStyle="bold" />
+
+                <androidx.appcompat.widget.SwitchCompat
+                    android:id="@+id/settings_auto_update_switch"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="12dp" />
+
+            </LinearLayout>
+
+            <TextView
+                android:id="@+id/settings_auto_update_subtitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:text="@string/settings_auto_update_subtitle"
+                android:textAppearance="@style/TextAppearance.AppCompat.Small"
+                android:textColor="?android:attr/textColorSecondary" />
+
+        </LinearLayout>
+
     </LinearLayout>
 
 </ScrollView>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -48,7 +48,26 @@
     <string name="update_subtitle_latest_version">%1$s</string>
     <string name="update_button_check_again">再確認</string>
     <string name="update_button_update">アップデート</string>
+    <!-- 自動アップデート確認: 通知 + ダウンロード/インストールのフロー。 -->
+    <string name="update_notification_channel_name">アプリのアップデート</string>
+    <string name="update_notification_channel_desc">GitHub に新しいバージョンの Bada があるときに通知します。</string>
+    <string name="update_notification_title">Bada のアップデートがあります</string>
+    <string name="update_notification_text">バージョン %1$s をインストールできます</string>
+    <string name="update_notification_action_github">GitHub で表示</string>
+    <string name="update_notification_action_download">ダウンロードしてインストール</string>
+    <string name="update_downloading_title">アップデートをダウンロードしています…</string>
+    <string name="update_downloading_text">Bada %1$s</string>
+    <string name="update_download_failed_title">アップデートのダウンロードに失敗しました</string>
+    <string name="update_download_failed_text">アップデートをダウンロードできませんでした。通知をタップして再試行するか、GitHub を開いてください。</string>
+    <string name="update_install_need_unknown_sources">Bada にアプリのインストールを許可してから、もう一度ダウンロードをタップしてください。</string>
+    <string name="update_install_started">アップデートをダウンロードしています…</string>
+    <string name="update_install_success">Bada をアップデートしました</string>
+    <string name="update_install_failed">アップデートをインストールできませんでした</string>
+    <string name="update_confirm_notification_title">Bada アップデートの確認</string>
+    <string name="update_confirm_notification_text">タップしてアップデートのインストールを完了してください。</string>
     <string name="update_open_release_failed">リリースページを開けませんでした。</string>
+    <string name="settings_auto_update_title">自動アップデート確認</string>
+    <string name="settings_auto_update_subtitle">6 時間ごとに GitHub で新しい Bada リリースを確認し、新しいバージョンがあれば通知します。</string>
 
     <!-- `credit_section_developer`, `credit_section_polisher`,
          `credit_section_qa`, `credit_section_thanks` are intentionally

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -49,7 +49,26 @@
     <string name="update_subtitle_latest_version">%1$s</string>
     <string name="update_button_check_again">다시 확인</string>
     <string name="update_button_update">업데이트</string>
+    <!-- 자동 업데이트 확인: 알림 + 다운로드/설치 흐름. -->
+    <string name="update_notification_channel_name">앱 업데이트</string>
+    <string name="update_notification_channel_desc">GitHub에 새 버전의 Bada가 있으면 알려 줍니다.</string>
+    <string name="update_notification_title">Bada 업데이트가 있습니다</string>
+    <string name="update_notification_text">버전 %1$s을(를) 설치할 수 있습니다</string>
+    <string name="update_notification_action_github">GitHub에서 보기</string>
+    <string name="update_notification_action_download">다운로드 및 설치</string>
+    <string name="update_downloading_title">업데이트를 다운로드하는 중…</string>
+    <string name="update_downloading_text">Bada %1$s</string>
+    <string name="update_download_failed_title">업데이트 다운로드 실패</string>
+    <string name="update_download_failed_text">업데이트를 다운로드할 수 없습니다. 알림을 눌러 다시 시도하거나 GitHub를 열어 주세요.</string>
+    <string name="update_install_need_unknown_sources">Bada의 앱 설치를 허용한 뒤 다운로드를 다시 눌러 주세요.</string>
+    <string name="update_install_started">업데이트를 다운로드하는 중…</string>
+    <string name="update_install_success">Bada가 업데이트되었습니다</string>
+    <string name="update_install_failed">업데이트를 설치할 수 없습니다</string>
+    <string name="update_confirm_notification_title">Bada 업데이트 설치 확인</string>
+    <string name="update_confirm_notification_text">눌러서 업데이트 설치를 마무리하세요.</string>
     <string name="update_open_release_failed">릴리스 페이지를 열 수 없습니다.</string>
+    <string name="settings_auto_update_title">자동 업데이트 확인</string>
+    <string name="settings_auto_update_subtitle">6시간마다 GitHub에서 새 Bada 릴리스를 확인하고, 새 버전이 있으면 알림을 표시합니다.</string>
 
     <!-- `credit_section_developer`, `credit_section_polisher`,
          `credit_section_qa`, `credit_section_thanks` are intentionally

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -335,6 +335,25 @@
     <string name="update_subtitle_latest_version">%1$s</string>
     <string name="update_button_check_again">再次檢查</string>
     <string name="update_button_update">更新</string>
+    <!-- 自動檢查更新：通知 + 下載/安裝流程。 -->
+    <string name="update_notification_channel_name">應用程式更新</string>
+    <string name="update_notification_channel_desc">當 GitHub 上有較新版本的 Bada 時通知您。</string>
+    <string name="update_notification_title">Bada 有可用更新</string>
+    <string name="update_notification_text">版本 %1$s 已可安裝</string>
+    <string name="update_notification_action_github">在 GitHub 上檢視</string>
+    <string name="update_notification_action_download">下載並安裝</string>
+    <string name="update_downloading_title">正在下載更新…</string>
+    <string name="update_downloading_text">Bada %1$s</string>
+    <string name="update_download_failed_title">更新下載失敗</string>
+    <string name="update_download_failed_text">無法下載更新。請點選通知重試，或開啟 GitHub。</string>
+    <string name="update_install_need_unknown_sources">請允許 Bada 安裝應用程式，然後再次點選下載。</string>
+    <string name="update_install_started">正在下載更新…</string>
+    <string name="update_install_success">Bada 已更新</string>
+    <string name="update_install_failed">無法安裝更新</string>
+    <string name="update_confirm_notification_title">確認安裝 Bada 更新</string>
+    <string name="update_confirm_notification_text">點選以完成更新安裝。</string>
     <string name="update_open_release_failed">無法開啟發行頁面。</string>
+    <string name="settings_auto_update_title">自動檢查更新</string>
+    <string name="settings_auto_update_subtitle">每 6 小時在 GitHub 檢查是否有新的 Bada 版本，並在有新版本時顯示通知。</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,7 +44,11 @@
     <string name="update_install_started">Downloading update…</string>
     <string name="update_install_success">Bada updated</string>
     <string name="update_install_failed">Couldn\'t install the update</string>
+    <string name="update_confirm_notification_title">Confirm Bada update</string>
+    <string name="update_confirm_notification_text">Tap to review and finish installing the update.</string>
     <string name="update_open_release_failed">Couldn\'t open the release page.</string>
+    <string name="settings_auto_update_title">Automatic update check</string>
+    <string name="settings_auto_update_subtitle">Every 6 hours, check GitHub for a newer Bada release and show a notification when one is available.</string>
     <string name="credit_placeholder_text">credit</string>
 
     <!--

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,6 +29,21 @@
     <string name="update_subtitle_latest_version">%1$s</string>
     <string name="update_button_check_again">Check again</string>
     <string name="update_button_update">Update</string>
+    <!-- Automatic update check: notification + download/install flow. -->
+    <string name="update_notification_channel_name">App updates</string>
+    <string name="update_notification_channel_desc">Notifies you when a newer version of Bada is available on GitHub.</string>
+    <string name="update_notification_title">Bada update available</string>
+    <string name="update_notification_text">Version %1$s is ready to install</string>
+    <string name="update_notification_action_github">View on GitHub</string>
+    <string name="update_notification_action_download">Download &amp; install</string>
+    <string name="update_downloading_title">Downloading update…</string>
+    <string name="update_downloading_text">Bada %1$s</string>
+    <string name="update_download_failed_title">Update download failed</string>
+    <string name="update_download_failed_text">Couldn\'t download the update. Tap the notification to try again or open GitHub.</string>
+    <string name="update_install_need_unknown_sources">Allow Bada to install apps, then tap Download again.</string>
+    <string name="update_install_started">Downloading update…</string>
+    <string name="update_install_success">Bada updated</string>
+    <string name="update_install_failed">Couldn\'t install the update</string>
     <string name="credit_placeholder_text">credit</string>
 
     <!--

--- a/app/src/test/kotlin/dev/bluehouse/bada/AndroidManifestPermissionsTest.kt
+++ b/app/src/test/kotlin/dev/bluehouse/bada/AndroidManifestPermissionsTest.kt
@@ -229,6 +229,31 @@ class AndroidManifestPermissionsTest {
     }
 
     @Test
+    fun `request install packages is declared for the auto-update self-install flow`() {
+        // The update notification's "Download & install" action streams the
+        // GitHub release APK into a PackageInstaller session and commits it
+        // as an update of this app. Without REQUEST_INSTALL_PACKAGES the
+        // platform rejects the session commit outright, silently breaking
+        // the entire self-update path.
+        assertTrue(
+            "REQUEST_INSTALL_PACKAGES must be declared for the self-update install path",
+            manifest.contains("android.permission.REQUEST_INSTALL_PACKAGES"),
+        )
+    }
+
+    @Test
+    fun `foreground service data sync is declared for the expedited update download worker`() {
+        // UpdateInstallWorker runs as expedited WorkManager work, which
+        // pre-API-31 executes inside WorkManager's SystemForegroundService.
+        // API 34+ requires the service's declared dataSync FGS type to be
+        // backed by the matching typed permission or startForeground crashes.
+        assertTrue(
+            "FOREGROUND_SERVICE_DATA_SYNC must be declared for the update-download worker",
+            manifest.contains("android.permission.FOREGROUND_SERVICE_DATA_SYNC"),
+        )
+    }
+
+    @Test
     fun `permissions onboarding activity is registered and not exported`() {
         assertTrue(
             "PermissionsOnboardingActivity must be registered",

--- a/app/src/test/kotlin/dev/bluehouse/bada/update/UpdateApkAssetsTest.kt
+++ b/app/src/test/kotlin/dev/bluehouse/bada/update/UpdateApkAssetsTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.update
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Unit tests for [UpdateApkAssets.selectAppApkUrl] — the release-asset
+ * matcher behind the notification's "Download & install" action. Releases
+ * can ship more than one `.apk` (the radio-helper companion app), so the
+ * selector must key on the app APK's `dev.bluehouse.bada-` filename prefix
+ * rather than "first `.apk` wins".
+ */
+class UpdateApkAssetsTest {
+    @Test
+    fun `selects the app apk by its applicationId prefix`() {
+        val assets =
+            listOf(
+                ReleaseAsset("dev.bluehouse.bada-20260701.01.apk", "https://example.com/app.apk"),
+            )
+        assertEquals("https://example.com/app.apk", UpdateApkAssets.selectAppApkUrl(assets))
+    }
+
+    @Test
+    fun `skips companion apks that precede the app apk`() {
+        // The radio-helper companion APK sorts before the app APK in some
+        // release listings; a naive "first .apk" selector would install it.
+        val assets =
+            listOf(
+                ReleaseAsset("dev.bluehouse.bada.radiohelper-1.0.apk", "https://example.com/helper.apk"),
+                ReleaseAsset("dev.bluehouse.bada-20260701.01.apk", "https://example.com/app.apk"),
+            )
+        assertEquals("https://example.com/app.apk", UpdateApkAssets.selectAppApkUrl(assets))
+    }
+
+    @Test
+    fun `returns null when only companion or unrelated assets exist`() {
+        val assets =
+            listOf(
+                ReleaseAsset("dev.bluehouse.bada.radiohelper-1.0.apk", "https://example.com/helper.apk"),
+                ReleaseAsset("checksums.txt", "https://example.com/checksums.txt"),
+            )
+        assertNull(UpdateApkAssets.selectAppApkUrl(assets))
+    }
+
+    @Test
+    fun `returns null for an empty asset list`() {
+        assertNull(UpdateApkAssets.selectAppApkUrl(emptyList()))
+    }
+
+    @Test
+    fun `ignores a matching name with a blank download url`() {
+        val assets =
+            listOf(
+                ReleaseAsset("dev.bluehouse.bada-20260701.01.apk", ""),
+            )
+        assertNull(UpdateApkAssets.selectAppApkUrl(assets))
+    }
+
+    @Test
+    fun `requires the apk file extension`() {
+        val assets =
+            listOf(
+                ReleaseAsset("dev.bluehouse.bada-20260701.01.aab", "https://example.com/app.aab"),
+            )
+        assertNull(UpdateApkAssets.selectAppApkUrl(assets))
+    }
+
+    @Test
+    fun `matches case-insensitively`() {
+        val assets =
+            listOf(
+                ReleaseAsset("Dev.Bluehouse.Bada-20260701.01.APK", "https://example.com/app.apk"),
+            )
+        assertEquals("https://example.com/app.apk", UpdateApkAssets.selectAppApkUrl(assets))
+    }
+}

--- a/app/src/test/kotlin/dev/bluehouse/bada/update/UpdateVersionsTest.kt
+++ b/app/src/test/kotlin/dev/bluehouse/bada/update/UpdateVersionsTest.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.update
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for the shared release-version comparison used by both
+ * [UpdateRepository] and [UpdateCheckWorker]. The project's versionName
+ * scheme is a fixed-width `YYYYMMDD.NN`, so plain lexicographic ordering
+ * must be monotonic with release order.
+ */
+class UpdateVersionsTest {
+    @Test
+    fun `newer date is strictly newer`() {
+        assertTrue(UpdateVersions.isNewer("20260701.01", "20260614.01"))
+    }
+
+    @Test
+    fun `newer same-day sequence number is strictly newer`() {
+        assertTrue(UpdateVersions.isNewer("20260614.02", "20260614.01"))
+    }
+
+    @Test
+    fun `equal versions are not newer`() {
+        assertFalse(UpdateVersions.isNewer("20260614.01", "20260614.01"))
+    }
+
+    @Test
+    fun `older version is not newer`() {
+        assertFalse(UpdateVersions.isNewer("20260601.09", "20260614.01"))
+        assertFalse(UpdateVersions.isNewer("20251231.99", "20260101.01"))
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,13 @@ androidxDynamicAnimation = "1.0.0"
 # send/receive tab and the settings tab.
 material = "1.12.0"
 
+# WorkManager — reboot-surviving periodic scheduler for the automatic update
+# check (UpdateCheckWorker polls GitHub Releases every 6h). Chosen over
+# AlarmManager+BootReceiver because WorkManager re-enqueues persisted
+# PeriodicWork after a reboot with ZERO user action. 2.9.1 is the current
+# stable line compatible with minSdk 24 / coroutines 1.9.0.
+androidxWork = "2.9.1"
+
 # Coroutines
 kotlinxCoroutines = "1.9.0"
 
@@ -82,6 +89,10 @@ material = { module = "com.google.android.material:material", version.ref = "mat
 # the BLE scan mode between BALANCED (background) and LOW_LATENCY
 # (foreground) without inventing a separate process-state mechanism.
 androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "androidxLifecycle" }
+
+# WorkManager (Kotlin/coroutines flavour) — drives the periodic GitHub update
+# check (UpdateCheckWorker) scheduled from BadaApplication.onCreate.
+androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "androidxWork" }
 
 # Kotlin coroutines
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }


### PR DESCRIPTION
## Summary
Extends the existing **Check for updates** feature (#211) with a proactive, automatic check. The app now polls GitHub Releases in the background every 6 hours and, when a newer version than the installed one is published, posts an **Update available** notification that lets the user open the release on GitHub or download and install it in place.

## What's new 
- A background check runs **every 6 hours** with no setup and no per-boot action.
- When a newer release exists, a notification appears: **"Bada update available — Version X is ready to install."**
- The notification's actions adapt to the release:
  - **View on GitHub** — always shown; opens the release page in a browser.
  - **Download & install** — shown **only when the release has an `.apk` asset attached**. It streams that APK into the system installer for a drop-in update. (When no APK is attached, only **View on GitHub** is offered.)
- Tapping the notification body opens the existing in-app Check-for-updates screen.

**In-app indicator:** the existing overflow-menu red dot is now also mirrored as a small red dot on the bottom-nav **Settings** tab, so a pending update is visible without opening the overflow menu. Both are driven by the same `UpdateRepository` state.

## How it works
- **`UpdateCheckWorker`** — a WorkManager `PeriodicWork` (`bada-update-check`, 6h, `NetworkType.CONNECTED`), scheduled in `BadaApplication.onCreate`. WorkManager persists the schedule across reboots, so the poll self-restarts on boot (no `BootReceiver` needed).
- **`UpdateChecker`** (existing) now also parses the release `assets[]` and exposes the first `.apk`'s `browser_download_url` (`LatestRelease.apkAssetUrl`), so the notification can decide whether a direct install is possible. The release endpoint is unchanged (`kyujin-cho/Bada` `releases/latest`).
- **`UpdateNotifier`** builds the adaptive notification (channel `app_update`).
- **`UpdateDownloadInstaller`** streams the APK into a `PackageInstaller` session (no temp file). The drop-in update works because the release ships the same package signed with the project key.
- **`UpdateInstallActivity`** (transparent trampoline) gates the one-time "install unknown apps" grant, then starts the install; **`UpdateInstallReceiver`** drives the system confirm dialog.
- The alert is de-duplicated per version (`UpdatePreferences.lastNotifiedVersion`), and an `autoCheckEnabled` flag (default on) is reserved for a future Settings toggle.

## Files
- `gradle/libs.versions.toml`, `app/build.gradle.kts` — add `androidx.work:work-runtime-ktx` 2.9.1.
- `app/.../update/UpdateChecker.kt`, `UpdatePreferences.kt` — extended.
- New: `UpdateNotifier.kt`, `UpdateDownloadInstaller.kt`, `UpdateInstallActivity.kt`, `UpdateInstallReceiver.kt`, `UpdateCheckWorker.kt`.
- `BadaApplication.kt` — schedule the worker.
- `AndroidManifest.xml` — add `REQUEST_INSTALL_PACKAGES`; register the trampoline activity + status receiver.
- `res/values/strings.xml` — `update_*` strings for the notification/install flow.

## Notes
- `POST_NOTIFICATIONS` (API 33+) is already declared/requested; if denied the notification is silently skipped (degraded, by design).
- Minimum WorkManager periodic interval is 15 min; 6 h is well within that and negligible for the GitHub unauthenticated quota.



