### PR TITLE
fix: follow theme for send peer names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+
+- Fix the send picker's peer-device names to inherit the DayNight theme text color instead of remaining dark in night mode. Source-contract checks passed; Android compilation and rendered UI verification were not run because compilation was not authorized for this turn.

--- a/app/src/main/kotlin/dev/bluehouse/bada/ui/sheet/DeviceIconView.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/ui/sheet/DeviceIconView.kt
@@ -19,6 +19,13 @@ import android.widget.TextView
  *
  * [peerId] carries the discovered peer's stable identity so the host can
  * route this chip's click back through the unchanged selection path.
+ * `nameView` is the centered peer-name label shown directly below the 64dp
+ * circular device icon in both the external share sheet and the in-app send
+ * screen. It renders up to two 13sp lines and inherits the activity theme's
+ * primary text color, keeping it dark in day mode and light in night mode.
+ * [SendPeerPickerController] creates the view whenever discovery renders a
+ * connectable peer. [DeviceIconViewSourceTest] guards the no-hardcoded-color
+ * contract; rendered day/night behavior still requires an on-device UI check.
  *
  * Programmatic custom view: dp sizes, text sizes, and ARGB colour components are
  * inherently numeric layout constants, so MagicNumber is suppressed.
@@ -47,7 +54,6 @@ public class DeviceIconView(
         nameView =
             TextView(context).apply {
                 text = name
-                setTextColor(NAME_COLOR)
                 textSize = 13f
                 gravity = Gravity.CENTER
                 setPadding(0, (6 * d).toInt(), 0, 0)
@@ -102,7 +108,6 @@ public class DeviceIconView(
     }
 
     public companion object {
-        private const val NAME_COLOR = 0xFF111114.toInt()
         private const val STATUS_COLOR = 0xFF0A84FF.toInt()
         private const val BOUNCE_DOWN_SCALE = 0.82f
         private const val BOUNCE_DOWN_MS = 90L

--- a/app/src/main/kotlin/dev/bluehouse/bada/ui/sheet/DeviceIconView.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/ui/sheet/DeviceIconView.kt
@@ -19,7 +19,7 @@ import android.widget.TextView
  *
  * [peerId] carries the discovered peer's stable identity so the host can
  * route this chip's click back through the unchanged selection path.
- * `nameView` is the centered peer-name label shown directly below the 64dp
+ * `peerNameLabel` is the centered peer-name label shown directly below the 64dp
  * circular device icon in both the external share sheet and the in-app send
  * screen. It renders up to two 13sp lines and inherits the activity theme's
  * primary text color, keeping it dark in day mode and light in night mode.
@@ -37,7 +37,7 @@ public class DeviceIconView(
     name: String,
 ) : LinearLayout(context) {
     private val ring: RingProgressView
-    private val nameView: TextView
+    private val peerNameLabel: TextView
     private val statusView: TextView
 
     init {
@@ -51,7 +51,12 @@ public class DeviceIconView(
         val size = (64 * d).toInt()
         addView(ring, LayoutParams(size, size))
 
-        nameView =
+        // peerNameLabel — stationary, borderless peer-name text centered 6dp
+        // below the blue 64dp device circle in both send pickers. Discovery
+        // supplies the visible device name; the label itself has no tap action
+        // or animation. Its TextView default must retain Theme.Bada's stateful
+        // day/night text color, so do not replace it with a fixed ARGB value.
+        peerNameLabel =
             TextView(context).apply {
                 text = name
                 textSize = 13f
@@ -60,7 +65,7 @@ public class DeviceIconView(
                 maxLines = 2
                 ellipsize = android.text.TextUtils.TruncateAt.END
             }
-        addView(nameView, LayoutParams((96 * d).toInt(), LayoutParams.WRAP_CONTENT))
+        addView(peerNameLabel, LayoutParams((96 * d).toInt(), LayoutParams.WRAP_CONTENT))
 
         statusView =
             TextView(context).apply {
@@ -104,7 +109,7 @@ public class DeviceIconView(
     }
 
     public fun setName(name: String) {
-        nameView.text = name
+        peerNameLabel.text = name
     }
 
     public companion object {

--- a/app/src/test/kotlin/dev/bluehouse/bada/ui/sheet/DeviceIconViewSourceTest.kt
+++ b/app/src/test/kotlin/dev/bluehouse/bada/ui/sheet/DeviceIconViewSourceTest.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.ui.sheet
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/** Source guard for the theme-adaptive peer-name label in [DeviceIconView]. */
+class DeviceIconViewSourceTest {
+    private val source: String by lazy {
+        val file = File("src/main/kotlin/dev/bluehouse/bada/ui/sheet/DeviceIconView.kt")
+        assertTrue("DeviceIconView.kt should exist at ${file.absolutePath}", file.exists())
+        file.readText()
+    }
+
+    @Test
+    fun `device name inherits the day-night theme text color`() {
+        val nameViewBlock = source.substringAfter("nameView =").substringBefore("addView(nameView")
+
+        assertFalse(
+            "The peer name must inherit TextView's theme color instead of overriding it.",
+            nameViewBlock.contains("setTextColor"),
+        )
+        assertFalse("Do not restore the old fixed peer-name color.", source.contains("NAME_COLOR"))
+    }
+}

--- a/app/src/test/kotlin/dev/bluehouse/bada/ui/sheet/DeviceIconViewSourceTest.kt
+++ b/app/src/test/kotlin/dev/bluehouse/bada/ui/sheet/DeviceIconViewSourceTest.kt
@@ -10,7 +10,15 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.File
 
-/** Source guard for the theme-adaptive peer-name label in [DeviceIconView]. */
+/**
+ * Source regression guard for the theme-adaptive `peerNameLabel` in
+ * [DeviceIconView]. The app unit-test task invokes it; it reads only the owning
+ * Kotlin source and rejects an explicit text-color override or restoration of
+ * the former fixed-color constant. It performs no Android rendering, lifecycle
+ * work, I/O beyond that source read, or device-data access. The equivalent
+ * direct source assertion has passed; Gradle execution and rendered day/night
+ * UI behavior remain unverified under the current no-compilation gate.
+ */
 class DeviceIconViewSourceTest {
     private val source: String by lazy {
         val file = File("src/main/kotlin/dev/bluehouse/bada/ui/sheet/DeviceIconView.kt")
@@ -20,11 +28,12 @@ class DeviceIconViewSourceTest {
 
     @Test
     fun `device name inherits the day-night theme text color`() {
-        val nameViewBlock = source.substringAfter("nameView =").substringBefore("addView(nameView")
+        val peerNameLabelBlock =
+            source.substringAfter("peerNameLabel =").substringBefore("addView(peerNameLabel")
 
         assertFalse(
             "The peer name must inherit TextView's theme color instead of overriding it.",
-            nameViewBlock.contains("setTextColor"),
+            peerNameLabelBlock.contains("setTextColor"),
         )
         assertFalse("Do not restore the old fixed peer-name color.", source.contains("NAME_COLOR"))
     }


### PR DESCRIPTION
## Summary

- let discovered peer names inherit the DayNight theme text color
- cover both the external share sheet and in-app send picker through the shared `DeviceIconView`
- add a regression guard preventing a fixed peer-name color from returning

Fixes #272