### PR TITLE
Expose the Radio Helper companion in Settings with bundled install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,4 +5,5 @@
 - Added a Settings card that reports whether the matching Radio Helper companion is installed, installs the helper bundled inside Bada, and opens the helper setup screen after installation.
 - Embedded the matching debug or release helper APK in generated app assets and applied Bada's release signing inputs to the release helper so the signature-protected radio service can bind.
 - Hardened PackageInstaller confirmation, duplicate taps, session cleanup, unknown-source denial, and background confirmation handling.
+- Documented the Settings visuals, installer/receiver ownership, variant and signing invariants, concurrency/lifecycle boundaries, failure fallbacks, and device test matrix adjacent to their source owners.
 - Verification: static source/reference checks, XML parsing, and `git diff --check` passed. Android compilation, pull-request CI, and the real Settings/system-installer click path were not run because compilation was not authorized for this task; CI can be requested later with a follow-up commit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,4 +5,4 @@
 - Added a Settings card that reports whether the matching Radio Helper companion is installed, installs the helper bundled inside Bada, and opens the helper setup screen after installation.
 - Embedded the matching debug or release helper APK in generated app assets and applied Bada's release signing inputs to the release helper so the signature-protected radio service can bind.
 - Hardened PackageInstaller confirmation, duplicate taps, session cleanup, unknown-source denial, and background confirmation handling.
