### PR TITLE
fix: add an instant pressed wash to the frosted button family

### DIFF
--- a/app/src/main/res/drawable/btn_frosted_background.xml
+++ b/app/src/main/res/drawable/btn_frosted_background.xml
@@ -21,6 +21,10 @@
       inside the rounded shape. The `@android:id/mask` shape clips
       the ripple to the same 24dp corner radius — without it, the
       ripple would spill out of the rounded ends as a square.
+    * Pressed wash — an instant `frosted_button_pressed` overlay
+      shared by every frosted button drawable, so the whole family
+      presses identically even where the animated ripple renders
+      poorly (see the token's comment in colors.xml).
 
   Borderless variants (`?android:attr/borderlessButtonStyle`, used
   for Skip / Reset) opt out of this drawable on a per-Button basis,
@@ -52,6 +56,22 @@
                         android:width="1dp"
                         android:color="@color/frosted_button_stroke" />
                     <corners android:radius="24dp" />
+                </shape>
+            </item>
+        </selector>
+    </item>
+
+    <item>
+        <selector>
+            <item android:state_pressed="true">
+                <shape android:shape="rectangle">
+                    <solid android:color="@color/frosted_button_pressed" />
+                    <corners android:radius="24dp" />
+                </shape>
+            </item>
+            <item>
+                <shape android:shape="rectangle">
+                    <solid android:color="@android:color/transparent" />
                 </shape>
             </item>
         </selector>

--- a/app/src/main/res/drawable/btn_frosted_outline_background.xml
+++ b/app/src/main/res/drawable/btn_frosted_outline_background.xml
@@ -5,6 +5,13 @@
   BackdropBlurView sitting behind the button shows through, while keeping
   the same 1dp frosted-button stroke + 24dp rounded shape + ripple so the
   button still reads with its usual outline and tap feedback.
+
+  The topmost layer is the shared instant pressed wash (see
+  `frosted_button_pressed` in colors.xml): on THIS button the ripple
+  alone was invisible in practice — the transparent fill sits over a
+  BackdropBlurView whose per-frame software recapture of the view tree
+  leaves the animated ripple imperceptible — so the wash is what
+  guarantees the press reads, here and identically across the family.
 -->
 <ripple xmlns:android="http://schemas.android.com/apk/res/android"
     android:color="@color/frosted_button_ripple">
@@ -31,6 +38,22 @@
                         android:width="1dp"
                         android:color="@color/frosted_button_stroke" />
                     <corners android:radius="24dp" />
+                </shape>
+            </item>
+        </selector>
+    </item>
+
+    <item>
+        <selector>
+            <item android:state_pressed="true">
+                <shape android:shape="rectangle">
+                    <solid android:color="@color/frosted_button_pressed" />
+                    <corners android:radius="24dp" />
+                </shape>
+            </item>
+            <item>
+                <shape android:shape="rectangle">
+                    <solid android:color="@android:color/transparent" />
                 </shape>
             </item>
         </selector>

--- a/app/src/main/res/drawable/btn_visibility_on_background.xml
+++ b/app/src/main/res/drawable/btn_visibility_on_background.xml
@@ -14,6 +14,10 @@
     * Default — the linear blue gradient fill.
     * Ripple color — soft white at low alpha so a press glows on top
       of the gradient without washing it out.
+    * Pressed wash — the same instant state_pressed overlay the
+      frosted button family carries, but in white: the brand-blue
+      `frosted_button_pressed` token would vanish on this blue
+      gradient, so the wash matches the ripple's white instead.
 -->
 <ripple xmlns:android="http://schemas.android.com/apk/res/android"
     android:color="#26FFFFFF">
@@ -34,6 +38,22 @@
                 android:startColor="#2D58D5"
                 android:type="linear" />
         </shape>
+    </item>
+
+    <item>
+        <selector>
+            <item android:state_pressed="true">
+                <shape android:shape="rectangle">
+                    <solid android:color="#33FFFFFF" />
+                    <corners android:radius="24dp" />
+                </shape>
+            </item>
+            <item>
+                <shape android:shape="rectangle">
+                    <solid android:color="@android:color/transparent" />
+                </shape>
+            </item>
+        </selector>
     </item>
 
 </ripple>

--- a/app/src/main/res/drawable/qr_button_subtle_background.xml
+++ b/app/src/main/res/drawable/qr_button_subtle_background.xml
@@ -2,9 +2,11 @@
 <!--
   Background for the send card's compact QR-share icon button. Uses the
   app's frosted-glass treatment (translucent fill + hairline stroke +
-  soft ripple) so the button recedes against the card, but keeps the
-  14dp rounded-square corner shape the QR button has always had rather
-  than the 24dp near-circle of the shared global button background.
+  soft ripple + the shared instant pressed wash, see
+  `frosted_button_pressed` in colors.xml) so the button recedes against
+  the card, but keeps the 14dp rounded-square corner shape the QR button
+  has always had rather than the 24dp near-circle of the shared global
+  button background.
 -->
 <ripple xmlns:android="http://schemas.android.com/apk/res/android"
     android:color="@color/frosted_button_ripple">
