### PR TITLE
fix: stop MdnsAdvertisementGate from flooding the diagnostics log during peer sessions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Run :discovery-android JVM unit tests
         run: ./gradlew :discovery-android:testDebugUnitTest --stacktrace
 
+      - name: Run :service-android JVM unit tests
+        run: ./gradlew :service-android:testDebugUnitTest --stacktrace
+
       - name: Run :app JVM unit tests
         run: ./gradlew :app:testDebugUnitTest --stacktrace
 

--- a/service-android/src/main/kotlin/dev/bluehouse/bada/service/receiver/MdnsAdvertisementGate.kt
+++ b/service-android/src/main/kotlin/dev/bluehouse/bada/service/receiver/MdnsAdvertisementGate.kt
@@ -91,6 +91,31 @@ import kotlinx.coroutines.launch
  *   recovery cases where the first publish attempt happens while Wi-Fi
  *   or Bluetooth is still unavailable, and Android does not emit a gate
  *   input change after the radio becomes usable.
+ * @param wallClockMillis wall-clock source for the failure-log throttle.
+ *   Injectable so JVM tests can drive the throttle window
+ *   deterministically; production uses [System.currentTimeMillis].
+ *
+ * ### Diagnostics hygiene (issue #262)
+ *
+ * `BleQuickShareScanner` republishes `ScanActivity.Active(lastSeenAtMillis)`
+ * on every sighting of a sender's BLE pulse — each carries a fresh
+ * timestamp, so `StateFlow`'s equality conflation never collapses them and
+ * [apply] re-runs several times per second while a peer session is active.
+ * The gate therefore must not treat "apply ran" as a loggable event:
+ *
+ *  * [startBleSafely] logs only when the (decision, outcome) pair changes
+ *    since the last BLE start log (reset when the BLE advertise stops), so
+ *    steady-state pulse traffic produces a single line per transition.
+ *  * Publish-path failures are logged as a single summary line (exception
+ *    class + message chain, no stack trace) and throttled to at most one
+ *    line per [FAILURE_LOG_THROTTLE_MILLIS] per (site, exception class):
+ *    an NsdManager registration stall on vivo otherwise floods the 512 KB
+ *    [DiagnosticLog] rotation with identical `TimeoutCancellationException`
+ *    stacks — and that file is the only field evidence on those devices.
+ *  * A failed mDNS publish is NOT re-attempted by every pulse-driven
+ *    [apply]: while the scheduled retry is pending and the decision is
+ *    unchanged, the (2-second-blocking) `NsdManager.registerService` call
+ *    is skipped so the retry cadence stays at [publishRetryDelayMillis].
  */
 @Suppress("LongParameterList")
 public class MdnsAdvertisementGate(
@@ -118,6 +143,7 @@ public class MdnsAdvertisementGate(
      * both sinks.
      */
     private val bleBroadcaster: BleVisibilityBroadcaster = BleVisibilityBroadcaster.Noop,
+    private val wallClockMillis: () -> Long = System::currentTimeMillis,
 ) {
     @Volatile
     private var collectorJob: Job? = null
@@ -140,6 +166,36 @@ public class MdnsAdvertisementGate(
      * are themselves serialised by the session's internal lock.
      */
     private val applyLock: Any = Any()
+
+    /**
+     * Guards the pure log-dedupe/throttle state below. Kept separate from
+     * [applyLock] because [stopBleSafely] also runs from the debounce
+     * coroutine outside the apply path, and the log bookkeeping must not
+     * change the existing locking semantics of the publish machinery.
+     */
+    private val logStateLock: Any = Any()
+
+    /**
+     * Last (decision, started) pair logged by [startBleSafely]. Consecutive
+     * identical outcomes are not re-logged; reset by [stopBleSafely] so the
+     * next start after a stop logs the transition again. Guarded by
+     * [logStateLock].
+     */
+    private var lastBleStartLog: Pair<Decision, Boolean>? = null
+
+    /**
+     * Wall-clock time of the last emitted throttled warning, keyed by
+     * `"<site>:<exception class>"`. Guarded by [logStateLock].
+     */
+    private val throttledWarningLastEmitMillis: MutableMap<String, Long> = HashMap()
+
+    /**
+     * Decision snapshot of the most recent failed publish attempt whose
+     * retry is still pending. While set (and the retry job is active),
+     * pulse-driven re-applies of the same decision skip the blocking
+     * `NsdManager.registerService` re-attempt. Guarded by [applyLock].
+     */
+    private var pendingRetryDecision: Decision? = null
 
     /**
      * Begin observing the gating signals on [scope].
@@ -232,6 +288,7 @@ public class MdnsAdvertisementGate(
             debounceJob = null
             publishRetryJob?.cancel()
             publishRetryJob = null
+            pendingRetryDecision = null
             if (session.isAdvertising) {
                 try {
                     session.unpublishAdvertisement()
@@ -256,37 +313,24 @@ public class MdnsAdvertisementGate(
             try {
                 session.prepareInitialControlServers()
             } catch (t: Throwable) {
-                DiagnosticLog.w(TAG, "publish: failed to prepare initial control (decision=$decision)", t)
+                logThrottledWarning(
+                    site = "prepare-initial-control",
+                    message = "publish: failed to prepare initial control (decision=$decision)",
+                    cause = t,
+                )
             }
             // Bring up BLE before the potentially slow mDNS path. Some
             // vivo builds stall inside NsdManager registration; the
             // receiver still needs to be BLE connectible while that
             // platform callback is pending.
             startBleSafely(decision)
-            if (!session.isAdvertising) {
-                try {
-                    session.publishAdvertisement()
-                    publishRetryJob?.cancel()
-                    publishRetryJob = null
-                    DiagnosticLog.w(TAG, "publish: published mDNS (decision=$decision)")
-                } catch (t: Throwable) {
-                    // The session may have been stopped between the
-                    // collector firing and the publish call, or Android's
-                    // NSD stack may be temporarily unavailable while Wi-Fi
-                    // is still coming up. Keep retrying while the current
-                    // decision still wants us to be published.
-                    DiagnosticLog.w(TAG, "publish: failed (decision=$decision)", t)
-                    schedulePublishRetry(scope)
-                }
-            } else {
-                publishRetryJob?.cancel()
-                publishRetryJob = null
-            }
+            attemptPublishLocked(decision, scope)
             return
         }
 
         publishRetryJob?.cancel()
         publishRetryJob = null
+        pendingRetryDecision = null
         // No "should publish" signal active: schedule an unpublish if
         // the advertisement is currently up. If the timer is already
         // running we leave it alone — re-arming it would extend the
@@ -321,6 +365,55 @@ public class MdnsAdvertisementGate(
             }
     }
 
+    /**
+     * Publish the mDNS advertisement if it is not already up. Called
+     * under [applyLock] from [apply].
+     *
+     * A failed attempt schedules a retry [publishRetryDelayMillis] later
+     * and records the failing [decision]; while that retry is pending,
+     * re-applies of the *same* decision (which arrive several times per
+     * second from BLE pulse sightings, see the class KDoc) skip the
+     * re-attempt entirely. `NsdManager.registerService` blocks for up to
+     * its 2 s registration timeout per attempt, so re-attempting at pulse
+     * cadence would hammer the platform NSD stack and flood the
+     * diagnostics log with identical timeout failures (issue #262). A
+     * decision *change* still attempts immediately.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    private fun attemptPublishLocked(
+        decision: Decision,
+        scope: CoroutineScope,
+    ) {
+        if (session.isAdvertising) {
+            publishRetryJob?.cancel()
+            publishRetryJob = null
+            pendingRetryDecision = null
+            return
+        }
+        if (publishRetryJob?.isActive == true && decision == pendingRetryDecision) return
+        try {
+            session.publishAdvertisement()
+            publishRetryJob?.cancel()
+            publishRetryJob = null
+            pendingRetryDecision = null
+            DiagnosticLog.w(TAG, "publish: published mDNS (decision=$decision)")
+        } catch (t: Throwable) {
+            // The session may have been stopped between the collector
+            // firing and the publish call, or Android's NSD stack may be
+            // temporarily unavailable while Wi-Fi is still coming up.
+            // Keep retrying while the current decision still wants us to
+            // be published. Expected/retried failure: summary line only,
+            // rate-limited — no stack trace (issue #262).
+            logThrottledWarning(
+                site = "publish",
+                message = "publish: failed (decision=$decision)",
+                cause = t,
+            )
+            pendingRetryDecision = decision
+            schedulePublishRetry(scope)
+        }
+    }
+
     private fun schedulePublishRetry(scope: CoroutineScope) {
         if (publishRetryJob?.isActive == true) return
         var retryJob: Job? = null
@@ -344,6 +437,14 @@ public class MdnsAdvertisementGate(
      * silently (no advertise permission, no LE peripheral, etc.); this
      * wrapper exists so a misbehaving fake in tests cannot poison the
      * gate's mDNS path.
+     *
+     * Logging is transition-only: BLE pulse sightings re-run [apply] (and
+     * therefore this call) several times per second during a peer
+     * session, but only a *change* in the (decision, outcome) pair is a
+     * loggable event (issue #262). The broadcaster call itself is still
+     * issued every time — the production implementation is an
+     * identity-unchanged no-op, and skipping it here would break identity
+     * refresh on decision changes.
      */
     @Suppress("TooGenericExceptionCaught")
     private fun startBleSafely(decision: Decision) {
@@ -351,19 +452,35 @@ public class MdnsAdvertisementGate(
             val started = bleBroadcaster.start()
             if (started) {
                 bleAdvertising = true
-                DiagnosticLog.w(TAG, "publish: BLE pulse advertise started (decision=$decision)")
-            } else {
-                DiagnosticLog.w(TAG, "publish: BLE pulse advertise unavailable (decision=$decision)")
+            }
+            val shouldLog =
+                synchronized(logStateLock) {
+                    val logKey = decision to started
+                    val changed = lastBleStartLog != logKey
+                    if (changed) lastBleStartLog = logKey
+                    changed
+                }
+            if (shouldLog) {
+                if (started) {
+                    DiagnosticLog.w(TAG, "publish: BLE pulse advertise started (decision=$decision)")
+                } else {
+                    DiagnosticLog.w(TAG, "publish: BLE pulse advertise unavailable (decision=$decision)")
+                }
             }
         } catch (t: Throwable) {
-            DiagnosticLog.w(TAG, "publish: BLE pulse advertise threw (decision=$decision)", t)
+            logThrottledWarning(
+                site = "ble-start",
+                message = "publish: BLE pulse advertise threw (decision=$decision)",
+                cause = t,
+            )
         }
     }
 
     /**
      * Best-effort `bleBroadcaster.stop` that swallows all exceptions.
      * Logging mirrors [startBleSafely] so the lifecycle is greppable
-     * end-to-end.
+     * end-to-end. Also resets the start-log dedupe state so the next
+     * start after this stop logs its transition again.
      */
     @Suppress("TooGenericExceptionCaught")
     private fun stopBleSafely(reason: String) {
@@ -371,10 +488,59 @@ public class MdnsAdvertisementGate(
         try {
             bleBroadcaster.stop()
             bleAdvertising = false
+            synchronized(logStateLock) { lastBleStartLog = null }
             DiagnosticLog.w(TAG, "unpublish: BLE pulse advertise stopped ($reason)")
         } catch (t: Throwable) {
             DiagnosticLog.w(TAG, "unpublish: BLE pulse advertise stop threw ($reason)", t)
         }
+    }
+
+    /**
+     * Emit `"<message>: <cause summary>"` as a single-line warning, at
+     * most once per [FAILURE_LOG_THROTTLE_MILLIS] per (site, exception
+     * class). The summary is the exception class + message chain — no
+     * stack trace. Used for expected/retried failures on the publish path
+     * so an NsdManager stall cannot flood the size-capped diagnostics
+     * rotation (issue #262); rare teardown-path failures keep their full
+     * stacks.
+     */
+    private fun logThrottledWarning(
+        site: String,
+        message: String,
+        cause: Throwable,
+    ) {
+        val now = wallClockMillis()
+        val throttleKey = "$site:${cause.javaClass.name}"
+        val shouldLog =
+            synchronized(logStateLock) {
+                val last = throttledWarningLastEmitMillis[throttleKey]
+                if (last != null && now - last < FAILURE_LOG_THROTTLE_MILLIS) {
+                    false
+                } else {
+                    throttledWarningLastEmitMillis[throttleKey] = now
+                    true
+                }
+            }
+        if (shouldLog) {
+            DiagnosticLog.w(TAG, "$message: ${summaryLine(cause)}")
+        }
+    }
+
+    /**
+     * Single-line `Class: message` rendering of [cause] and its cause
+     * chain (bounded to [MAX_SUMMARY_CAUSE_DEPTH] links so a cyclic chain
+     * cannot loop).
+     */
+    private fun summaryLine(cause: Throwable): String {
+        val parts = mutableListOf<String>()
+        var current: Throwable? = cause
+        var depth = 0
+        while (current != null && depth < MAX_SUMMARY_CAUSE_DEPTH) {
+            parts += "${current.javaClass.simpleName}: ${current.message}"
+            current = current.cause
+            depth += 1
+        }
+        return parts.joinToString(separator = " caused by ")
     }
 
     /**
@@ -408,6 +574,17 @@ public class MdnsAdvertisementGate(
          * hammering Android NSD when it is stuck.
          */
         public const val DEFAULT_PUBLISH_RETRY_DELAY_MILLIS: Long = 5_000L
+
+        /**
+         * Minimum spacing between two throttled failure warnings for the
+         * same (site, exception class). Chosen well above the 5 s publish
+         * retry cadence so a stuck NsdManager produces one summary line
+         * per window instead of one stack trace per retry (issue #262).
+         */
+        public const val FAILURE_LOG_THROTTLE_MILLIS: Long = 30_000L
+
+        /** Bound on the cause chain rendered by the failure summary line. */
+        private const val MAX_SUMMARY_CAUSE_DEPTH: Int = 4
     }
 }
 

--- a/service-android/src/test/kotlin/dev/bluehouse/bada/service/receiver/MdnsAdvertisementGateTest.kt
+++ b/service-android/src/test/kotlin/dev/bluehouse/bada/service/receiver/MdnsAdvertisementGateTest.kt
@@ -8,6 +8,7 @@ package dev.bluehouse.bada.service.receiver
 import com.google.common.truth.Truth.assertThat
 import dev.bluehouse.bada.discovery.AdvertiseHandle
 import dev.bluehouse.bada.discovery.ble.ScanActivity
+import dev.bluehouse.bada.discovery.diagnostics.DiagnosticLog
 import dev.bluehouse.bada.protocol.endpoint.DeviceType
 import dev.bluehouse.bada.protocol.endpoint.EndpointInfo
 import dev.bluehouse.bada.protocol.medium.MediumRegistry
@@ -47,6 +48,7 @@ import java.security.SecureRandom
  * without sleeping.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
+@Suppress("LargeClass")
 class MdnsAdvertisementGateTest {
     @BeforeEach
     fun setUp() {
@@ -657,9 +659,203 @@ class MdnsAdvertisementGateTest {
             session.stop()
         }
 
+    @Test
+    fun `repeated BLE pulse sightings log advertise start only once`() =
+        runTest {
+            val advertiser = RecordingAdvertiser()
+            val session = startedGatedSession(advertiser = advertiser)
+            val ble = MutableStateFlow<ScanActivity>(ScanActivity.Idle)
+            val override = MutableStateFlow(false)
+            val qr = MutableStateFlow(false)
+            val broadcaster = RecordingBleBroadcaster()
+
+            val gate =
+                MdnsAdvertisementGate(
+                    session = session,
+                    bleActivity = ble,
+                    alwaysVisibleOverride = override,
+                    qrSessionActive = qr,
+                    bleBroadcaster = broadcaster,
+                )
+            gate.start(this)
+            advanceUntilIdle()
+            val baseline = diagnosticCount("BLE pulse advertise started")
+
+            // Every BLE pulse sighting re-publishes ScanActivity.Active
+            // with a fresh timestamp, so each is a distinct StateFlow
+            // value the gate re-applies on (#262). The broadcaster is
+            // still invoked each time (its production implementation is
+            // an identity-unchanged no-op), but the diagnostics line must
+            // be logged only on the transition.
+            repeat(20) { i ->
+                ble.value = ScanActivity.Active(lastSeenAtMillis = 1_000L + i)
+                advanceUntilIdle()
+            }
+
+            assertThat(broadcaster.startCount).isEqualTo(20)
+            assertThat(diagnosticCount("BLE pulse advertise started") - baseline).isEqualTo(1)
+
+            gate.stop()
+            session.stop()
+        }
+
+    @Test
+    fun `BLE advertise start is logged again after a stop transition`() =
+        runTest {
+            val advertiser = RecordingAdvertiser()
+            val session = startedGatedSession(advertiser = advertiser)
+            val ble = MutableStateFlow<ScanActivity>(ScanActivity.Idle)
+            val override = MutableStateFlow(false)
+            val qr = MutableStateFlow(false)
+            val broadcaster = RecordingBleBroadcaster()
+
+            val gate =
+                MdnsAdvertisementGate(
+                    session = session,
+                    bleActivity = ble,
+                    alwaysVisibleOverride = override,
+                    qrSessionActive = qr,
+                    debounceIdleMillis = 30_000L,
+                    bleBroadcaster = broadcaster,
+                )
+            gate.start(this)
+            advanceUntilIdle()
+            val baseline = diagnosticCount("BLE pulse advertise started")
+
+            // First up transition: logged.
+            ble.value = ScanActivity.Active(lastSeenAtMillis = 1_000L)
+            advanceUntilIdle()
+            assertThat(diagnosticCount("BLE pulse advertise started") - baseline).isEqualTo(1)
+
+            // Idle past the debounce: both channels torn down.
+            ble.value = ScanActivity.Idle
+            advanceTimeBy(1L)
+            advanceTimeBy(30_010L)
+            advanceUntilIdle()
+            assertThat(broadcaster.stopCount).isAtLeast(1)
+
+            // Second up transition after the stop: logged again — the
+            // dedupe suppresses repeats, not transitions.
+            ble.value = ScanActivity.Active(lastSeenAtMillis = 50_000L)
+            advanceUntilIdle()
+            assertThat(diagnosticCount("BLE pulse advertise started") - baseline).isEqualTo(2)
+
+            gate.stop()
+            session.stop()
+        }
+
+    @Test
+    fun `failed publish is not re-attempted per pulse and logs a throttled summary line`() =
+        runTest {
+            val advertiser = FailThenSucceedAdvertiser(failuresBeforeSuccess = Int.MAX_VALUE)
+            val session = startedGatedSession(advertiser = advertiser)
+            val ble = MutableStateFlow<ScanActivity>(ScanActivity.Idle)
+            val override = MutableStateFlow(false)
+            val qr = MutableStateFlow(false)
+            var fakeNow = 0L
+
+            val gate =
+                MdnsAdvertisementGate(
+                    session = session,
+                    bleActivity = ble,
+                    alwaysVisibleOverride = override,
+                    qrSessionActive = qr,
+                    publishRetryDelayMillis = 5_000L,
+                    wallClockMillis = { fakeNow },
+                )
+            gate.start(this)
+            runCurrent()
+            val failBaseline = diagnosticCount("publish: failed (decision=")
+            val stackBaseline = diagnosticCount("\tat ")
+
+            ble.value = ScanActivity.Active(lastSeenAtMillis = 1_000L)
+            runCurrent()
+            assertThat(advertiser.attempts).isEqualTo(1)
+
+            // Ten more pulse sightings inside the retry window: the
+            // 2-s-blocking NsdManager registration must NOT be re-attempted
+            // per pulse — the scheduled retry owns the cadence (#262).
+            repeat(10) { i ->
+                ble.value = ScanActivity.Active(lastSeenAtMillis = 2_000L + i)
+                runCurrent()
+            }
+            assertThat(advertiser.attempts).isEqualTo(1)
+
+            // Exactly one summary line, and no stack trace frames.
+            assertThat(diagnosticCount("publish: failed (decision=") - failBaseline).isEqualTo(1)
+            assertThat(diagnosticCount("\tat ") - stackBaseline).isEqualTo(0)
+
+            // The scheduled retry still fires and re-attempts...
+            advanceTimeBy(5_001L)
+            runCurrent()
+            assertThat(advertiser.attempts).isEqualTo(2)
+            // ...but its identical failure stays throttled.
+            assertThat(diagnosticCount("publish: failed (decision=") - failBaseline).isEqualTo(1)
+
+            // Past the throttle window the failure logs again (one line).
+            fakeNow += MdnsAdvertisementGate.FAILURE_LOG_THROTTLE_MILLIS + 1
+            advanceTimeBy(5_001L)
+            runCurrent()
+            assertThat(advertiser.attempts).isEqualTo(3)
+            assertThat(diagnosticCount("publish: failed (decision=") - failBaseline).isEqualTo(2)
+            assertThat(diagnosticCount("\tat ") - stackBaseline).isEqualTo(0)
+
+            // Dropping the publish signal cancels the pending retry so the
+            // test scheduler quiesces.
+            ble.value = ScanActivity.Idle
+            advanceUntilIdle()
+            assertThat(advertiser.attempts).isEqualTo(3)
+
+            gate.stop()
+            session.stop()
+        }
+
+    @Test
+    fun `decision change re-attempts publish immediately despite pending retry`() =
+        runTest {
+            val advertiser = FailThenSucceedAdvertiser(failuresBeforeSuccess = 1)
+            val session = startedGatedSession(advertiser = advertiser)
+            val ble = MutableStateFlow<ScanActivity>(ScanActivity.Idle)
+            val override = MutableStateFlow(false)
+            val qr = MutableStateFlow(false)
+
+            val gate =
+                MdnsAdvertisementGate(
+                    session = session,
+                    bleActivity = ble,
+                    alwaysVisibleOverride = override,
+                    qrSessionActive = qr,
+                    publishRetryDelayMillis = 5_000L,
+                )
+            gate.start(this)
+            runCurrent()
+
+            ble.value = ScanActivity.Active(lastSeenAtMillis = 1_000L)
+            runCurrent()
+            assertThat(advertiser.attempts).isEqualTo(1)
+            assertThat(session.isAdvertising).isFalse()
+
+            // A different decision (override flips on) must not wait for
+            // the retry timer.
+            override.value = true
+            runCurrent()
+            assertThat(advertiser.attempts).isEqualTo(2)
+            assertThat(session.isAdvertising).isTrue()
+
+            gate.stop()
+            session.stop()
+        }
+
     // --------------------------------------------------------------
     // Helpers
     // --------------------------------------------------------------
+
+    /**
+     * Count DiagnosticLog ring-buffer lines containing [marker]. The
+     * buffer is process-global, so callers snapshot a baseline first and
+     * assert on the delta.
+     */
+    private fun diagnosticCount(marker: String): Int = DiagnosticLog.dumpRecent().lines().count { it.contains(marker) }
 
     /**
      * Build a [ReceiverSession] configured with `advertiseGated = true`,


### PR DESCRIPTION
## Observed flood

During the #256 debug loops (vivo V2547A receiver, stock GMS sender connected), `bada-diagnostics.log` filled at ~7 lines/second with

```
W/BadaMdnsGate: publish: BLE pulse advertise started (decision=Decision(bleActive=true, ...))
```

interleaved with repeated full `TimeoutCancellationException` ("Timed out waiting for 2000 ms") stack traces. One session evicted the useful transfer history out of the 512 KB `DiagnosticLog` rotation — and on vivo that file is the only sender/receiver field evidence.

## Mechanism

1. **Why ~7×/sec:** `BleQuickShareScanner` republishes `ScanActivity.Active(lastSeenAtMillis = now)` on every sighting of the sender's BLE pulse. `Active` is a data class carrying the timestamp, so every sighting is a *distinct* `StateFlow` value — equality conflation never collapses them, and the gate's collector (`MdnsAdvertisementGate.kt:174`) re-runs `apply()` on each one. `startBleSafely` then logged "BLE pulse advertise started" unconditionally on every apply.
2. **Why the stack traces:** when `NsdManager.registerService` stalls (a known vivo behavior), `NsdAdvertiseHandle.register()` throws `IOException` caused by `TimeoutCancellationException` after its 2 s registration timeout. The gate logged the full stack via `DiagnosticLog.w(tag, msg, throwable)` on every attempt — and every pulse-driven `apply` with the advertisement still down re-attempted the 2-s-blocking registration immediately, instead of waiting for the scheduled 5 s retry.

## Was real radio work being churned?

**No BLE radio churn.** `bleBroadcaster.start()` maps to `BleQuickShareAdvertiser.start`, which explicitly short-circuits (returns `true`, touches no platform advertiser) when the identity bytes are unchanged, and `BleEndpointIdHolder.bytesFor()` returns a stable cached slug — so the 7×/sec loop was only re-*logging* the BLE start, not restarting the advertisement.

**But there was real repeated NSD work in the failure case:** while the mDNS advertisement was down (registration stalling), each pulse-driven `apply` re-invoked the blocking `NsdManager.registerService` back-to-back rather than at the intended 5 s retry cadence. That is fixed here too (see below). Successful steady state (`session.isAdvertising == true`) never re-registered mDNS — that path was already a no-op.

## Fix

- **Transition-only BLE start log:** `startBleSafely` logs only when the `(decision, outcome)` pair changes; the dedupe resets on `stopBleSafely` so every genuine up-transition still logs. The broadcaster call itself is still issued each time (production impl is an identity-unchanged no-op; skipping it would break identity refresh).
- **Single-line, throttled failure warnings:** publish-path failures (`publishAdvertisement`, `prepareInitialControlServers`, BLE-start throw) now log one line with the exception class + message chain (no stack trace), at most once per 30 s per (site, exception class). `DiagnosticLog` has no built-in rate-limit helper, so the gate carries a small keyed throttle with an injectable wall clock. Rare teardown-path failures keep their full stacks.
- **Retry cadence honored:** a failed publish records its decision; while the scheduled retry is pending, pulse-driven re-applies of the *same* decision skip the blocking re-registration. A decision *change* still attempts immediately, and the retry job re-attempts on schedule.

## Tests

The gate already had pure-JVM tests (`service-android/src/test`, JUnit 5 + coroutines-test + `unitTests.isReturnDefaultValues`). Added four regression tests asserting against the `DiagnosticLog` ring buffer: dedupe under 20 pulse sightings (one log line, 20 broadcaster calls), re-log after a stop transition, throttled single-line failure with no stack frames and no per-pulse re-attempts, and immediate re-attempt on decision change. All 17 gate tests pass.

CI previously did not run `:service-android:testDebugUnitTest` at all (only discovery/app/radio-helper); added it to `ci.yml` so these tests actually gate merges.

## Validation

- `./gradlew staticAnalysis` — pass
- `./gradlew :app:testDebugUnitTest` — pass
- `./gradlew :service-android:testDebugUnitTest` — pass

Fixes #262