-- Verification: static source/reference checks, XML parsing, and `git diff --check` passed. Android compilation and the real Settings/system-installer click path were not run because compilation was not authorized for this task.
+- Verification: static source/reference checks, XML parsing, and `git diff --check` passed. Android compilation, pull-request CI, and the real Settings/system-installer click path were not run because compilation was not authorized for this task; CI can be requested later with a follow-up commit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## Unreleased — Radio Helper installation from Settings
+
+- Added a Settings card that reports whether the matching Radio Helper companion is installed, installs the helper bundled inside Bada, and opens the helper setup screen after installation.
+- Embedded the matching debug or release helper APK in generated app assets and applied Bada's release signing inputs to the release helper so the signature-protected radio service can bind.
+- Hardened PackageInstaller confirmation, duplicate taps, session cleanup, unknown-source denial, and background confirmation handling.
+- Verification: static source/reference checks, XML parsing, and `git diff --check` passed. Android compilation and the real Settings/system-installer click path were not run because compilation was not authorized for this task.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -143,13 +143,24 @@ kotlin {
 }
 
 /**
- * Bundle the matching Radio Helper APK inside each Bada APK so Settings can
- * install the companion without a browser or a second download. Debug embeds
- * the `.debug` helper; release embeds the release helper. Variant-specific
- * generated asset directories prevent a stale helper variant from leaking
- * into another build. `mergeDebugAssets` / `mergeReleaseAssets` own the final
- * embedding boundary; configuration and asset-presence checks are static-only
- * in this change because Android compilation was not authorized.
+ * Build-time owner of the embedded **Radio Helper** companion offered by
+ * Bada's Settings > Radio Helper > "Install Radio Helper" action.
+ *
+ * For each requested app variant, `bundleRadioHelper<Variant>` first assembles
+ * the same helper variant, renames its APK to the stable runtime contract
+ * `assets/radio-helper.apk`, and writes it to a variant-specific generated
+ * assets directory before `merge<Variant>Assets`. Debug therefore embeds the
+ * `.debug` helper package and release embeds the release package; neither asset
+ * directory is shared, so one variant cannot consume a stale APK from another.
+ * [dev.bluehouse.bada.helper.HelperInstaller] owns the runtime stream from that
+ * asset into PackageInstaller.
+ *
+ * Release usability additionally requires `:app` and `:radio-helper` to receive
+ * the same complete signing input set because the helper service is guarded by
+ * a signature permission. Validate by building both app variants, inspecting
+ * the embedded asset/package identity, then exercising the Settings install
+ * flow. Only configuration/source checks have run; Gradle assembly and device
+ * installation remain UNVERIFIED because Android compilation was not authorized.
  */
 fun registerBundledRadioHelper(variantName: String) {
     val capitalizedVariant = variantName.replaceFirstChar { it.uppercase() }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.android.build.gradle.internal.api.BaseVariantOutputImpl
+import org.gradle.api.tasks.Sync
 
 // :app — Android application module. Empty by design at this stage; the
 // real share intent handling (#24), settings UI, and device list land in
@@ -140,6 +141,37 @@ android.applicationVariants.configureEach {
 kotlin {
     jvmToolchain(17)
 }
+
+/**
+ * Bundle the matching Radio Helper APK inside each Bada APK so Settings can
+ * install the companion without a browser or a second download. Debug embeds
+ * the `.debug` helper; release embeds the release helper. Variant-specific
+ * generated asset directories prevent a stale helper variant from leaking
+ * into another build. `mergeDebugAssets` / `mergeReleaseAssets` own the final
+ * embedding boundary; configuration and asset-presence checks are static-only
+ * in this change because Android compilation was not authorized.
+ */
+fun registerBundledRadioHelper(variantName: String) {
+    val capitalizedVariant = variantName.replaceFirstChar { it.uppercase() }
+    val generatedAssets = layout.buildDirectory.dir("generated/radio-helper/$variantName")
+    val bundleTask =
+        tasks.register<Sync>("bundleRadioHelper$capitalizedVariant") {
+            dependsOn(":radio-helper:assemble$capitalizedVariant")
+            from(project(":radio-helper").layout.buildDirectory.dir("outputs/apk/$variantName")) {
+                include("*.apk")
+                rename { "radio-helper.apk" }
+            }
+            into(generatedAssets)
+        }
+
+    android.sourceSets.getByName(variantName).assets.srcDir(generatedAssets)
+    tasks.matching { it.name == "merge${capitalizedVariant}Assets" }.configureEach {
+        dependsOn(bundleTask)
+    }
+}
+
+registerBundledRadioHelper("debug")
+registerBundledRadioHelper("release")
 
 dependencies {
     implementation(project(":core-protocol"))

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -612,6 +612,13 @@
             android:name=".update.UpdateInstallReceiver"
             android:exported="false" />
 
+        <!-- Receives PackageInstaller status for the Settings > Radio Helper
+             install flow. Not exported: only the app's explicit session
+             PendingIntent can deliver status or the confirmation Intent. -->
+        <receiver
+            android:name=".helper.HelperInstallReceiver"
+            android:exported="false" />
+
         <!-- WorkManager's foreground-service host. The merge override pins the
              dataSync FGS type so the expedited update-download worker
              (UpdateInstallWorker) can foreground itself on API 34+, where an

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -612,9 +612,16 @@
             android:name=".update.UpdateInstallReceiver"
             android:exported="false" />
 
-        <!-- Receives PackageInstaller status for the Settings > Radio Helper
-             install flow. Not exported: only the app's explicit session
-             PendingIntent can deliver status or the confirmation Intent. -->
+        <!-- HelperInstallReceiver — private PackageInstaller state-machine owner
+             for Settings > Radio Helper > "Install Radio Helper". The explicit,
+             mutable session PendingIntent uses action
+             dev.bluehouse.bada.helper.INSTALL_STATUS so Android can attach its
+             status/confirmation extras. Pending confirmation opens the system
+             installer while Bada is foregrounded, or posts a high-importance
+             shade action when background launch is unavailable; terminal status
+             clears the process-local duplicate-install latch. exported=false
+             prevents another app from invoking this receiver directly. Runtime
+             delivery and system-installer UI remain device-UNVERIFIED. -->
         <receiver
             android:name=".helper.HelperInstallReceiver"
             android:exported="false" />

--- a/app/src/main/kotlin/dev/bluehouse/bada/helper/HelperInstallReceiver.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/helper/HelperInstallReceiver.kt
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.helper
+
+import android.app.ActivityManager
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageInstaller
+import android.os.Build
+import android.widget.Toast
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import dev.bluehouse.bada.R
+
+/**
+ * PackageInstaller status receiver for the Settings-managed helper install.
+ * Pending confirmation opens directly while Bada is foregrounded; otherwise a
+ * high-priority notification provides a user-initiated launch path that remains
+ * valid under Android 14+ background-activity restrictions. The receiver is
+ * manifest-private and accepts only [HelperInstaller.ACTION_INSTALL_STATUS]. It
+ * never reads the APK or controls radios; PackageInstaller owns identity/signing
+ * enforcement, and the helper owns Wi-Fi/Bluetooth after installation.
+ *
+ * Device test: complete or cancel Settings' "Install Radio Helper" action both
+ * while Bada remains foregrounded and after backgrounding it. This source is
+ * currently device/UI-unverified because Android compilation was not authorized.
+ */
+internal class HelperInstallReceiver : BroadcastReceiver() {
+    override fun onReceive(
+        context: Context,
+        intent: Intent,
+    ) {
+        if (intent.action != HelperInstaller.ACTION_INSTALL_STATUS) return
+        when (intent.getIntExtra(PackageInstaller.EXTRA_STATUS, Int.MIN_VALUE)) {
+            PackageInstaller.STATUS_PENDING_USER_ACTION -> handlePendingUserAction(context, intent)
+            PackageInstaller.STATUS_SUCCESS -> {
+                HelperInstaller.markInstallFinished()
+                Toast
+                    .makeText(
+                        context,
+                        R.string.settings_radio_helper_install_success,
+                        Toast.LENGTH_SHORT,
+                    ).show()
+            }
+            else -> {
+                HelperInstaller.markInstallFinished()
+                Toast
+                    .makeText(
+                        context,
+                        R.string.settings_radio_helper_install_failed,
+                        Toast.LENGTH_LONG,
+                    ).show()
+            }
+        }
+    }
+
+    private fun handlePendingUserAction(
+        context: Context,
+        intent: Intent,
+    ) {
+        val confirm = extractConfirmIntent(intent)
+        if (confirm == null) {
+            HelperInstaller.markInstallFinished()
+            Toast
+                .makeText(
+                    context,
+                    R.string.settings_radio_helper_install_failed,
+                    Toast.LENGTH_LONG,
+                ).show()
+            return
+        }
+        confirm.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        val launched = isAppInForeground() && runCatching { context.startActivity(confirm) }.isSuccess
+        if (!launched) postConfirmNotification(context, confirm)
+    }
+
+    private fun isAppInForeground(): Boolean {
+        val processInfo = ActivityManager.RunningAppProcessInfo()
+        ActivityManager.getMyMemoryState(processInfo)
+        return processInfo.importance <= ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
+    }
+
+    private fun postConfirmNotification(
+        context: Context,
+        confirm: Intent,
+    ) {
+        ensureNotificationChannel(context)
+        val pending =
+            PendingIntent.getActivity(
+                context,
+                REQUEST_CONFIRM,
+                confirm,
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+            )
+        val notification =
+            NotificationCompat
+                .Builder(context, NOTIFICATION_CHANNEL_ID)
+                .setSmallIcon(android.R.drawable.stat_sys_download)
+                .setContentTitle(context.getString(R.string.settings_radio_helper_confirm_title))
+                .setContentText(context.getString(R.string.settings_radio_helper_confirm_text))
+                .setPriority(NotificationCompat.PRIORITY_HIGH)
+                .setAutoCancel(true)
+                .setContentIntent(pending)
+                .build()
+        NotificationManagerCompat.from(context).notify(CONFIRM_NOTIFICATION_ID, notification)
+    }
+
+    /**
+     * Create the dedicated high-importance "Radio Helper installation"
+     * channel. Keeping this separate from app-update alerts makes the fallback
+     * confirmation accurately identifiable in Android notification settings.
+     */
+    private fun ensureNotificationChannel(context: Context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val manager = context.getSystemService(NotificationManager::class.java) ?: return
+        if (manager.getNotificationChannel(NOTIFICATION_CHANNEL_ID) != null) return
+        manager.createNotificationChannel(
+            NotificationChannel(
+                NOTIFICATION_CHANNEL_ID,
+                context.getString(R.string.settings_radio_helper_channel_name),
+                NotificationManager.IMPORTANCE_HIGH,
+            ).apply {
+                description = context.getString(R.string.settings_radio_helper_channel_description)
+            },
+        )
+    }
+
+    @Suppress("DEPRECATION")
+    private fun extractConfirmIntent(intent: Intent): Intent? =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            intent.getParcelableExtra(Intent.EXTRA_INTENT, Intent::class.java)
+        } else {
+            intent.getParcelableExtra(Intent.EXTRA_INTENT)
+        }
+
+    private companion object {
+        private const val NOTIFICATION_CHANNEL_ID = "radio_helper_install"
+        private const val CONFIRM_NOTIFICATION_ID = 0x5248_434E // "RHCN"
+        private const val REQUEST_CONFIRM = 6
+    }
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/helper/HelperInstallReceiver.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/helper/HelperInstallReceiver.kt
@@ -20,19 +20,44 @@ import androidx.core.app.NotificationManagerCompat
 import dev.bluehouse.bada.R
 
 /**
- * PackageInstaller status receiver for the Settings-managed helper install.
- * Pending confirmation opens directly while Bada is foregrounded; otherwise a
- * high-priority notification provides a user-initiated launch path that remains
- * valid under Android 14+ background-activity restrictions. The receiver is
- * manifest-private and accepts only [HelperInstaller.ACTION_INSTALL_STATUS]. It
- * never reads the APK or controls radios; PackageInstaller owns identity/signing
- * enforcement, and the helper owns Wi-Fi/Bluetooth after installation.
+ * WHAT THIS IS
+ * ------------
+ * `HelperInstallReceiver` — the manifest-private [PackageInstaller] status
+ * state machine for Settings > Radio Helper > **"Install Radio Helper"**.
  *
- * Device test: complete or cancel Settings' "Install Radio Helper" action both
- * while Bada remains foregrounded and after backgrounding it. This source is
- * currently device/UI-unverified because Android compilation was not authorized.
+ * STATE, OWNERSHIP, AND ORDERING
+ * ------------------------------
+ * [HelperInstaller] commits an explicit, mutable status PendingIntent carrying
+ * [HelperInstaller.ACTION_INSTALL_STATUS]. This receiver rejects other actions:
+ * `STATUS_PENDING_USER_ACTION` keeps the duplicate-install latch set and routes
+ * the supplied system confirmation Intent; terminal success/failure clears the
+ * latch and surfaces a toast. It never reads the APK or controls radios.
+ * PackageInstaller owns package/signature checks and the system confirmation;
+ * the installed helper owns later Wi-Fi/Bluetooth share-session behavior.
+ *
+ * BACKGROUND, SECURITY, AND FAILURE BOUNDARIES
+ * --------------------------------------------
+ * Foreground Bada attempts the confirmation activity directly. Background Bada
+ * or a failed direct launch posts the high-importance **"Finish installing
+ * Radio Helper"** notification, whose tap launches that same Intent. The
+ * notification is best-effort when notification permission is denied; the
+ * PackageInstaller session remains system-owned. A missing confirmation Intent
+ * is treated as terminal local failure. `exported=false`, the explicit component,
+ * and action check prevent another app from driving this state machine.
+ *
+ * TEST STATUS
+ * -----------
+ * Complete and cancel installation with Bada foregrounded and backgrounded;
+ * test denied notifications, malformed pending confirmation, and success/fail
+ * callbacks, then verify the Settings status after returning. Source/static
+ * checks are proven; compilation, callback delivery, notification appearance,
+ * and system-installer UI remain device-UNVERIFIED.
  */
 internal class HelperInstallReceiver : BroadcastReceiver() {
+    /**
+     * PackageInstaller callback dispatcher. Pending confirmation is non-terminal;
+     * every other status is terminal for this app's process-local latch.
+     */
     override fun onReceive(
         context: Context,
         intent: Intent,
@@ -61,6 +86,7 @@ internal class HelperInstallReceiver : BroadcastReceiver() {
         }
     }
 
+    /** Route system confirmation directly only while visible, otherwise through the shade. */
     private fun handlePendingUserAction(
         context: Context,
         intent: Intent,
@@ -87,6 +113,11 @@ internal class HelperInstallReceiver : BroadcastReceiver() {
         return processInfo.importance <= ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
     }
 
+    /**
+     * Best-effort background-launch fallback. The full-width notification row
+     * shows the download glyph, title "Finish installing Radio Helper", and
+     * explanatory text; tapping it opens the PackageInstaller confirmation.
+     */
     private fun postConfirmNotification(
         context: Context,
         confirm: Intent,
@@ -114,8 +145,9 @@ internal class HelperInstallReceiver : BroadcastReceiver() {
 
     /**
      * Create the dedicated high-importance "Radio Helper installation"
-     * channel. Keeping this separate from app-update alerts makes the fallback
-     * confirmation accurately identifiable in Android notification settings.
+     * channel once on API 26+. Keeping it separate from app-update alerts makes
+     * the fallback identifiable and independently configurable in Android
+     * notification settings; pre-26 devices use builder priority only.
      */
     private fun ensureNotificationChannel(context: Context) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return

--- a/app/src/main/kotlin/dev/bluehouse/bada/helper/HelperInstaller.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/helper/HelperInstaller.kt
@@ -20,19 +20,42 @@ import dev.bluehouse.bada.R
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
- * Installer owned by Settings' user-facing "Radio Helper" card.
+ * WHAT THIS IS
+ * ------------
+ * `HelperInstaller` — the process-side installer for Settings' user-facing
+ * **Radio Helper** card and its **"Install Radio Helper"** action.
  *
+ * INVOCATION AND OWNERSHIP
+ * ------------------------
+ * [dev.bluehouse.bada.ui.SettingsFragment] queries package/install state, opens
+ * the one-time "Install unknown apps" system page when required, then calls
+ * [installBundledHelper]. `:app` embeds the matching debug/release helper as
+ * `assets/radio-helper.apk`; [HelperInstallReceiver] owns PackageInstaller
+ * confirmation and terminal status after commit. This object never toggles a
+ * radio—the installed helper service owns that separate share-session lifecycle.
+ *
+ * SECURITY, THREADING, AND FAILURE CONTRACT
+ * -----------------------------------------
  * `:app` embeds the debug helper in debug builds and the release helper in
  * release builds. The two APKs use the same signing configuration because the
  * helper's `BIND_RADIO` service permission is signature protected. The asset is
- * streamed into PackageInstaller off the main thread; no browser, download, or
- * temporary APK file is involved. [HelperInstallReceiver] owns confirmation
- * and terminal status; an atomic process latch rejects duplicate taps.
+ * local-only: it is streamed into PackageInstaller on the dedicated
+ * `radio-helper-install` thread, with no network, browser, or temporary APK
+ * file. SessionParams pins the expected variant package; Android owns final APK
+ * identity/signature validation. Every failure before commit abandons the
+ * staged session and clears the latch. The [AtomicBoolean] is intentionally
+ * process-local: it prevents double taps while this process lives, remains set
+ * through pending confirmation, clears on terminal callback, and naturally
+ * resets if Android recreates the process. No app-level cancellation control is
+ * exposed after commit; the system installer owns the user's confirm/cancel UI.
  *
- * Test route: open Bada > Settings > Radio Helper, grant "Install unknown apps"
- * if requested, tap Install, confirm the system installer, then return and open
- * the helper setup. This change is source/diff-checked only; compilation and the
- * real device click path remain unverified because they were not authorized.
+ * TEST STATUS
+ * -----------
+ * Exercise Bada > Settings > Radio Helper in missing, permission-denied,
+ * installing, installed, cancelled, and failed states; confirm the debug build
+ * installs `.debug`, release installs the release package, and "Open Radio
+ * Helper setup" launches the matching package. Source/diff checks are proven;
+ * compilation and the real device click path remain UNVERIFIED.
  */
 internal object HelperInstaller {
     const val ACTION_INSTALL_STATUS = "dev.bluehouse.bada.helper.INSTALL_STATUS"
@@ -41,6 +64,7 @@ internal object HelperInstaller {
     private const val HELPER_BASE_PACKAGE = "dev.bluehouse.bada.radiohelper"
     private val installInFlight = AtomicBoolean(false)
 
+    /** Variant identity shared by installed-state lookup, session pinning, and setup launch. */
     fun helperPackage(context: Context): String =
         if (context.packageName.endsWith(".debug")) {
             "$HELPER_BASE_PACKAGE.debug"
@@ -48,6 +72,7 @@ internal object HelperInstaller {
             HELPER_BASE_PACKAGE
         }
 
+    /** PackageManager is the durable source of truth; the in-flight latch is not. */
     @Suppress("DEPRECATION")
     fun isHelperInstalled(context: Context): Boolean =
         try {
@@ -59,16 +84,19 @@ internal object HelperInstaller {
 
     fun isInstallInFlight(): Boolean = installInFlight.get()
 
+    /** Precondition checked before any asset/session work or unknown-source round trip. */
     fun canInstallPackages(context: Context): Boolean =
         Build.VERSION.SDK_INT < Build.VERSION_CODES.O ||
             context.packageManager.canRequestPackageInstalls()
 
+    /** App-scoped system Settings route used by SettingsFragment's result launcher. */
     fun unknownSourcesSettingsIntent(context: Context): Intent =
         Intent(
             Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES,
             Uri.parse("package:${context.packageName}"),
         )
 
+    /** Launch the matching helper's setup activity; false means no resolvable launcher. */
     fun openHelper(context: Context): Boolean {
         val launchIntent =
             context.packageManager.getLaunchIntentForPackage(helperPackage(context))
@@ -77,11 +105,14 @@ internal object HelperInstaller {
     }
 
     /**
-     * Stage the bundled helper for system confirmation. Repeated taps while a
-     * session is active are ignored; every pre-commit failure abandons its
-     * PackageInstaller session and surfaces a user-visible error. The helper's
-     * declared package is pinned into SessionParams; Android still performs the
-     * final APK identity and signing checks in the system confirmation flow.
+     * Stage the bundled helper for system confirmation after Settings has
+     * established unknown-source permission. Repeated taps while this process
+     * owns a live request are no-ops. The background thread creates one full-
+     * install session, pins [helperPackage], copies the local asset, fsyncs it,
+     * and commits an explicit status PendingIntent. Every pre-commit exception
+     * abandons the session, clears the latch, and posts the visible failure
+     * toast on the main looper; success here means only "staged for system
+     * confirmation," not installed.
      */
     fun installBundledHelper(context: Context) {
         if (!installInFlight.compareAndSet(false, true)) return
@@ -111,6 +142,12 @@ internal object HelperInstaller {
         ).start()
     }
 
+    /**
+     * Blocking asset-copy/commit boundary; called only by the installer thread.
+     * The API-31+ PendingIntent must remain mutable because PackageInstaller
+     * supplies status and confirmation extras before delivering it to the
+     * manifest-private [HelperInstallReceiver].
+     */
     private fun commitSession(
         appContext: Context,
         installer: PackageInstaller,
@@ -138,7 +175,7 @@ internal object HelperInstaller {
         }
     }
 
-    /** Clear the duplicate-install latch only after terminal installer status. */
+    /** Clear the duplicate-install latch only after terminal success/failure or pre-commit failure. */
     fun markInstallFinished() {
         installInFlight.set(false)
     }

--- a/app/src/main/kotlin/dev/bluehouse/bada/helper/HelperInstaller.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/helper/HelperInstaller.kt
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2026 Bada contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package dev.bluehouse.bada.helper
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageInstaller
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.provider.Settings
+import android.widget.Toast
+import dev.bluehouse.bada.R
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Installer owned by Settings' user-facing "Radio Helper" card.
+ *
+ * `:app` embeds the debug helper in debug builds and the release helper in
+ * release builds. The two APKs use the same signing configuration because the
+ * helper's `BIND_RADIO` service permission is signature protected. The asset is
+ * streamed into PackageInstaller off the main thread; no browser, download, or
+ * temporary APK file is involved. [HelperInstallReceiver] owns confirmation
+ * and terminal status; an atomic process latch rejects duplicate taps.
+ *
+ * Test route: open Bada > Settings > Radio Helper, grant "Install unknown apps"
+ * if requested, tap Install, confirm the system installer, then return and open
+ * the helper setup. This change is source/diff-checked only; compilation and the
+ * real device click path remain unverified because they were not authorized.
+ */
+internal object HelperInstaller {
+    const val ACTION_INSTALL_STATUS = "dev.bluehouse.bada.helper.INSTALL_STATUS"
+
+    private const val ASSET_NAME = "radio-helper.apk"
+    private const val HELPER_BASE_PACKAGE = "dev.bluehouse.bada.radiohelper"
+    private val installInFlight = AtomicBoolean(false)
+
+    fun helperPackage(context: Context): String =
+        if (context.packageName.endsWith(".debug")) {
+            "$HELPER_BASE_PACKAGE.debug"
+        } else {
+            HELPER_BASE_PACKAGE
+        }
+
+    @Suppress("DEPRECATION")
+    fun isHelperInstalled(context: Context): Boolean =
+        try {
+            context.packageManager.getPackageInfo(helperPackage(context), 0)
+            true
+        } catch (_: PackageManager.NameNotFoundException) {
+            false
+        }
+
+    fun isInstallInFlight(): Boolean = installInFlight.get()
+
+    fun canInstallPackages(context: Context): Boolean =
+        Build.VERSION.SDK_INT < Build.VERSION_CODES.O ||
+            context.packageManager.canRequestPackageInstalls()
+
+    fun unknownSourcesSettingsIntent(context: Context): Intent =
+        Intent(
+            Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES,
+            Uri.parse("package:${context.packageName}"),
+        )
+
+    fun openHelper(context: Context): Boolean {
+        val launchIntent =
+            context.packageManager.getLaunchIntentForPackage(helperPackage(context))
+                ?: return false
+        return runCatching { context.startActivity(launchIntent) }.isSuccess
+    }
+
+    /**
+     * Stage the bundled helper for system confirmation. Repeated taps while a
+     * session is active are ignored; every pre-commit failure abandons its
+     * PackageInstaller session and surfaces a user-visible error. The helper's
+     * declared package is pinned into SessionParams; Android still performs the
+     * final APK identity and signing checks in the system confirmation flow.
+     */
+    fun installBundledHelper(context: Context) {
+        if (!installInFlight.compareAndSet(false, true)) return
+        val appContext = context.applicationContext
+        Thread(
+            {
+                var sessionId: Int? = null
+                runCatching {
+                    val installer = appContext.packageManager.packageInstaller
+                    val params =
+                        PackageInstaller.SessionParams(PackageInstaller.SessionParams.MODE_FULL_INSTALL).apply {
+                            setAppPackageName(helperPackage(appContext))
+                        }
+                    sessionId = installer.createSession(params)
+                    commitSession(appContext, installer, sessionId!!)
+                }.onSuccess {
+                    postToast(appContext, R.string.settings_radio_helper_install_started)
+                }.onFailure {
+                    sessionId?.let { id ->
+                        runCatching { appContext.packageManager.packageInstaller.abandonSession(id) }
+                    }
+                    installInFlight.set(false)
+                    postToast(appContext, R.string.settings_radio_helper_install_failed)
+                }
+            },
+            "radio-helper-install",
+        ).start()
+    }
+
+    private fun commitSession(
+        appContext: Context,
+        installer: PackageInstaller,
+        sessionId: Int,
+    ) {
+        installer.openSession(sessionId).use { session ->
+            appContext.assets.open(ASSET_NAME).use { input ->
+                session.openWrite("radio-helper", 0, -1).use { output ->
+                    input.copyTo(output)
+                    session.fsync(output)
+                }
+            }
+            val statusIntent =
+                Intent(appContext, HelperInstallReceiver::class.java)
+                    .setAction(ACTION_INSTALL_STATUS)
+                    .setPackage(appContext.packageName)
+            val flags =
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+                } else {
+                    PendingIntent.FLAG_UPDATE_CURRENT
+                }
+            val pending = PendingIntent.getBroadcast(appContext, sessionId, statusIntent, flags)
+            session.commit(pending.intentSender)
+        }
+    }
+
+    /** Clear the duplicate-install latch only after terminal installer status. */
+    fun markInstallFinished() {
+        installInFlight.set(false)
+    }
+
+    private fun postToast(
+        context: Context,
+        message: Int,
+    ) {
+        Handler(Looper.getMainLooper()).post {
+            Toast.makeText(context, message, Toast.LENGTH_LONG).show()
+        }
+    }
+}

--- a/app/src/main/kotlin/dev/bluehouse/bada/ui/SettingsFragment.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/ui/SettingsFragment.kt
@@ -24,6 +24,7 @@ import dev.bluehouse.bada.R
 import dev.bluehouse.bada.battery.BatteryOptimizationOemHelper
 import dev.bluehouse.bada.bugreport.BugReportPreferences
 import dev.bluehouse.bada.consent.FullScreenIntentPermission
+import dev.bluehouse.bada.helper.HelperInstaller
 import dev.bluehouse.bada.namecard.NameCardProfileStore
 import dev.bluehouse.bada.namecard.NameCardSetupActivity
 import dev.bluehouse.bada.service.downloads.SaveLocationDisplayName
@@ -50,6 +51,9 @@ import dev.bluehouse.bada.update.UpdatePreferences
  *     battery-optimization Settings page after the first-launch dialog
  *     has been skipped. Status summary is refreshed on every onStart
  *     so a system-Settings round trip reflects immediately.
+ *   * "Radio Helper" companion management — show whether the matching
+ *     debug/release helper package is installed; install the APK bundled in
+ *     this Bada build, or open the helper's own setup screen when present.
  *
  * Each control mutates a single SharedPreferences-backed value (or
  * platform power-manager state for the battery row) and refreshes
@@ -67,6 +71,14 @@ internal class SettingsFragment : Fragment(R.layout.fragment_settings) {
      * selection.
      */
     private lateinit var saveLocationLauncher: ActivityResultLauncher<Uri?>
+
+    /**
+     * Owns the one-time Android "Install unknown apps" round trip for the
+     * Radio Helper card. Returning with the grant stages the bundled companion;
+     * returning without it leaves the helper missing and surfaces that denial.
+     * The system Settings and installer UI remain device/UI-unverified here.
+     */
+    private lateinit var unknownSourcesLauncher: ActivityResultLauncher<Intent>
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -92,6 +104,21 @@ internal class SettingsFragment : Fragment(R.layout.fragment_settings) {
                         ).show()
                 }
             }
+
+        unknownSourcesLauncher =
+            registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+                if (HelperInstaller.canInstallPackages(requireContext())) {
+                    HelperInstaller.installBundledHelper(requireContext())
+                    refreshRadioHelperSection()
+                } else {
+                    Toast
+                        .makeText(
+                            requireContext(),
+                            R.string.settings_radio_helper_unknown_sources_denied,
+                            Toast.LENGTH_LONG,
+                        ).show()
+                }
+            }
     }
 
     override fun onViewCreated(
@@ -103,6 +130,25 @@ internal class SettingsFragment : Fragment(R.layout.fragment_settings) {
         // "Name Card" row → My Name Card setup page (tap-to-share contacts).
         view.findViewById<View>(R.id.settings_name_card_row).setOnClickListener {
             startActivity(Intent(requireContext(), NameCardSetupActivity::class.java))
+        }
+
+        // settings_radio_helper_action — full-width button at the bottom of
+        // the white Radio Helper card. Its visible label changes from
+        // "Install Radio Helper" to "Open Radio Helper setup" based on the
+        // matching package's installed state.
+        view.findViewById<Button>(R.id.settings_radio_helper_action).setOnClickListener {
+            if (HelperInstaller.isHelperInstalled(requireContext())) {
+                if (!HelperInstaller.openHelper(requireContext())) {
+                    Toast
+                        .makeText(
+                            requireContext(),
+                            R.string.settings_radio_helper_open_failed,
+                            Toast.LENGTH_LONG,
+                        ).show()
+                }
+            } else {
+                startRadioHelperInstall()
+            }
         }
 
         view.findViewById<Button>(R.id.main_save_location_pick).setOnClickListener {
@@ -181,6 +227,7 @@ internal class SettingsFragment : Fragment(R.layout.fragment_settings) {
         refreshBugReportSwitch()
         refreshTransferSwitches()
         refreshNameCardDot()
+        refreshRadioHelperSection()
     }
 
     /**
@@ -214,6 +261,63 @@ internal class SettingsFragment : Fragment(R.layout.fragment_settings) {
         // immediately after the user grants the exemption, instead
         // of waiting for the next manual tab switch.
         refreshBatteryStatus()
+        refreshRadioHelperSection()
+    }
+
+    /**
+     * Entry point for Settings' "Install Radio Helper" button. The one-time
+     * unknown-source grant is resolved before [HelperInstaller] starts any
+     * asset I/O; denial leaves the card in its explicit missing state.
+     */
+    private fun startRadioHelperInstall() {
+        val context = requireContext()
+        if (HelperInstaller.canInstallPackages(context)) {
+            HelperInstaller.installBundledHelper(context)
+            refreshRadioHelperSection()
+            return
+        }
+        Toast
+            .makeText(context, R.string.settings_radio_helper_allow_sources, Toast.LENGTH_LONG)
+            .show()
+        runCatching {
+            unknownSourcesLauncher.launch(HelperInstaller.unknownSourcesSettingsIntent(context))
+        }.onFailure {
+            Toast
+                .makeText(
+                    context,
+                    R.string.settings_radio_helper_unknown_sources_unavailable,
+                    Toast.LENGTH_LONG,
+                ).show()
+        }
+    }
+
+    /**
+     * Refresh the card's gray rounded status chip and full-width action button.
+     * PackageManager is the installed-state source of truth; the process-local
+     * in-flight latch only disables duplicate taps while PackageInstaller owns
+     * an active session. Called onStart/onResume and after staging begins.
+     */
+    private fun refreshRadioHelperSection() {
+        val v = view ?: return
+        val context = requireContext()
+        val installed = HelperInstaller.isHelperInstalled(context)
+        val installing = HelperInstaller.isInstallInFlight()
+        v.findViewById<TextView>(R.id.settings_radio_helper_status).text =
+            when {
+                installed -> getString(R.string.settings_radio_helper_status_installed)
+                installing -> getString(R.string.settings_radio_helper_status_installing)
+                else -> getString(R.string.settings_radio_helper_status_missing)
+            }
+        v.findViewById<Button>(R.id.settings_radio_helper_action).apply {
+            isEnabled = installed || !installing
+            setText(
+                if (installed) {
+                    R.string.settings_radio_helper_open
+                } else {
+                    R.string.settings_radio_helper_install
+                },
+            )
+        }
     }
 
     /**

--- a/app/src/main/kotlin/dev/bluehouse/bada/ui/SettingsFragment.kt
+++ b/app/src/main/kotlin/dev/bluehouse/bada/ui/SettingsFragment.kt
@@ -55,11 +55,13 @@ import dev.bluehouse.bada.update.UpdatePreferences
  *     debug/release helper package is installed; install the APK bundled in
  *     this Bada build, or open the helper's own setup screen when present.
  *
- * Each control mutates a single SharedPreferences-backed value (or
- * platform power-manager state for the battery row) and refreshes
- * its summary line on every onStart so an external state change
- * (e.g. the user revoked the SAF grant in system Settings while we
- * were paused) reflects immediately.
+ * Preference controls mutate one SharedPreferences-backed value; platform rows
+ * instead re-query their owning system API. The Radio Helper card reads
+ * PackageManager plus [HelperInstaller]'s process-local staging latch. Summary
+ * state is refreshed on every onStart/onResume so system-Settings round trips,
+ * package installation, and external permission changes are reflected without
+ * recreating the fragment. Radio Helper compilation and rendered interaction
+ * remain device-UNVERIFIED; the documented source/static contracts are proven.
  */
 internal class SettingsFragment : Fragment(R.layout.fragment_settings) {
     /**
@@ -132,10 +134,12 @@ internal class SettingsFragment : Fragment(R.layout.fragment_settings) {
             startActivity(Intent(requireContext(), NameCardSetupActivity::class.java))
         }
 
-        // settings_radio_helper_action — full-width button at the bottom of
-        // the white Radio Helper card. Its visible label changes from
-        // "Install Radio Helper" to "Open Radio Helper setup" based on the
-        // matching package's installed state.
+        // settings_radio_helper_action — standard-height, full-width button
+        // 16dp below the gray status chip at the bottom of the white rounded
+        // Radio Helper card. It has no custom motion. Missing state shows
+        // "Install Radio Helper" and starts permission/install staging;
+        // installing keeps that label but disables the button; installed shows
+        // "Open Radio Helper setup" and launches the matching companion.
         view.findViewById<Button>(R.id.settings_radio_helper_action).setOnClickListener {
             if (HelperInstaller.isHelperInstalled(requireContext())) {
                 if (!HelperInstaller.openHelper(requireContext())) {
@@ -267,7 +271,10 @@ internal class SettingsFragment : Fragment(R.layout.fragment_settings) {
     /**
      * Entry point for Settings' "Install Radio Helper" button. The one-time
      * unknown-source grant is resolved before [HelperInstaller] starts any
-     * asset I/O; denial leaves the card in its explicit missing state.
+     * asset I/O. If the platform Settings route cannot open or the user returns
+     * without granting access, no session is created and the card remains in
+     * its explicit missing state with a toast. Returning with access stages one
+     * request and immediately refreshes the card to installing.
      */
     private fun startRadioHelperInstall() {
         val context = requireContext()
@@ -295,7 +302,10 @@ internal class SettingsFragment : Fragment(R.layout.fragment_settings) {
      * Refresh the card's gray rounded status chip and full-width action button.
      * PackageManager is the installed-state source of truth; the process-local
      * in-flight latch only disables duplicate taps while PackageInstaller owns
-     * an active session. Called onStart/onResume and after staging begins.
+     * an active request. Installed wins over the latch so a terminal install is
+     * actionable even before its callback updates the process. Called from
+     * onStart/onResume and immediately after staging begins; it performs only
+     * local PackageManager/view work and no APK I/O.
      */
     private fun refreshRadioHelperSection() {
         val v = view ?: return

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -533,12 +533,16 @@
         </LinearLayout>
 
         <!-- ============ Card 7: Radio Helper companion ============
-             White rounded Settings card below the shake-to-report toggle.
-             It shows a gray rounded status chip (installed / installing /
-             missing) and one full-width action button. SettingsFragment maps
-             the button to bundled installation while missing and to the
-             helper's launcher/setup screen after installation. No motion or
-             hidden gesture is attached to this card. -->
+             White rounded, wrap-height Settings card 12dp below the
+             shake-to-report card, with 20dp inner padding. The bold "Radio
+             Helper" title and gray explanatory subtitle sit above
+             settings_radio_helper_status: a full-width gray rounded chip with
+             12dp horizontal/10dp vertical padding and installed / waiting /
+             missing text. settings_radio_helper_action is the full-width
+             standard Button 16dp below it; SettingsFragment changes its visible
+             label/action between bundled installation and "Open Radio Helper
+             setup", and disables it while waiting. No animation, hidden
+             gesture, icon, or automatic tap action belongs to this card. -->
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -532,7 +532,59 @@
 
         </LinearLayout>
 
-        <!-- ============ Card 7: Automatic update check ============ -->
+        <!-- ============ Card 7: Radio Helper companion ============
+             White rounded Settings card below the shake-to-report toggle.
+             It shows a gray rounded status chip (installed / installing /
+             missing) and one full-width action button. SettingsFragment maps
+             the button to bundled installation while missing and to the
+             helper's launcher/setup screen after installation. No motion or
+             hidden gesture is attached to this card. -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:background="@drawable/settings_card_background"
+            android:orientation="vertical"
+            android:padding="20dp">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/settings_radio_helper_title"
+                android:textAppearance="@style/TextAppearance.AppCompat.Subhead"
+                android:textColor="?android:attr/textColorPrimary"
+                android:textStyle="bold" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:text="@string/settings_radio_helper_subtitle"
+                android:textAppearance="@style/TextAppearance.AppCompat.Small"
+                android:textColor="?android:attr/textColorSecondary" />
+
+            <TextView
+                android:id="@+id/settings_radio_helper_status"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:background="@drawable/qr_url_background"
+                android:paddingHorizontal="12dp"
+                android:paddingVertical="10dp"
+                android:textAppearance="@style/TextAppearance.AppCompat.Body2"
+                android:textColor="?android:attr/textColorPrimary"
+                tools:text="Currently: not installed" />
+
+            <Button
+                android:id="@+id/settings_radio_helper_action"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:text="@string/settings_radio_helper_install" />
+
+        </LinearLayout>
+
+        <!-- ============ Card 8: Automatic update check ============ -->
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,7 +50,11 @@
     <string name="settings_auto_update_title">Automatic update check</string>
     <string name="settings_auto_update_subtitle">Every 6 hours, check GitHub for a newer Bada release and show a notification when one is available.</string>
 
-    <!-- Settings-managed installation of the bundled Radio Helper companion. -->
+    <!-- Settings > Radio Helper card, PackageInstaller status/toasts, and the
+         background confirmation notification. These labels are consumed by
+         SettingsFragment, HelperInstaller, and HelperInstallReceiver; status
+         text deliberately distinguishes durable PackageManager state from the
+         process-local waiting latch. -->
     <string name="settings_radio_helper_title">Radio Helper</string>
     <string name="settings_radio_helper_subtitle">Turns Wi-Fi and Bluetooth on when a transfer starts, then restores the radios Bada enabled when the transfer ends.</string>
     <string name="settings_radio_helper_status_installed">Currently: installed</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,6 +49,26 @@
     <string name="update_open_release_failed">Couldn\'t open the release page.</string>
     <string name="settings_auto_update_title">Automatic update check</string>
     <string name="settings_auto_update_subtitle">Every 6 hours, check GitHub for a newer Bada release and show a notification when one is available.</string>
+
+    <!-- Settings-managed installation of the bundled Radio Helper companion. -->
+    <string name="settings_radio_helper_title">Radio Helper</string>
+    <string name="settings_radio_helper_subtitle">Turns Wi-Fi and Bluetooth on when a transfer starts, then restores the radios Bada enabled when the transfer ends.</string>
+    <string name="settings_radio_helper_status_installed">Currently: installed</string>
+    <string name="settings_radio_helper_status_installing">Currently: waiting for installation confirmation</string>
+    <string name="settings_radio_helper_status_missing">Currently: not installed — automatic radio control is unavailable</string>
+    <string name="settings_radio_helper_install">Install Radio Helper</string>
+    <string name="settings_radio_helper_open">Open Radio Helper setup</string>
+    <string name="settings_radio_helper_allow_sources">Allow Bada to install apps, then return to continue.</string>
+    <string name="settings_radio_helper_unknown_sources_denied">Radio Helper was not installed because Bada is not allowed to install apps.</string>
+    <string name="settings_radio_helper_unknown_sources_unavailable">This device did not open the “Install unknown apps” setting. Radio Helper was not installed.</string>
+    <string name="settings_radio_helper_install_started">Radio Helper is ready for installation.</string>
+    <string name="settings_radio_helper_install_success">Radio Helper installed</string>
+    <string name="settings_radio_helper_install_failed">Couldn’t install Radio Helper</string>
+    <string name="settings_radio_helper_open_failed">Couldn’t open Radio Helper setup</string>
+    <string name="settings_radio_helper_confirm_title">Finish installing Radio Helper</string>
+    <string name="settings_radio_helper_confirm_text">Tap to confirm the companion app installation.</string>
+    <string name="settings_radio_helper_channel_name">Radio Helper installation</string>
+    <string name="settings_radio_helper_channel_description">Installation confirmation for Bada’s Radio Helper companion app</string>
     <string name="credit_placeholder_text">credit</string>
 
     <!--

--- a/docs/release.md
+++ b/docs/release.md
@@ -8,7 +8,12 @@ The workflow is separate from normal CI and runs when:
 The workflow builds `:app:assembleRelease`, signs the APK with a keystore
 supplied through GitHub Actions secrets, uploads the signed APK as a workflow
 artifact, and attaches it to a matching GitHub Release when one exists for the
-tag. Release APK filenames come from the Gradle release variant and follow
+tag. The app build also assembles `:radio-helper:assembleRelease` with the same
+signing inputs and embeds that companion as `assets/radio-helper.apk`. Bada's
+Settings > Radio Helper card streams the embedded APK into Android's system
+installer, so users do not need a browser or a separate helper download. Shared
+signing is required because the helper's `BIND_RADIO` service is protected by a
+signature permission. Release APK filenames come from the Gradle release variant and follow
 `<applicationId>-<versionName>.apk`, for example
 `dev.bluehouse.bada-0.1.0-alpha01.apk`. The decoded keystore lives in
 `$RUNNER_TEMP/release.keystore` for the Gradle step only and is removed before
@@ -84,4 +89,6 @@ environment variables:
   -PKEY_PASSWORD="$KEY_PASSWORD"
 ```
 
-If no signing values are supplied, local release builds remain unsigned.
+If no signing values are supplied, local release builds remain unsigned. A
+locally installable release must provide the complete signing set so both Bada
+and its embedded Radio Helper carry the same certificate.

--- a/radio-helper/build.gradle.kts
+++ b/radio-helper/build.gradle.kts
@@ -14,6 +14,52 @@ plugins {
     alias(libs.plugins.kotlin.android)
 }
 
+data class HelperReleaseSigningInputs(
+    val keystoreFile: String,
+    val keystorePassword: String,
+    val keyAlias: String,
+    val keyPassword: String,
+)
+
+/**
+ * Reads the same four signing inputs as `:app`. A complete set signs the
+ * release helper with Bada's release key so its signature-protected
+ * `BIND_RADIO` service accepts the main app; a partial set fails configuration
+ * instead of producing an unusable mismatched pair. Local builds with no
+ * signing inputs retain the Android plugin's ordinary unsigned-release rule.
+ */
+fun helperReleaseSigningInputs(): HelperReleaseSigningInputs? {
+    fun propertyOrEnvironment(name: String): String? =
+        providers
+            .gradleProperty(name)
+            .orElse(providers.environmentVariable(name))
+            .orNull
+            ?.takeIf { it.isNotBlank() }
+
+    val values =
+        mapOf(
+            "KEYSTORE_FILE" to propertyOrEnvironment("KEYSTORE_FILE"),
+            "KEYSTORE_PASSWORD" to propertyOrEnvironment("KEYSTORE_PASSWORD"),
+            "KEY_ALIAS" to propertyOrEnvironment("KEY_ALIAS"),
+            "KEY_PASSWORD" to propertyOrEnvironment("KEY_PASSWORD"),
+        )
+    val present = values.filterValues { it != null }
+    if (present.isEmpty()) return null
+
+    val missing = values.filterValues { it == null }.keys
+    check(missing.isEmpty()) {
+        "Radio Helper signing config is incomplete. Missing: ${missing.joinToString()}"
+    }
+    return HelperReleaseSigningInputs(
+        keystoreFile = values.getValue("KEYSTORE_FILE")!!,
+        keystorePassword = values.getValue("KEYSTORE_PASSWORD")!!,
+        keyAlias = values.getValue("KEY_ALIAS")!!,
+        keyPassword = values.getValue("KEY_PASSWORD")!!,
+    )
+}
+
+val helperReleaseSigningInputs = helperReleaseSigningInputs()
+
 android {
     namespace = "dev.bluehouse.bada.radiohelper"
     compileSdk =
@@ -33,6 +79,17 @@ android {
         versionName = "1.0"
     }
 
+    signingConfigs {
+        if (helperReleaseSigningInputs != null) {
+            create("release") {
+                storeFile = file(helperReleaseSigningInputs.keystoreFile)
+                storePassword = helperReleaseSigningInputs.keystorePassword
+                keyAlias = helperReleaseSigningInputs.keyAlias
+                keyPassword = helperReleaseSigningInputs.keyPassword
+            }
+        }
+    }
+
     buildTypes {
         debug {
             applicationIdSuffix = ".debug"
@@ -40,6 +97,9 @@ android {
         }
         release {
             isMinifyEnabled = false
+            if (helperReleaseSigningInputs != null) {
+                signingConfig = signingConfigs.getByName("release")
+            }
         }
     }
 

--- a/radio-helper/build.gradle.kts
+++ b/radio-helper/build.gradle.kts
@@ -22,11 +22,21 @@ data class HelperReleaseSigningInputs(
 )
 
 /**
- * Reads the same four signing inputs as `:app`. A complete set signs the
- * release helper with Bada's release key so its signature-protected
- * `BIND_RADIO` service accepts the main app; a partial set fails configuration
- * instead of producing an unusable mismatched pair. Local builds with no
- * signing inputs retain the Android plugin's ordinary unsigned-release rule.
+ * Signing contract for the release **Radio Helper** companion embedded by
+ * `:app` and installed from Settings > Radio Helper.
+ *
+ * Reads the same `KEYSTORE_FILE`, `KEYSTORE_PASSWORD`, `KEY_ALIAS`, and
+ * `KEY_PASSWORD` properties/environment variables as `:app`. All four present
+ * signs the helper with Bada's release certificate so the main app may bind the
+ * helper's signature-protected `BIND_RADIO` service; a partial set fails during
+ * configuration instead of producing an installable-looking but unusable pair.
+ * No inputs preserves the Android plugin's ordinary unsigned local-release
+ * behavior. Values are consumed only by Gradle signing configuration and are
+ * never copied into generated assets or source.
+ *
+ * Verify with certificate comparison on assembled app/helper release APKs and
+ * a real service bind after installation. Input-shape/source checks are proven;
+ * release assembly, certificate comparison, and device binding are UNVERIFIED.
  */
 fun helperReleaseSigningInputs(): HelperReleaseSigningInputs? {
     fun propertyOrEnvironment(name: String): String? =


### PR DESCRIPTION
## Summary

This follow-up to #234 makes the existing Radio Helper companion visible and installable from Bada itself.

- add a **Settings → Radio Helper** card with explicit `installed`, `installing`, and `not installed` states
- install the matching helper APK from Bada's bundled assets through Android `PackageInstaller` — no browser or separate download
- change the action to **Open Radio Helper setup** after installation
- embed the debug helper in debug builds and the release helper in release builds
- sign the release helper with the same release inputs as Bada so the signature-protected `BIND_RADIO` service can bind

## How Bada uses the companion to control Wi-Fi and Bluetooth

1. At transfer start, Bada's `ShareRadioController` binds `RadioHelperClient` to the companion's `RadioService` and sends `MSG_PREPARE_SHARE` with `RADIO_BOTH`.
2. `ShareRadioSession` reads Wi-Fi and Bluetooth independently. A radio that was already on is left untouched and is not marked for restoration. For each requested radio that was off, the helper synchronously persists that it owns the restore before attempting the toggle, so process death between the toggle and persistence cannot strand the radio on.
3. **Wi-Fi:** `RadioToggler` tries the silent ladder in order: legacy `WifiManager.setWifiEnabled()` in the API-28 helper, self-ADB `svc wifi enable/disable`, then the optional Shizuku shell service. The bound service never opens a settings panel from the background.
4. **Bluetooth:** `RadioToggler` reads `BluetoothAdapter.isEnabled` and, only when Bluetooth was requested and off, directly calls `BluetoothAdapter.enable()`. The helper declares the legacy `BLUETOOTH` and `BLUETOOTH_ADMIN` permissions and targets API 28, below Android's target-SDK gate for programmatic `enable()`/`disable()`. A missing adapter, exception, or rejected call returns `false`; the Bluetooth bit is then absent from the `nowOn` reply. Restoration uses the matching direct `BluetoothAdapter.disable()` call only when the original Bluetooth state was off and the helper recorded that enable attempt as its restoration responsibility.
5. Bada sends `MSG_TRANSFER_HEARTBEAT` every five seconds while the transfer is active. Each beat re-arms the durable restore alarm for about 20 seconds after the last beat; a separate 20-minute watchdog remains the coarse fallback.
6. A completed, cancelled, declined, failed, or timed-out transfer sends `MSG_TRANSFER_FINISHED`. The helper restores Wi-Fi and Bluetooth independently, turns off only the radios recorded as helper-owned for that session, clears the persisted flags synchronously, and cancels the watchdog. A radio that the user already had on stays on.

The companion is separate because the main app targets a modern Android SDK, while both legacy radio controls are target-SDK gated: Wi-Fi requires target SDK 28 or lower and Bluetooth programmatic enable/disable requires target SDK 32 or lower. The helper remains target SDK 28 and is isolated behind a same-signature bound-service permission.

## Installation and failure handling

- Android's one-time **Install unknown apps** grant is requested only after the user taps Install.
- APK streaming runs off the main thread and uses no temporary file.
- duplicate taps are blocked while one installer session is active
- failed pre-commit sessions are abandoned
- Android 14+ background confirmation falls back to a dedicated high-importance notification
- Settings always re-reads PackageManager state when the screen resumes

## Validation status

Verified in this change:

- `git diff --check`
- Android manifest, Settings layout, and string-resource XML parsing
- static package/query, receiver, Settings ID/string, variant-bundle, shared-signing, off-main I/O, session-cleanup, and confirmation-path checks

Not run under the current task constraint:

- Gradle compilation / Android lint / unit tests
- pull-request CI (the head commit uses `[skip ci]` so opening this PR does not start the repository's Android build)
- real Settings → unknown-source grant → system installer → helper setup clicks

This is therefore a draft until Android compilation and the real device install path are exercised.