@@ -24,6 +26,22 @@
                 android:color="@color/frosted_button_stroke" />
             <corners android:radius="14dp" />
         </shape>
+    </item>
+
+    <item>
+        <selector>
+            <item android:state_pressed="true">
+                <shape android:shape="rectangle">
+                    <solid android:color="@color/frosted_button_pressed" />
+                    <corners android:radius="14dp" />
+                </shape>
+            </item>
+            <item>
+                <shape android:shape="rectangle">
+                    <solid android:color="@android:color/transparent" />
+                </shape>
+            </item>
+        </selector>
     </item>
 
 </ripple>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -47,6 +47,10 @@
     <color name="frosted_button_stroke">#33FFFFFF</color>
     <color name="frosted_button_disabled">#1A000000</color>
     <color name="frosted_button_ripple">#3D5B82FF</color>
+    <!-- Pressed wash mirrors the day token: lighter brand tint at
+         higher alpha so the instant pressed cue stays legible on the
+         darker plate. See values/colors.xml for why this exists. -->
+    <color name="frosted_button_pressed">#455B82FF</color>
 
     <!-- Popup menu surface flips dark too — keeping it white on
          dark would create a glaring rectangle when the toolbar

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -75,6 +75,17 @@
     <color name="frosted_button_stroke">#22000000</color>
     <color name="frosted_button_disabled">#33000000</color>
     <color name="frosted_button_ripple">#1F0F62FE</color>
+    <!--
+      Instant pressed wash layered under the ripple in every frosted
+      button drawable. The ripple alone is not a reliable pressed cue:
+      on the send sheet's Cancel/Done plate the transparent fill sits
+      on a BackdropBlurView that software-recaptures the view tree
+      every frame, and the animated ripple ends up imperceptible
+      there. A plain state_pressed shape renders through the normal
+      draw path everywhere, so every button in the family presses
+      identically; the ripple still glows on top where it renders.
+    -->
+    <color name="frosted_button_pressed">#2B0F62FE</color>
 
     <!--
       Popup menu (toolbar overflow). Same surface_card token in spirit


### PR DESCRIPTION
## Summary

The send sheet's Cancel/Done button showed no pressed effect when tapped. The ripple is actually defined in `btn_frosted_outline_background`, but this is the one button in the app whose transparent fill sits on a `BackdropBlurView`, and that view software-recaptures the whole view tree every frame (`onPreDraw` -> `invalidate`), which leaves the animated ripple imperceptible in practice.

Rather than depending on the ripple rendering path, this adds an explicit `state_pressed` wash layer to every frosted button drawable. The wash renders through the plain draw path, so the press registers instantly and identically across the family; the ripple still glows on top wherever it renders normally.

## Changes

- New `frosted_button_pressed` color token: `#2B0F62FE` (day) / `#455B82FF` (night), same brand-blue family as the existing ripple color.
- `btn_frosted_outline_background` (Cancel/Done, the reported button): pressed wash layer added.
- `btn_frosted_background` (theme-wide default via `Widget.Bada.Button`): same wash, so every plain button in the app presses the same way.
- `qr_button_subtle_background` (QR icon button): same wash at its 14dp corner radius.
- `btn_visibility_on_background` (blue gradient toggle): same structure, but a white `#33FFFFFF` wash — the brand-blue token would vanish on the blue gradient.

Intentional exceptions left untouched: the toolbar kebab (icon-tint press feedback by design, documented in `toolbar_action_background.xml`) and `DeviceIconView` (bounce animation).

## Test plan

- `./gradlew :app:assembleDebug` passes.
- Verified on a V2547A (vivo, OriginOS): the Cancel button now shows the pressed wash on touch, matching the rest of the buttons.