### PR TITLE
fix: track prior-channel teardown commitment on both upgrade roles

### DIFF
--- a/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/BandwidthUpgradeOrchestrator.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/BandwidthUpgradeOrchestrator.kt
@@ -73,12 +73,14 @@ internal object BandwidthUpgradeOrchestrator {
             return ActiveTransportChannel(oldChannel, currentMedium)
         }
 
+        var priorChannelTeardownBegan = false
         return runCatching {
             completeServerUpgrade(
                 oldChannel = oldChannel,
                 transport = transport,
                 credentials = credentials,
                 peerEndpointId = peerEndpointId,
+                onPriorChannelTeardown = { priorChannelTeardownBegan = true },
                 logger = logger,
             )
         }.getOrElse { failure ->
@@ -88,7 +90,15 @@ internal object BandwidthUpgradeOrchestrator {
             )
             transport.close()
             provider.cancelPendingUpgrade()
-            ActiveTransportChannel(oldChannel, currentMedium)
+            // See the client-side twin above: once the CLIENT_INTRODUCTION_ACK
+            // went out, the peer proceeds with its own prior-channel teardown
+            // (its LAST_WRITE follows the ack immediately), so the prior
+            // channel is no longer a safe place to keep the session.
+            ActiveTransportChannel(
+                channel = oldChannel,
+                medium = currentMedium,
+                fallbackChannelUsable = !priorChannelTeardownBegan,
+            )
         }
     }
 
