### PR TITLE
Name Card: tap two phones to swap contacts

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -221,6 +221,20 @@
          killers from severing in-flight transfers. -->
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
+    <!-- Name Card (tap-to-share contacts): the "Use my phone info" button in the
+         My Name Card setup screen reads the device "Me" contact name and the SIM
+         line number to pre-fill the card. Both are runtime-requested on demand and
+         purely optional (the user can type the card manually); a denial is handled
+         gracefully. READ_PHONE_NUMBERS is the modern (API 33+) number read;
+         READ_PHONE_STATE backs the legacy getLine1Number() path below API 33. -->
+    <uses-permission android:name="android.permission.READ_CONTACTS" />
+    <uses-permission android:name="android.permission.READ_PHONE_NUMBERS" />
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
+    <!-- Name Card: save a received contact directly via ContactsContract. Runtime,
+         optional — if not granted, the receive screen falls back to the system
+         Add-contact screen (ACTION_INSERT), which needs no permission. -->
+    <uses-permission android:name="android.permission.WRITE_CONTACTS" />
+
     <!-- #145: probe whether a coresident pre-Bada install is still present so
          the launcher can warn the user to uninstall it. The old install
          registers a duplicate `0xFEF3` GATT advertisement service on the same
@@ -479,6 +493,67 @@
             <meta-data
                 android:name="android.service.quicksettings.TOGGLEABLE_TILE"
                 android:value="true" />
+        </service>
+
+        <!--
+          My Name Card setup screen (tap-to-share contacts). Opened from the
+          "Name Card" row in Settings; lets the user enter the contact card
+          shared when two phones tap. Not exported (in-app navigation only).
+        -->
+        <activity
+            android:name=".namecard.NameCardSetupActivity"
+            android:exported="false"
+            android:label="@string/name_card_activity_label"
+            android:parentActivityName=".MainActivity" />
+
+        <!--
+          Name Card transfer screen (tap-to-share contacts). Full-screen page that
+          a tap drags you into; shows the received card + Receive Only / Share (or
+          Save). Plain Activity — NO overlay permission, NO lock-screen bypass (it
+          only ever appears while unlocked). Launched in-app by the reader (client
+          role) and by NameCardExchangeService (server role). Not exported.
+          singleTop so a second tap reuses the open screen.
+        -->
+        <activity
+            android:name=".namecard.NameCardTransferActivity"
+            android:exported="false"
+            android:launchMode="singleTop"
+            android:excludeFromRecents="true"
+            android:label="@string/name_card_activity_label"
+            android:theme="@style/Theme.Bada.NameCardTransfer" />
+
+        <!--
+          Name Card exchange foreground service (card/server side). Started by
+          NameCardHceService on a tap to run the BLE GATT server (advertise token
+          + serve our card) and, when the peer writes its card, launch the
+          transfer screen. FGS type connectedDevice (Bluetooth); the app already
+          holds the connectedDevice FGS-type gate permission. Not exported.
+        -->
+        <service
+            android:name=".namecard.NameCardExchangeService"
+            android:exported="false"
+            android:foregroundServiceType="connectedDevice" />
+
+        <!--
+          Name Card tap HCE (proprietary AID F0534443415244). The card side of
+          the NameDrop-style tap-to-share-contacts feature: another Bada phone in
+          reader-mode SELECTs this AID + EXCHANGEs to read our rendezvous token
+          (NameCardHceService), waking both apps; the contact card itself is then
+          swapped over Bluetooth. Distinct AID from the iPhone NDEF service and the
+          Quick Share tap service so all three coexist. The card answers only while
+          the device is unlocked (gated in code). exported=true + BIND_NFC_SERVICE:
+          only the system NFC service binds/routes APDUs here.
+        -->
+        <service
+            android:name=".nfc.NameCardHceService"
+            android:exported="true"
+            android:permission="android.permission.BIND_NFC_SERVICE">
+            <intent-filter>
+                <action android:name="android.nfc.cardemulation.action.HOST_APDU_SERVICE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.nfc.cardemulation.host_apdu_service"
+                android:resource="@xml/bada_namecard_apduservice" />
         </service>
 
     </application>

--- a/app/src/main/kotlin/dev/bluehouse/bada/MainActivity.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/MainActivity.kt
@@ -40,6 +40,9 @@ import dev.bluehouse.bada.ui.CreditActivity
 import dev.bluehouse.bada.ui.ElasticBottomNavigationView
 import dev.bluehouse.bada.ui.SendReceiveFragment
 import dev.bluehouse.bada.ui.SettingsFragment
+import dev.bluehouse.bada.namecard.NameCardPreferences
+import dev.bluehouse.bada.namecard.NameCardTransferActivity
+import dev.bluehouse.bada.nfc.NameCardTapReader
 import dev.bluehouse.bada.update.CenteredImageSpan
 import dev.bluehouse.bada.update.CheckForUpdatesActivity
 import dev.bluehouse.bada.update.UpdateRepository
