### PR TITLE
fix: only solicit Wi-Fi Direct at upgrade-loop entry while still on Bluetooth

### DIFF
--- a/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnectionDriver.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnectionDriver.kt
@@ -792,10 +792,15 @@ internal class OutboundConnectionDriver(
             }
         }
         try {
-            if (!upgradeRequired) {
+            if (!upgradeRequired && activeMedium == Medium.BLUETOOTH) {
                 // Solicit the Wi-Fi Direct path NOW so the receiver's P2P
                 // group bring-up overlaps PKE/introduction/consent instead of
-                // delaying the first payload byte.
+                // delaying the first payload byte. Gated on the CURRENT medium,
+                // not the bootstrap: the post-UKEY2 offer probe may already
+                // have upgraded this session to another high-bandwidth medium
+                // (WIFI_HOTSPOT / WEB_RTC), and soliciting Wi-Fi Direct on
+                // that freshly upgraded channel would invite the receiver to
+                // tear down a working group mid-consent (#258).
                 activeChannel.sendOfflineFrame(
                     BandwidthUpgradeFrames.upgradePathRequest(setOf(Medium.WIFI_DIRECT)),
                 )

--- a/core-protocol/src/test/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnectionTest.kt
+++ b/core-protocol/src/test/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnectionTest.kt
@@ -614,6 +614,82 @@ class OutboundConnectionTest {
         }
 
     @Test
+    fun `bluetooth bootstrap already upgraded to WebRTC does not solicit Wi-Fi Direct`() =
+        runBlocking {
+            withTimeout(WALLCLOCK_TIMEOUT_MS) {
+                val (client, server) = connectedSocketPair()
+                val factory = InMemoryFactory()
+                val upgradePair = LoopbackUpgradePair(Medium.WEB_RTC)
+                val logs = java.util.Collections.synchronizedList(mutableListOf<String>())
+                // Sender supports Wi-Fi Direct too, so the upgrade-aware loop
+                // runs — but the receiver's step-7 offer upgrades the session
+                // to WEB_RTC inside the post-UKEY2 probe, and the loop must
+                // NOT then solicit Wi-Fi Direct on the upgraded channel.
+                val outbound =
+                    OutboundConnection(
+                        transport = client.asConnectedTransport(Medium.BLUETOOTH),
+                        secureRandom = SecureRandom("outbound-bt-webrtc-no-solicit".toByteArray()),
+                        mediumRegistry =
+                            MediumRegistry(
+                                providers =
+                                    listOf(
+                                        MediumRegistry.DefaultWifiLan.providerFor(Medium.WIFI_LAN)!!,
+                                        upgradePair.clientProvider,
+                                        SupportedProvider(Medium.WIFI_DIRECT),
+                                    ),
+                                ladder = MediumLadder(listOf(Medium.WIFI_LAN, Medium.WEB_RTC)),
+                            ),
+                        logger = { logs.add(it) },
+                    )
+
+                val fileBytes = ByteArray(1024) { (it xor 0x11).toByte() }
+                val payloadId = 0x5159L
+                val files = listOf(bytesSource("bt-webrtc-no-solicit.bin", fileBytes, payloadId))
+
+                try {
+                    coroutineScope {
+                        val outboundJob = async { outbound.run(files) }
+                        val inbound =
+                            InboundConnection(
+                                transport = server.asConnectedTransport(Medium.BLUETOOTH),
+                                secureRandom = SecureRandom("inbound-bt-webrtc-no-solicit".toByteArray()),
+                                mediumRegistry =
+                                    MediumRegistry(
+                                        providers =
+                                            listOf(
+                                                MediumRegistry.DefaultWifiLan.providerFor(Medium.WIFI_LAN)!!,
+                                                upgradePair.serverProvider,
+                                            ),
+                                        ladder = MediumLadder(listOf(Medium.WIFI_LAN, Medium.WEB_RTC)),
+                                    ),
+                            )
+
+                        launch {
+                            inbound.state.first { it is InboundConnectionState.WaitingForUserConsent }
+                            inbound.submitUserConsent(accepted = true)
+                        }
+
+                        val inboundResult = inbound.run(factory)
+                        val outboundResult = outboundJob.await()
+
+                        assertThat(outboundResult).isEqualTo(OutboundResult.Completed)
+                        assertThat(inboundResult).isInstanceOf(InboundResult.Completed::class.java)
+                        assertThat(inbound.activeMedium.value).isEqualTo(Medium.WEB_RTC)
+                        assertThat(outbound.activeMedium.value).isEqualTo(Medium.WEB_RTC)
+                    }
+
+                    assertThat(factory.output[payloadId]?.toByteArray()).isEqualTo(fileBytes)
+                    assertThat(outbound.state.value).isEqualTo(OutboundConnectionState.Completed)
+                    assertThat(
+                        logs.toList().none { it.contains("requested receiver Wi-Fi Direct upgrade") },
+                    ).isTrue()
+                } finally {
+                    upgradePair.close()
+                }
+            }
+        }
+
+    @Test
     fun `preconnected BLE bootstrap upgrades to Wi-Fi Direct from initial medium advertisement`() =
         runBlocking {
             withTimeout(WALLCLOCK_TIMEOUT_MS) {


### PR DESCRIPTION
Fixes #258

The upgrade-aware receive loop's eager `UPGRADE_PATH_REQUEST([WIFI_DIRECT])` was gated only on the *bootstrap* medium being eligible, so a Bluetooth-bootstrapped session that the post-UKEY2 offer probe had already upgraded to `WIFI_HOTSPOT`/`WEB_RTC` still solicited Wi-Fi Direct on the freshly upgraded channel — inviting the receiver to tear down a working group and renegotiate mid-consent.

**Change**: the entry request now additionally requires `activeMedium == BLUETOOTH` — the same current-medium guard `ensureWifiDirectBeforePayloads` already applies via its early return. BLE bootstraps are unaffected (they never sent the entry request), and plain RFCOMM sessions behave exactly as before.

**Test**: new loopback test `bluetooth bootstrap already upgraded to WebRTC does not solicit Wi-Fi Direct` — sender registry includes Wi-Fi Direct (so the upgrade-aware loop runs), receiver offers WEB_RTC at step 7 which window B adopts; asserts completion on WEB_RTC with no solicit log line. Confirmed to FAIL with the driver change reverted and pass with it.

`:core-protocol:test` + `staticAnalysis` green.

Not addressed here (still open in #258's related notes): the LOW-6 observation that a failure of the eager request write itself is terminal — behavior unchanged and still documented in AGENTS.md.
