### PR TITLE
fix: restore the gap below the Name Card settings card and its setup screen's status-bar inset

### DIFF
--- a/app/src/main/res/layout/activity_name_card_setup.xml
+++ b/app/src/main/res/layout/activity_name_card_setup.xml
@@ -7,11 +7,18 @@
   Visual: a single rounded white panel (@drawable/settings_card_background)
   matching the Settings cards, with a title, subtitle, three labelled text
   fields (name / phone / email), and an action row.
+
+  System-bar inset handling: `fitsSystemWindows="true"` on the root, the
+  same pattern every other full-screen activity here uses (main / credit /
+  onboarding / check-for-updates / in-app send) — with targetSdk 35+
+  edge-to-edge enforcement the content otherwise starts underneath the
+  status bar.
 -->
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     android:fillViewport="true">
 
     <LinearLayout

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -111,10 +111,15 @@
 
         </LinearLayout>
 
-        <!-- ============ Card 1: Save location ============ -->
+        <!-- ============ Card 1: Save location ============
+             marginTop matches every other card's 12dp gap. It was absent
+             while this was the FIRST card; the Name Card row (#251) now
+             sits above, and without the margin the two cards render
+             flush against each other. -->
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
             android:background="@drawable/settings_card_background"
             android:orientation="vertical"
             android:padding="20dp">


### PR DESCRIPTION
## Summary

Fixes the two Name Card UI bugs reported in #281: the Settings Name Card card rendered flush against the save-location card below it, and the My Name Card setup screen drew its title underneath the status bar.

## Changes

- `fragment_settings.xml`: the save-location card was historically the first card and had no top margin; now that the Name Card row (#251) sits above it, add the same 12dp `layout_marginTop` every other card uses, with a comment explaining why it exists.
- `activity_name_card_setup.xml`: add `fitsSystemWindows="true"` on the root, the same pattern every other full-screen activity here uses (main / credit / onboarding / check-for-updates / in-app send). With targetSdk 35+ edge-to-edge enforcement the content otherwise starts underneath the status bar.

## Test plan

- `./gradlew :app:assembleDebug` passes.
- Both changes reuse the exact spacing/inset conventions of sibling screens, so the rendered result matches the rest of Settings; a device spot check of the Settings list and the My Name Card screen confirms the gap and the safe area.

Fixes #281