@@ -97,6 +107,7 @@ internal object BandwidthUpgradeOrchestrator {
         transport: UpgradedTransport,
         credentials: UpgradePathCredentials,
         peerEndpointId: String,
+        onPriorChannelTeardown: () -> Unit,
         logger: (String) -> Unit,
     ): ActiveTransportChannel {
         val bufferedFrames = mutableListOf<OfflineFrame>()
@@ -111,6 +122,11 @@ internal object BandwidthUpgradeOrchestrator {
             intro = clientIntro,
             peerEndpointId = peerEndpointId,
         )
+        // The ack is the peer's cue to begin tearing down the prior channel
+        // (stock GMS clients send their LAST_WRITE right after receiving it),
+        // so fallback safety ends here even though our own LAST_WRITE goes
+        // out a few lines later.
+        onPriorChannelTeardown()
         newFramedConnection.sendFrame(BandwidthUpgradeFrames.clientIntroductionAck().toByteArray())
         logger("medium-upgrade: server sent raw CLIENT_INTRODUCTION_ACK")
         val newChannel = oldChannel.withTransport(newFramedConnection)
@@ -218,6 +234,12 @@ internal object BandwidthUpgradeOrchestrator {
         val bufferedFrames = mutableListOf<OfflineFrame>()
         val newFramedConnection = transport.asFramedConnection()
         newFramedConnection.sendFrame(BandwidthUpgradeFrames.clientIntroduction(endpointId).toByteArray())
+        // Fallback safety ends once the CLIENT_INTRODUCTION is on the wire:
+        // a stock GMS server starts sending its own LAST_WRITE on the prior
+        // channel as soon as the introduction is delivered, without waiting
+        // for ours (#260). Failures before this write (dead adopted
+        // transport) still hand the prior channel back intact.
+        onPriorChannelTeardown()
         if (expectsClientIntroductionAck) {
             receiveRawUpgradeFrame(
                 framedConnection = newFramedConnection,
@@ -228,7 +250,6 @@ internal object BandwidthUpgradeOrchestrator {
         }
         val newChannel = oldChannel.withTransport(newFramedConnection)
         val reader = DualChannelFrameReader(oldChannel, newChannel, logger)
-        onPriorChannelTeardown()
         exchangeClientPriorChannelClose(
             oldChannel = oldChannel,
             reader = reader,
@@ -667,18 +688,20 @@ internal data class ActiveTransportChannel(
     val wifiFrequencyMhz: Int? = null,
     /**
      * False only when this is a failure result whose [channel] is the prior
-     * channel AND the failed upgrade already began the prior-channel teardown
-     * (LAST_WRITE/SAFE_TO_CLOSE possibly sent, channel possibly closed) —
-     * continuing to stream on it would write into a socket the peer stopped
-     * reading. True for every other result, including the pre-teardown
-     * failure paths that hand the prior channel back intact.
+     * channel AND the failed upgrade had already passed the point where the
+     * peer commits to tearing the prior channel down — continuing the session
+     * on it would write into a socket the peer stopped reading. True for
+     * every other result, including the pre-commitment failure paths that
+     * hand the prior channel back intact.
      *
-     * Caveats: the flag tracks OUR writes only — a GMS peer starts its own
-     * prior-channel teardown as soon as our CLIENT_INTRODUCTION is delivered,
-     * so "usable" is best-effort for failures in that sub-second window. And
-     * only the client path ([BandwidthUpgradeOrchestrator.runClientUpgradeFromOffer])
-     * maintains it today; the server path's failure fallback still returns
-     * the default without tracking teardown.
+     * The commitment boundary is peer-behavior-driven, not our-writes-driven
+     * (#260): the client path marks it once its CLIENT_INTRODUCTION is on the
+     * wire (a stock GMS server LAST_WRITEs the prior channel as soon as the
+     * introduction is delivered), and the server path marks it once its
+     * CLIENT_INTRODUCTION_ACK goes out (a stock GMS client LAST_WRITEs right
+     * after receiving the ack). Both
+     * [BandwidthUpgradeOrchestrator.runClientUpgradeFromOffer] and
+     * [BandwidthUpgradeOrchestrator.runServerUpgradeIfAvailable] maintain it.
      */
     val fallbackChannelUsable: Boolean = true,
 )

--- a/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/InboundConnectionDriver.kt
+++ b/core-protocol/src/main/kotlin/dev/bluehouse/bada/protocol/connection/InboundConnectionDriver.kt
@@ -273,6 +273,7 @@ internal class InboundConnectionDriver(
                     peerEndpointId = initialFrame.v1.connectionRequest.endpointId,
                     logger = logger,
                 )
+        if (!activeTransport.fallbackChannelUsable) return failDirtyUpgradeFallback(activeTransport)
         val activeChannel = activeTransport.channel.also { secureChannel = it }
         publishActiveTransport(activeTransport.medium, activeTransport.wifiFrequencyMhz)
         val initialWireFrames =
@@ -303,6 +304,22 @@ internal class InboundConnectionDriver(
         onHandshakeComplete()
 
         return runReceiveLoop(activeChannel, negotiationFsm, initialWireFrames)
+    }
+
+    /**
+     * Terminal for a server upgrade that failed after the peer's
+     * teardown-commitment point (our CLIENT_INTRODUCTION_ACK went out, so
+     * the sender has stopped reading the prior channel): running the whole
+     * sharing session on the handed-back channel would stall against a dead
+     * socket (#260).
+     */
+    private fun failDirtyUpgradeFallback(activeTransport: ActiveTransportChannel): InboundResult {
+        val reason =
+            "bandwidth upgrade failed after prior-channel teardown began; " +
+                "cannot continue on ${activeTransport.medium}"
+        logger("medium-upgrade: $reason")
+        mutableState.value = InboundConnectionState.Failed(reason)
+        return InboundResult.Failed(reason)
     }
 
     private fun publishActiveTransport(

--- a/core-protocol/src/test/kotlin/dev/bluehouse/bada/protocol/connection/BandwidthUpgradeOrchestratorTest.kt
+++ b/core-protocol/src/test/kotlin/dev/bluehouse/bada/protocol/connection/BandwidthUpgradeOrchestratorTest.kt
@@ -308,6 +308,136 @@ class BandwidthUpgradeOrchestratorTest {
             }
         }
 
+    @Test
+    fun `server failure before intro ack keeps fallback channel usable`() =
+        runBlocking {
+            withTimeout(WALLCLOCK_TIMEOUT_MILLIS) {
+                val (oldClientSocket, oldServerSocket) = connectedSocketPair()
+                val (newClientSocket, newServerSocket) = connectedSocketPair()
+                val oldClientChannel =
+                    SecureChannel(
+                        FramedConnection(oldClientSocket),
+                        freshSessionKeys(D2DRole.CLIENT),
+                        SecureRandom(),
+                    )
+                val oldServerChannel =
+                    SecureChannel(
+                        FramedConnection(oldServerSocket),
+                        freshSessionKeys(D2DRole.SERVER),
+                        SecureRandom(),
+                    )
+                val newClientFramed = FramedConnection(newClientSocket)
+                val registry =
+                    MediumRegistry(
+                        providers = listOf(serverProvider(newServerSocket)),
+                        ladder = MediumLadder(listOf(Medium.WIFI_DIRECT)),
+                    )
+                val logs = Collections.synchronizedList(mutableListOf<String>())
+
+                coroutineScope {
+                    val server =
+                        async {
+                            BandwidthUpgradeOrchestrator.runServerUpgradeIfAvailable(
+                                oldChannel = oldServerChannel,
+                                currentMedium = Medium.BLE,
+                                mediumRegistry = registry,
+                                peerSupportedMediums = setOf(Medium.WIFI_DIRECT),
+                                peerEndpointId = ENDPOINT_ID,
+                                logger = logs::add,
+                            )
+                        }
+                    val client =
+                        async {
+                            oldClientChannel.receiveOfflineFrame().assertUpgradeEvent(
+                                BandwidthUpgradeNegotiationFrame.EventType.UPGRADE_PATH_AVAILABLE,
+                            )
+                            // A KEEP_ALIVE where the raw CLIENT_INTRODUCTION
+                            // belongs fails the server BEFORE its intro-ack —
+                            // the prior channel must come back usable.
+                            newClientFramed.sendFrame(keepAliveFrame().toByteArray())
+                        }
+
+                    val result = server.await()
+                    client.await()
+
+                    assertThat(result.channel).isSameInstanceAs(oldServerChannel)
+                    assertThat(result.medium).isEqualTo(Medium.BLE)
+                    assertThat(result.fallbackChannelUsable).isTrue()
+                    assertThat(logs.joinToString("\n")).contains("server failed WIFI_DIRECT")
+                }
+            }
+        }
+
+    @Test
+    fun `server failure after intro ack marks fallback channel unusable`() =
+        runBlocking {
+            withTimeout(WALLCLOCK_TIMEOUT_MILLIS) {
+                val (oldClientSocket, oldServerSocket) = connectedSocketPair()
+                val (newClientSocket, newServerSocket) = connectedSocketPair()
+                val oldClientChannel =
+                    SecureChannel(
+                        FramedConnection(oldClientSocket),
+                        freshSessionKeys(D2DRole.CLIENT),
+                        SecureRandom(),
+                    )
+                val oldServerChannel =
+                    SecureChannel(
+                        FramedConnection(oldServerSocket),
+                        freshSessionKeys(D2DRole.SERVER),
+                        SecureRandom(),
+                    )
+                val newClientFramed = FramedConnection(newClientSocket)
+                val registry =
+                    MediumRegistry(
+                        providers = listOf(serverProvider(newServerSocket)),
+                        ladder = MediumLadder(listOf(Medium.WIFI_DIRECT)),
+                    )
+                val logs = Collections.synchronizedList(mutableListOf<String>())
+
+                coroutineScope {
+                    val server =
+                        async {
+                            BandwidthUpgradeOrchestrator.runServerUpgradeIfAvailable(
+                                oldChannel = oldServerChannel,
+                                currentMedium = Medium.BLE,
+                                mediumRegistry = registry,
+                                peerSupportedMediums = setOf(Medium.WIFI_DIRECT),
+                                peerEndpointId = ENDPOINT_ID,
+                                logger = logs::add,
+                            )
+                        }
+                    val client =
+                        async {
+                            oldClientChannel.receiveOfflineFrame().assertUpgradeEvent(
+                                BandwidthUpgradeNegotiationFrame.EventType.UPGRADE_PATH_AVAILABLE,
+                            )
+                            newClientFramed.sendFrame(
+                                BandwidthUpgradeFrames.clientIntroduction(ENDPOINT_ID).toByteArray(),
+                            )
+                            newClientFramed.receiveRawOfflineFrame().assertUpgradeEvent(
+                                BandwidthUpgradeNegotiationFrame.EventType.CLIENT_INTRODUCTION_ACK,
+                            )
+                            oldClientChannel.receiveOfflineFrame().assertUpgradeEvent(
+                                BandwidthUpgradeNegotiationFrame.EventType.LAST_WRITE_TO_PRIOR_CHANNEL,
+                            )
+                            // Answer the server's LAST_WRITE with UPGRADE_FAILURE:
+                            // the intro-ack already went out, so the sender side
+                            // has begun its own teardown — no fallback allowed.
+                            oldClientChannel.sendOfflineFrame(
+                                BandwidthUpgradeFrames.upgradeFailure(Medium.WIFI_DIRECT),
+                            )
+                        }
+
+                    val result = server.await()
+                    client.await()
+
+                    assertThat(result.channel).isSameInstanceAs(oldServerChannel)
+                    assertThat(result.medium).isEqualTo(Medium.BLE)
+                    assertThat(result.fallbackChannelUsable).isFalse()
+                }
+            }
+        }
+
     private fun clientProvider(socket: Socket): MediumProvider =
         object : MediumProvider {
             override val medium: Medium = Medium.WIFI_DIRECT


### PR DESCRIPTION
Fixes #260

Completes the `fallbackChannelUsable` tracking introduced in PR #257 (review findings N2 + N3):

**Server path now tracks teardown (N2).** `completeServerUpgrade` gets the same `onPriorChannelTeardown` marker as the client path, and `runServerUpgradeIfAvailable`'s failure fallback sets `fallbackChannelUsable = !priorChannelTeardownBegan`. `InboundConnectionDriver` fails the connection (`InboundResult.Failed`) when handed a dirty fallback channel instead of running the whole sharing session against a socket the sender stopped reading.

**Marker boundary follows peer behavior (N3).** Both roles now mark commitment at the point where the *peer* starts its own prior-channel teardown, not where we write ours:
- client: once `CLIENT_INTRODUCTION` is on the wire (stock GMS servers LAST_WRITE the prior channel as soon as the introduction is delivered, without waiting for ours);
- server: once `CLIENT_INTRODUCTION_ACK` goes out (stock GMS clients LAST_WRITE right after the ack).

The trade-off documented in the issue is taken as proposed: we lose fallback in the narrow case where the introduction was written but never arrived, in exchange for never streaming into a peer that already committed to teardown. Pre-commitment failures (malformed offer, no provider, adopt/accept timeout, dead adopted transport) still fall back exactly as before — including the server's long-standing accept-timeout → `UPGRADE_FAILURE` → stay-on-old-channel path, which remains pre-commitment.

**Tests**: two new `BandwidthUpgradeOrchestratorTest` cases pin the server stages (pre-ack failure → usable; post-ack `UPGRADE_FAILURE` answer to LAST_WRITE → unusable), mirroring the existing client pair; the client pair still passes with the earlier marker since both its scenarios sit on the same side of the new boundary.

`:core-protocol:test`, `staticAnalysis`, `:app:testDebugUnitTest` all green.
