### PR TITLE
chore: log consent-notification post outcome for backgrounded-consent triage

### DIFF
--- a/service-android/src/main/kotlin/dev/bluehouse/bada/service/receiver/ReceiverForegroundService.kt
+++ b/service-android/src/main/kotlin/dev/bluehouse/bada/service/receiver/ReceiverForegroundService.kt
@@ -833,6 +833,7 @@ public class ReceiverForegroundService : Service() {
                                 connectionId = connectionId,
                                 entry = entry,
                                 trampolineTarget = consentTrampolineTarget,
+                                diagnostic = { line -> ConsentDiagnostic.log(ctx, line) },
                             )
                         }
 

--- a/service-android/src/main/kotlin/dev/bluehouse/bada/service/receiver/consent/ConsentNotification.kt
+++ b/service-android/src/main/kotlin/dev/bluehouse/bada/service/receiver/consent/ConsentNotification.kt
@@ -320,16 +320,40 @@ public object ConsentNotification {
      *
      * Returns the notification id used so callers (foreground service,
      * tests) can correlate.
+     *
+     * [diagnostic] records the post attempt with the two states that make
+     * `NotificationManager.notify` a SILENT no-op — app-level
+     * notifications disabled, and the effective channel importance —
+     * plus the notify outcome. Field evidence for #263: on a vivo
+     * (OriginOS) receiver the consent notification never appeared in
+     * `dumpsys notification` while this channel was registered at
+     * IMPORTANCE_HIGH, and without this line there is no way to tell an
+     * app-side skipped post from an OEM-suppressed one.
      */
     public fun post(
         context: Context,
         connectionId: Long,
         entry: ConsentRegistry.Entry,
         trampolineTarget: Class<*>?,
+        diagnostic: (String) -> Unit = {},
     ): Int {
-        val manager = context.getSystemService(NotificationManager::class.java) ?: return -1
+        val manager = context.getSystemService(NotificationManager::class.java)
+        if (manager == null) {
+            diagnostic("notification post id=- result=no-notification-manager")
+            return -1
+        }
         val id = stableNotificationIdFor(connectionId)
-        manager.notify(id, build(context, connectionId, entry, trampolineTarget))
+        val outcome =
+            runCatching { manager.notify(id, build(context, connectionId, entry, trampolineTarget)) }
+        diagnostic(
+            "notification post id=$id " +
+                "appEnabled=${manager.areNotificationsEnabled()} " +
+                "channelImportance=${manager.getNotificationChannel(CHANNEL_ID)?.importance} " +
+                "result=${outcome.fold({ "ok" }, { e -> "${e::class.simpleName}: ${e.message}" })}",
+        )
+        // Keep the pre-instrumentation contract: a throwing notify still
+        // propagates to the caller after the evidence is written.
+        outcome.getOrThrow()
         return id
     }
 


### PR DESCRIPTION
Refs #263 (instrumentation only — does not close the issue).

`NotificationManager.notify` is a silent no-op when app-level notifications are disabled, and the #263 investigation found the debug package has **never** landed a consent post on the `incoming_transfer` channel on the test vivo (`mLastNotificationUpdateTimeMs=0`) even though the channel is registered at IMPORTANCE_HIGH. Nothing in the current logs distinguishes "the app never called notify" from "OriginOS suppressed the post".

`ConsentNotification.post` gains an optional `diagnostic` sink (wired to `ConsentDiagnostic` → `bada-inbound.log` by the service) that records, per post attempt: the notification id, `areNotificationsEnabled()`, the effective channel importance, and the notify outcome. The pre-existing contract is preserved: a null NotificationManager still returns −1 (now with an evidence line), and a throwing `notify` still propagates after logging.

With this in place, one successful `isForeground=false` consent run on the vivo settles the #263 question. Gates: `staticAnalysis`, `:service-android:testDebugUnitTest`, `:app:testDebugUnitTest` green.