@@ -121,6 +124,17 @@ class MainActivity : AppCompatActivity() {
      * is detected (or cleared after an in-app upgrade).
      */
     private var mainToolbar: MaterialToolbar? = null
+
+    /**
+     * NFC reader for the Name Card tap-to-share-contacts feature, armed while
+     * MainActivity is foreground so "app open = ready to tap and read another
+     * phone's card" (no button). On a tap it reads the peer's rendezvous token
+     * and opens [NameCardTransferActivity] (client role) to run the Bluetooth
+     * swap. Reader-mode suppresses this phone's own HCE while the main screen is
+     * foreground, which is fine because the iPhone-NDEF / Quick Share HCE services
+     * are used from other screens, not here.
+     */
+    private var nameCardReader: NameCardTapReader? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -271,6 +285,39 @@ class MainActivity : AppCompatActivity() {
                     .setDuration(ICON_PRESS_DURATION_MS)
                     .start()
             }.start()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        armNameCardReader()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        nameCardReader?.disable()
+    }
+
+    /**
+     * Arm the Name Card NFC reader while foreground (tap-to-share-contacts). On a
+     * tap it reads the other phone's token and opens the transfer screen. Created
+     * lazily; safe to re-arm on every resume. Respects the master on/off switch in
+     * the My Name Card screen — when off, the reader stays disabled so tapping does nothing.
+     */
+    private fun armNameCardReader() {
+        if (!NameCardPreferences.from(this).isEnabled()) {
+            nameCardReader?.disable()
+            return
+        }
+        val reader =
+            nameCardReader ?: NameCardTapReader(
+                activity = this,
+                onPeerBootstrap = { bootstrap ->
+                    runOnUiThread {
+                        startActivity(NameCardTransferActivity.clientIntent(this, bootstrap.token))
+                    }
+                },
+            ).also { nameCardReader = it }
+        reader.enable()
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {

--- a/app/src/main/kotlin/dev/bluehouse/bada/namecard/AndroidDeviceContactSources.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/namecard/AndroidDeviceContactSources.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.namecard
+
+import android.content.Context
+import android.os.Build
+import android.provider.ContactsContract
+import android.telephony.SubscriptionManager
+import android.telephony.TelephonyManager
+import androidx.annotation.RequiresApi
+
+/**
+ * Real [DeviceContactSources] for [NameCardResolver]: reads the device owner's
+ * "Me"/profile display name and the SIM line number so a user who never set up a
+ * Name Card still shares *something* on a tap (the user's requested fallback).
+ *
+ * Every read is best-effort and permission-gated — any failure (denied
+ * permission, eSIM with no readable number, no "Me" contact, OEM quirk) returns
+ * `null`, and [NameCardResolver] degrades to whatever is left (or prompts setup).
+ *
+ *  - `profileDisplayName()` → `ContactsContract.Profile` DISPLAY_NAME (needs
+ *    `READ_CONTACTS`).
+ *  - `simPhoneNumber()` → `SubscriptionManager.getPhoneNumber` on API 33+
+ *    (needs `READ_PHONE_NUMBERS`), falling back to the deprecated
+ *    `TelephonyManager.getLine1Number()` below that. Often `null` in practice
+ *    (carriers/eSIM rarely expose it) — that's expected, not an error.
+ */
+internal class AndroidDeviceContactSources(
+    private val context: Context,
+) : DeviceContactSources {
+    override fun profileDisplayName(): String? =
+        try {
+            context.contentResolver
+                .query(
+                    ContactsContract.Profile.CONTENT_URI,
+                    arrayOf(ContactsContract.Profile.DISPLAY_NAME),
+                    null,
+                    null,
+                    null,
+                )?.use { cursor ->
+                    if (cursor.moveToFirst()) cursor.getString(0)?.ifBlank { null } else null
+                }
+        } catch (_: SecurityException) {
+            null // READ_CONTACTS not granted.
+        }
+
+    override fun simPhoneNumber(): String? =
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                subscriptionPhoneNumber()
+            } else {
+                @Suppress("DEPRECATION", "HardwareIds")
+                legacyTelephony()?.line1Number?.ifBlank { null }
+            }
+        } catch (_: SecurityException) {
+            null // READ_PHONE_NUMBERS / READ_PHONE_STATE not granted.
+        }
+
+    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
+    @Suppress("ReturnCount")
+    private fun subscriptionPhoneNumber(): String? {
+        val subs = context.getSystemService(SubscriptionManager::class.java) ?: return null
+        val activeSub = SubscriptionManager.getDefaultSubscriptionId()
+        if (activeSub == SubscriptionManager.INVALID_SUBSCRIPTION_ID) return null
+        return subs.getPhoneNumber(activeSub).ifBlank { null }
+    }
+
+    private fun legacyTelephony(): TelephonyManager? =
+        context.getSystemService(Context.TELEPHONY_SERVICE) as? TelephonyManager
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/namecard/NameCardBleExchange.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/namecard/NameCardBleExchange.kt
@@ -1,0 +1,454 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+@file:android.annotation.SuppressLint("MissingPermission")
+// BluetoothGattCharacteristic.value get/set + the no-value writeCharacteristic overload are
+// deprecated on API 33+; we keep them for the minSdk-24 path and pass values explicitly where
+// the new overloads exist. Suppressed file-wide to keep the BLE plumbing readable.
+@file:Suppress("DEPRECATION")
+
+package dev.bluehouse.bada.namecard
+
+import android.Manifest
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCallback
+import android.bluetooth.BluetoothGattCharacteristic
+import android.bluetooth.BluetoothGattServer
+import android.bluetooth.BluetoothGattServerCallback
+import android.bluetooth.BluetoothGattService
+import android.bluetooth.BluetoothManager
+import android.bluetooth.BluetoothProfile
+import android.bluetooth.le.AdvertiseCallback
+import android.bluetooth.le.AdvertiseData
+import android.bluetooth.le.AdvertiseSettings
+import android.bluetooth.le.BluetoothLeAdvertiser
+import android.bluetooth.le.BluetoothLeScanner
+import android.bluetooth.le.ScanCallback
+import android.bluetooth.le.ScanFilter
+import android.bluetooth.le.ScanResult
+import android.bluetooth.le.ScanSettings
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.os.ParcelUuid
+import androidx.core.content.ContextCompat
+import dev.bluehouse.bada.discovery.diagnostics.DiagnosticLog
+import dev.bluehouse.bada.protocol.namecard.NameCard
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * **Name Card Bluetooth exchange** — carries the actual contact card between two
+ * Bada phones AFTER an NFC tap has triggered them and shared a rendezvous
+ * token ([NameCardBootstrap]). NFC is only the trigger; Bluetooth carries the card.
+ *
+ * The two phones meet by the 16-byte token from the tap, not a Bluetooth MAC
+ * (Android hides the local MAC): the **server** advertises the token in BLE
+ * service data; the **client** scans for exactly that token.
+ *
+ * Roles follow the NFC roles:
+ *  - [startServer] — the CARD phone (the tapped, HCE side). Advertises the token
+ *    and runs a GATT server with one READ|WRITE characteristic that serves our
+ *    [NameCard] (read) and receives the peer's (write).
+ *  - [startClient] — the READER phone (the initiator). Scans for the token,
+ *    connects, READs the peer's card, then holds for the user's choice:
+ *    [shareBack] WRITEs ours (Share) or [declineShare] closes (Receive Only).
+ *
+ * Both deliver the peer's card via [onPeerCard]. The reader then chooses Share
+ * ([shareBack]) or Receive-Only ([declineShare]) on the held connection, driven by
+ * [NameCardTransferActivity].
+ *
+ * Permissions (already declared): BLUETOOTH_ADVERTISE (server), BLUETOOTH_SCAN
+ * (client), BLUETOOTH_CONNECT (both GATT). Runtime-checked; a missing one logs
+ * and returns false rather than throwing.
+ *
+ * Standard Android BLE APIs. Driven by [NameCardExchangeService] (server) and
+ * [NameCardTransferActivity] (client); a [ShareRadioController] in each forces
+ * Bluetooth on (+ heartbeat) before this runs.
+ */
+@Suppress("ReturnCount", "MagicNumber")
+internal class NameCardBleExchange(
+    context: Context,
+) {
+    private val appContext = context.applicationContext
+    private val running = AtomicBoolean(false)
+
+    /** Safety-timeout handler: auto-[stop] a session that never completes (battery backstop). */
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    // Server-side handles.
+    private var advertiser: BluetoothLeAdvertiser? = null
+    private var advertiseCallback: AdvertiseCallback? = null
+    private var gattServer: BluetoothGattServer? = null
+
+    // Client-side handles.
+    private var scanner: BluetoothLeScanner? = null
+    private var scanCallback: ScanCallback? = null
+    private var clientGatt: BluetoothGatt? = null
+
+    // Held between READ (peer card surfaced) and the user's Share/Receive-Only choice.
+    private var pendingGatt: BluetoothGatt? = null
+    private var pendingCharacteristic: BluetoothGattCharacteristic? = null
+
+    /**
+     * Card side: advertise [token] and serve [localCard] over GATT. Calls
+     * [onPeerCard] when the connecting peer writes its card. Returns false if BLE
+     * is unavailable / permissions missing.
+     */
+    fun startServer(
+        localCard: NameCard,
+        token: ByteArray,
+        onPeerCard: (NameCard) -> Unit,
+    ): Boolean {
+        if (!running.compareAndSet(false, true)) return false
+        if (!hasPermission(advertisePermission()) || !hasPermission(Manifest.permission.BLUETOOTH_CONNECT)) {
+            DiagnosticLog.w(TAG, "server: missing BLE permission → skip")
+            running.set(false)
+            return false
+        }
+        val manager = appContext.getSystemService(BluetoothManager::class.java)
+        val adapter = manager?.adapter
+        if (adapter == null || !adapter.isEnabled) {
+            DiagnosticLog.w(TAG, "server: Bluetooth off/unavailable → skip")
+            running.set(false)
+            return false
+        }
+
+        val cardBytes = localCard.serialize()
+        val server =
+            manager.openGattServer(
+                appContext,
+                serverCallback(cardBytes, onPeerCard),
+            ) ?: run {
+                DiagnosticLog.w(TAG, "server: openGattServer null → skip")
+                running.set(false)
+                return false
+            }
+        gattServer = server
+        val characteristic =
+            BluetoothGattCharacteristic(
+                CARD_CHARACTERISTIC_UUID,
+                BluetoothGattCharacteristic.PROPERTY_READ or BluetoothGattCharacteristic.PROPERTY_WRITE,
+                BluetoothGattCharacteristic.PERMISSION_READ or BluetoothGattCharacteristic.PERMISSION_WRITE,
+            ).also { it.value = cardBytes }
+        val service =
+            BluetoothGattService(SERVICE_UUID, BluetoothGattService.SERVICE_TYPE_PRIMARY)
+                .also { it.addCharacteristic(characteristic) }
+        server.addService(service)
+
+        val advertiser = adapter.bluetoothLeAdvertiser ?: run {
+            DiagnosticLog.w(TAG, "server: no advertiser → skip")
+            stop()
+            return false
+        }
+        this.advertiser = advertiser
+        val cb = advertiseCallbackImpl()
+        advertiseCallback = cb
+        return try {
+            advertiser.startAdvertising(advertiseSettings(), advertiseData(token), cb)
+            mainHandler.postDelayed({ stop() }, MAX_SESSION_MS)
+            DiagnosticLog.w(TAG, "server: advertising token + GATT serving card(${cardBytes.size}B)")
+            true
+        } catch (@Suppress("TooGenericExceptionCaught") t: Throwable) {
+            DiagnosticLog.w(TAG, "server: startAdvertising threw: ${t.message}")
+            stop()
+            false
+        }
+    }
+
+    /**
+     * Reader side: scan for [token], connect, and READ the peer card, delivering
+     * it via [onPeerCard]. The connection is then HELD open for the user's choice:
+     * [shareBack] writes our card back (Share) or [declineShare] closes it
+     * (Receive Only). A [MAX_SESSION_MS] backstop auto-closes if neither is called.
+     */
+    fun startClient(
+        token: ByteArray,
+        onPeerCard: (NameCard) -> Unit,
+    ): Boolean {
+        if (!running.compareAndSet(false, true)) return false
+        if (!hasPermission(scanPermission()) || !hasPermission(Manifest.permission.BLUETOOTH_CONNECT)) {
+            DiagnosticLog.w(TAG, "client: missing BLE permission → skip")
+            running.set(false)
+            return false
+        }
+        val adapter = appContext.getSystemService(BluetoothManager::class.java)?.adapter
+        if (adapter == null || !adapter.isEnabled) {
+            DiagnosticLog.w(TAG, "client: Bluetooth off/unavailable → skip")
+            running.set(false)
+            return false
+        }
+        val scanner = adapter.bluetoothLeScanner ?: run {
+            DiagnosticLog.w(TAG, "client: no scanner → skip")
+            running.set(false)
+            return false
+        }
+        this.scanner = scanner
+        val filter =
+            ScanFilter.Builder()
+                .setServiceData(ParcelUuid(SERVICE_DATA_UUID), token)
+                .build()
+        val settings =
+            ScanSettings.Builder()
+                .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
+                .build()
+        val cb = scanCallbackImpl(onPeerCard)
+        scanCallback = cb
+        return try {
+            scanner.startScan(listOf(filter), settings, cb)
+            mainHandler.postDelayed({ stop() }, MAX_SESSION_MS)
+            DiagnosticLog.w(TAG, "client: scanning for token")
+            true
+        } catch (@Suppress("TooGenericExceptionCaught") t: Throwable) {
+            DiagnosticLog.w(TAG, "client: startScan threw: ${t.message}")
+            stop()
+            false
+        }
+    }
+
+    /**
+     * Reader side, after the user taps **Share**: write our [localCard] to the
+     * held connection so the peer (server) receives it too. The connection is
+     * torn down once the write completes ([onCharacteristicWrite] → [stop]).
+     */
+    fun shareBack(localCard: NameCard) {
+        val gatt = pendingGatt
+        val characteristic = pendingCharacteristic
+        if (gatt == null || characteristic == null) {
+            DiagnosticLog.w(TAG, "shareBack: no held connection → stop")
+            stop()
+            return
+        }
+        characteristic.value = localCard.serialize()
+        if (!gatt.writeCharacteristic(characteristic)) {
+            DiagnosticLog.w(TAG, "shareBack: writeCharacteristic returned false → stop")
+            stop()
+        } else {
+            DiagnosticLog.w(TAG, "client: Share → writing our card")
+        }
+    }
+
+    /** Reader side, **Receive Only**: don't send our card; close the connection. */
+    fun declineShare() {
+        DiagnosticLog.w(TAG, "client: Receive Only → not sharing our card")
+        stop()
+    }
+
+    /** Tear down all BLE handles. Idempotent. */
+    fun stop() {
+        running.set(false)
+        mainHandler.removeCallbacksAndMessages(null)
+        pendingGatt = null
+        pendingCharacteristic = null
+        runCatching { scanCallback?.let { scanner?.stopScan(it) } }
+        scanner = null
+        scanCallback = null
+        runCatching { clientGatt?.disconnect() }
+        runCatching { clientGatt?.close() }
+        clientGatt = null
+        runCatching { advertiseCallback?.let { advertiser?.stopAdvertising(it) } }
+        advertiser = null
+        advertiseCallback = null
+        runCatching { gattServer?.clearServices() }
+        runCatching { gattServer?.close() }
+        gattServer = null
+    }
+
+    // ---- server callbacks ----
+
+    private fun serverCallback(
+        cardBytes: ByteArray,
+        onPeerCard: (NameCard) -> Unit,
+    ): BluetoothGattServerCallback =
+        object : BluetoothGattServerCallback() {
+            override fun onCharacteristicReadRequest(
+                device: BluetoothDevice,
+                requestId: Int,
+                offset: Int,
+                characteristic: BluetoothGattCharacteristic,
+            ) {
+                // Offset-aware so a card larger than one MTU is read in chunks.
+                val inRange = offset in 0..cardBytes.size
+                val slice = if (inRange) cardBytes.copyOfRange(offset, cardBytes.size) else ByteArray(0)
+                val status = if (inRange) BluetoothGatt.GATT_SUCCESS else BluetoothGatt.GATT_INVALID_OFFSET
+                gattServer?.sendResponse(device, requestId, status, offset, slice)
+            }
+
+            override fun onCharacteristicWriteRequest(
+                device: BluetoothDevice,
+                requestId: Int,
+                characteristic: BluetoothGattCharacteristic,
+                preparedWrite: Boolean,
+                responseNeeded: Boolean,
+                offset: Int,
+                value: ByteArray,
+            ) {
+                if (responseNeeded) {
+                    gattServer?.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, null)
+                }
+                val peer = NameCard.parse(value)
+                if (peer != null) {
+                    DiagnosticLog.w(TAG, "server: received peer card (${value.size}B)")
+                    onPeerCard(peer)
+                } else {
+                    DiagnosticLog.w(TAG, "server: peer wrote unparseable card (${value.size}B)")
+                }
+            }
+        }
+
+    // ---- client callbacks ----
+
+    private fun scanCallbackImpl(
+        onPeerCard: (NameCard) -> Unit,
+    ): ScanCallback =
+        object : ScanCallback() {
+            override fun onScanResult(
+                callbackType: Int,
+                result: ScanResult,
+            ) {
+                if (!running.get()) return
+                // First match wins; stop scanning and connect.
+                runCatching { scanCallback?.let { scanner?.stopScan(it) } }
+                DiagnosticLog.w(TAG, "client: token match ${result.device.address?.takeLast(5)} → connecting")
+                clientGatt = result.device.connectGatt(appContext, false, gattClientCallback(onPeerCard))
+            }
+
+            override fun onScanFailed(errorCode: Int) {
+                DiagnosticLog.w(TAG, "client: scan failed code=$errorCode")
+            }
+        }
+
+    private fun gattClientCallback(
+        onPeerCard: (NameCard) -> Unit,
+    ): BluetoothGattCallback =
+        object : BluetoothGattCallback() {
+            override fun onConnectionStateChange(
+                gatt: BluetoothGatt,
+                status: Int,
+                newState: Int,
+            ) {
+                if (newState == BluetoothProfile.STATE_CONNECTED) {
+                    DiagnosticLog.w(TAG, "client: connected → requestMtu")
+                    if (!gatt.requestMtu(REQUESTED_MTU)) gatt.discoverServices()
+                } else if (newState == BluetoothProfile.STATE_DISCONNECTED) {
+                    DiagnosticLog.w(TAG, "client: disconnected status=$status")
+                }
+            }
+
+            override fun onMtuChanged(
+                gatt: BluetoothGatt,
+                mtu: Int,
+                status: Int,
+            ) {
+                DiagnosticLog.w(TAG, "client: mtu=$mtu → discoverServices")
+                gatt.discoverServices()
+            }
+
+            override fun onServicesDiscovered(
+                gatt: BluetoothGatt,
+                status: Int,
+            ) {
+                val ch = gatt.getService(SERVICE_UUID)?.getCharacteristic(CARD_CHARACTERISTIC_UUID)
+                if (ch == null) {
+                    DiagnosticLog.w(TAG, "client: Name Card characteristic not found")
+                    stop()
+                    return
+                }
+                gatt.readCharacteristic(ch)
+            }
+
+            @Suppress("DEPRECATION")
+            override fun onCharacteristicRead(
+                gatt: BluetoothGatt,
+                characteristic: BluetoothGattCharacteristic,
+                status: Int,
+            ) {
+                // Hold the connection open for the user's Share / Receive-Only choice.
+                pendingGatt = gatt
+                pendingCharacteristic = characteristic
+                val peer = characteristic.value?.let { NameCard.parse(it) }
+                if (peer != null) {
+                    DiagnosticLog.w(TAG, "client: read peer card → awaiting Share/Receive-Only")
+                    onPeerCard(peer)
+                } else {
+                    DiagnosticLog.w(TAG, "client: peer card unreadable")
+                    stop()
+                }
+            }
+
+            override fun onCharacteristicWrite(
+                gatt: BluetoothGatt,
+                characteristic: BluetoothGattCharacteristic,
+                status: Int,
+            ) {
+                DiagnosticLog.w(TAG, "client: wrote our card status=$status → exchange done")
+                stop()
+            }
+        }
+
+    // ---- advertising helpers (idiom from BleAdvertiser) ----
+
+    private fun advertiseSettings(): AdvertiseSettings =
+        AdvertiseSettings.Builder()
+            .setAdvertiseMode(AdvertiseSettings.ADVERTISE_MODE_LOW_LATENCY)
+            .setTxPowerLevel(AdvertiseSettings.ADVERTISE_TX_POWER_HIGH)
+            .setConnectable(true)
+            .build()
+
+    private fun advertiseData(token: ByteArray): AdvertiseData =
+        AdvertiseData.Builder()
+            .addServiceData(ParcelUuid(SERVICE_DATA_UUID), token)
+            .setIncludeDeviceName(false)
+            .setIncludeTxPowerLevel(false)
+            .build()
+
+    private fun advertiseCallbackImpl(): AdvertiseCallback =
+        object : AdvertiseCallback() {
+            override fun onStartFailure(errorCode: Int) {
+                DiagnosticLog.w(TAG, "server: advertise onStartFailure code=$errorCode")
+            }
+        }
+
+    // ---- permission helpers ----
+
+    private fun hasPermission(permission: String): Boolean =
+        ContextCompat.checkSelfPermission(appContext, permission) == PackageManager.PERMISSION_GRANTED
+
+    private fun advertisePermission(): String =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            Manifest.permission.BLUETOOTH_ADVERTISE
+        } else {
+            Manifest.permission.BLUETOOTH
+        }
+
+    private fun scanPermission(): String =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            Manifest.permission.BLUETOOTH_SCAN
+        } else {
+            Manifest.permission.BLUETOOTH
+        }
+
+    companion object {
+        private const val TAG = "NameCardBle"
+
+        /** Default ATT MTU to request so a ~200-byte card writes in one go. */
+        private const val REQUESTED_MTU = 247
+
+        /** Battery backstop: auto-stop a session (advertise/scan/GATT) that never completes. */
+        private const val MAX_SESSION_MS = 30_000L
+
+        /** GATT service holding the single Name Card read/write characteristic. */
+        val SERVICE_UUID: UUID = UUID.fromString("f0534443-0001-4000-8000-534443415244")
+
+        /** The one characteristic: READ serves our card, WRITE receives the peer's. */
+        val CARD_CHARACTERISTIC_UUID: UUID = UUID.fromString("f0534443-0002-4000-8000-534443415244")
+
+        /** 16-bit-style UUID under which the rendezvous token rides in adv service data. */
+        val SERVICE_DATA_UUID: UUID = UUID.fromString("0000fe2d-0000-1000-8000-00805f9b34fb")
+    }
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/namecard/NameCardExchangeService.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/namecard/NameCardExchangeService.kt
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.namecard
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import android.bluetooth.BluetoothManager
+import androidx.core.app.NotificationCompat
+import androidx.core.app.ServiceCompat
+import dev.bluehouse.bada.R
+import dev.bluehouse.bada.discovery.diagnostics.DiagnosticLog
+import dev.bluehouse.bada.protocol.namecard.NameCard
+import dev.bluehouse.bada.service.radio.RadioHelperClient
+import dev.bluehouse.bada.service.radio.ShareRadioController
+
+/**
+ * **Name Card exchange foreground service (card/server side).** Started from
+ * [dev.bluehouse.bada.nfc.NameCardHceService] when this phone is tapped: it brings the
+ * process up reliably (a tap can wake us cold) and runs [NameCardBleExchange] as
+ * the GATT **server** — advertising the rendezvous token and serving our card —
+ * so the tapping phone can read it. When the peer writes its card back, this
+ * launches the full-screen [NameCardTransferActivity] to show it + Save.
+ *
+ * Reader/client side does NOT use this service — that runs from the foreground
+ * [NameCardTransferActivity] directly (no service needed when already foreground).
+ *
+ * FGS type `connectedDevice` (Bluetooth); the manifest declares the type and the
+ * app already holds the `connectedDevice` FGS-type gate permission. See
+ * `docs/NAMEDROP_CONTACT_EXCHANGE_JOURNAL.md`.
+ */
+internal class NameCardExchangeService : Service() {
+    private var exchange: NameCardBleExchange? = null
+    private val timeoutHandler = android.os.Handler(android.os.Looper.getMainLooper())
+
+    /** Forces Bluetooth on for the swap + runs the 5s helper heartbeat; restored on stop. */
+    private val shareRadios by lazy { ShareRadioController(this, TAG) }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    @Suppress("ReturnCount")
+    override fun onStartCommand(
+        intent: Intent?,
+        flags: Int,
+        startId: Int,
+    ): Int {
+        startInForeground()
+        val token = intent?.getByteArrayExtra(EXTRA_TOKEN)
+        if (token == null) {
+            DiagnosticLog.w(TAG, "no token → stop")
+            stopSelf()
+            return START_NOT_STICKY
+        }
+        val localCard =
+            NameCardResolver(
+                storedCard = NameCardProfileStore.from(this)::load,
+                deviceSources = AndroidDeviceContactSources(this),
+            ).resolve()
+        if (localCard == null) {
+            // Nothing to share (no in-app card and no device fallback). The
+            // Settings row's red dot nudges the user to set one up.
+            DiagnosticLog.w(TAG, "no resolvable card to share → stop")
+            stopSelf()
+            return START_NOT_STICKY
+        }
+
+        // Force Bluetooth on via the helper (+ start the 5s keep-alive heartbeat so a
+        // crash mid-swap restores radios ~20s after the last beat, not minutes later).
+        shareRadios.requestRadiosOn(RadioHelperClient.RADIO_BT)
+        // The helper enables BT asynchronously; start serving once BT is actually on
+        // (immediately if already on, else after a short grace for the helper toggle).
+        startServerWhenBtReady(localCard, token, attempt = 0)
+
+        // Backstop: stop if the tapping phone never connects/exchanges (e.g. Receive-Only,
+        // which never reaches onPeerCard) so we don't advertise + foreground forever.
+        timeoutHandler.postDelayed({
+            DiagnosticLog.w(TAG, "server: exchange timeout → stop")
+            stopSelf()
+        }, SERVE_TIMEOUT_MS)
+        return START_NOT_STICKY
+    }
+
+    private fun startServerWhenBtReady(
+        localCard: NameCard,
+        token: ByteArray,
+        attempt: Int,
+    ) {
+        val adapter = getSystemService(BluetoothManager::class.java)?.adapter
+        if (adapter?.isEnabled == true || attempt >= MAX_BT_WAIT_ATTEMPTS) {
+            startServerNow(localCard, token)
+            return
+        }
+        DiagnosticLog.w(TAG, "server: BT not on yet (attempt $attempt) → waiting for helper")
+        timeoutHandler.postDelayed({ startServerWhenBtReady(localCard, token, attempt + 1) }, BT_GRACE_MS)
+    }
+
+    private fun startServerNow(
+        localCard: NameCard,
+        token: ByteArray,
+    ) {
+        val ble = NameCardBleExchange(this)
+        exchange = ble
+        val started =
+            ble.startServer(localCard = localCard, token = token) { peerCard ->
+                DiagnosticLog.w(TAG, "server: peer card received → launch transfer screen")
+                startActivity(
+                    NameCardTransferActivity.serverIntent(this, peerCard).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+                )
+                ble.stop()
+                stopSelf()
+            }
+        if (!started) {
+            DiagnosticLog.w(TAG, "startServer failed (BT off / no perm) → stop")
+            stopSelf()
+        }
+    }
+
+    override fun onDestroy() {
+        timeoutHandler.removeCallbacksAndMessages(null)
+        exchange?.stop()
+        exchange = null
+        // Stop the heartbeat + restore the radios the helper turned on.
+        shareRadios.restoreRadios()
+        super.onDestroy()
+    }
+
+    private fun startInForeground() {
+        val manager = getSystemService(NotificationManager::class.java)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            manager?.createNotificationChannel(
+                NotificationChannel(
+                    CHANNEL_ID,
+                    getString(R.string.name_card_exchange_channel),
+                    NotificationManager.IMPORTANCE_LOW,
+                ),
+            )
+        }
+        val notification =
+            NotificationCompat.Builder(this, CHANNEL_ID)
+                .setSmallIcon(R.mipmap.ic_launcher)
+                .setContentTitle(getString(R.string.name_card_exchange_notification))
+                .setOngoing(true)
+                .build()
+        val type =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE
+            } else {
+                0
+            }
+        ServiceCompat.startForeground(this, NOTIFICATION_ID, notification, type)
+    }
+
+    companion object {
+        private const val TAG = "NameCardExchangeSvc"
+        private const val CHANNEL_ID = "name_card_exchange"
+        private const val NOTIFICATION_ID = 4310
+        private const val EXTRA_TOKEN = "token"
+
+        /** Stop the service if no exchange completes (> the BLE manager's own backstop). */
+        private const val SERVE_TIMEOUT_MS = 33_000L
+
+        /** Grace between retries while the helper turns Bluetooth on, and the cap. */
+        private const val BT_GRACE_MS = 1_500L
+        private const val MAX_BT_WAIT_ATTEMPTS = 2
+
+        /** Start the server-side exchange for [token] (from the HCE tap). */
+        fun start(
+            context: Context,
+            token: ByteArray,
+        ) {
+            val intent =
+                Intent(context, NameCardExchangeService::class.java).putExtra(EXTRA_TOKEN, token)
+            context.startForegroundService(intent)
+        }
+    }
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/namecard/NameCardPreferences.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/namecard/NameCardPreferences.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.namecard
+
+import android.content.Context
+import android.content.SharedPreferences
+
+/**
+ * **Name Card feature on/off preference.** Master switch for the NameDrop-style
+ * tap-to-share-contacts feature (see `docs/NAMEDROP_CONTACT_EXCHANGE_JOURNAL.md`).
+ * Set from the **"Share my card when phones tap"** switch on the My Name Card
+ * setup screen ([NameCardSetupActivity]).
+ *
+ * Read at the two entry points so a tap is a complete no-op when OFF:
+ *  - [dev.bluehouse.bada.nfc.NameCardHceService] — when OFF it does not answer the
+ *    Name Card AID (no token minted, nothing served) so this phone is not
+ *    tappable as a card.
+ *  - [dev.bluehouse.bada.MainActivity] — when OFF it does not arm the reader, so
+ *    tapping another phone does nothing.
+ *
+ * Default **ON** (the feature is the point; it still does nothing until the user
+ * has set up a card / has a device fallback). Backed by a private SharedPreferences
+ * file.
+ */
+internal class NameCardPreferences(
+    private val prefs: SharedPreferences,
+) {
+    /** True (default) when tap-to-share-contacts is enabled. */
+    fun isEnabled(): Boolean = prefs.getBoolean(KEY_ENABLED, true)
+
+    fun setEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_ENABLED, enabled).apply()
+    }
+
+    companion object {
+        private const val PREFS_NAME = "bada.name_card_prefs"
+        private const val KEY_ENABLED = "enabled"
+
+        fun from(context: Context): NameCardPreferences =
+            NameCardPreferences(
+                context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE),
+            )
+    }
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/namecard/NameCardProfileStore.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/namecard/NameCardProfileStore.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.namecard
+
+import android.content.Context
+import android.content.SharedPreferences
+import dev.bluehouse.bada.protocol.namecard.NameCard
+
+/**
+ * **My Name Card profile store** — persists the contact card the user sets up
+ * in the "Name Card" settings screen ([NameCardSetupActivity]) and shares by
+ * tapping phones (NameDrop-style; see `docs/NAMEDROP_CONTACT_EXCHANGE_JOURNAL.md`).
+ *
+ * Backed by a private [SharedPreferences] file. Each field (name / phone /
+ * email) is stored independently and may be blank; [load] assembles them into a
+ * [NameCard], or returns `null` when the user has set up nothing (no name, no
+ * phone, no email) so callers can fall back to device sources via
+ * [NameCardResolver].
+ *
+ * Blank strings are normalised to "unset" (trimmed-empty → `null`) so an
+ * accidentally-saved space never produces an empty TLV on the wire.
+ *
+ * Exercised indirectly by [NameCardResolver] tests (which inject a fake card).
+ */
+internal class NameCardProfileStore(
+    private val prefs: SharedPreferences,
+) {
+    /** The saved display name, or `null`/blank if unset. */
+    fun displayName(): String? = prefs.getString(KEY_NAME, null)?.trimToNull()
+
+    /** The saved phone number, or `null`/blank if unset. */
+    fun phoneNumber(): String? = prefs.getString(KEY_PHONE, null)?.trimToNull()
+
+    /** The saved email, or `null`/blank if unset. */
+    fun email(): String? = prefs.getString(KEY_EMAIL, null)?.trimToNull()
+
+    /** True once the user has entered at least one of name / phone / email. */
+    fun isConfigured(): Boolean =
+        displayName() != null || phoneNumber() != null || email() != null
+
+    /**
+     * Assemble the saved fields into a [NameCard], or `null` if nothing is set.
+     * Never throws: a card requires ≥1 field, which [isConfigured] guarantees
+     * before we construct it.
+     */
+    fun load(): NameCard? {
+        if (!isConfigured()) return null
+        return NameCard(
+            displayName = displayName(),
+            phoneNumber = phoneNumber(),
+            email = email(),
+        )
+    }
+
+    /** Persist the three fields (each blank → cleared). Applied asynchronously. */
+    fun save(
+        name: String?,
+        phone: String?,
+        email: String?,
+    ) {
+        prefs.edit()
+            .putString(KEY_NAME, name?.trimToNull())
+            .putString(KEY_PHONE, phone?.trimToNull())
+            .putString(KEY_EMAIL, email?.trimToNull())
+            .apply()
+    }
+
+    /** Wipe the saved card. */
+    fun clear() {
+        prefs.edit().remove(KEY_NAME).remove(KEY_PHONE).remove(KEY_EMAIL).apply()
+    }
+
+    private fun String.trimToNull(): String? = trim().ifEmpty { null }
+
+    companion object {
+        private const val PREFS_NAME = "bada.name_card_profile"
+        private const val KEY_NAME = "name"
+        private const val KEY_PHONE = "phone"
+        private const val KEY_EMAIL = "email"
+
+        fun from(context: Context): NameCardProfileStore =
+            NameCardProfileStore(
+                context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE),
+            )
+    }
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/namecard/NameCardResolver.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/namecard/NameCardResolver.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.namecard
+
+import dev.bluehouse.bada.protocol.namecard.NameCard
+
+/**
+ * **Name Card source resolver** — decides WHICH card this phone shares when two
+ * phones tap (NameDrop-style; see `docs/NAMEDROP_CONTACT_EXCHANGE_JOURNAL.md`).
+ *
+ * Fallback chain (user's decision):
+ *  1. The in-app **My Name Card** the user set up ([NameCardProfileStore]).
+ *  2. Else, whatever the phone already has: the device "Me"/profile display name
+ *     + the SIM line number (read via [DeviceContactSources], permission-gated).
+ *  3. Else, if only a number is known, a **bare-number** card.
+ *  4. Else `null` — nothing to share; the UI prompts the user to set up a card.
+ *
+ * The device-side reads (SIM number, "Me" name) sit behind [DeviceContactSources]
+ * so this precedence logic is pure and unit-testable without Android (see
+ * `NameCardResolverTest`). [AndroidDeviceContactSources] is the real implementation.
+ */
+internal class NameCardResolver(
+    /** Loads the in-app My Name Card, or `null` if not set up. Normally `store::load`. */
+    private val storedCard: () -> NameCard?,
+    private val deviceSources: DeviceContactSources,
+) {
+    /**
+     * Resolve the card to share, or `null` when this phone has nothing to offer
+     * (no in-app card AND no device name/number) — callers then nudge the user
+     * to fill in their Name Card.
+     */
+    @Suppress("ReturnCount")
+    fun resolve(): NameCard? {
+        storedCard()?.let { return it }
+
+        val name = deviceSources.profileDisplayName()?.trim()?.ifEmpty { null }
+        val number = deviceSources.simPhoneNumber()?.trim()?.ifEmpty { null }
+        if (name == null && number == null) return null
+
+        return NameCard(displayName = name, phoneNumber = number)
+    }
+
+    /** True when [resolve] would return a card (in-app or device fallback). */
+    fun canResolve(): Boolean = resolve() != null
+}
+
+/**
+ * Device-side fallback sources for [NameCardResolver]. Abstracted behind an
+ * interface so the resolver's precedence is testable on a plain JVM. The real
+ * reads require runtime permissions and may legitimately return `null` (denied,
+ * unavailable, eSIM with no readable number, no "Me" contact).
+ */
+internal interface DeviceContactSources {
+    /** The device owner's display name from the "Me"/profile contact, or `null`. */
+    fun profileDisplayName(): String?
+
+    /** The SIM/line phone number, or `null` if unavailable/denied. */
+    fun simPhoneNumber(): String?
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/namecard/NameCardSaver.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/namecard/NameCardSaver.kt
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.namecard
+
+import android.Manifest
+import android.content.ContentProviderOperation
+import android.content.ContentUris
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.provider.ContactsContract
+import androidx.core.content.ContextCompat
+import dev.bluehouse.bada.discovery.diagnostics.DiagnosticLog
+import dev.bluehouse.bada.protocol.namecard.NameCard
+
+/**
+ * **Name Card → Android contact saver.** Saves a received [NameCard] as a REAL
+ * Android contact for the tap-to-share feature (see
+ * `docs/NAMEDROP_CONTACT_EXCHANGE_JOURNAL.md`).
+ *
+ * Deliberately does NOT go through a vCard `.vcf` file (vCard file import is
+ * unreliable across OEM Contacts apps, and the card already has structured
+ * fields). Instead:
+ *  - [saveDirect] — a `ContactsContract` raw-contact insert (needs WRITE_CONTACTS).
+ *    Seamless, stays in Bada.
+ *  - [systemInsertIntent] — the system **Add contact** screen prefilled
+ *    (`Intent.ACTION_INSERT`), used as the no-permission fallback when
+ *    WRITE_CONTACTS is denied; the user confirms in the OS Contacts UI.
+ *
+ * Callers ([NameCardTransferActivity]) try [saveDirect] when [hasWritePermission]
+ * and otherwise `startActivity([systemInsertIntent])`.
+ */
+internal object NameCardSaver {
+    private const val TAG = "NameCardSaver"
+
+    fun hasWritePermission(context: Context): Boolean =
+        ContextCompat.checkSelfPermission(context, Manifest.permission.WRITE_CONTACTS) ==
+            PackageManager.PERMISSION_GRANTED
+
+    /**
+     * Insert [card] directly via ContactsContract. Builds a new raw contact
+     * (no account = device/local) with a structured name + phone + email as
+     * present. Returns the saved contact's viewable [Uri] (for opening it in the
+     * Contacts app), or `null` on any failure (caller falls back to
+     * [systemInsertIntent]).
+     */
+    fun saveDirect(
+        context: Context,
+        card: NameCard,
+    ): Uri? {
+        val ops = ArrayList<ContentProviderOperation>()
+        // Raw contact anchor (index 0); subsequent rows back-reference it.
+        ops.add(
+            ContentProviderOperation
+                .newInsert(ContactsContract.RawContacts.CONTENT_URI)
+                .withValue(ContactsContract.RawContacts.ACCOUNT_TYPE, null)
+                .withValue(ContactsContract.RawContacts.ACCOUNT_NAME, null)
+                .build(),
+        )
+        card.displayName?.let { name ->
+            ops.add(
+                dataInsert()
+                    .withValue(
+                        ContactsContract.Data.MIMETYPE,
+                        ContactsContract.CommonDataKinds.StructuredName.CONTENT_ITEM_TYPE,
+                    ).withValue(ContactsContract.CommonDataKinds.StructuredName.DISPLAY_NAME, name)
+                    .build(),
+            )
+        }
+        card.phoneNumber?.let { phone ->
+            ops.add(
+                dataInsert()
+                    .withValue(
+                        ContactsContract.Data.MIMETYPE,
+                        ContactsContract.CommonDataKinds.Phone.CONTENT_ITEM_TYPE,
+                    ).withValue(ContactsContract.CommonDataKinds.Phone.NUMBER, phone)
+                    .withValue(
+                        ContactsContract.CommonDataKinds.Phone.TYPE,
+                        ContactsContract.CommonDataKinds.Phone.TYPE_MOBILE,
+                    ).build(),
+            )
+        }
+        card.email?.let { email ->
+            ops.add(
+                dataInsert()
+                    .withValue(
+                        ContactsContract.Data.MIMETYPE,
+                        ContactsContract.CommonDataKinds.Email.CONTENT_ITEM_TYPE,
+                    ).withValue(ContactsContract.CommonDataKinds.Email.ADDRESS, email)
+                    .withValue(
+                        ContactsContract.CommonDataKinds.Email.TYPE,
+                        ContactsContract.CommonDataKinds.Email.TYPE_HOME,
+                    ).build(),
+            )
+        }
+        return try {
+            val results = context.contentResolver.applyBatch(ContactsContract.AUTHORITY, ops)
+            DiagnosticLog.w(TAG, "saved contact directly (${ops.size - 1} fields)")
+            results.firstOrNull()?.uri?.let { rawContactUri -> viewUriFor(context, rawContactUri) }
+        } catch (@Suppress("TooGenericExceptionCaught") t: Throwable) {
+            DiagnosticLog.w(TAG, "saveDirect failed: ${t.message}")
+            null
+        }
+    }
+
+    /**
+     * Resolve the aggregated-contact view [Uri] (content://…/contacts/<id>) for a
+     * freshly inserted raw-contact [Uri], so the caller can open it in Contacts.
+     * Returns `null` if the contact id can't be read.
+     */
+    private fun viewUriFor(
+        context: Context,
+        rawContactUri: Uri,
+    ): Uri? =
+        try {
+            context.contentResolver
+                .query(rawContactUri, arrayOf(ContactsContract.RawContacts.CONTACT_ID), null, null, null)
+                ?.use { cursor ->
+                    if (cursor.moveToFirst()) {
+                        ContentUris.withAppendedId(ContactsContract.Contacts.CONTENT_URI, cursor.getLong(0))
+                    } else {
+                        null
+                    }
+                }
+        } catch (@Suppress("TooGenericExceptionCaught") t: Throwable) {
+            DiagnosticLog.w(TAG, "viewUriFor failed: ${t.message}")
+            null
+        }
+
+    /**
+     * The system "Add contact" screen prefilled from [card]. No permission
+     * required; the user taps Save in the OS Contacts UI.
+     */
+    fun systemInsertIntent(card: NameCard): Intent =
+        Intent(Intent.ACTION_INSERT).apply {
+            type = ContactsContract.Contacts.CONTENT_TYPE
+            card.displayName?.let { putExtra(ContactsContract.Intents.Insert.NAME, it) }
+            card.phoneNumber?.let { putExtra(ContactsContract.Intents.Insert.PHONE, it) }
+            card.email?.let { putExtra(ContactsContract.Intents.Insert.EMAIL, it) }
+        }
+
+    private fun dataInsert(): ContentProviderOperation.Builder =
+        ContentProviderOperation
+            .newInsert(ContactsContract.Data.CONTENT_URI)
+            .withValueBackReference(ContactsContract.Data.RAW_CONTACT_ID, 0)
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/namecard/NameCardSetupActivity.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/namecard/NameCardSetupActivity.kt
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.namecard
+
+import android.Manifest
+import android.os.Build
+import android.os.Bundle
+import android.widget.Button
+import android.widget.EditText
+import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.SwitchCompat
+import dev.bluehouse.bada.R
+
+/**
+ * **My Name Card setup screen** — the page reached by tapping the **"Name Card"**
+ * row in Settings ([dev.bluehouse.bada.ui.SettingsFragment]). Here the user enters
+ * the contact card they share when two phones tap (NameDrop-style; see
+ * `docs/NAMEDROP_CONTACT_EXCHANGE_JOURNAL.md`).
+ *
+ * UI (R.layout.activity_name_card_setup):
+ *  - `nameCardNameInput` — text field, "Name".
+ *  - `nameCardPhoneInput` — phone field, "Phone".
+ *  - `nameCardEmailInput` — email field, "Email".
+ *  - `nameCardUsePhoneInfoButton` — pill, "Use my phone info": fills empty fields
+ *    from the device "Me"/SIM ([AndroidDeviceContactSources]) after granting
+ *    READ_CONTACTS / READ_PHONE_NUMBERS.
+ *  - `nameCardSaveButton` — primary pill, "Save": persists via
+ *    [NameCardProfileStore] and finishes.
+ *  - `nameCardClearButton` — secondary pill, "Clear": wipes the saved card.
+ *
+ * Persists to [NameCardProfileStore]; read back here on open and by
+ * [NameCardResolver] at tap time.
+ */
+internal class NameCardSetupActivity : AppCompatActivity() {
+    private lateinit var store: NameCardProfileStore
+
+    private val nameInput by lazy { findViewById<EditText>(R.id.nameCardNameInput) }
+    private val phoneInput by lazy { findViewById<EditText>(R.id.nameCardPhoneInput) }
+    private val emailInput by lazy { findViewById<EditText>(R.id.nameCardEmailInput) }
+
+    /**
+     * Permission request for "Use my phone info". On grant, fills any empty
+     * field from the device sources; on denial, a Toast (the user can still type
+     * manually). Requests both contacts + phone-number reads at once.
+     */
+    private val pullInfoPermission =
+        registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { grants ->
+            if (grants.values.any { it }) {
+                fillFromDevice()
+            } else {
+                toast(R.string.name_card_use_phone_info_denied)
+            }
+        }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_name_card_setup)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+
+        store = NameCardProfileStore.from(this)
+        nameInput.setText(store.displayName().orEmpty())
+        phoneInput.setText(store.phoneNumber().orEmpty())
+        emailInput.setText(store.email().orEmpty())
+
+        // "Share my card when phones tap" master switch.
+        val enablePrefs = NameCardPreferences.from(this)
+        findViewById<SwitchCompat>(R.id.nameCardEnableSwitch).apply {
+            isChecked = enablePrefs.isEnabled()
+            setOnCheckedChangeListener { _, checked -> enablePrefs.setEnabled(checked) }
+        }
+
+        findViewById<Button>(R.id.nameCardSaveButton).setOnClickListener { save() }
+        findViewById<Button>(R.id.nameCardClearButton).setOnClickListener { clear() }
+        findViewById<Button>(R.id.nameCardUsePhoneInfoButton).setOnClickListener {
+            pullInfoPermission.launch(devicePermissions())
+        }
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        finish()
+        return true
+    }
+
+    private fun save() {
+        val name = nameInput.text?.toString()
+        val phone = phoneInput.text?.toString()
+        val email = emailInput.text?.toString()
+        if (name.isNullOrBlank() && phone.isNullOrBlank() && email.isNullOrBlank()) {
+            toast(R.string.name_card_save_empty)
+            return
+        }
+        store.save(name, phone, email)
+        toast(R.string.name_card_saved)
+        finish()
+    }
+
+    private fun clear() {
+        store.clear()
+        nameInput.setText("")
+        phoneInput.setText("")
+        emailInput.setText("")
+        toast(R.string.name_card_cleared)
+    }
+
+    /** Fill only the EMPTY fields from the device sources (don't clobber typed text). */
+    private fun fillFromDevice() {
+        val sources = AndroidDeviceContactSources(this)
+        var filledAnything = false
+        if (nameInput.text.isNullOrBlank()) {
+            sources.profileDisplayName()?.let {
+                nameInput.setText(it)
+                filledAnything = true
+            }
+        }
+        if (phoneInput.text.isNullOrBlank()) {
+            sources.simPhoneNumber()?.let {
+                phoneInput.setText(it)
+                filledAnything = true
+            }
+        }
+        toast(if (filledAnything) R.string.name_card_use_phone_info_filled else R.string.name_card_use_phone_info_empty)
+    }
+
+    private fun devicePermissions(): Array<String> =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            arrayOf(Manifest.permission.READ_CONTACTS, Manifest.permission.READ_PHONE_NUMBERS)
+        } else {
+            arrayOf(Manifest.permission.READ_CONTACTS, Manifest.permission.READ_PHONE_STATE)
+        }
+
+    private fun toast(resId: Int) {
+        Toast.makeText(this, resId, Toast.LENGTH_SHORT).show()
+    }
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/namecard/NameCardTransferActivity.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/namecard/NameCardTransferActivity.kt
@@ -1,0 +1,737 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.namecard
+
+import android.Manifest
+import android.animation.Animator
+import android.animation.AnimatorListenerAdapter
+import android.animation.ObjectAnimator
+import android.animation.PropertyValuesHolder
+import android.animation.ValueAnimator
+import android.bluetooth.BluetoothManager
+import android.content.Context
+import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.BitmapShader
+import android.graphics.Canvas
+import android.graphics.Matrix
+import android.graphics.Paint
+import android.graphics.RenderEffect
+import android.graphics.RuntimeShader
+import android.graphics.Shader
+import android.os.Build
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.view.View
+import android.view.ViewGroup
+import android.view.animation.AccelerateDecelerateInterpolator
+import android.view.animation.AccelerateInterpolator
+import android.view.animation.DecelerateInterpolator
+import android.widget.Button
+import android.widget.FrameLayout
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
+import dev.bluehouse.bada.R
+import dev.bluehouse.bada.discovery.diagnostics.DiagnosticLog
+import dev.bluehouse.bada.protocol.namecard.NameCard
+import dev.bluehouse.bada.service.radio.RadioHelperClient
+import dev.bluehouse.bada.service.radio.ShareRadioController
+
+/**
+ * **Name Card transfer screen** — the full-screen, NameDrop-style page shown when
+ * two phones tap to swap contacts (see `docs/NAMEDROP_CONTACT_EXCHANGE_JOURNAL.md`).
+ *
+ * The card animation values are baked as the constants in [Anim] below.
+ *
+ * **Window:** launched under `Theme.Bada.NameCardTransfer` (translucent, no dim,
+ * no window animation) + [overrideOpenTransition] so the card floats OVER whatever
+ * screen you were on (home / another app) and the ONLY motion is the view-level
+ * animation below.
+ *
+ * **The card = one unit.** `nameCardCard` (R.layout.activity_name_card_transfer)
+ * wraps the avatar + name + phone + email AND the two action buttons, so they
+ * descend + expand together on entry and (on Share) fly up + shrink together.
+ *
+ * **Choreography:**
+ *  - PRE-ENTRANCE RIPPLE ([playTriggerRipple]) — the AirDrop glow/wave shader on a
+ *    transparent full-screen layer over the previous screen, as the "tap happened"
+ *    cue (API 33+; skipped otherwise). Then the card enters.
+ *  - ENTRANCE ([twoPhaseEntrance]) — the small card DESCENDS (decelerate) to a stop,
+ *    then EXPANDS in place (accelerate) around a near-top pivot.
+ *  - SHARE = reverse-exit ([reverseExit]) — the card RISES + SHRINKS off the top,
+ *    then a glow ripple, then the contact opens.
+ *  - RECEIVE ONLY / SAVE = send ripple ([playSendRipple]) — the AirDrop "suck the
+ *    card up into the island" effect on a flipped snapshot, then the contact opens.
+ *
+ * Two roles:
+ *  - **CLIENT** (the phone that tapped / has the app foreground): runs the BLE
+ *    client, shows "Connecting…" then the received card with **Receive Only** /
+ *    **Share** (Share also sends your card back). Launched via [clientIntent].
+ *  - **SERVER** (the tapped, idle phone): its card was already served on the tap;
+ *    shows the received card with **Save** / **Done**. Launched by
+ *    [NameCardExchangeService] via [serverIntent] once the peer wrote its card.
+ *
+ * Saving uses [NameCardSaver] (ContactsContract — direct insert if WRITE_CONTACTS is
+ * granted, else the system Add-contact screen), never a vCard import.
+ */
+internal class NameCardTransferActivity : AppCompatActivity() {
+    private var exchange: NameCardBleExchange? = null
+    private var localCard: NameCard? = null
+    private var peerReceived = false
+
+    /** Guards against a second Share/Receive/Save tap re-running the exit + save. */
+    private var committed = false
+
+    /** Forces Bluetooth on for the swap + the 5s helper heartbeat (client role); restored on destroy. */
+    private val shareRadios by lazy { ShareRadioController(this, "NameCardTransfer") }
+    private val btHandler = Handler(Looper.getMainLooper())
+    private val ui = Handler(Looper.getMainLooper())
+
+    /** Card awaiting save once the WRITE_CONTACTS prompt returns. */
+    private var pendingSaveCard: NameCard? = null
+
+    /**
+     * Contacts permissions fired on Accept: WRITE_CONTACTS to save directly (auto,
+     * no extra screen) + READ_CONTACTS so the saved contact can be opened in the
+     * Contacts app afterwards.
+     */
+    private val contactsPermission =
+        registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { result ->
+            val card = pendingSaveCard ?: return@registerForActivityResult
+            pendingSaveCard = null
+            persistCard(card, granted = result[Manifest.permission.WRITE_CONTACTS] == true)
+        }
+
+    private val root by lazy { findViewById<FrameLayout>(R.id.nameCardRoot) }
+
+    /** nameCardCard — the whole card (avatar/name/fields + buttons); the single animated unit. */
+    private val card by lazy { findViewById<View>(R.id.nameCardCard) }
+    private val glow by lazy { findViewById<View>(R.id.nameCardGlow) }
+    private val avatar by lazy { findViewById<TextView>(R.id.nameCardAvatar) }
+    private val nameView by lazy { findViewById<TextView>(R.id.nameCardName) }
+    private val phoneView by lazy { findViewById<TextView>(R.id.nameCardPhone) }
+    private val emailView by lazy { findViewById<TextView>(R.id.nameCardEmail) }
+    private val connecting by lazy { findViewById<TextView>(R.id.nameCardConnecting) }
+    private val primary by lazy { findViewById<Button>(R.id.nameCardPrimary) }
+    private val secondary by lazy { findViewById<Button>(R.id.nameCardSecondary) }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        overrideOpenTransition() // kill the OEM window-open anim; only our view entrance plays
+        // Full-screen NameDrop look: no action bar / title chrome.
+        supportActionBar?.hide()
+        setContentView(R.layout.activity_name_card_transfer)
+        startGlowLoop()
+
+        when (intent.getStringExtra(EXTRA_ROLE)) {
+            ROLE_SERVER -> setupServer()
+            else -> setupClient()
+        }
+    }
+
+    /**
+     * Suppress the OS/OEM window open animation (e.g. OxygenOS launcher zoom) so the
+     * ONLY motion is the view-level [twoPhaseEntrance]. Belt-and-suspenders with the
+     * theme's windowAnimationStyle=@null.
+     */
+    private fun overrideOpenTransition() {
+        runCatching {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                overrideActivityTransition(OVERRIDE_TRANSITION_OPEN, 0, 0)
+            } else {
+                @Suppress("DEPRECATION")
+                overridePendingTransition(0, 0)
+            }
+        }
+    }
+
+    /** SERVER role: the peer card already arrived; play the tap-cue ripple, show it + Save/Done. */
+    private fun setupServer() {
+        val peer = intent.getByteArrayExtra(EXTRA_PEER_CARD)?.let { NameCard.parse(it) }
+        if (peer == null) {
+            DiagnosticLog.w(TAG, "server screen: no peer card → finish")
+            finish()
+            return
+        }
+        bindCard(peer)
+        primary.text = getString(R.string.name_card_transfer_save)
+        // SAVE = take their card. Send ripple (card sucked up = saved), then open the contact.
+        primary.setOnClickListener { commitWithSendRipple(primary) { saveAndFinish(peer) } }
+        secondary.text = getString(R.string.name_card_transfer_done)
+        // DONE = dismiss without saving. Reverse-exit the card, then close.
+        secondary.setOnClickListener { commitWithReverseExit(secondary) { finish() } }
+        // Tap-cue ripple over the previous screen, THEN the card enters.
+        playTriggerRipple { revealAndEnter() }
+    }
+
+    /** CLIENT role: run the exchange, show Connecting…, then the card + Receive Only / Share. */
+    private fun setupClient() {
+        val token = intent.getByteArrayExtra(EXTRA_TOKEN)
+        if (token == null) {
+            finish()
+            return
+        }
+        localCard =
+            NameCardResolver(
+                storedCard = NameCardProfileStore.from(this)::load,
+                deviceSources = AndroidDeviceContactSources(this),
+            ).resolve()
+
+        connecting.visibility = View.VISIBLE
+        card.visibility = View.INVISIBLE
+
+        // Force Bluetooth on via the helper (+ 5s heartbeat); start scanning once BT is on.
+        shareRadios.requestRadiosOn(RadioHelperClient.RADIO_BT)
+        startClientWhenBtReady(token, attempt = 0)
+
+        // Play the tap-cue ripple over the previous screen while we connect (fire-and-forget;
+        // the card's own entrance plays when the peer card actually arrives).
+        playTriggerRipple {}
+
+        // Don't sit on "Connecting…" forever if no peer is found / BLE never connects.
+        connecting.postDelayed({
+            if (!peerReceived && !isFinishing) {
+                DiagnosticLog.w(TAG, "client: connect timeout → no peer")
+                connecting.text = getString(R.string.name_card_transfer_failed)
+                exchange?.stop()
+            }
+        }, CONNECT_TIMEOUT_MS)
+    }
+
+    private fun startClientWhenBtReady(
+        token: ByteArray,
+        attempt: Int,
+    ) {
+        if (isFinishing) return
+        val adapter = getSystemService(BluetoothManager::class.java)?.adapter
+        if (adapter?.isEnabled != true && attempt < MAX_BT_WAIT_ATTEMPTS) {
+            DiagnosticLog.w(TAG, "client: BT not on yet (attempt $attempt) → waiting for helper")
+            btHandler.postDelayed({ startClientWhenBtReady(token, attempt + 1) }, BT_GRACE_MS)
+            return
+        }
+        val ble = NameCardBleExchange(this)
+        exchange = ble
+        val started = ble.startClient(token) { peer -> runOnUiThread { onPeerCardReceived(peer) } }
+        if (!started) {
+            connecting.text = getString(R.string.name_card_transfer_failed)
+        }
+    }
+
+    private fun onPeerCardReceived(peer: NameCard) {
+        peerReceived = true
+        connecting.visibility = View.GONE
+        bindCard(peer)
+        revealAndEnter()
+        // Share = send my card back too; Receive Only = take theirs only. Both save theirs.
+        primary.text = getString(R.string.name_card_transfer_share)
+        primary.setOnClickListener {
+            // Fire the BLE share-back immediately (don't wait on the exit animation), then
+            // reverse-exit the card → glow ripple → open the saved contact.
+            localCard?.let { exchange?.shareBack(it) } ?: exchange?.declineShare()
+            commitWithReverseExit(primary) { playTriggerRipple { saveAndFinish(peer) } }
+        }
+        secondary.text = getString(R.string.name_card_transfer_receive_only)
+        secondary.setOnClickListener {
+            exchange?.declineShare()
+            commitWithSendRipple(secondary) { saveAndFinish(peer) }
+        }
+    }
+
+    // ---- entrance / exit / ripple (values baked in [Anim]) ----
+
+    /** Make the card visible and play the two-phase entrance once it has been laid out. */
+    private fun revealAndEnter() {
+        card.visibility = View.VISIBLE
+        card.post { twoPhaseEntrance(card) }
+    }
+
+    /**
+     * TWO-PHASE entrance: the small card DESCENDS (decelerate) from above to a stop
+     * point, then EXPANDS in place from the start scale to full size (accelerate,
+     * factor [Anim.EXPAND_EASE]) around a near-top pivot ([Anim.EXPAND_PIVOT_Y_FRAC]).
+     * No overlap between the two phases. A tween, NOT a physics bounce.
+     */
+    @Suppress("MagicNumber")
+    private fun twoPhaseEntrance(v: View) {
+        val screenH = v.rootView.height
+        val h = v.height.toFloat()
+        val restCenterY = h / 2f
+        val fromY = Anim.START_CENTER_Y_FRAC * screenH - restCenterY // start above the top
+        val stopY = Anim.STOP_FRAC * screenH - restCenterY // phase-1 stop (0.5 → 0 = centered rest)
+        val s0 = Anim.SCALE_FROM
+        v.pivotX = v.width * 0.5f
+        v.pivotY = h * Anim.EXPAND_PIVOT_Y_FRAC
+        v.scaleX = s0
+        v.scaleY = s0
+        v.translationY = fromY
+        v.alpha = 1f
+        // PHASE 1 — descend and slow to a stop (no scaling yet).
+        ObjectAnimator.ofFloat(v, View.TRANSLATION_Y, fromY, stopY).apply {
+            duration = Anim.DESCENT_MS
+            interpolator = DecelerateInterpolator()
+            start()
+        }
+        // PHASE 2 — after the descent, expand in place from s0 to full size.
+        val ease = AccelerateInterpolator(Anim.EXPAND_EASE.coerceAtLeast(0.1f))
+        ObjectAnimator.ofFloat(v, View.SCALE_X, s0, 1f).apply {
+            startDelay = Anim.DESCENT_MS
+            duration = Anim.EXPAND_MS
+            interpolator = ease
+            start()
+        }
+        ObjectAnimator.ofFloat(v, View.SCALE_Y, s0, 1f).apply {
+            startDelay = Anim.DESCENT_MS
+            duration = Anim.EXPAND_MS
+            interpolator = ease
+            start()
+        }
+    }
+
+    /**
+     * SHARE reverse-exit: the card RISES UP and SHRINKS to a point off the top of the
+     * screen (retraces the entrance start pos+scale) over [Anim.SHARE_EXIT_MS] with an
+     * accelerate (leave-fast) easing; on end hides the card and runs [onEnd].
+     */
+    @Suppress("MagicNumber")
+    private fun reverseExit(
+        v: View,
+        onEnd: () -> Unit,
+    ) {
+        val screenH = v.rootView.height
+        val h = v.height.toFloat()
+        val restCenterY = h / 2f
+        val toY = Anim.START_CENTER_Y_FRAC * screenH - restCenterY
+        val s1 = Anim.SCALE_FROM
+        v.pivotX = v.width * 0.5f
+        v.pivotY = h * 0.5f
+        val ease = AccelerateInterpolator(1.5f)
+        ObjectAnimator.ofFloat(v, View.TRANSLATION_Y, v.translationY, toY).apply {
+            duration = Anim.SHARE_EXIT_MS
+            interpolator = ease
+            addListener(
+                object : AnimatorListenerAdapter() {
+                    override fun onAnimationEnd(animation: Animator) {
+                        v.visibility = View.INVISIBLE
+                        onEnd()
+                    }
+                },
+            )
+            start()
+        }
+        ObjectAnimator.ofFloat(v, View.SCALE_X, v.scaleX, s1).apply {
+            duration = Anim.SHARE_EXIT_MS
+            interpolator = ease
+            start()
+        }
+        ObjectAnimator.ofFloat(v, View.SCALE_Y, v.scaleY, s1).apply {
+            duration = Anim.SHARE_EXIT_MS
+            interpolator = ease
+            start()
+        }
+    }
+
+    /** Commit path A: [tapped] button pop → reverse-exit the card → [after]. Guarded against double taps. */
+    private fun commitWithReverseExit(
+        tapped: View,
+        after: () -> Unit,
+    ) {
+        if (committed) return
+        committed = true
+        pressAnim(tapped)
+        ui.postDelayed({
+            if (!isFinishing) reverseExit(card) { if (!isFinishing) after() }
+        }, Anim.BUTTON_PRESS_MS)
+    }
+
+    /** Commit path B: [tapped] button pop → send (suck-up) ripple → [after]. Guarded against double taps. */
+    private fun commitWithSendRipple(
+        tapped: View,
+        after: () -> Unit,
+    ) {
+        if (committed) return
+        committed = true
+        pressAnim(tapped)
+        ui.postDelayed({
+            if (isFinishing) return@postDelayed
+            playSendRipple()
+            ui.postDelayed({ if (!isFinishing) after() }, Anim.SENT_RIPPLE_MS + Anim.AUTO_OPEN_DELAY_MS)
+        }, Anim.BUTTON_PRESS_MS)
+    }
+
+    /**
+     * PRE-ENTRANCE ripple (INSTANCE 1) — the AirDrop glow/wave shader drawn on a
+     * TRANSPARENT full-screen layer over the previous screen (bgAlpha=0 → only the
+     * additive glow shows; the screen behind stays visible). Always calls [onDone]
+     * whether or not the ripple actually plays (API 33+), so the flow never stalls.
+     */
+    private fun playTriggerRipple(onDone: () -> Unit) {
+        var started = false
+        runCatching {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                val sh = RuntimeShader(AGSL)
+                applyRippleUniforms(sh)
+                sh.setFloatUniform("bgAlpha", 0f)
+                val transparentPx = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
+                sh.setInputShader(
+                    "layer",
+                    BitmapShader(transparentPx, Shader.TileMode.CLAMP, Shader.TileMode.CLAMP),
+                )
+                val rv = RippleBgView(this, sh)
+                rv.layoutParams =
+                    FrameLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                    )
+                root.addView(rv)
+                ValueAnimator.ofFloat(0f, 2f).apply {
+                    duration = Anim.TRIGGER_GLOW_MS
+                    addUpdateListener {
+                        sh.setFloatUniform("t", it.animatedValue as Float)
+                        rv.invalidate()
+                    }
+                    addListener(
+                        object : AnimatorListenerAdapter() {
+                            override fun onAnimationEnd(animation: Animator) {
+                                root.removeView(rv)
+                                onDone()
+                            }
+                        },
+                    )
+                    start()
+                }
+                started = true
+            }
+        }
+        if (!started) onDone()
+    }
+
+    /**
+     * SEND ripple (INSTANCE 2) — AirDrop "suck the card up into the island". NON-FLIPPING:
+     * snapshot the card to a bitmap, flip it vertically (cancels the shader's own Y-flip),
+     * run the shader on an ImageView of that bitmap; the real card is hidden while it plays.
+     * API 33+; a no-op otherwise (the caller's [after] still runs on its timer).
+     */
+    private fun playSendRipple() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
+        if (card.width <= 0 || card.height <= 0) return
+        runCatching {
+            val w = card.width
+            val h = card.height
+            val snap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
+            card.draw(Canvas(snap))
+            val flip = Matrix().apply { preScale(1f, -1f) }
+            val flipped = Bitmap.createBitmap(snap, 0, 0, w, h, flip, true)
+            val iv = ImageView(this)
+            iv.layoutParams =
+                FrameLayout.LayoutParams(w, h).apply {
+                    leftMargin = card.x.toInt()
+                    topMargin = card.y.toInt()
+                }
+            iv.setImageBitmap(flipped)
+            root.addView(iv)
+            card.visibility = View.INVISIBLE
+            val sh = RuntimeShader(AGSL)
+            sh.setFloatUniform("viewSize", w.toFloat(), h.toFloat())
+            applyRippleUniforms(sh)
+            sh.setFloatUniform("bgAlpha", 1f) // opaque: acts on the card snapshot
+            ValueAnimator.ofFloat(0f, 2f).apply {
+                duration = Anim.SENT_RIPPLE_MS
+                addUpdateListener {
+                    sh.setFloatUniform("t", it.animatedValue as Float)
+                    iv.setRenderEffect(RenderEffect.createRuntimeShaderEffect(sh, "layer"))
+                }
+                addListener(
+                    object : AnimatorListenerAdapter() {
+                        override fun onAnimationEnd(animation: Animator) {
+                            iv.setRenderEffect(null)
+                            root.removeView(iv)
+                        }
+                    },
+                )
+                start()
+            }
+        }
+    }
+
+    /** Apply the (baked) AirDrop-ripple split uniforms shared by both ripple instances. */
+    private fun applyRippleUniforms(sh: RuntimeShader) {
+        sh.setFloatUniform("glowXBias", Anim.R_GLOW_X_BIAS)
+        sh.setFloatUniform("stretchAmt", Anim.R_STRETCH)
+        sh.setFloatUniform("waveYOffset", Anim.R_WAVE_Y)
+        sh.setFloatUniform("waveXBias", Anim.R_WAVE_X)
+        sh.setFloatUniform("glowMoveYShift", Anim.R_GLOW_MOVE_Y)
+        sh.setFloatUniform("glowMoveSize", Anim.R_GLOW_MOVE_SIZE)
+        sh.setFloatUniform("glowCircleAmt", Anim.R_GLOW_CIRCLE)
+    }
+
+    /** Button tap feedback: a quick pop-EXPAND (scale up past 1 and back). */
+    private fun pressAnim(v: View) {
+        val sx = PropertyValuesHolder.ofFloat(View.SCALE_X, 1f, Anim.BUTTON_PRESS_SCALE, 1f)
+        val sy = PropertyValuesHolder.ofFloat(View.SCALE_Y, 1f, Anim.BUTTON_PRESS_SCALE, 1f)
+        ObjectAnimator.ofPropertyValuesHolder(v, sx, sy).apply {
+            duration = Anim.BUTTON_PRESS_MS
+            start()
+        }
+    }
+
+    /**
+     * Full-screen View that DRAWS the ripple RuntimeShader via a Paint (renders real
+     * pixels over the translucent window; reads its own size each frame so there's no
+     * first-frame size-gate). Used for the pre-entrance over-background ripple cue.
+     */
+    private class RippleBgView(context: Context, private val sh: RuntimeShader) : View(context) {
+        private val paint =
+            Paint().apply {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) shader = sh
+            }
+
+        override fun onDraw(canvas: Canvas) {
+            val w = width
+            val h = height
+            if (w <= 0 || h <= 0) return
+            sh.setFloatUniform("viewSize", w.toFloat(), h.toFloat())
+            canvas.drawRect(0f, 0f, w.toFloat(), h.toFloat(), paint)
+        }
+    }
+
+    private fun saveAndFinish(card: NameCard) {
+        if (NameCardSaver.hasWritePermission(this)) {
+            persistCard(card, granted = true)
+        } else {
+            pendingSaveCard = card
+            contactsPermission.launch(
+                arrayOf(Manifest.permission.WRITE_CONTACTS, Manifest.permission.READ_CONTACTS),
+            )
+        }
+    }
+
+    /**
+     * Save [card] and finish. With permission: a direct ContactsContract insert off
+     * the UI thread, then OPEN the saved contact in the Contacts app. Without: the
+     * system Add-contact screen. [persistCard] owns the finish in every branch.
+     */
+    private fun persistCard(
+        card: NameCard,
+        granted: Boolean,
+    ) {
+        if (!granted) {
+            runCatching { startActivity(NameCardSaver.systemInsertIntent(card)) }
+            finish()
+            return
+        }
+        val appCtx = applicationContext
+        Thread {
+            val contactUri = NameCardSaver.saveDirect(appCtx, card)
+            runOnUiThread {
+                contactUri?.let { runCatching { startActivity(Intent(Intent.ACTION_VIEW, it)) } }
+                finish()
+            }
+        }.start()
+    }
+
+    /** Bind [card]'s fields into the panel (card left INVISIBLE until [revealAndEnter]). */
+    private fun bindCard(card: NameCard) {
+        avatar.text = (card.displayName ?: card.phoneNumber ?: "?").trim().take(1).uppercase()
+        nameView.text = card.displayName ?: getString(R.string.name_card_transfer_no_name)
+        bindOptional(phoneView, card.phoneNumber)
+        bindOptional(emailView, card.email)
+    }
+
+    private fun bindOptional(
+        view: TextView,
+        value: String?,
+    ) {
+        if (value.isNullOrBlank()) {
+            view.visibility = View.GONE
+        } else {
+            view.visibility = View.VISIBLE
+            view.text = value
+        }
+    }
+
+    /** Top "light beam" glow: a looping fade in/out via a tween (no physics spec). */
+    private fun startGlowLoop() {
+        ObjectAnimator.ofFloat(glow, View.ALPHA, GLOW_MIN, GLOW_MAX).apply {
+            duration = GLOW_MS
+            repeatMode = ObjectAnimator.REVERSE
+            repeatCount = ObjectAnimator.INFINITE
+            interpolator = AccelerateDecelerateInterpolator()
+            start()
+        }
+    }
+
+    override fun onDestroy() {
+        btHandler.removeCallbacksAndMessages(null)
+        ui.removeCallbacksAndMessages(null)
+        exchange?.stop()
+        exchange = null
+        shareRadios.restoreRadios()
+        super.onDestroy()
+    }
+
+    /** Baked animation constants for the entrance / exit / ripple. Times in ms. */
+    private object Anim {
+        // Two-phase entrance / reverse-exit.
+        const val START_CENTER_Y_FRAC = -0.3f // card center starts this frac of screen height (above top)
+        const val SCALE_FROM = 0.09f // start scale (proportional miniature)
+        const val STOP_FRAC = 0.5f // phase-1 stop: center at 0.5 → centered full-screen rest
+        const val DESCENT_MS = 500L
+        const val EXPAND_MS = 700L
+        const val EXPAND_EASE = 1.3f // AccelerateInterpolator factor
+        const val EXPAND_PIVOT_Y_FRAC = 0.08f // expansion origin near the TOP of the card
+        const val SHARE_EXIT_MS = 500L
+
+        // Ripples.
+        const val TRIGGER_GLOW_MS = 1100L
+        const val SENT_RIPPLE_MS = 1200L
+        const val AUTO_OPEN_DELAY_MS = 200L
+
+        // Split AirDrop-ripple uniforms (defaults = the verbatim iOS look).
+        const val R_GLOW_X_BIAS = 0f
+        const val R_STRETCH = 1f
+        const val R_WAVE_Y = 0.46f
+        const val R_WAVE_X = 0f
+        const val R_GLOW_MOVE_Y = -0.55f
+        const val R_GLOW_MOVE_SIZE = 1f
+        const val R_GLOW_CIRCLE = 1f
+
+        // Button feedback.
+        const val BUTTON_PRESS_MS = 200L
+        const val BUTTON_PRESS_SCALE = 1.1f
+    }
+
+    companion object {
+        private const val TAG = "NameCardTransfer"
+        private const val EXTRA_ROLE = "role"
+        private const val EXTRA_TOKEN = "token"
+        private const val EXTRA_PEER_CARD = "peer_card"
+        private const val ROLE_CLIENT = "client"
+        private const val ROLE_SERVER = "server"
+
+        private const val GLOW_MS = 1100L
+        private const val GLOW_MIN = 0.35f
+        private const val GLOW_MAX = 1.0f
+        private const val CONNECT_TIMEOUT_MS = 18_000L
+        private const val BT_GRACE_MS = 1_500L
+        private const val MAX_BT_WAIT_ATTEMPTS = 2
+
+        /**
+         * The AirDrop "suck into the Dynamic Island" ripple (AGSL). `bgAlpha` 1 = opaque
+         * (on the card snapshot); 0 = transparent except the glow (over the previous screen).
+         */
+        private val AGSL =
+            """
+            uniform shader layer;
+            uniform float  t;
+            uniform float2 viewSize;
+            uniform float  glowXBias;
+            uniform float  stretchAmt;
+            uniform float  waveYOffset;
+            uniform float  waveXBias;
+            uniform float  glowMoveYShift;
+            uniform float  glowMoveSize;
+            uniform float  glowCircleAmt;
+            uniform float  bgAlpha;
+
+            half4 main(float2 position) {
+                float2 position_yflip = float2(position.x, viewSize.y - position.y);
+                float uv_y_dynamic_island_offset = 0.46;
+
+                float t2 = pow(t, 2.0);
+                float t3 = pow(t, 3.0);
+
+                float2 uv = position_yflip / viewSize;
+                float2 uv_stretch = float2(uv.x+((uv.x-0.5)*pow(uv.y,6.0)*t3*0.1*stretchAmt), uv.y * (uv.y * pow((1.0-(t2*0.01)), 8.0)) + (1.0-uv.y) * uv.y);
+                uv_stretch = mix(uv, uv_stretch, smoothstep(1.1, 1.0, t));
+                float4 color = float4(layer.eval(uv_stretch * viewSize));
+
+                float2 bang_offset = float2(0.0);
+                float bang_d = 0.0;
+                if (t >= 1.0) {
+                    float aT = t - 1.0;
+                    float2 uv2 = uv;
+                    uv2 -= 0.5;
+                    uv2.x *= viewSize.x / viewSize.y;
+                    uv2.x -= waveXBias;
+
+                    float2 uv_bang = float2(uv2.x, uv2.y);
+                    float2 uv_bang_origin = float2(uv_bang.x, uv_bang.y-waveYOffset);
+                    bang_d = (aT*0.16)/length(uv_bang_origin);
+                    bang_d = smoothstep(0.09, 0.05, bang_d) * smoothstep(0.04, 0.07, bang_d) * (uv.y+0.05);
+                    bang_offset = float2(-8.0*bang_d*uv2.x, -4.0*bang_d*(uv2.y-0.4))*0.1;
+
+                    float bang_d2 = ((aT-0.085) * 0.14)/length(uv_bang_origin);
+                    bang_d2 = smoothstep(0.09, 0.05, bang_d2) * smoothstep(0.04, 0.07, bang_d2) * (uv.y+0.05);
+                    bang_offset += float2(-8.0*bang_d2*uv2.x, -4.0*bang_d2*(uv2.y-0.4))*-0.02;
+                }
+
+                float2 uv_stretch_bang = uv_stretch+bang_offset;
+                color = float4(layer.eval(uv_stretch_bang * viewSize));
+                color += bang_d*500.0 * smoothstep(1.05, 1.1, t);
+
+                const float Pi = 6.28318530718 * 2.0;
+                const float Directions = 60.0;
+                const float Quality = 10.0;
+                float Radius = t2*0.1 * pow(uv.y, 6.0) * 0.5;
+                Radius *= smoothstep(1.3, 0.9, t);
+                Radius += bang_d*0.05;
+                for ( float d=0.0; d<Pi; d+=Pi/Directions )
+                {
+                    for ( float i=1.0/Quality; i<=1.0; i+=1.0/Quality )
+                    {
+                        float2 blurPos = (uv_stretch_bang + float2(cos(d),sin(d))*Radius*i);
+                        color += float4(layer.eval(blurPos*viewSize));
+                    }
+                }
+                color /= Quality * Directions;
+
+                uv -= 0.5;
+                uv.x *= viewSize.x / viewSize.y;
+                uv.x -= glowXBias;
+
+                float2 lighten_uv = float2(uv.x*0.65, uv.y - t + 0.5 + glowMoveYShift);
+                float d = smoothstep(0.0, 0.6, (0.1*glowMoveSize)/length(lighten_uv)-uv_y_dynamic_island_offset)*0.25;
+                float t_smooth = smoothstep(0.0, 0.3, t);
+                d *= t_smooth;
+                color = color + float4(color.r*d, color.g*d, 0.0, 1.0);
+
+                float2 lighten2_uv = float2(uv.x*0.4, uv.y-uv_y_dynamic_island_offset);
+                float d2 = smoothstep(0.0, 0.5, pow(1.0-length(lighten2_uv), 28.0))*0.5;
+                float t2_smooth = smoothstep(0.0, 1.0, t2)*1.0;
+                d2 *= t2_smooth;
+                d2 *= smoothstep(1.13, 1.0, t);
+                d2 *= glowCircleAmt;
+                color = float4(color.rgb*(1.0-d2), 1.0) + float4(float3(d2), 1.0);
+
+                half4 outc = half4(color);
+                float glowLum = clamp(max(outc.r, max(outc.g, outc.b)), 0.0, 1.0);
+                outc.a = mix(outc.a, glowLum, 1.0 - bgAlpha);
+                return outc;
+            }
+            """.trimIndent()
+
+        /** Reader side: open the screen to run the BLE client for [token]. */
+        fun clientIntent(
+            context: Context,
+            token: ByteArray,
+        ): Intent =
+            Intent(context, NameCardTransferActivity::class.java)
+                .putExtra(EXTRA_ROLE, ROLE_CLIENT)
+                .putExtra(EXTRA_TOKEN, token)
+
+        /** Card side: open the screen to show the [peerCard] the tapper sent back. */
+        fun serverIntent(
+            context: Context,
+            peerCard: NameCard,
+        ): Intent =
+            Intent(context, NameCardTransferActivity::class.java)
+                .putExtra(EXTRA_ROLE, ROLE_SERVER)
+                .putExtra(EXTRA_PEER_CARD, peerCard.serialize())
+    }
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/nfc/NameCardBootstrapHolder.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/nfc/NameCardBootstrapHolder.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.nfc
+
+import dev.bluehouse.bada.protocol.namecard.NameCardBootstrap
+import java.security.SecureRandom
+
+/**
+ * **Name Card rendezvous-token minter.** The Name Card NFC tap is only a TRIGGER
+ * (see `docs/NAMEDROP_CONTACT_EXCHANGE_JOURNAL.md`): on a tap the card-side
+ * [NameCardHceService] calls [newSession] to mint a fresh random rendezvous token,
+ * returns it to the tapping phone over NFC, and passes the same token to the
+ * Bluetooth layer ([dev.bluehouse.bada.namecard.NameCardExchangeService]) to advertise.
+ * The reader side reads the token from the NFC response and hands it straight to
+ * the transfer Activity — so the token flows NFC-response → Intent, not through any
+ * shared field here. This object only centralises secure token generation.
+ */
+internal object NameCardBootstrapHolder {
+    private val secureRandom = SecureRandom()
+
+    /** Mint a fresh bootstrap (new random [NameCardBootstrap.TOKEN_LEN]-byte token) for THIS tap. */
+    fun newSession(): NameCardBootstrap {
+        val token = ByteArray(NameCardBootstrap.TOKEN_LEN).also { secureRandom.nextBytes(it) }
+        return NameCardBootstrap(version = NameCardBootstrap.CURRENT_VERSION, token = token)
+    }
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/nfc/NameCardHceService.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/nfc/NameCardHceService.kt
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.nfc
+
+import android.app.KeyguardManager
+import android.nfc.cardemulation.HostApduService
+import android.os.Bundle
+import dev.bluehouse.bada.discovery.diagnostics.DiagnosticLog
+import dev.bluehouse.bada.namecard.NameCardPreferences
+import dev.bluehouse.bada.protocol.namecard.NameCardBootstrap
+
+/**
+ * **Name Card tap — card (HCE) side.** Host Card Emulation service for the Super
+ * Drop **Name Card** proprietary AID [NAME_CARD_AID]. When another Bada
+ * phone (in reader-mode) taps this phone, this service answers the bootstrap
+ * exchange so BOTH apps wake and learn a shared rendezvous token; the actual
+ * contact swap happens afterwards over Bluetooth.
+ *
+ * The tap is only a TRIGGER — this never carries the contact card, only a tiny
+ * [NameCardBootstrap] (version + 16-byte token via [NameCardBootstrapHolder]).
+ *
+ * APDU exchange (both ends are our app, so this is a private protocol distinct
+ * from the iPhone NDEF AID `D2760000850101` and the Quick Share AID `F00000FE2C`):
+ *  1. SELECT by name `00 A4 04 00 <Lc> F0534443415244` → `9000` (else `6A82`).
+ *  2. EXCHANGE `80 10 00 00 00` → `<bootstrap(17B)> 9000`.
+ *
+ * **Unlock gate (privacy):** the card answers SELECT/EXCHANGE
+ * only while the device is UNLOCKED ([KeyguardManager.isDeviceLocked] false).
+ * Locked → `6982` (security status not satisfied) and no token is emitted, so a
+ * locked/lost phone never leaks anything.
+ *
+ * Being invoked here also wakes our process (the platform binds the service on a
+ * tap even from cold); on EXCHANGE it starts
+ * [dev.bluehouse.bada.namecard.NameCardExchangeService] with the minted token to run
+ * the Bluetooth rendezvous (advertise + serve the card).
+ *
+ * Public `android.nfc.cardemulation` APIs + the auto-granted `BIND_NFC_SERVICE`.
+ * The bootstrap codec is unit-tested.
+ */
+@Suppress("MagicNumber", "ReturnCount")
+public class NameCardHceService : HostApduService() {
+    private val keyguard: KeyguardManager? by lazy {
+        getSystemService(KeyguardManager::class.java)
+    }
+
+    override fun processCommandApdu(
+        apdu: ByteArray?,
+        extras: Bundle?,
+    ): ByteArray {
+        if (apdu == null || apdu.size < MIN_APDU_LEN) return SW_WRONG_LENGTH
+
+        // Master switch: when the user has turned the feature off, decline every
+        // tap (no token, nothing served) so this phone is not tappable as a card.
+        if (!NameCardPreferences.from(this).isEnabled()) {
+            DiagnosticLog.w(TAG, "tap ignored — Name Card feature disabled in settings")
+            return SW_FILE_NOT_FOUND
+        }
+
+        // SELECT by name → match our Name Card AID.
+        if (apdu[1] == INS_SELECT && apdu[2] == P1_SELECT_BY_NAME) {
+            if (!apduSelectsAid(apdu, NAME_CARD_AID)) return SW_FILE_NOT_FOUND
+            if (isLocked()) {
+                DiagnosticLog.w(TAG, "SELECT while locked → 6982 (no card shared from a locked phone)")
+                return SW_LOCKED
+            }
+            DiagnosticLog.w(TAG, "SELECT Name Card AID → 9000")
+            return SW_OK
+        }
+
+        // EXCHANGE → mint + return a fresh bootstrap token (unlocked only).
+        if (apdu[0] == CLA_PROPRIETARY && apdu[1] == INS_EXCHANGE) {
+            if (isLocked()) {
+                DiagnosticLog.w(TAG, "EXCHANGE while locked → 6982")
+                return SW_LOCKED
+            }
+            val bootstrap = NameCardBootstrapHolder.newSession()
+            // Wake the card-side Bluetooth server (foreground service) so the tapping
+            // phone can read our card over BLE using this token.
+            runCatching {
+                dev.bluehouse.bada.namecard.NameCardExchangeService.start(this, bootstrap.token)
+            }.onFailure { DiagnosticLog.w(TAG, "EXCHANGE: start exchange service failed: ${it.message}") }
+            DiagnosticLog.w(TAG, "Name Card EXCHANGE → bootstrap(${bootstrap.serialize().size}B) + server FGS")
+            return bootstrap.serialize() + SW_OK
+        }
+
+        return SW_INS_NOT_SUPPORTED
+    }
+
+    override fun onDeactivated(reason: Int) {
+        // No per-session APDU state to reset; the token lives in the holder for
+        // the Bluetooth layer to pick up.
+    }
+
+    private fun isLocked(): Boolean = keyguard?.isDeviceLocked == true
+
+    public companion object {
+        private const val TAG = "NameCardHce"
+
+        private const val MIN_APDU_LEN = 4
+        private const val P1_SELECT_BY_NAME: Byte = 0x04
+        private const val INS_SELECT: Byte = 0xA4.toByte()
+        private const val CLA_PROPRIETARY: Byte = 0x80.toByte()
+        private const val INS_EXCHANGE: Byte = 0x10
+
+        /**
+         * Proprietary Name Card AID = `F0` (proprietary range) + ASCII "SDCARD".
+         * Distinct from the iPhone NDEF AID and the Quick Share AID so all three
+         * HCE services coexist on the one controller. Declared in
+         * `res/xml/bada_namecard_apduservice.xml`.
+         */
+        public val NAME_CARD_AID: ByteArray =
+            byteArrayOf(0xF0.toByte(), 0x53, 0x44, 0x43, 0x41, 0x52, 0x44)
+
+        private val SW_OK = byteArrayOf(0x90.toByte(), 0x00)
+        private val SW_FILE_NOT_FOUND = byteArrayOf(0x6A.toByte(), 0x82.toByte())
+        private val SW_LOCKED = byteArrayOf(0x69.toByte(), 0x82.toByte())
+        private val SW_WRONG_LENGTH = byteArrayOf(0x67.toByte(), 0x00)
+        private val SW_INS_NOT_SUPPORTED = byteArrayOf(0x6D.toByte(), 0x00)
+
+        /** True iff this SELECT-by-name APDU carries exactly [aid]. */
+        internal fun apduSelectsAid(
+            apdu: ByteArray,
+            aid: ByteArray,
+        ): Boolean {
+            if (apdu.size < 5 + aid.size) return false
+            val lc = apdu[4].toInt() and 0xFF
+            if (lc != aid.size) return false
+            for (i in aid.indices) {
+                if (apdu[5 + i] != aid[i]) return false
+            }
+            return true
+        }
+
+        /** Build the SELECT-by-name APDU for the Name Card AID (used by the reader). */
+        @Suppress("MagicNumber")
+        internal fun buildSelectApdu(): ByteArray {
+            val aid = NAME_CARD_AID
+            val apdu = ByteArray(5 + aid.size + 1)
+            apdu[1] = INS_SELECT
+            apdu[2] = P1_SELECT_BY_NAME
+            apdu[4] = aid.size.toByte()
+            System.arraycopy(aid, 0, apdu, 5, aid.size)
+            apdu[apdu.size - 1] = 0x00 // Le
+            return apdu
+        }
+
+        /** Build the EXCHANGE APDU `80 10 00 00 00` (used by the reader). */
+        internal fun buildExchangeApdu(): ByteArray =
+            byteArrayOf(CLA_PROPRIETARY, INS_EXCHANGE, 0x00, 0x00, 0x00)
+
+        /** Whether [resp] ends with the `9000` success status word. */
+        internal fun endsWithOk(resp: ByteArray): Boolean =
+            resp.size >= 2 && resp[resp.size - 2] == SW_OK[0] && resp[resp.size - 1] == SW_OK[1]
+    }
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/nfc/NameCardTapReader.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/nfc/NameCardTapReader.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.nfc
+
+import android.app.Activity
+import android.nfc.NfcAdapter
+import android.nfc.Tag
+import android.nfc.tech.IsoDep
+import dev.bluehouse.bada.discovery.diagnostics.DiagnosticLog
+import dev.bluehouse.bada.protocol.namecard.NameCardBootstrap
+import java.io.IOException
+
+/**
+ * **Name Card tap — reader side.** Puts the foreground [activity] into NFC
+ * reader-mode and, on a tap to another Bada phone's [NameCardHceService],
+ * runs the bootstrap exchange (SELECT Name Card AID → EXCHANGE) to read the
+ * peer's rendezvous [NameCardBootstrap]. The parsed token is handed to
+ * [onPeerBootstrap], which opens [NameCardTransferActivity] to connect over
+ * Bluetooth by scanning for that token.
+ *
+ * Why a foreground reader: Android assigns NFC roles only when one side is an
+ * explicit reader, and reader-mode requires a resumed Activity. The person
+ * sharing has the app foreground; the other phone can be idle (its background
+ * [NameCardHceService] answers). `enableReaderMode` also suppresses this phone's
+ * own card so the roles are deterministic.
+ *
+ * Public `android.nfc` APIs only.
+ */
+internal class NameCardTapReader(
+    private val activity: Activity,
+    private val onPeerBootstrap: (NameCardBootstrap) -> Unit,
+    /** One-line human-readable outcome of each tap, for on-screen diagnostics. */
+    private val onTapDiagnostic: (String) -> Unit = {},
+) {
+    private val nfcAdapter: NfcAdapter? = NfcAdapter.getDefaultAdapter(activity)
+
+    /** Enter reader-mode. No-op without an NFC adapter. Safe to call repeatedly. */
+    fun enable() {
+        val adapter = nfcAdapter ?: return
+        val flags =
+            NfcAdapter.FLAG_READER_NFC_A or
+                NfcAdapter.FLAG_READER_NFC_B or
+                NfcAdapter.FLAG_READER_SKIP_NDEF_CHECK
+        runCatching {
+            adapter.enableReaderMode(activity, ::onTag, flags, null)
+        }.onFailure { DiagnosticLog.w(TAG, "enableReaderMode failed: ${it.message}") }
+    }
+
+    /** Leave reader-mode. */
+    fun disable() {
+        nfcAdapter?.let { runCatching { it.disableReaderMode(activity) } }
+    }
+
+    /** Reader-mode tag callback (binder thread). Marshalling to UI is the caller's job. */
+    private fun onTag(tag: Tag) {
+        val isoDep = IsoDep.get(tag) ?: return
+        val bootstrap =
+            try {
+                isoDep.connect()
+                exchange(isoDep)
+            } catch (e: IOException) {
+                DiagnosticLog.w(TAG, "Name Card tap exchange failed: ${e.message}")
+                null
+            } finally {
+                runCatching { isoDep.close() }
+            }
+
+        if (bootstrap == null) {
+            onTapDiagnostic("Name Card tap: no Bada card (or tag lost)")
+            return
+        }
+        DiagnosticLog.w(TAG, "Name Card tap resolved peer token (${bootstrap.token.size}B)")
+        onTapDiagnostic("Name Card tap: peer resolved → connecting over Bluetooth")
+        onPeerBootstrap(bootstrap)
+    }
+
+    /** SELECT then EXCHANGE; returns the parsed peer bootstrap, or null on any failure. */
+    @Suppress("ReturnCount")
+    private fun exchange(isoDep: IsoDep): NameCardBootstrap? {
+        val selectResp = isoDep.transceive(NameCardHceService.buildSelectApdu())
+        if (!NameCardHceService.endsWithOk(selectResp)) {
+            DiagnosticLog.w(TAG, "SELECT not OK (${selectResp.size}B) — not a Name Card peer / locked")
+            return null
+        }
+        val exchangeResp = isoDep.transceive(NameCardHceService.buildExchangeApdu())
+        if (!NameCardHceService.endsWithOk(exchangeResp) || exchangeResp.size <= STATUS_LEN) return null
+        val body = exchangeResp.copyOfRange(0, exchangeResp.size - STATUS_LEN)
+        return NameCardBootstrap.parse(body)
+    }
+
+    private companion object {
+        private const val TAG = "NameCardTapReader"
+        private const val STATUS_LEN = 2
+    }
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/ui/SettingsFragment.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/ui/SettingsFragment.kt
@@ -5,6 +5,7 @@
  */
 package dev.bluehouse.bada.ui
 
+import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.util.Log
@@ -22,6 +23,8 @@ import dev.bluehouse.bada.R
 import dev.bluehouse.bada.battery.BatteryOptimizationOemHelper
 import dev.bluehouse.bada.bugreport.BugReportPreferences
 import dev.bluehouse.bada.consent.FullScreenIntentPermission
+import dev.bluehouse.bada.namecard.NameCardProfileStore
+import dev.bluehouse.bada.namecard.NameCardSetupActivity
 import dev.bluehouse.bada.service.downloads.SaveLocationDisplayName
 import dev.bluehouse.bada.service.downloads.SaveLocationPreferences
 import dev.bluehouse.bada.service.receiver.AdvertisedDeviceNames
@@ -95,6 +98,11 @@ internal class SettingsFragment : Fragment(R.layout.fragment_settings) {
     ) {
         super.onViewCreated(view, savedInstanceState)
 
+        // "Name Card" row → My Name Card setup page (tap-to-share contacts).
+        view.findViewById<View>(R.id.settings_name_card_row).setOnClickListener {
+            startActivity(Intent(requireContext(), NameCardSetupActivity::class.java))
+        }
+
         view.findViewById<Button>(R.id.main_save_location_pick).setOnClickListener {
             saveLocationLauncher.launch(null)
         }
@@ -159,6 +167,20 @@ internal class SettingsFragment : Fragment(R.layout.fragment_settings) {
         refreshFullScreenIntentSection()
         refreshBugReportSwitch()
         refreshTransferSwitches()
+        refreshNameCardDot()
+    }
+
+    /**
+     * Show the small red dot on the "Name Card" row when the user hasn't set up a
+     * card yet (mirrors the update badge). Re-checked on every onStart so it clears
+     * immediately after the user saves a card in NameCardSetupActivity and returns.
+     * The dot reflects the in-app card only — a device fallback (SIM / "Me" contact)
+     * still counts as "not set up" so the user is nudged to fill it in.
+     */
+    private fun refreshNameCardDot() {
+        val dot = view?.findViewById<View>(R.id.settings_name_card_dot) ?: return
+        val configured = NameCardProfileStore.from(requireContext()).isConfigured()
+        dot.visibility = if (configured) View.GONE else View.VISIBLE
     }
 
     override fun onResume() {

--- a/app/src/main/res/drawable/name_card_avatar_bg.xml
+++ b/app/src/main/res/drawable/name_card_avatar_bg.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  name_card_avatar_bg — solid blue filled circle behind the contact's first
+  initial on the Name Card transfer screen (nameCardAvatar).
+-->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="#448AFF" />
+</shape>

--- a/app/src/main/res/drawable/name_card_glow.xml
+++ b/app/src/main/res/drawable/name_card_glow.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  name_card_glow — the thin "light beam" strip across the top of the Name Card
+  transfer screen (NameDrop-style). A horizontal gradient that fades from
+  transparent at the edges to a bright accent in the middle; the View's alpha is
+  pulsed by a tween loop in NameCardTransferActivity.
+-->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <gradient
+        android:startColor="#00448AFF"
+        android:centerColor="#FF448AFF"
+        android:endColor="#00448AFF"
+        android:angle="0" />
+</shape>

--- a/app/src/main/res/layout/activity_name_card_setup.xml
+++ b/app/src/main/res/layout/activity_name_card_setup.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  My Name Card setup screen (NameCardSetupActivity). Reached from the
+  "Name Card" row in Settings. Lets the user enter the contact card they
+  share when two phones tap (NameDrop-style).
+
+  Visual: a single rounded white panel (@drawable/settings_card_background)
+  matching the Settings cards, with a title, subtitle, three labelled text
+  fields (name / phone / email), and an action row.
+-->
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingHorizontal="16dp"
+        android:paddingTop="8dp"
+        android:paddingBottom="24dp">
+
+        <!-- Name Card editor panel -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@drawable/settings_card_background"
+            android:orientation="vertical"
+            android:padding="20dp">
+
+            <TextView
+                android:id="@+id/nameCardTitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/name_card_setup_title"
+                android:textAppearance="@style/TextAppearance.AppCompat.Subhead"
+                android:textColor="?android:attr/textColorPrimary"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/nameCardSubtitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:text="@string/name_card_setup_subtitle"
+                android:textAppearance="@style/TextAppearance.AppCompat.Small"
+                android:textColor="?android:attr/textColorSecondary" />
+
+            <!-- nameCardEnableRow — "Share my card when phones tap" master on/off switch.
+                 When off, this phone won't answer a tap and won't read another's card. -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/name_card_enable_title"
+                    android:textAppearance="@style/TextAppearance.AppCompat.Body2"
+                    android:textColor="?android:attr/textColorPrimary" />
+
+                <androidx.appcompat.widget.SwitchCompat
+                    android:id="@+id/nameCardEnableSwitch"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="12dp" />
+
+            </LinearLayout>
+
+            <!-- nameCardNameInput — "Name" text field -->
+            <EditText
+                android:id="@+id/nameCardNameInput"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:autofillHints="name"
+                android:hint="@string/name_card_field_name"
+                android:inputType="textPersonName"
+                android:maxLines="1" />
+
+            <!-- nameCardPhoneInput — "Phone" field -->
+            <EditText
+                android:id="@+id/nameCardPhoneInput"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:autofillHints="phone"
+                android:hint="@string/name_card_field_phone"
+                android:inputType="phone"
+                android:maxLines="1" />
+
+            <!-- nameCardEmailInput — "Email" field -->
+            <EditText
+                android:id="@+id/nameCardEmailInput"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:autofillHints="emailAddress"
+                android:hint="@string/name_card_field_email"
+                android:inputType="textEmailAddress"
+                android:maxLines="1" />
+
+            <!-- nameCardUsePhoneInfoButton — full-width pill: fills empty fields from the device "Me"/SIM -->
+            <Button
+                android:id="@+id/nameCardUsePhoneInfoButton"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:text="@string/name_card_use_phone_info" />
+
+            <!-- action row: Clear (secondary) + Save (primary), mirroring the Settings two-pill rows -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:orientation="horizontal">
+
+                <Button
+                    android:id="@+id/nameCardClearButton"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/name_card_clear" />
+
+                <Space
+                    android:layout_width="12dp"
+                    android:layout_height="wrap_content" />
+
+                <Button
+                    android:id="@+id/nameCardSaveButton"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/name_card_save"
+                    tools:ignore="ButtonStyle" />
+
+            </LinearLayout>
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+</ScrollView>

--- a/app/src/main/res/layout/activity_name_card_transfer.xml
+++ b/app/src/main/res/layout/activity_name_card_transfer.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Name Card transfer screen (NameCardTransferActivity) — full-screen, NameDrop-
+  style. A top "light beam" glow strip; a "Connecting…" line (client) until the
+  card arrives; then the CARD — the avatar circle, name, phone, email AND the two
+  action buttons, all inside ONE container (nameCardCard) that animates as a single
+  unit (the two-phase descend+expand entrance, and the Share reverse-exit). Plain
+  Activity (no overlay permission, no lock-screen bypass); the existing app theme
+  is untouched — every animation here is view-level (ObjectAnimator / RuntimeShader).
+-->
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/nameCardRoot"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?android:attr/colorBackground">
+
+    <!-- nameCardGlow — thin horizontal "light beam" across the very top; alpha pulses (tween loop). -->
+    <View
+        android:id="@+id/nameCardGlow"
+        android:layout_width="match_parent"
+        android:layout_height="6dp"
+        android:layout_gravity="top"
+        android:background="@drawable/name_card_glow" />
+
+    <!-- nameCardConnecting — centred "Connecting…" line shown (client) until the card arrives. -->
+    <TextView
+        android:id="@+id/nameCardConnecting"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="@string/name_card_transfer_connecting"
+        android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+        android:textColor="?android:attr/textColorSecondary"
+        android:visibility="gone" />
+
+    <!--
+      nameCardCard — THE animated unit. Transparent, full-screen; holds the centred
+      info panel AND the bottom action row so they descend + expand together (and, on
+      Share, fly up + shrink together). Starts invisible; the entrance reveals it.
+    -->
+    <FrameLayout
+        android:id="@+id/nameCardCard"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="invisible">
+
+        <!-- nameCardPanel — avatar + name + phone + email, centred. -->
+        <LinearLayout
+            android:id="@+id/nameCardPanel"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:gravity="center_horizontal"
+            android:orientation="vertical"
+            android:paddingHorizontal="32dp">
+
+            <!-- nameCardAvatar — large blue circle with the contact's first initial. -->
+            <TextView
+                android:id="@+id/nameCardAvatar"
+                android:layout_width="96dp"
+                android:layout_height="96dp"
+                android:background="@drawable/name_card_avatar_bg"
+                android:gravity="center"
+                android:textColor="#FFFFFF"
+                android:textSize="40sp"
+                android:textStyle="bold"
+                tools:ignore="HardcodedText" />
+
+            <!-- nameCardName — large bold contact name. -->
+            <TextView
+                android:id="@+id/nameCardName"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="20dp"
+                android:textAppearance="@style/TextAppearance.AppCompat.Headline"
+                android:textColor="?android:attr/textColorPrimary"
+                android:textStyle="bold"
+                tools:ignore="HardcodedText" />
+
+            <!-- nameCardPhone — phone number line (hidden if absent). -->
+            <TextView
+                android:id="@+id/nameCardPhone"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+                android:textColor="?android:attr/textColorSecondary" />
+
+            <!-- nameCardEmail — email line (hidden if absent). -->
+            <TextView
+                android:id="@+id/nameCardEmail"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+                android:textColor="?android:attr/textColorSecondary" />
+
+        </LinearLayout>
+
+        <!-- Action row pinned to the bottom: secondary (Receive Only / Done) + primary (Share / Save). -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom"
+            android:orientation="horizontal"
+            android:paddingHorizontal="24dp"
+            android:paddingBottom="32dp">
+
+            <!-- nameCardSecondary — left pill: "Receive Only" (client) / "Done" (server). -->
+            <Button
+                android:id="@+id/nameCardSecondary"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1" />
+
+            <Space
+                android:layout_width="12dp"
+                android:layout_height="wrap_content" />
+
+            <!-- nameCardPrimary — right pill: "Share" (client) / "Save" (server). -->
+            <Button
+                android:id="@+id/nameCardPrimary"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1" />
+
+        </LinearLayout>
+
+    </FrameLayout>
+
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -49,6 +49,68 @@
         android:paddingTop="8dp"
         android:paddingBottom="@dimen/settings_content_bottom_padding">
 
+        <!-- ============ Card 0: Name Card (tap-to-share contacts) ============
+             settings_name_card_row — clickable card (title "Name Card" + subtitle
+             + a "›" chevron) that opens NameCardSetupActivity, the My Name Card
+             setup page. Wired in SettingsFragment.onViewCreated. -->
+        <LinearLayout
+            android:id="@+id/settings_name_card_row"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@drawable/settings_card_background"
+            android:clickable="true"
+            android:focusable="true"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:padding="20dp">
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/settings_name_card_row_title"
+                    android:textAppearance="@style/TextAppearance.AppCompat.Subhead"
+                    android:textColor="?android:attr/textColorPrimary"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="6dp"
+                    android:text="@string/settings_name_card_row_subtitle"
+                    android:textAppearance="@style/TextAppearance.AppCompat.Small"
+                    android:textColor="?android:attr/textColorSecondary" />
+
+            </LinearLayout>
+
+            <!-- settings_name_card_dot — 8dp red dot (same as the update badge) shown
+                 when no Name Card is set up yet. Toggled in SettingsFragment by
+                 NameCardProfileStore.isConfigured(). -->
+            <View
+                android:id="@+id/settings_name_card_dot"
+                android:layout_width="8dp"
+                android:layout_height="8dp"
+                android:layout_marginStart="12dp"
+                android:background="@drawable/update_badge_dot"
+                android:visibility="gone" />
+
+            <!-- chevron — ">" affordance signalling this row opens a sub-page -->
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="12dp"
+                android:text="›"
+                android:textColor="?android:attr/textColorSecondary"
+                android:textSize="22sp"
+                tools:ignore="HardcodedText" />
+
+        </LinearLayout>
+
         <!-- ============ Card 1: Save location ============ -->
         <LinearLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -566,4 +566,39 @@
          service broadcasts the current pairing link to a tapped iPhone so it
          opens that link in Safari. -->
     <string name="nfc_hce_service_description">Bada NFC link</string>
+
+    <!-- ===== Name Card (tap-to-share contacts) ===== -->
+    <!-- HCE service description shown in system NFC settings for the Name Card
+         tap (proprietary AID F0534443415244). -->
+    <string name="nfc_namecard_hce_service_description">Bada Name Card</string>
+    <!-- Settings row that opens the Name Card setup screen. -->
+    <string name="settings_name_card_row_title">Name Card</string>
+    <string name="settings_name_card_row_subtitle">Set up the contact card you share by tapping phones</string>
+    <!-- NameCardSetupActivity (the setup page) -->
+    <string name="name_card_activity_label">Name Card</string>
+    <string name="name_card_setup_title">My Name Card</string>
+    <string name="name_card_setup_subtitle">Shared with another Bada phone when you tap them together. Leave blank to fall back to your phone’s own name and number.</string>
+    <string name="name_card_enable_title">Share my card when phones tap</string>
+    <string name="name_card_field_name">Name</string>
+    <string name="name_card_field_phone">Phone</string>
+    <string name="name_card_field_email">Email</string>
+    <string name="name_card_use_phone_info">Use my phone info</string>
+    <string name="name_card_use_phone_info_filled">Filled from your phone</string>
+    <string name="name_card_use_phone_info_empty">Nothing found on your phone to fill</string>
+    <string name="name_card_use_phone_info_denied">Permission denied — enter your details manually</string>
+    <string name="name_card_save">Save</string>
+    <string name="name_card_saved">Name card saved</string>
+    <string name="name_card_clear">Clear</string>
+    <string name="name_card_cleared">Name card cleared</string>
+    <string name="name_card_save_empty">Enter a name, phone, or email first</string>
+    <!-- Transfer/exchange screen (NameCardTransferActivity) + exchange service -->
+    <string name="name_card_transfer_connecting">Connecting…</string>
+    <string name="name_card_transfer_failed">Couldn’t connect</string>
+    <string name="name_card_transfer_share">Share</string>
+    <string name="name_card_transfer_receive_only">Receive Only</string>
+    <string name="name_card_transfer_save">Save</string>
+    <string name="name_card_transfer_done">Done</string>
+    <string name="name_card_transfer_no_name">(No name)</string>
+    <string name="name_card_exchange_channel">Name Card exchange</string>
+    <string name="name_card_exchange_notification">Sharing your name card…</string>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -400,6 +400,23 @@
     </style>
 
     <!--
+      Translucent window for the Name Card transfer screen (NameCardTransferActivity).
+      Like Theme.Bada.ReceiveSheet it floats over whatever is behind it, but with NO dim
+      and no window animation, so the previous screen shows through fully and the only
+      motion is the screen's own view-level entrance/exit. Inherits Theme.Bada, so colors,
+      fonts and button styling are unchanged — this only controls window transparency.
+    -->
+    <style name="Theme.Bada.NameCardTransfer" parent="Theme.Bada">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="windowNoTitle">true</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:backgroundDimEnabled">false</item>
+        <item name="android:windowAnimationStyle">@null</item>
+    </style>
+
+    <!--
       Toolbar title text style — larger and bolder than the platform
       default to match the vivo / OriginOS native header pattern (the
       "연락처" title on a vivo Contacts screen sits at ~26sp bold,

--- a/app/src/main/res/xml/bada_namecard_apduservice.xml
+++ b/app/src/main/res/xml/bada_namecard_apduservice.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  HCE descriptor for the Bada Name Card tap (tap-to-share contacts).
+
+  Declares the proprietary Name Card AID F0534443415244 ("F0" + ASCII "SDCARD")
+  that another Bada phone in reader-mode SELECTs, then issues the EXCHANGE
+  command to read our rendezvous bootstrap token (NameCardHceService). The tap is
+  only a trigger; the contact card itself is swapped afterwards over Bluetooth.
+
+  Distinct AID from the iPhone NDEF-link service (D2760000850101) and the Quick
+  Share tap service (F00000FE2C), so all three HostApduServices coexist on the
+  one NFC controller.
+
+  category="other"  -> no default-payment role required.
+  requireDeviceUnlock="false" -> the platform routes the tap to us even from the
+  lock screen, but NameCardHceService GATES on KeyguardManager.isDeviceLocked in
+  code (returns 6982 + no token while locked), so a locked phone never shares a
+  card. (Code gating is used instead of requireDeviceUnlock="true" so we don't
+  trigger the platform's "unlock then tap again" two-tap flow.)
+-->
+<host-apdu-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:description="@string/nfc_namecard_hce_service_description"
+    android:requireDeviceUnlock="false">
+    <aid-group android:description="@string/nfc_namecard_hce_service_description"
+        android:category="other">
+        <aid-filter android:name="F0534443415244" />
+    </aid-group>
+</host-apdu-service>

--- a/app/src/test/kotlin/dev/bluehouse/bada/namecard/NameCardResolverTest.kt
+++ b/app/src/test/kotlin/dev/bluehouse/bada/namecard/NameCardResolverTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.namecard
+
+import dev.bluehouse.bada.protocol.namecard.NameCard
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-JVM tests for [NameCardResolver]'s fallback precedence: in-app card →
+ * device "Me"/SIM → bare number → nothing.
+ */
+class NameCardResolverTest {
+    private fun sources(
+        name: String? = null,
+        number: String? = null,
+    ) = object : DeviceContactSources {
+        override fun profileDisplayName(): String? = name
+
+        override fun simPhoneNumber(): String? = number
+    }
+
+    @Test
+    fun `in-app card wins over device sources`() {
+        val card = NameCard(displayName = "Mike", phoneNumber = "111")
+        val resolver = NameCardResolver({ card }, sources(name = "Device Owner", number = "999"))
+        assertEquals(card, resolver.resolve())
+    }
+
+    @Test
+    fun `falls back to device name and SIM number when no in-app card`() {
+        val resolver = NameCardResolver({ null }, sources(name = "Device Owner", number = "999"))
+        assertEquals(NameCard(displayName = "Device Owner", phoneNumber = "999"), resolver.resolve())
+    }
+
+    @Test
+    fun `falls back to a bare-number card when only the SIM number is known`() {
+        val resolver = NameCardResolver({ null }, sources(name = null, number = "5550199"))
+        val resolved = resolver.resolve()
+        assertEquals("5550199", resolved!!.phoneNumber)
+        assertNull(resolved.displayName)
+    }
+
+    @Test
+    fun `falls back to a name-only card when only the device name is known`() {
+        val resolver = NameCardResolver({ null }, sources(name = "Device Owner", number = null))
+        val resolved = resolver.resolve()
+        assertEquals("Device Owner", resolved!!.displayName)
+        assertNull(resolved.phoneNumber)
+    }
+
+    @Test
+    fun `resolves to null when nothing is available`() {
+        val resolver = NameCardResolver({ null }, sources())
+        assertNull(resolver.resolve())
+        assertFalse(resolver.canResolve())
+    }
+
+    @Test
+    fun `blank device strings are treated as absent`() {
+        val resolver = NameCardResolver({ null }, sources(name = "   ", number = ""))
+        assertNull(resolver.resolve())
+    }
+
+    @Test
+    fun `canResolve is true when a device fallback exists`() {
+        val resolver = NameCardResolver({ null }, sources(number = "999"))
+        assertTrue(resolver.canResolve())
+    }
+}

--- a/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/namecard/NameCard.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/namecard/NameCard.kt
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.protocol.namecard
+
+import java.nio.charset.CharacterCodingException
+import java.nio.charset.CodingErrorAction
+import java.nio.charset.StandardCharsets
+
+/**
+ * **Bada Name Card** — the contact descriptor exchanged by the
+ * NameDrop-style "tap two phones to swap contacts" feature (see
+ * `docs/NAMEDROP_CONTACT_EXCHANGE_JOURNAL.md`).
+ *
+ * ## What it is / what it's called
+ * A small, self-describing binary blob carrying a person's shareable contact
+ * details (name, phone, email, plus room to grow). It is the **payload** the
+ * two apps swap **after** an NFC tap bootstraps a Bluetooth (or Wi-Fi-LAN)
+ * link — the NFC tap itself never carries this; it is only the trigger.
+ *
+ * ## Why a dedicated wire format (not vCard on the wire)
+ * Both ends are our own app, so we control the bytes. A compact
+ * type-length-value (TLV) layout keeps the blob tiny (well under a Bluetooth
+ * MTU's worth for name+number+email) and **forward compatible**: a newer app
+ * can add fields (a photo, an organisation, a second number) and an older app
+ * round-trips the unknown TLVs verbatim instead of corrupting them. We only
+ * convert to/from an actual Android contact (vCard / ContactsContract) at the
+ * UI edges (profile setup on send; "Save contact" on receive).
+ *
+ * ## Wire format
+ * ```
+ * +---------+---------------------------------------------+
+ * | byte 0  |              zero or more TLV records        |
+ * | version |  type(1) | length(2, big-endian) | value(n) |
+ * +---------+---------------------------------------------+
+ * ```
+ * - `version` (1 byte, 0..255): bumped on incompatible changes; [CURRENT_VERSION] today.
+ * - Each TLV: 1-byte `type`, 2-byte big-endian `length` (0..65535), then `length` value bytes.
+ *   The 2-byte length leaves headroom for a future small photo field.
+ * - Known string field types are [TYPE_DISPLAY_NAME], [TYPE_PHONE], [TYPE_EMAIL]
+ *   (UTF-8). Unknown types are preserved in [extraFields] across a round trip.
+ *
+ * ## Invariants
+ * A card must carry at least one of name / phone / email (an empty card is
+ * meaningless). String fields must fit in the 2-byte length when UTF-8 encoded.
+ *
+ * Pure-JVM, unit-tested in `NameCardTest` (round-trip, optional fields,
+ * unknown-TLV preservation, malformed → null, strict UTF-8). The NFC/BLE
+ * transport and the profile/save UI that produce and consume it are separate.
+ *
+ * @see dev.bluehouse.bada.protocol.endpoint.EndpointInfo for the sibling TLV codec this mirrors.
+ */
+public data class NameCard(
+    /** Wire format version. [CURRENT_VERSION] for cards this build creates. */
+    val version: Int = CURRENT_VERSION,
+    /** Display name (UTF-8), or `null` if the sender shares only a number. */
+    val displayName: String? = null,
+    /** Phone number as free text (kept verbatim; formatting is the UI's job). */
+    val phoneNumber: String? = null,
+    /** Email address, or `null`. */
+    val email: String? = null,
+    /**
+     * TLV records whose `type` this build does not recognise, preserved
+     * verbatim so a round trip through an older app never drops a newer app's
+     * fields. Normally empty.
+     */
+    val extraFields: List<NameCardField> = emptyList(),
+) {
+    init {
+        require(version in 0..MAX_VERSION) {
+            "version must fit in 1 byte (0..$MAX_VERSION), got $version"
+        }
+        require(displayName != null || phoneNumber != null || email != null) {
+            "a NameCard must carry at least one of displayName / phoneNumber / email"
+        }
+        requireFits(TYPE_DISPLAY_NAME, displayName)
+        requireFits(TYPE_PHONE, phoneNumber)
+        requireFits(TYPE_EMAIL, email)
+        for (field in extraFields) {
+            require(field.value.size <= MAX_FIELD_LEN) {
+                "extra field type ${field.type} value must fit in 2 bytes (<= $MAX_FIELD_LEN)"
+            }
+        }
+    }
+
+    /**
+     * Encode this card into the canonical wire format. Freshly allocated;
+     * mutating the result never affects this instance. Known fields are
+     * emitted in a stable order (name, phone, email) followed by [extraFields].
+     */
+    public fun serialize(): ByteArray {
+        val known =
+            buildList {
+                displayName?.let { add(NameCardField(TYPE_DISPLAY_NAME, it.toUtf8())) }
+                phoneNumber?.let { add(NameCardField(TYPE_PHONE, it.toUtf8())) }
+                email?.let { add(NameCardField(TYPE_EMAIL, it.toUtf8())) }
+            }
+        val all = known + extraFields
+
+        val total = HEADER_LEN + all.sumOf { TLV_HEADER_LEN + it.value.size }
+        val out = ByteArray(total)
+        out[0] = version.toByte()
+
+        var offset = HEADER_LEN
+        for (field in all) {
+            out[offset] = field.type.toByte()
+            val len = field.value.size
+            out[offset + 1] = ((len ushr BITS_PER_BYTE) and UNSIGNED_BYTE_MASK).toByte()
+            out[offset + 2] = (len and UNSIGNED_BYTE_MASK).toByte()
+            offset += TLV_HEADER_LEN
+            field.value.copyInto(out, destinationOffset = offset)
+            offset += len
+        }
+        check(offset == total) { "serializer offset drift: wrote $offset, expected $total" }
+        return out
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is NameCard) return false
+        return version == other.version &&
+            displayName == other.displayName &&
+            phoneNumber == other.phoneNumber &&
+            email == other.email &&
+            extraFields == other.extraFields
+    }
+
+    override fun hashCode(): Int {
+        var result = version
+        result = 31 * result + (displayName?.hashCode() ?: 0)
+        result = 31 * result + (phoneNumber?.hashCode() ?: 0)
+        result = 31 * result + (email?.hashCode() ?: 0)
+        result = 31 * result + extraFields.hashCode()
+        return result
+    }
+
+    public companion object {
+        /** Wire version this build emits. */
+        public const val CURRENT_VERSION: Int = 1
+
+        /** Max value of the 1-byte version field. */
+        public const val MAX_VERSION: Int = 0xFF
+
+        /** Length of the version header byte. */
+        public const val HEADER_LEN: Int = 1
+
+        /** TLV header = type(1) + length(2). */
+        public const val TLV_HEADER_LEN: Int = 3
+
+        /** Max value-length a TLV can carry (2-byte big-endian length). */
+        public const val MAX_FIELD_LEN: Int = 0xFFFF
+
+        /** TLV type: UTF-8 display name. */
+        public const val TYPE_DISPLAY_NAME: Int = 1
+
+        /** TLV type: UTF-8 phone number. */
+        public const val TYPE_PHONE: Int = 2
+
+        /** TLV type: UTF-8 email address. */
+        public const val TYPE_EMAIL: Int = 3
+
+        private const val UNSIGNED_BYTE_MASK: Int = 0xFF
+        private const val BITS_PER_BYTE: Int = 8
+
+        /**
+         * Parse a card from the wire format, or `null` for any malformed input
+         * (truncated header/TLV, length past the buffer, invalid UTF-8 in a
+         * known string field, or a blob with no name/phone/email). Callers
+         * treat `null` as "ignore this card" — never a hard error — because the
+         * peer is another build we don't fully control.
+         *
+         * The first occurrence of each known type wins; later duplicates of a
+         * known type are dropped. Unknown types are collected into [extraFields].
+         */
+        @Suppress("ReturnCount", "CyclomaticComplexMethod")
+        public fun parse(bytes: ByteArray): NameCard? {
+            if (bytes.size < HEADER_LEN) return null
+            val version = bytes[0].toInt() and UNSIGNED_BYTE_MASK
+
+            var displayName: String? = null
+            var phoneNumber: String? = null
+            var email: String? = null
+            val extras = mutableListOf<NameCardField>()
+
+            var offset = HEADER_LEN
+            while (offset < bytes.size) {
+                if (offset + TLV_HEADER_LEN > bytes.size) return null
+                val type = bytes[offset].toInt() and UNSIGNED_BYTE_MASK
+                val len =
+                    ((bytes[offset + 1].toInt() and UNSIGNED_BYTE_MASK) shl BITS_PER_BYTE) or
+                        (bytes[offset + 2].toInt() and UNSIGNED_BYTE_MASK)
+                offset += TLV_HEADER_LEN
+                if (offset + len > bytes.size) return null
+                val value = bytes.copyOfRange(offset, offset + len)
+                offset += len
+
+                when (type) {
+                    TYPE_DISPLAY_NAME ->
+                        if (displayName == null) displayName = decodeUtf8Strict(value) ?: return null
+                    TYPE_PHONE ->
+                        if (phoneNumber == null) phoneNumber = decodeUtf8Strict(value) ?: return null
+                    TYPE_EMAIL ->
+                        if (email == null) email = decodeUtf8Strict(value) ?: return null
+                    else -> extras += NameCardField(type, value)
+                }
+            }
+
+            if (displayName == null && phoneNumber == null && email == null) return null
+            return NameCard(
+                version = version,
+                displayName = displayName,
+                phoneNumber = phoneNumber,
+                email = email,
+                extraFields = extras.toList(),
+            )
+        }
+
+        private fun requireFits(
+            type: Int,
+            value: String?,
+        ) {
+            if (value == null) return
+            val size = value.toUtf8().size
+            require(size <= MAX_FIELD_LEN) {
+                "field type $type UTF-8 length must fit in 2 bytes (<= $MAX_FIELD_LEN), got $size"
+            }
+        }
+
+        private fun String.toUtf8(): ByteArray = toByteArray(StandardCharsets.UTF_8)
+
+        /** Strict UTF-8 decode; `null` on any malformed/unmappable byte sequence. */
+        private fun decodeUtf8Strict(bytes: ByteArray): String? =
+            try {
+                StandardCharsets.UTF_8
+                    .newDecoder()
+                    .onMalformedInput(CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(CodingErrorAction.REPORT)
+                    .decode(java.nio.ByteBuffer.wrap(bytes))
+                    .toString()
+            } catch (_: CharacterCodingException) {
+                null
+            }
+    }
+}
+
+/**
+ * One type-length-value record. Used for forward-compatible fields whose
+ * `type` an older build does not recognise — kept verbatim so a round trip
+ * never loses a newer build's data. See [NameCard].
+ */
+public data class NameCardField(
+    /** 1-byte TLV type (0..255). */
+    val type: Int,
+    /** Raw value bytes (interpretation depends on [type]). */
+    val value: ByteArray,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is NameCardField) return false
+        return type == other.type && value.contentEquals(other.value)
+    }
+
+    override fun hashCode(): Int = 31 * type + value.contentHashCode()
+}

--- a/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/namecard/NameCardBootstrap.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/namecard/NameCardBootstrap.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.protocol.namecard
+
+/**
+ * **Name Card NFC bootstrap** — the tiny blob the NFC tap carries (see
+ * `docs/NAMEDROP_CONTACT_EXCHANGE_JOURNAL.md`). The tap is only a TRIGGER: it
+ * does NOT carry the contact card. It carries a fresh random **session token**
+ * so the two woken apps can find *each other* (and only each other) over
+ * Bluetooth — both filter BLE advertisements by this token, then swap the actual
+ * [NameCard]s over that link.
+ *
+ * Why a token instead of a Bluetooth MAC: Android does not expose the local
+ * Bluetooth MAC to apps, so we cannot put an address in the tap. A shared random
+ * token is the rendezvous key instead — whichever phone reads the other's token
+ * advertises/scans for it, so a third nearby Bada phone can't hijack the
+ * pairing.
+ *
+ * Wire format (fixed [SIZE] = 17 bytes): `version(1) | token(16)`.
+ *
+ * Pure-JVM, unit-tested in `NameCardBootstrapTest`. Emitted/parsed by the NFC
+ * HCE/reader and consumed by the BLE rendezvous.
+ */
+public data class NameCardBootstrap(
+    /** Format version; [CURRENT_VERSION] today. */
+    val version: Int,
+    /** Random rendezvous token, exactly [TOKEN_LEN] bytes. */
+    val token: ByteArray,
+) {
+    init {
+        require(version in 0..MAX_VERSION) {
+            "version must fit in 1 byte (0..$MAX_VERSION), got $version"
+        }
+        require(token.size == TOKEN_LEN) {
+            "token must be exactly $TOKEN_LEN bytes, got ${token.size}"
+        }
+    }
+
+    /** Encode to the fixed [SIZE]-byte wire form. Freshly allocated. */
+    public fun serialize(): ByteArray {
+        val out = ByteArray(SIZE)
+        out[0] = version.toByte()
+        token.copyInto(out, destinationOffset = HEADER_LEN)
+        return out
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is NameCardBootstrap) return false
+        return version == other.version && token.contentEquals(other.token)
+    }
+
+    override fun hashCode(): Int = 31 * version + token.contentHashCode()
+
+    public companion object {
+        /** Format version this build emits. */
+        public const val CURRENT_VERSION: Int = 1
+
+        /** Max value of the 1-byte version field. */
+        public const val MAX_VERSION: Int = 0xFF
+
+        /** Length of the version header byte. */
+        public const val HEADER_LEN: Int = 1
+
+        /** Length of the rendezvous token. */
+        public const val TOKEN_LEN: Int = 16
+
+        /** Total fixed wire size. */
+        public const val SIZE: Int = HEADER_LEN + TOKEN_LEN
+
+        private const val UNSIGNED_BYTE_MASK: Int = 0xFF
+
+        /**
+         * Parse a bootstrap from the wire form, or `null` if it is not exactly
+         * [SIZE] bytes (truncated / wrong length). Callers treat `null` as "this
+         * was not a Name Card tap" and ignore it.
+         */
+        public fun parse(bytes: ByteArray): NameCardBootstrap? {
+            if (bytes.size != SIZE) return null
+            return NameCardBootstrap(
+                version = bytes[0].toInt() and UNSIGNED_BYTE_MASK,
+                token = bytes.copyOfRange(HEADER_LEN, SIZE),
+            )
+        }
+    }
+}

--- a/core-protocol/src/test/kotlin/dev/bluehouse/bada/protocol/namecard/NameCardBootstrapTest.kt
+++ b/core-protocol/src/test/kotlin/dev/bluehouse/bada/protocol/namecard/NameCardBootstrapTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.protocol.namecard
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+/** Pure-JVM tests for [NameCardBootstrap] — the fixed 17-byte NFC tap token. */
+class NameCardBootstrapTest {
+    private fun token(fill: Byte = 7) = ByteArray(NameCardBootstrap.TOKEN_LEN) { fill }
+
+    @Test
+    fun `round-trips`() {
+        val b = NameCardBootstrap(NameCardBootstrap.CURRENT_VERSION, token())
+        assertThat(NameCardBootstrap.parse(b.serialize())).isEqualTo(b)
+    }
+
+    @Test
+    fun `serialized size is fixed at 17 bytes`() {
+        assertThat(NameCardBootstrap(1, token()).serialize().size).isEqualTo(NameCardBootstrap.SIZE)
+        assertThat(NameCardBootstrap.SIZE).isEqualTo(17)
+    }
+
+    @Test
+    fun `parse rejects wrong length`() {
+        assertThat(NameCardBootstrap.parse(ByteArray(0))).isNull()
+        assertThat(NameCardBootstrap.parse(ByteArray(NameCardBootstrap.SIZE - 1))).isNull()
+        assertThat(NameCardBootstrap.parse(ByteArray(NameCardBootstrap.SIZE + 1))).isNull()
+    }
+
+    @Test
+    fun `constructor rejects a wrong-size token`() {
+        assertThrows<IllegalArgumentException> { NameCardBootstrap(1, ByteArray(8)) }
+    }
+
+    @Test
+    fun `preserves the version byte`() {
+        assertThat(NameCardBootstrap.parse(NameCardBootstrap(5, token()).serialize())!!.version)
+            .isEqualTo(5)
+    }
+}

--- a/core-protocol/src/test/kotlin/dev/bluehouse/bada/protocol/namecard/NameCardTest.kt
+++ b/core-protocol/src/test/kotlin/dev/bluehouse/bada/protocol/namecard/NameCardTest.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.protocol.namecard
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * Pure-JVM tests for [NameCard] — the contact blob swapped by the tap-to-share
+ * Name Card feature. Covers round-trip fidelity, optional fields (the
+ * "number-only" fallback), forward-compat unknown-TLV preservation, and that
+ * malformed input parses to `null` rather than throwing.
+ */
+class NameCardTest {
+    @Test
+    fun `round-trips a full card`() {
+        val card =
+            NameCard(
+                displayName = "Mike Peskoff",
+                phoneNumber = "+1 415 555 0199",
+                email = "mike@example.com",
+            )
+        assertThat(NameCard.parse(card.serialize())).isEqualTo(card)
+    }
+
+    @Test
+    fun `round-trips a name-only card`() {
+        val card = NameCard(displayName = "Mike")
+        val parsed = NameCard.parse(card.serialize())
+        assertThat(parsed).isEqualTo(card)
+        assertThat(parsed!!.phoneNumber).isNull()
+        assertThat(parsed.email).isNull()
+    }
+
+    @Test
+    fun `round-trips a number-only card (the no-profile fallback)`() {
+        val card = NameCard(phoneNumber = "5550199")
+        val parsed = NameCard.parse(card.serialize())
+        assertThat(parsed).isEqualTo(card)
+        assertThat(parsed!!.displayName).isNull()
+    }
+
+    @Test
+    fun `round-trips non-ASCII UTF-8 names`() {
+        val card = NameCard(displayName = "Михаил 日本語 😀", phoneNumber = "123")
+        assertThat(NameCard.parse(card.serialize())).isEqualTo(card)
+    }
+
+    @Test
+    fun `preserves unknown TLV fields across a round trip (forward compat)`() {
+        val future = NameCardField(type = 99, value = byteArrayOf(1, 2, 3, 4))
+        val card = NameCard(displayName = "Mike", extraFields = listOf(future))
+        val parsed = NameCard.parse(card.serialize())
+        assertThat(parsed).isEqualTo(card)
+        assertThat(parsed!!.extraFields).containsExactly(future)
+    }
+
+    @Test
+    fun `preserves the version byte`() {
+        val card = NameCard(version = 7, displayName = "Mike")
+        assertThat(card.serialize()[0].toInt()).isEqualTo(7)
+        assertThat(NameCard.parse(card.serialize())!!.version).isEqualTo(7)
+    }
+
+    @Test
+    fun `parse returns null on empty input`() {
+        assertThat(NameCard.parse(ByteArray(0))).isNull()
+    }
+
+    @Test
+    fun `parse returns null on a card with no fields`() {
+        // Just a version byte, no TLVs → meaningless card.
+        assertThat(NameCard.parse(byteArrayOf(NameCard.CURRENT_VERSION.toByte()))).isNull()
+    }
+
+    @Test
+    fun `parse returns null on a truncated TLV header`() {
+        // version + a single type byte but no length bytes.
+        assertThat(NameCard.parse(byteArrayOf(1, NameCard.TYPE_PHONE.toByte()))).isNull()
+    }
+
+    @Test
+    fun `parse returns null when a TLV length runs past the buffer`() {
+        // version=1, type=phone, length=0x000A (10) but only 2 value bytes present.
+        val blob = byteArrayOf(1, NameCard.TYPE_PHONE.toByte(), 0x00, 0x0A, 0x35, 0x35)
+        assertThat(NameCard.parse(blob)).isNull()
+    }
+
+    @Test
+    fun `parse returns null on invalid UTF-8 in a known string field`() {
+        // version=1, type=name, length=1, value=0xFF (not valid UTF-8).
+        val blob = byteArrayOf(1, NameCard.TYPE_DISPLAY_NAME.toByte(), 0x00, 0x01, 0xFF.toByte())
+        assertThat(NameCard.parse(blob)).isNull()
+    }
+
+    @Test
+    fun `duplicate known field types keep the first occurrence`() {
+        // Two name TLVs: "A" then "B" → parser keeps "A".
+        val blob =
+            byteArrayOf(
+                1,
+                NameCard.TYPE_DISPLAY_NAME.toByte(), 0x00, 0x01, 'A'.code.toByte(),
+                NameCard.TYPE_DISPLAY_NAME.toByte(), 0x00, 0x01, 'B'.code.toByte(),
+            )
+        assertThat(NameCard.parse(blob)!!.displayName).isEqualTo("A")
+    }
+
+    @Test
+    fun `constructing an empty card is rejected`() {
+        assertThrows<IllegalArgumentException> { NameCard() }
+    }
+
+    @Test
+    fun `serialized size is compact for a typical card`() {
+        // header(1) + 3 TLVs: name(3+12) + phone(3+15) + email(3+16) = 1 + 15 + 18 + 19 = 53 bytes.
+        val card =
+            NameCard(
+                displayName = "Mike Peskoff",
+                phoneNumber = "+1 415 555 0199",
+                email = "mike@example.com",
+            )
+        assertThat(card.serialize().size).isLessThan(256)
+    }
+}


### PR DESCRIPTION
## Name Card — tap two phones to swap contacts

Adds a **Name Card** feature: tap two phones back-to-back and, when neither is sending a file, they exchange contact cards — the same gesture as iPhone NameDrop.

### How it works
- **NFC is only the trigger.** A tap over a proprietary Name Card AID (`F0534443415244`) wakes both apps and hands over a 16-byte rendezvous token. It carries no contact data and is answered only while the device is unlocked (gated in code), so a locked phone never shares a card.
- **The card rides Bluetooth.** Using the token, the two phones connect over BLE GATT and exchange cards. The idle (tapped) phone runs the GATT server from a short foreground service; the phone with the app open is the reader/client.
- **Saving uses ContactsContract.** A received card is inserted directly when contacts permission is granted, otherwise it opens in the system Add-contact screen.

### What the user sees
- A **Name Card** row in Settings opens **My Name Card**, where you enter the name / phone / email to share (or fill it from your phone). A red dot on the row until a card is set up.
- On a tap, a full-screen card screen slides in over whatever was on screen: the received contact with **Receive Only** / **Share** (Share also sends your card back), or **Save** / **Done** on the tapped phone. The screen descends and expands in, and the AirDrop-style ripple plays on send.
