### PR TITLE
refactor: scale the pre-payload Wi-Fi Direct offer wait by time since the entry request (#261)

### DIFF
--- a/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnectionDriver.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnectionDriver.kt
@@ -1146,7 +1146,10 @@ internal class OutboundConnectionDriver(
      * full window at payload time) keeps a never-offering receiver from
      * adding dead air between the user's Accept and the first payload byte;
      * the [BLUETOOTH_WIFI_DIRECT_MIN_OFFER_WAIT_MILLIS] floor still catches
-     * an offer already in flight.
+     * an offer already in flight — or one from a receiver that only begins
+     * its group bring-up around consent time. The result is clamped to the
+     * full window so a backward wall-clock step can never make the wait
+     * LONGER than the declared total.
      */
     private fun bluetoothOfferWaitMillis(upgradeRequestSentAtMillis: Long?): Long {
         if (upgradeRequestSentAtMillis == null) {
@@ -1154,7 +1157,10 @@ internal class OutboundConnectionDriver(
         }
         val elapsedSinceRequest = nowMillisSource() - upgradeRequestSentAtMillis
         return (BLUETOOTH_WIFI_DIRECT_OFFER_TIMEOUT_MILLIS - elapsedSinceRequest)
-            .coerceAtLeast(BLUETOOTH_WIFI_DIRECT_MIN_OFFER_WAIT_MILLIS)
+            .coerceIn(
+                BLUETOOTH_WIFI_DIRECT_MIN_OFFER_WAIT_MILLIS,
+                BLUETOOTH_WIFI_DIRECT_OFFER_TIMEOUT_MILLIS,
+            )
     }
 
     private suspend fun adoptOfferBeforePayloads(
@@ -2002,14 +2008,19 @@ internal class OutboundConnectionDriver(
         /**
          * Floor on the residual pre-payload offer wait when the entry
          * `UPGRADE_PATH_REQUEST`'s window has already (nearly) elapsed
-         * during the PKE/introduction/consent phase. A receiver that was
-         * ever going to offer has had the whole negotiation phase to do
-         * so; this short grace only covers an offer already in flight —
-         * e.g. a group that finished bring-up moments before the user's
-         * Accept — without re-spending the full window against a receiver
-         * that will never answer (issue #261).
+         * during the PKE/introduction/consent phase.
+         *
+         * Sized against asymmetric costs: expiring too early strands the
+         * WHOLE payload on Bluetooth (~140 KB/s — minutes for a large
+         * file), while waiting too long adds at most this many ms of dead
+         * air after the user's Accept. Stock GMS receivers observed on
+         * real devices (#256 debug loop) answer the entry request in
+         * ~0.65 s, long before consent — but a receiver implementation
+         * that defers group bring-up until around its local consent needs
+         * more than a token grace here, so keep half the full window
+         * rather than a bare in-flight allowance (#261 review).
          */
-        private const val BLUETOOTH_WIFI_DIRECT_MIN_OFFER_WAIT_MILLIS: Long = 1_000L
+        private const val BLUETOOTH_WIFI_DIRECT_MIN_OFFER_WAIT_MILLIS: Long = 2_500L
         private const val WIFI_DIRECT_UPGRADE_POLL_DELAY_MILLIS: Long = 25L
 
         /**

--- a/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnectionDriver.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnectionDriver.kt
@@ -1975,6 +1975,18 @@ internal class OutboundConnectionDriver(
             v1.bandwidthUpgradeNegotiation.eventType == expected
 
     private companion object {
+        init {
+            // bluetoothOfferWaitMillis clamps with coerceIn(MIN, TOTAL),
+            // which throws at runtime on the RFCOMM payload path if a
+            // tuning pass ever inverts the pair — fail at class load
+            // instead.
+            require(
+                BLUETOOTH_WIFI_DIRECT_MIN_OFFER_WAIT_MILLIS <= BLUETOOTH_WIFI_DIRECT_OFFER_TIMEOUT_MILLIS,
+            ) {
+                "BLUETOOTH_WIFI_DIRECT_MIN_OFFER_WAIT_MILLIS must not exceed the total offer window"
+            }
+        }
+
         // How long to wait for a pre-UKEY2 BLE bandwidth-upgrade offer
         // before giving up and sending ClientInit on the current medium.
         // This bounds ONLY the no-offer path: the probe returns the instant

--- a/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnectionDriver.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnectionDriver.kt
@@ -791,6 +791,11 @@ internal class OutboundConnectionDriver(
                 OutboundDriverEvent.PeerClosed
             }
         }
+        // When the entry UPGRADE_PATH_REQUEST below goes out, remember when:
+        // the pre-payload offer wait in ensureWifiDirectBeforePayloads counts
+        // the receiver's answer window from this timestamp, not from payload
+        // time. Stays null on paths that send no entry request (BLE).
+        var upgradeRequestSentAtMillis: Long? = null
         try {
             if (!upgradeRequired) {
                 // Solicit the Wi-Fi Direct path NOW so the receiver's P2P
@@ -799,6 +804,7 @@ internal class OutboundConnectionDriver(
                 activeChannel.sendOfflineFrame(
                     BandwidthUpgradeFrames.upgradePathRequest(setOf(Medium.WIFI_DIRECT)),
                 )
+                upgradeRequestSentAtMillis = nowMillisSource()
                 logger("medium-upgrade: requested receiver Wi-Fi Direct upgrade (bootstrap=$activeMedium)")
             }
             while (true) {
@@ -894,6 +900,7 @@ internal class OutboundConnectionDriver(
                                 currentMedium = activeMedium,
                                 currentWifiFrequencyMhz = activeWifiFrequencyMhz,
                                 upgradeRequired = upgradeRequired,
+                                upgradeRequestSentAtMillis = upgradeRequestSentAtMillis,
                             )
                         if (upgraded is PayloadChannelSelection.Failed) {
                             return failWifiDirectUpgrade(upgraded.reason, activeChannel)
@@ -1052,11 +1059,18 @@ internal class OutboundConnectionDriver(
         }
     }
 
+    /**
+     * [upgradeRequestSentAtMillis] is when the entry `UPGRADE_PATH_REQUEST`
+     * went out in [runWifiDirectUpgradeReceiveLoop] (null when no entry
+     * request was sent — the BLE/[upgradeRequired] path, which sends its own
+     * request here at ensure-time and keeps its fixed timeout).
+     */
     private suspend fun ensureWifiDirectBeforePayloads(
         channel: SecureChannel,
         currentMedium: Medium,
         currentWifiFrequencyMhz: Int?,
         upgradeRequired: Boolean,
+        upgradeRequestSentAtMillis: Long?,
     ): PayloadChannelSelection {
         // Also covers a mid-loop upgrade that landed on another Wi-Fi
         // medium (e.g. WIFI_HOTSPOT): payloads are already off the
@@ -1075,13 +1089,16 @@ internal class OutboundConnectionDriver(
         // Bluetooth bootstraps sent their UPGRADE_PATH_REQUEST when the
         // upgrade loop started; re-requesting here could make the receiver
         // tear down and recreate a group that is already being offered.
-        logger("medium-upgrade: waiting for receiver Wi-Fi Direct offer before streaming payloads")
         val offerTimeoutMillis =
             if (upgradeRequired) {
                 BLE_WIFI_DIRECT_UPGRADE_TIMEOUT_MILLIS
             } else {
-                BLUETOOTH_WIFI_DIRECT_OFFER_TIMEOUT_MILLIS
+                bluetoothOfferWaitMillis(upgradeRequestSentAtMillis)
             }
+        logger(
+            "medium-upgrade: waiting up to ${offerTimeoutMillis}ms for receiver " +
+                "Wi-Fi Direct offer before streaming payloads",
+        )
         return when (val probe = pollWifiDirectOffer(channel, offerTimeoutMillis)) {
             UpgradeOfferProbe.None -> {
                 logger(
@@ -1116,6 +1133,28 @@ internal class OutboundConnectionDriver(
                     upgradeRequired = upgradeRequired,
                 )
         }
+    }
+
+    /**
+     * Residual pre-payload offer wait for a Bluetooth-RFCOMM bootstrap.
+     *
+     * The solicited offer's answer window is
+     * [BLUETOOTH_WIFI_DIRECT_OFFER_TIMEOUT_MILLIS] counted from when the
+     * entry `UPGRADE_PATH_REQUEST` was sent — the receiver has had the whole
+     * PKE/introduction/consent phase since then to bring its P2P group up and
+     * offer. Waiting only for what remains of that window (instead of a fresh
+     * full window at payload time) keeps a never-offering receiver from
+     * adding dead air between the user's Accept and the first payload byte;
+     * the [BLUETOOTH_WIFI_DIRECT_MIN_OFFER_WAIT_MILLIS] floor still catches
+     * an offer already in flight.
+     */
+    private fun bluetoothOfferWaitMillis(upgradeRequestSentAtMillis: Long?): Long {
+        if (upgradeRequestSentAtMillis == null) {
+            return BLUETOOTH_WIFI_DIRECT_OFFER_TIMEOUT_MILLIS
+        }
+        val elapsedSinceRequest = nowMillisSource() - upgradeRequestSentAtMillis
+        return (BLUETOOTH_WIFI_DIRECT_OFFER_TIMEOUT_MILLIS - elapsedSinceRequest)
+            .coerceAtLeast(BLUETOOTH_WIFI_DIRECT_MIN_OFFER_WAIT_MILLIS)
     }
 
     private suspend fun adoptOfferBeforePayloads(
@@ -1945,15 +1984,32 @@ internal class OutboundConnectionDriver(
         private const val BLE_WIFI_DIRECT_UPGRADE_TIMEOUT_MILLIS: Long = 3_000L
 
         /**
-         * How long a Bluetooth-RFCOMM bootstrap waits before payload
-         * streaming for the Wi-Fi Direct offer it solicited when the
-         * upgrade loop started. Group bring-up on stock GMS receivers
-         * takes ~1–3 s and usually overlaps the consent wait, so this
-         * bound only bites when consent was near-instant; the cost of
-         * expiring is staying on Bluetooth for the whole payload, so
-         * spend a bit more than the BLE bound.
+         * Total answer window a Bluetooth-RFCOMM bootstrap grants the
+         * receiver for the Wi-Fi Direct offer it solicited when the
+         * upgrade loop started, measured FROM the entry
+         * `UPGRADE_PATH_REQUEST`'s send time — not from payload time.
+         * Group bring-up on stock GMS receivers takes ~1–3 s and usually
+         * overlaps the consent wait, so by payload time most of this
+         * window has already elapsed; the pre-payload wait only spends
+         * whatever remains of it (issue #261). The full 5 s therefore
+         * only bites when consent came back near-instantly (auto-accept),
+         * which is the case it was sized for; the cost of expiring is
+         * staying on Bluetooth for the whole payload, so spend a bit more
+         * than the BLE bound.
          */
         private const val BLUETOOTH_WIFI_DIRECT_OFFER_TIMEOUT_MILLIS: Long = 5_000L
+
+        /**
+         * Floor on the residual pre-payload offer wait when the entry
+         * `UPGRADE_PATH_REQUEST`'s window has already (nearly) elapsed
+         * during the PKE/introduction/consent phase. A receiver that was
+         * ever going to offer has had the whole negotiation phase to do
+         * so; this short grace only covers an offer already in flight —
+         * e.g. a group that finished bring-up moments before the user's
+         * Accept — without re-spending the full window against a receiver
+         * that will never answer (issue #261).
+         */
+        private const val BLUETOOTH_WIFI_DIRECT_MIN_OFFER_WAIT_MILLIS: Long = 1_000L
         private const val WIFI_DIRECT_UPGRADE_POLL_DELAY_MILLIS: Long = 25L
 
         /**

--- a/core-protocol/src/test/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnectionTest.kt
+++ b/core-protocol/src/test/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnectionTest.kt
@@ -27,6 +27,7 @@ import dev.bluehouse.bada.protocol.transport.asConnectedTransport
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -876,6 +877,14 @@ class OutboundConnectionTest {
 
                     launch {
                         inbound.state.first { it is InboundConnectionState.WaitingForUserConsent }
+                        // Consent that arrives >4s after the entry
+                        // UPGRADE_PATH_REQUEST: the pre-payload offer wait must
+                        // shrink to the 1s residual floor instead of re-spending
+                        // the full 5s window against a receiver that will never
+                        // offer (issue #261). delay() has at-least semantics, so
+                        // elapsed-since-request deterministically exceeds 4s and
+                        // the coerceAtLeast floor is what remains.
+                        delay(SLOW_CONSENT_DELAY_MS)
                         inbound.submitUserConsent(accepted = true)
                     }
 
@@ -892,6 +901,11 @@ class OutboundConnectionTest {
                 val log = logs.toList()
                 assertThat(log)
                     .contains("medium-upgrade: requested receiver Wi-Fi Direct upgrade (bootstrap=BLUETOOTH)")
+                assertThat(log)
+                    .contains(
+                        "medium-upgrade: waiting up to 1000ms for receiver " +
+                            "Wi-Fi Direct offer before streaming payloads",
+                    )
                 assertThat(log)
                     .contains(
                         "medium-upgrade: Wi-Fi Direct upgrade was not offered before payload streaming; " +
@@ -1674,6 +1688,15 @@ class OutboundConnectionTest {
         private const val LONG_WALLCLOCK_TIMEOUT_MS: Long = 60_000L
 
         private const val SHORT_INITIAL_HANDSHAKE_TIMEOUT_MS: Long = 50L
+
+        // Consent delay for the no-offer Bluetooth-bootstrap scenario: long
+        // enough (>4s, with delay()'s at-least semantics) that the 5s
+        // Wi-Fi Direct answer window counted from the entry
+        // UPGRADE_PATH_REQUEST has under 1s left at payload time, so the
+        // pre-payload wait deterministically lands on its 1s floor
+        // (issue #261) — shaving the scenario's wall time versus the old
+        // fixed 5s pre-payload wait.
+        private const val SLOW_CONSENT_DELAY_MS: Long = 4_100L
 
         private val MediumLadderForBluetoothFirst: MediumLadder =
             MediumLadder(listOf(Medium.BLUETOOTH, Medium.WIFI_LAN))

--- a/core-protocol/src/test/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnectionTest.kt
+++ b/core-protocol/src/test/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnectionTest.kt
@@ -879,7 +879,7 @@ class OutboundConnectionTest {
                         inbound.state.first { it is InboundConnectionState.WaitingForUserConsent }
                         // Consent that arrives >4s after the entry
                         // UPGRADE_PATH_REQUEST: the pre-payload offer wait must
-                        // shrink to the 1s residual floor instead of re-spending
+                        // shrink to the 2.5s residual floor instead of re-spending
                         // the full 5s window against a receiver that will never
                         // offer (issue #261). delay() has at-least semantics, so
                         // elapsed-since-request deterministically exceeds 4s and
@@ -903,7 +903,7 @@ class OutboundConnectionTest {
                     .contains("medium-upgrade: requested receiver Wi-Fi Direct upgrade (bootstrap=BLUETOOTH)")
                 assertThat(log)
                     .contains(
-                        "medium-upgrade: waiting up to 1000ms for receiver " +
+                        "medium-upgrade: waiting up to 2500ms for receiver " +
                             "Wi-Fi Direct offer before streaming payloads",
                     )
                 assertThat(log)
@@ -1693,7 +1693,7 @@ class OutboundConnectionTest {
         // enough (>4s, with delay()'s at-least semantics) that the 5s
         // Wi-Fi Direct answer window counted from the entry
         // UPGRADE_PATH_REQUEST has under 1s left at payload time, so the
-        // pre-payload wait deterministically lands on its 1s floor
+        // pre-payload wait deterministically lands on its 2.5s floor
         // (issue #261) — shaving the scenario's wall time versus the old
         // fixed 5s pre-payload wait.
         private const val SLOW_CONSENT_DELAY_MS: Long = 4_100L

--- a/core-protocol/src/test/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnectionTest.kt
+++ b/core-protocol/src/test/kotlin/dev/bluehouse/bada/protocol/connection/OutboundConnectionTest.kt
@@ -1690,13 +1690,13 @@ class OutboundConnectionTest {
         private const val SHORT_INITIAL_HANDSHAKE_TIMEOUT_MS: Long = 50L
 
         // Consent delay for the no-offer Bluetooth-bootstrap scenario: long
-        // enough (>4s, with delay()'s at-least semantics) that the 5s
+        // enough (>2.5s, with delay()'s at-least semantics) that the 5s
         // Wi-Fi Direct answer window counted from the entry
-        // UPGRADE_PATH_REQUEST has under 1s left at payload time, so the
-        // pre-payload wait deterministically lands on its 2.5s floor
-        // (issue #261) — shaving the scenario's wall time versus the old
-        // fixed 5s pre-payload wait.
-        private const val SLOW_CONSENT_DELAY_MS: Long = 4_100L
+        // UPGRADE_PATH_REQUEST has less than the 2.5s floor left at
+        // payload time, so the pre-payload wait deterministically lands
+        // on the floor (issue #261). 3s keeps a 500ms determinism margin
+        // while minimising the scenario's wall time.
+        private const val SLOW_CONSENT_DELAY_MS: Long = 3_000L
 
         private val MediumLadderForBluetoothFirst: MediumLadder =
             MediumLadder(listOf(Medium.BLUETOOTH, Medium.WIFI_LAN))


### PR DESCRIPTION
## Summary

Implements idea 1 from #261 (follow-up to #256 / PR #257, review finding LOW-9).

### Before

On a Bluetooth-RFCOMM-bootstrapped send, `runWifiDirectUpgradeReceiveLoop` solicits the Wi-Fi Direct upgrade with an `UPGRADE_PATH_REQUEST` at loop entry — so the receiver's P2P group bring-up overlaps the PKE/introduction/consent phase. But when the transfer reached `ReadyToSendPayloads` still on Bluetooth, `ensureWifiDirectBeforePayloads` waited a fresh fixed `BLUETOOTH_WIFI_DIRECT_OFFER_TIMEOUT_MILLIS = 5_000` for the offer. Against a receiver that will never offer (the request already went unanswered for the entire negotiation phase), that was up to 5 s of dead air between the user's Accept and the first payload byte.

### After

The driver records `nowMillisSource()` when the entry request is sent and threads that timestamp into `ensureWifiDirectBeforePayloads` (nullable — null when no entry request was sent). The non-required (Bluetooth) arm now waits only for what remains of the original 5 s answer window:

```
remaining = (BLUETOOTH_WIFI_DIRECT_OFFER_TIMEOUT_MILLIS - elapsedSinceRequest)
    .coerceAtLeast(BLUETOOTH_WIFI_DIRECT_MIN_OFFER_WAIT_MILLIS)  // new, 1_000L
```

- Near-instant consent (auto-accept — the case the 5 s constant was sized for): most of the window remains, behavior essentially unchanged.
- Consent took >= 4 s (a human tapping Accept): the residual wait shrinks to the 1 s floor, which still catches an offer already in flight (e.g. a group that finished bring-up moments before Accept) without re-spending the full window.
- BLE (`upgradeRequired`) arm untouched: it still sends its own request at ensure-time and uses `BLE_WIFI_DIRECT_UPGRADE_TIMEOUT_MILLIS`.

The offer-wait log line now carries the computed timeout so the wait budget is visible in field logs.

### Tests

Updated `preconnected bluetooth bootstrap stays on Bluetooth when Wi-Fi Direct offer never arrives` to delay consent 4.1 s (`delay()` has at-least semantics, so elapsed-since-request deterministically exceeds 4 s) and assert the new `waiting up to 1000ms` log line — under the old fixed wait this scenario would log 5000ms and run ~4 s longer. Scenario wall time stays ~5.4 s; no timing-sensitive sleeps added.

Quality gates: `./gradlew :core-protocol:test staticAnalysis` and `./gradlew :app:testDebugUnitTest` pass.

Fixes #261